### PR TITLE
Implement br_delay, br_delay_nr, br_delay_valid, br_delay_valid_next

### DIFF
--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -1,0 +1,59 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Delay Line
+//
+// Delays an input signal by a fixed number of clock cycles.
+// There are NumStages pipeline registers. If NumStages is 0,
+// then the output is the input. The pipeline registers are reset
+// to 0.
+
+`include "br_registers.svh"
+`include "br_asserts.svh"
+
+module br_delay #(
+    parameter int BitWidth = 1,  // Must be at least 1
+    parameter int NumStages = 0  // Must be at least 0
+) (
+    input  logic clk,
+    input  logic rst,
+    input  logic [BitWidth-1:0] in,
+    output logic [BitWidth-1:0] out
+);
+
+    //------------------------------------------
+    // Integration checks
+    //------------------------------------------
+    `BR_ASSERT_STATIC(BitWidthMustBeAtLeastOne_A, BitWidth >= 1)
+    `BR_ASSERT_STATIC(NumStagesMustBeAtLeastZero_A, NumStages >= 0)
+
+    //------------------------------------------
+    // Implementation
+    //------------------------------------------
+    logic [NumStages:0][BitWidth-1:0] stages;
+
+    assign stages[0] = in;
+
+    for (int i = 1; i <= NumStages; i++) begin : gen_stages
+        `BR_REG(stages[i], stages[i-1])
+    end
+
+    assign out = stages[NumStages];
+
+    //------------------------------------------
+    // Implementation checks
+    //------------------------------------------
+    `BR_ASSERT_IMPL(delay_A, ##NumStages out == $past(in, NumStages))
+
+endmodule : br_delay

--- a/delay/rtl/br_delay_nr.sv
+++ b/delay/rtl/br_delay_nr.sv
@@ -1,0 +1,58 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Delay Line (No Reset)
+//
+// Delays an input signal by a fixed number of clock cycles.
+// There are NumStages pipeline registers. If NumStages is 0,
+// then the output is the input. The pipeline registers do not
+// get reset.
+
+`include "br_registers.svh"
+`include "br_asserts.svh"
+
+module br_delay_nr #(
+    parameter int BitWidth = 1,  // Must be at least 1
+    parameter int NumStages = 0  // Must be at least 0
+) (
+    input  logic clk,
+    input  logic [BitWidth-1:0] in,
+    output logic [BitWidth-1:0] out
+);
+
+    //------------------------------------------
+    // Integration checks
+    //------------------------------------------
+    `BR_ASSERT_STATIC(BitWidthMustBeAtLeastOne_A, BitWidth >= 1)
+    `BR_ASSERT_STATIC(NumStagesMustBeAtLeastZero_A, NumStages >= 0)
+
+    //------------------------------------------
+    // Implementation
+    //------------------------------------------
+    logic [NumStages:0][BitWidth-1:0] stages;
+
+    assign stages[0] = in;
+
+    for (int i = 1; i <= NumStages; i++) begin : gen_stages
+        `BR_REGN(stages[i], stages[i-1])
+    end
+
+    assign out = stages[NumStages];
+
+    //------------------------------------------
+    // Implementation checks
+    //------------------------------------------
+    `BR_ASSERT_IMPL(delay_A, ##NumStages out == $past(in, NumStages))
+
+endmodule : br_delay_nr

--- a/delay/rtl/br_delay_valid.sv
+++ b/delay/rtl/br_delay_valid.sv
@@ -1,0 +1,69 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Delay Line (With Valid)
+//
+// Delays a valid input signal by a fixed number of clock cycles.
+// There are NumStages pipeline registers. If NumStages is 0,
+// then the output is the input. The valid registers are reset to 0
+// but the datapath registers are not. Each datapath register is clock
+// gated using the valid signal.
+
+`include "br_registers.svh"
+`include "br_asserts.svh"
+
+module br_delay #(
+    parameter int BitWidth = 1,  // Must be at least 1
+    parameter int NumStages = 0  // Must be at least 0
+) (
+    input  logic clk,
+    input  logic rst,
+    input  logic                in_valid,
+    input  logic [BitWidth-1:0] in,
+    output logic                out_valid,
+    output logic [BitWidth-1:0] out
+);
+
+    //------------------------------------------
+    // Integration checks
+    //------------------------------------------
+    `BR_ASSERT_STATIC(BitWidthMustBeAtLeastOne_A, BitWidth >= 1)
+    `BR_ASSERT_STATIC(NumStagesMustBeAtLeastZero_A, NumStages >= 0)
+
+    `BR_COVER_INTG(in_valid_C, in_valid)
+
+    //------------------------------------------
+    // Implementation
+    //------------------------------------------
+    logic [NumStages:0][BitWidth-1:0] stage_valid;
+    logic [NumStages:0][BitWidth-1:0] stage;
+
+    assign stage_valid[0] = in_valid;
+    assign stage[0] = in;
+
+    for (int i = 1; i <= NumStages; i++) begin : gen_stages
+        `BR_REGN(stage_valid[i], stage_valid[i-1])
+        `BR_REGL(stage[i], stage[i-1], stage_valid[i-1])
+    end
+
+    assign out_valid = stage_valid[NumStages];
+    assign out = stage[NumStages];
+
+    //------------------------------------------
+    // Implementation checks
+    //------------------------------------------
+    `BR_ASSERT_IMPL(valid_delay_A, ##NumStages out_valid == $past(in_valid, NumStages))
+    `BR_ASSERT_IMPL(data_delay_A, in_valid |-> ##NumStages out_valid && out == $past(in, NumStages))
+
+endmodule : br_delay

--- a/delay/rtl/br_delay_valid_next.sv
+++ b/delay/rtl/br_delay_valid_next.sv
@@ -1,0 +1,76 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Delay Line (With Valid-Next)
+//
+// Delays a valid input signal by a fixed number of clock cycles.
+// There are NumStages pipeline registers. If NumStages is 0,
+// then the output is the input. The valid registers are reset
+// to 0 but the datapath registers are not reset. Each datapath register is
+// clock gated using the valid_next signal.
+//
+// valid_next runs one cycle ahead of the data, i.e., if valid_next is 1 then
+// the data is valid on the following cycle. This can be very useful for closing
+// timing on a wide bus that covers a long wire distance. The width-wise fanout
+// delay is on a different cycle than the lengthwise wire delay.
+
+`include "br_registers.svh"
+`include "br_asserts.svh"
+
+module br_delay_valid_next #(
+    parameter int BitWidth = 1,  // Must be at least 1
+    parameter int NumStages = 0  // Must be at least 0
+) (
+    input  logic clk,
+    input  logic rst,
+    input  logic                in_valid_next,
+    input  logic [BitWidth-1:0] in,
+    output logic                out_valid_next,
+    output logic [BitWidth-1:0] out
+);
+
+    //------------------------------------------
+    // Integration checks
+    //------------------------------------------
+    `BR_ASSERT_STATIC(BitWidthMustBeAtLeastOne_A, BitWidth >= 1)
+    `BR_ASSERT_STATIC(NumStagesMustBeAtLeastZero_A, NumStages >= 0)
+
+    `BR_COVER_INTG(in_valid_next_C, in_valid_next)
+
+    //------------------------------------------
+    // Implementation
+    //------------------------------------------
+    logic [NumStages:0][BitWidth-1:0] stage_valid_next;
+    logic [NumStages:0][BitWidth-1:0] stage;
+
+    assign stage_valid_next[0] = in_valid_next;
+    assign stage[0] = in;
+
+    for (int i = 1; i <= NumStages; i++) begin : gen_stages
+        `BR_REG(stage_valid_next[i], stage_valid_next[i-1])
+        // stage_valid_next[i] is equivalent to hypothetical stage_valid[i-1],
+        // which would be aligned to stage[i-1].
+        `BR_REGLN(stage[i], stage[i-1], stage_valid_next[i])
+    end
+
+    assign out_valid_next = stage_valid_next[NumStages];
+    assign out = stage[NumStages];
+
+    //------------------------------------------
+    // Implementation checks
+    //------------------------------------------
+    `BR_ASSERT_IMPL(valid_next_delay_A, ##NumStages out_valid_next == $past(in_valid_next, NumStages))
+    `BR_ASSERT_IMPL(data_delay_A, in_valid_next |-> ##NumStages out_valid_next ##1 out == $past(in, NumStages))
+
+endmodule : br_delay_valid_next


### PR DESCRIPTION
* `br_delay` - delay line, everything reset to 0
  * Typical use: delaying control signals that are always valid and where 0 is the correct initial value
* `br_delay_nr` - delay line, no reset
  * Typical use: delaying reset signals or global buses where signals are always valid but can be X for some time after reset (because there is some reset handshake mechanism in place to prevent incorrect consumption of Xes)
* `br_delay_valid` - delay line with valid bit; only valid is reset
  * Typical use: delaying data that is only sometimes valid and where clock gating the datapath is useful
* `br_delay_valid_next` - delay line with valid-next bit; only valid-next is reset
  * Typical use: delaying data that is only sometimes valid and where the clock gate fanout should be timed on a different cycle from the lengthwise wire delay

`valid` is simpler to use than `valid_next` but has worse timing properties when delaying a wide bus over a long wirelength.