### PR TITLE
Guard assert macros with `SV_ASSERT_ON`

### DIFF
--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -41,13 +41,13 @@ end \
 // Reset: 'rst'
 `define BR_ASSERT(__name__, __expr__) \
 `ifdef SV_ASSERT_ON \
-__name__ : assert property (@(posedge clk) disable iff (rst) __expr__); \
+__name__ : assert property (@(posedge clk) disable iff (rst) (__expr__)); \
 `endif
 
 // More expressive form of BR_ASSERT that allows the use of custom clock and reset signal names.
 `define BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) \
 `ifdef SV_ASSERT_ON \
-__name__ : assert property (@(posedge __clk__) disable iff (__rst__) __expr__); \
+__name__ : assert property (@(posedge __clk__) disable iff (__rst__) (__expr__)); \
 `endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -70,13 +70,13 @@ endgenerate \
 // Reset: 'rst'
 `define BR_COVER(__name__, __expr__) \
 `ifdef SV_ASSERT_ON \
-__name__ : cover property (@(posedge clk) disable iff (rst) __expr__); \
+__name__ : cover property (@(posedge clk) disable iff (rst) (__expr__)); \
 `endif
 
 // More expressive form of BR_COVER that allows the use of custom clock and reset signal names.
 `define BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
 `ifdef SV_ASSERT_ON \
-__name__ : cover property (@(posedge __clk__) disable iff (__rst__) __expr__); \
+__name__ : cover property (@(posedge __clk__) disable iff (__rst__) (__expr__)); \
 `endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -26,12 +26,6 @@
 // Static (elaboration-time) assertion macros
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO(mgottscho): This does not work with the following iverilog command:
-// verilator --lint-only enc/rtl/br_enc_bin2onehot.sv -Imacros +1800-2005ext+sv --assert 
-// ChatGPT suggests sim-time?
-// initial begin \
-//     $error("Static assertion failed: %s", "`__name__"); \
-// end \
 `define BR_ASSERT_STATIC(__name__, __expr__) \
 `ifdef SV_ASSERT_ON \
 if (!(__expr__)) begin : gen__``__name__ \


### PR DESCRIPTION
Not all tools support SystemVerilog Assertions. It can also be useful to globally disable them. Do this by guarding with `SV_ASSERT_ON`.