### PR TITLE
Add cover macros

### DIFF
--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -53,4 +53,27 @@ assert property (__expr__); \
 end \
 endgenerate
 
+////////////////////////////////////////////////////////////////////////////////
+// Concurrent cover macros (evaluated on posedge of a clock and disabled during a reset)
+////////////////////////////////////////////////////////////////////////////////
+
+// Clock: 'clk'
+// Reset: 'rst'
+`define BR_COVER(__name__, __expr__) \
+__name__ : cover property (@(posedge clk) disable iff (rst) __expr__);
+
+// More expressive form of BR_COVER that allows the use of custom clock and reset signal names.
+`define BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
+__name__ : cover property (@(posedge __clk__) disable iff (__rst__) __expr__);
+
+////////////////////////////////////////////////////////////////////////////////
+// Combinational cover macros (evaluated continuously based on the expression sensitivity)
+////////////////////////////////////////////////////////////////////////////////
+`define BR_COVER_COMB(__name__, __expr__) \
+generate : __name__ \
+always_comb begin \
+cover property (__expr__); \
+end \
+endgenerate
+
 `endif // BR_ASSERTS_SVH

--- a/macros/br_asserts_internal.svh
+++ b/macros/br_asserts_internal.svh
@@ -45,7 +45,7 @@
 `endif
 
 // More expressive form of BR_ASSERT_INTG that allows the use of custom clock and reset signal names.
-`define BR_ASSERT_INTG_CR(__name__, __expr__, __clk__, __rst__) \
+`define BR_ASSERT_CR_INTG(__name__, __expr__, __clk__, __rst__) \
 `ifdef BR_DISABLE_INTG_CHECKS \
 `BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) \
 `endif
@@ -58,7 +58,7 @@
 `endif
 
 // More expressive form of BR_ASSERT_IMPL that allows the use of custom clock and reset signal names.
-`define BR_ASSERT_IMPL_CR(__name__, __expr__, __clk__, __rst__) \
+`define BR_ASSERT_CR_IMPL(__name__, __expr__, __clk__, __rst__) \
 `ifdef BR_ENABLE_IMPL_CHECKS \
 `BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) \
 `endif
@@ -88,7 +88,7 @@
 `endif
 
 // More expressive form of BR_COVER_INTG that allows the use of custom clock and reset signal names.
-`define BR_COVER_INTG_CR(__name__, __expr__, __clk__, __rst__) \
+`define BR_COVER_CR_INTG(__name__, __expr__, __clk__, __rst__) \
 `ifdef BR_DISABLE_INTG_CHECKS \
 `BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
 `endif
@@ -101,7 +101,7 @@
 `endif
 
 // More expressive form of BR_COVER_IMPL that allows the use of custom clock and reset signal names.
-`define BR_COVER_IMPL_CR(__name__, __expr__, __clk__, __rst__) \
+`define BR_COVER_CR_IMPL(__name__, __expr__, __clk__, __rst__) \
 `ifdef BR_ENABLE_IMPL_CHECKS \
 `BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
 `endif

--- a/macros/br_asserts_internal.svh
+++ b/macros/br_asserts_internal.svh
@@ -76,5 +76,47 @@
 `BR_ASSERT_COMB(__name__, __expr__) \
 `endif
 
-`endif // BR_ASSERTS_INTERNAL_SVH
+////////////////////////////////////////////////////////////////////////////////
+// Concurrent cover macros (evaluated on posedge of a clock and disabled during a reset)
+////////////////////////////////////////////////////////////////////////////////
 
+// Clock: 'clk'
+// Reset: 'rst'
+`define BR_COVER_INTG(__name__, __expr__) \
+`ifndef BR_DISABLE_INTG_CHECKS \
+`BR_COVER(__name__, __expr__) \
+`endif
+
+// More expressive form of BR_COVER_INTG that allows the use of custom clock and reset signal names.
+`define BR_COVER_INTG_CR(__name__, __expr__, __clk__, __rst__) \
+`ifdef BR_DISABLE_INTG_CHECKS \
+`BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
+`endif
+
+// Clock: 'clk'
+// Reset: 'rst'
+`define BR_COVER_IMPL(__name__, __expr__) \
+`ifndef BR_ENABLE_IMPL_CHECKS \
+`BR_COVER(__name__, __expr__) \
+`endif
+
+// More expressive form of BR_COVER_IMPL that allows the use of custom clock and reset signal names.
+`define BR_COVER_IMPL_CR(__name__, __expr__, __clk__, __rst__) \
+`ifdef BR_ENABLE_IMPL_CHECKS \
+`BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
+`endif
+
+////////////////////////////////////////////////////////////////////////////////
+// Combinational cover macros (evaluated continuously based on the expression sensitivity)
+////////////////////////////////////////////////////////////////////////////////
+`define BR_COVER_COMB_INTG(__name__, __expr__) \
+`ifndef BR_DISABLE_INTG_CHECKS \
+`BR_COVER_COMB(__name__, __expr__) \
+`endif
+
+`define BR_COVER_COMB_IMPL(__name__, __expr__) \
+`ifdef BR_ENABLE_IMPL_CHECKS \
+`BR_COVER_COMB(__name__, __expr__) \
+`endif
+
+`endif // BR_ASSERTS_INTERNAL_SVH


### PR DESCRIPTION
* `BR_COVER` - concurrent; implicit `clk` and `rst` signal names
* `BR_COVER_CR` - concurrent; custom clock and reset signal names
* `BR_COVER_COMB` - combinational
* `BR_COVER_INTG` - wrapper around `BR_COVER` for library-internal usage on integration checks
* `BR_COVER_CR_INTG` - wrapper around `BR_COVER_CR` for library-internal usage on integration checks
* `BR_COVER_COMB_INTG` - wrapper around `BR_COVER_COMB` for library-internal usage on integration checks
* `BR_COVER_IMPL` - wrapper around `BR_COVER` for library-internal usage on implementation checks
* `BR_COVER_CR_IMPL` - wrapper around `BR_COVER_CR` for library-internal usage on implementation checks
* `BR_COVER_COMB_IMPL` - wrapper around `BR_COVER_COMB` for library-internal usage on implementation checks