### PR TITLE
Set up Verible lint and format tests with Bazel; bring up `@rules_hdl`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,0 @@
-# TODO(mgottscho): Temporary! We want to use bzlmod.
-common --noenable_bzlmod

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bazel-*
+MODULE.bazel.lock
 .vscode

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,18 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "bedrock-rtl",
+    version = "0.0.1",
+)

--- a/README.adoc
+++ b/README.adoc
@@ -17,3 +17,32 @@
 WARNING: UNDER CONSTRUCTION. Everything is broken.
 
 High quality and composable base RTL libraries in Verilog
+
+== Prerequisites
+
+You need to have the following tools installed in your environment.
+
+* Bazel 6 or later
+* Verible (tested with v0.0-3798-ga602f072 commit 2024-09-23, YMMV)
+* TODO(mgottscho): Add more as we implement more things
+
+== Testing
+
+[source,shell]
+----
+bazel test //...
+----
+
+If you get a lint test error, go fix the code.
+If you get a format test error, you can automatically fix via:
+
+[source,shell]
+----
+verible-verilog-format --inplace <file1.sv> <file2.sv> ...
+----
+
+#TODO(mgottscho): Improve the formatter to be more user-friendly. Details in bazel/verible.bzl.#
+
+== Continuous Integration
+
+Using GitHub Actions, which currently just runs Verible lint and format tests.

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -14,6 +14,8 @@
 
 workspace(name = "bedrock_rtl")
 
+# TODO(mgottscho): migrate everything to bzlmod (in MODULE.bazel)
+
 #################################################################################
 # The following content is a stripped-down version of https://github.com/google/xls/blob/main/WORKSPACE
 # taking only what is needed to get @rules_hdl working. Retains the XLS copyright notice.

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,63 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(name = "bedrock_rtl")
+
+#################################################################################
+# The following content is a stripped-down version of https://github.com/google/xls/blob/main/WORKSPACE
+# taking only what is needed to get @rules_hdl working. Retains the XLS copyright notice.
+#################################################################################
+
+# Copyright 2022 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//dependency_support:load_external.bzl", "load_external_repositories")
+
+load_external_repositories()
+
+load(
+  "@rules_python//python:repositories.bzl",
+  "py_repositories",
+  "python_register_toolchains",
+)
+
+# Must be called before using anything from rules_python.
+# https://github.com/bazelbuild/rules_python/issues/1560#issuecomment-1815118394
+py_repositories()
+
+python_register_toolchains(
+    name = "project_python",
+    python_version = "3.11",
+)
+
+# gRPC deps should be loaded before initializing other repos. Otherwise, various
+# errors occur during repo loading and initialization.
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("//dependency_support:initialize_external.bzl", "initialize_external_repositories")
+
+initialize_external_repositories()

--- a/arb/rtl/BUILD.bazel
+++ b/arb/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_and_format_test")
+load("//bazel:verible.bzl", "verible_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -42,18 +42,17 @@ verilog_library(
     ],
 )
 
-################ Verible lint tests ################
-verible_lint_and_format_test(
-    name = "br_arb_fixed_verible_lint_and_format_test",
+verible_test(
+    name = "br_arb_fixed_verible_test",
     srcs = ["br_arb_fixed.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_arb_lru_verible_lint_and_format_test",
+verible_test(
+    name = "br_arb_lru_verible_test",
     srcs = ["br_arb_lru.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_arb_rr_verible_lint_and_format_test",
+verible_test(
+    name = "br_arb_rr_verible_test",
     srcs = ["br_arb_rr.sv"],
 )

--- a/arb/rtl/BUILD.bazel
+++ b/arb/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_test")
+load("//bazel:verible.bzl", "verible_lint_and_format_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -43,17 +43,17 @@ verilog_library(
 )
 
 ################ Verible lint tests ################
-verible_lint_test(
-    name = "br_arb_fixed_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_arb_fixed_verible_lint_and_format_test",
     srcs = ["br_arb_fixed.sv"],
 )
 
-verible_lint_test(
-    name = "br_arb_lru_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_arb_lru_verible_lint_and_format_test",
     srcs = ["br_arb_lru.sv"],
 )
 
-verible_lint_test(
-    name = "br_arb_rr_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_arb_rr_verible_lint_and_format_test",
     srcs = ["br_arb_rr.sv"],
 )

--- a/arb/rtl/BUILD.bazel
+++ b/arb/rtl/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:verible.bzl", "verible_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -39,4 +40,20 @@ verilog_library(
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],
+)
+
+################ Verible lint tests ################
+verible_lint_test(
+    name = "br_arb_fixed_verible_lint_test",
+    srcs = ["br_arb_fixed.sv"],
+)
+
+verible_lint_test(
+    name = "br_arb_lru_verible_lint_test",
+    srcs = ["br_arb_lru.sv"],
+)
+
+verible_lint_test(
+    name = "br_arb_rr_verible_lint_test",
+    srcs = ["br_arb_rr.sv"],
 )

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,0 +1,15 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])

--- a/bazel/verible.bzl
+++ b/bazel/verible.bzl
@@ -62,7 +62,7 @@ verible_lint_test = rule(
     doc = "Tests that the given source files don't require Verible lint fixes.",
     implementation = _verible_lint_test_impl,
     attrs = {
-        "srcs": attr.label_list(allow_files = True),
+        "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),
         "tool": attr.string(default = "verible-verilog-lint"),
     },
     test = True,
@@ -98,7 +98,7 @@ verible_format_test = rule(
     doc = "Tests that the given source files don't require Verible formatting changes.",
     implementation = _verible_format_test_impl,
     attrs = {
-        "srcs": attr.label_list(allow_files = True),
+        "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),
         "tool": attr.string(default = "verible-verilog-format"),
     },
     test = True,

--- a/bazel/verible.bzl
+++ b/bazel/verible.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Verible lint and format test rules for Bazel."""
+
 # TODO(mgottscho): The lint and format rules here are not the ideal solution.
 # We'd prefer to only run the linter and formatter on the changed lines in a
 # git diff so that we can change the lint/format rules over time (if needed)
@@ -33,9 +35,7 @@
 def _verible_lint_test_impl(ctx):
     input_files = [src.path for src in ctx.files.srcs]
 
-    args = [
-        "--ruleset=default",
-    ]
+    args = ["--ruleset=default"]
 
     executable_file = ctx.actions.declare_file(ctx.label.name + ".sh")
     cmd = " ".join([ctx.attr.tool] + args + input_files)
@@ -71,9 +71,7 @@ verible_lint_test = rule(
 def _verible_format_test_impl(ctx):
     input_files = [src.path for src in ctx.files.srcs]
 
-    args = [
-        "--verify=true",
-    ]
+    args = ["--verify=true"]
 
     executable_file = ctx.actions.declare_file(ctx.label.name + ".sh")
     cmd = " ".join([ctx.attr.tool] + args + input_files)

--- a/bazel/verible.bzl
+++ b/bazel/verible.bzl
@@ -89,6 +89,8 @@ verible_lint_test = rule(
     implementation = _verible_lint_test_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),
+        # By default, expect to find the tool in the system $PATH.
+        # TODO(mgottscho): It would be better to do this hermetically.
         "tool": attr.string(default = "verible-verilog-lint"),
     },
     test = True,
@@ -99,6 +101,8 @@ verible_format_test = rule(
     implementation = _verible_format_test_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),
+        # By default, expect to find the tool in the system $PATH.
+        # TODO(mgottscho): It would be better to do this hermetically.
         "tool": attr.string(default = "verible-verilog-format"),
     },
     test = True,

--- a/bazel/verible.bzl
+++ b/bazel/verible.bzl
@@ -85,7 +85,7 @@ def _verible_format_test_impl(ctx):
     )
 
 verible_lint_test = rule(
-    doc = "Tests that the given source files don't require Verible lint fixes.",
+    doc = "Tests that the given source files don't have syntax errors or Verible lint errors.",
     implementation = _verible_lint_test_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),
@@ -97,7 +97,7 @@ verible_lint_test = rule(
 )
 
 verible_format_test = rule(
-    doc = "Tests that the given source files don't require Verible formatting changes.",
+    doc = "Tests that the given source files don't have syntax errors or Verible formatting errors.",
     implementation = _verible_format_test_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),

--- a/bazel/verible.bzl
+++ b/bazel/verible.bzl
@@ -58,16 +58,6 @@ def _verible_lint_test_impl(ctx):
         executable = executable_file,
     )
 
-verible_lint_test = rule(
-    doc = "Tests that the given source files don't require Verible lint fixes.",
-    implementation = _verible_lint_test_impl,
-    attrs = {
-        "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),
-        "tool": attr.string(default = "verible-verilog-lint"),
-    },
-    test = True,
-)
-
 def _verible_format_test_impl(ctx):
     input_files = [src.path for src in ctx.files.srcs]
 
@@ -93,6 +83,16 @@ def _verible_format_test_impl(ctx):
         files = depset(direct = [executable_file]),
         executable = executable_file,
     )
+
+verible_lint_test = rule(
+    doc = "Tests that the given source files don't require Verible lint fixes.",
+    implementation = _verible_lint_test_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),
+        "tool": attr.string(default = "verible-verilog-lint"),
+    },
+    test = True,
+)
 
 verible_format_test = rule(
     doc = "Tests that the given source files don't require Verible formatting changes.",

--- a/bazel/verible.bzl
+++ b/bazel/verible.bzl
@@ -1,0 +1,60 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _verible_lint_test_impl(ctx):
+    input_files = [src.path for src in ctx.files.srcs]
+
+    args = [
+        "--rules=" + ctx.attr.rules,
+        "--rules_config=" + ctx.attr.rules_config,
+        "--ruleset=" + ctx.attr.ruleset,
+        "--waiver_files=" + ctx.attr.waiver_files,
+        "--show_diagnostic_context=" + ctx.attr.show_diagnostic_context,
+    ]
+
+    executable_file = ctx.actions.declare_file(ctx.label.name + ".sh")
+    cmd = " ".join([ctx.attr.tool] + args + input_files)
+    runfiles = ctx.runfiles(files = getattr(ctx.files, "srcs", []))
+
+    ctx.actions.write(
+        output = executable_file,
+        content = "\n".join([
+            "#!/usr/bin/env bash",
+            "set -e",
+            "exec " + cmd,
+            "exit 0",
+        ]),
+        is_executable = True,
+    )
+
+    return DefaultInfo(
+        runfiles = runfiles,
+        files = depset(direct = [executable_file]),
+        executable = executable_file,
+    )
+
+verible_lint_test = rule(
+    doc = "Runs the Verible verilog linter on the given source files.",
+    implementation = _verible_lint_test_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "rules": attr.string(default = ""),
+        "rules_config": attr.string(default = ""),
+        "ruleset": attr.string(default = "default"),
+        "waiver_files": attr.string(default = ""),
+        "show_diagnostic_context": attr.string(default = "false"),
+        "tool": attr.string(default = "verible-verilog-lint"),
+    },
+    test = True,
+)

--- a/bazel/verible.bzl
+++ b/bazel/verible.bzl
@@ -106,9 +106,12 @@ verible_format_test = rule(
     test = True,
 )
 
-def verible_lint_and_format_test(name, srcs, lint_tool = "verible-verilog-lint", format_tool = "verible-verilog-format"):
+def verible_test(name, srcs, lint_tool = "verible-verilog-lint", format_tool = "verible-verilog-format"):
     """Expands to a pair of test targets that check for Verible lint and formatting issues."""
-    name = name.replace("_test", "")
+    if not name.endswith("_verible_test"):
+        fail("verible_test target names must end with '_verible_test'")
+
+    name = name.rstrip("_verible_test")
 
     verible_lint_test(
         name = name + "_verible_lint_test",

--- a/delay/rtl/BUILD.bazel
+++ b/delay/rtl/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:verible.bzl", "verible_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -50,4 +51,25 @@ verilog_library(
         "//macros:br_registers",
         "//macros:br_asserts_internal",
     ],
+)
+
+################ Verible lint tests ################
+verible_lint_test(
+    name = "br_delay_verible_lint_test",
+    srcs = ["br_delay.sv"],
+)
+
+verible_lint_test(
+    name = "br_delay_nr_verible_lint_test",
+    srcs = ["br_delay_nr.sv"],
+)
+
+verible_lint_test(
+    name = "br_delay_valid_verible_lint_test",
+    srcs = ["br_delay_valid.sv"],
+)
+
+verible_lint_test(
+    name = "br_delay_valid_next_verible_lint_test",
+    srcs = ["br_delay_valid_next.sv"],
 )

--- a/delay/rtl/BUILD.bazel
+++ b/delay/rtl/BUILD.bazel
@@ -53,6 +53,15 @@ verilog_library(
     ],
 )
 
+verilog_library(
+    name = "br_delay_valid_next_nr",
+    srcs = ["br_delay_valid_next_nr.sv"],
+    deps = [
+        "//macros:br_registers",
+        "//macros:br_asserts_internal",
+    ],
+)
+
 verible_test(
     name = "br_delay_verible_test",
     srcs = ["br_delay.sv"],
@@ -71,4 +80,9 @@ verible_test(
 verible_test(
     name = "br_delay_valid_next_verible_test",
     srcs = ["br_delay_valid_next.sv"],
+)
+
+verible_test(
+    name = "br_delay_valid_next_nr_verible_test",
+    srcs = ["br_delay_valid_next_nr.sv"],
 )

--- a/delay/rtl/BUILD.bazel
+++ b/delay/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_and_format_test")
+load("//bazel:verible.bzl", "verible_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -53,23 +53,22 @@ verilog_library(
     ],
 )
 
-################ Verible lint tests ################
-verible_lint_and_format_test(
-    name = "br_delay_verible_lint_and_format_test",
+verible_test(
+    name = "br_delay_verible_test",
     srcs = ["br_delay.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_delay_nr_verible_lint_and_format_test",
+verible_test(
+    name = "br_delay_nr_verible_test",
     srcs = ["br_delay_nr.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_delay_valid_verible_lint_and_format_test",
+verible_test(
+    name = "br_delay_valid_verible_test",
     srcs = ["br_delay_valid.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_delay_valid_next_verible_lint_and_format_test",
+verible_test(
+    name = "br_delay_valid_next_verible_test",
     srcs = ["br_delay_valid_next.sv"],
 )

--- a/delay/rtl/BUILD.bazel
+++ b/delay/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_test")
+load("//bazel:verible.bzl", "verible_lint_and_format_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -54,22 +54,22 @@ verilog_library(
 )
 
 ################ Verible lint tests ################
-verible_lint_test(
-    name = "br_delay_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_delay_verible_lint_and_format_test",
     srcs = ["br_delay.sv"],
 )
 
-verible_lint_test(
-    name = "br_delay_nr_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_delay_nr_verible_lint_and_format_test",
     srcs = ["br_delay_nr.sv"],
 )
 
-verible_lint_test(
-    name = "br_delay_valid_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_delay_valid_verible_lint_and_format_test",
     srcs = ["br_delay_valid.sv"],
 )
 
-verible_lint_test(
-    name = "br_delay_valid_next_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_delay_valid_next_verible_lint_and_format_test",
     srcs = ["br_delay_valid_next.sv"],
 )

--- a/dependency_support/BUILD.bazel
+++ b/dependency_support/BUILD.bazel
@@ -1,0 +1,13 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/dependency_support/boost/BUILD.bazel
+++ b/dependency_support/boost/BUILD.bazel
@@ -1,0 +1,15 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/boost/add_python.patch
+++ b/dependency_support/boost/add_python.patch
@@ -1,0 +1,60 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+diff --git boost.BUILD boost.BUILD
+index e5d0b60..4f52d3c 100644
+--- boost.BUILD
++++ boost.BUILD
+@@ -2642,3 +2642,41 @@ boost_library(
+         ":variant2",
+     ],
+ )
++
++boost_library(
++    name = "python",
++    srcs = glob([
++        "libs/python/src/converter/*.cpp",
++        "libs/python/src/numpy/*.cpp",
++        "libs/python/src/object/*.cpp",
++    ]),
++    deps = [
++        ":assert",
++        ":bind",
++        ":config",
++        ":conversion",
++        ":cstdint",
++        ":detail",
++        ":function",
++        ":get_pointer",
++        ":graph",
++        ":integer",
++        ":iterator",
++        ":lexical_cast",
++        ":math",
++        ":mpl",
++        ":noncopyable",
++        ":operators",
++        ":preprocessor",
++        ":property_map",
++        ":ref",
++        ":scoped_array",
++        ":shared_ptr",
++        ":smart_ptr",
++        ":static_assert",
++        ":tuple",
++        ":type",
++        ":utility",
++        "@local_config_python//:python_headers",
++    ],
++)

--- a/dependency_support/boost/backtrace_from_rule.patch
+++ b/dependency_support/boost/backtrace_from_rule.patch
@@ -1,0 +1,29 @@
+--- boost.BUILD	2023-07-22 21:40:32.570049258 -0700
++++ boost.BUILD	2023-07-23 07:33:08.760174104 -0700
+@@ -1901,18 +1901,6 @@
+         "//conditions:default": [],
+     }),
+     exclude_src = ["libs/stacktrace/src/*.cpp"],
+-    linkopts = select({
+-        ":linux_ppc": [
+-            "-lbacktrace -ldl",
+-        ],
+-        ":linux_x86_64": [
+-            "-lbacktrace -ldl",
+-        ],
+-        ":linux_aarch64": [
+-            "-lbacktrace -ldl",
+-        ],
+-        "//conditions:default": [],
+-    }),
+     deps = [
+         ":array",
+         ":config",
+@@ -1922,6 +1910,7 @@
+         ":predef",
+         ":static_assert",
+         ":type_traits",
++        "@com_github_libbacktrace//:libbacktrace",
+     ],
+ )
+ 

--- a/dependency_support/boost/downgrade_lzma.patch
+++ b/dependency_support/boost/downgrade_lzma.patch
@@ -1,0 +1,17 @@
+diff --git boost/boost.bzl boost/boost.bzl
+index 4381996..587a37d 100644
+--- boost/boost.bzl
++++ boost/boost.bzl
+@@ -140,9 +140,9 @@ def boost_deps():
+         http_archive,
+         name = "org_lzma_lzma",
+         build_file = "@com_github_nelhage_rules_boost//:lzma.BUILD",
+-        url = "https://github.com/tukaani-project/xz/releases/download/v5.4.3/xz-5.4.3.tar.gz",
+-        sha256 = "1c382e0bc2e4e0af58398a903dd62fff7e510171d2de47a1ebe06d1528e9b7e9",
+-        strip_prefix = "xz-5.4.3",
++        url = "https://src.fedoraproject.org/lookaside/extras/xz/xz-5.4.6.tar.gz/sha512/b08a61d8d478d3b4675cb1ddacdbbd98dc6941a55bcdd81a28679e54e9367d3a595fa123ac97874a17da571c1b712e2a3e901c2737099a9d268616a1ba3de497/xz-5.4.6.tar.gz",
++        sha256 = "aeba3e03bf8140ddedf62a0a367158340520f6b384f75ca6045ccc6c0d43fd5c",
++        strip_prefix = "xz-5.4.6",
+     )
+ 
+     maybe(

--- a/dependency_support/boost/initialize.bzl
+++ b/dependency_support/boost/initialize.bzl
@@ -1,0 +1,20 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loads the Boost C++ libraries."""
+
+load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
+
+def initialize():
+    boost_deps()

--- a/dependency_support/boost/workspace.bzl
+++ b/dependency_support/boost/workspace.bzl
@@ -1,0 +1,39 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registers Bazel workspaces for the Boost C++ libraries."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def repo():
+    maybe(
+        http_archive,
+        name = "com_github_nelhage_rules_boost",
+        url = "https://github.com/nelhage/rules_boost/archive/1217caae292dc9f14e8109777ba43c988cf89c5b.tar.gz",
+        strip_prefix = "rules_boost-1217caae292dc9f14e8109777ba43c988cf89c5b",
+        sha256 = "b3280ba677fb53c08dfe9fc3d77504c53efd31288c3b8445711c2e7b82281315",
+        patches = [
+            # rules_boost does not include Boost Python, see
+            # https://github.com/nelhage/rules_boost/issues/67
+            # This is because there doesn't exist a nice standard way in
+            # Bazel to depend on the Python headers of the current Python
+            # toolchain. The patch below selects the same Python headers
+            # that the rest of XLS uses.
+            "//dependency_support/boost:add_python.patch",
+            "//dependency_support/boost:backtrace_from_rule.patch",
+            # See: https://github.com/nelhage/rules_boost/issues/555
+            "//dependency_support/boost:downgrade_lzma.patch",
+        ],
+    )

--- a/dependency_support/com_github_grpc_grpc/0001-Add-absl-status-to-deps.patch
+++ b/dependency_support/com_github_grpc_grpc/0001-Add-absl-status-to-deps.patch
@@ -1,0 +1,24 @@
+From 160a546da6ce0a76b160b57e6350f610ccf8b808 Mon Sep 17 00:00:00 2001
+From: Paul Rigge <rigge@google.com>
+Date: Mon, 22 Jul 2024 20:59:04 -0700
+Subject: [PATCH] Add absl:status to deps.
+
+---
+ src/core/BUILD | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git src/core/BUILD src/core/BUILD
+index e76dc300ac..0688bb9dcc 100644
+--- src/core/BUILD
++++ src/core/BUILD
+@@ -2563,6 +2563,7 @@ grpc_cc_library(
+     external_deps = [
+         "absl/container:flat_hash_map",
+         "absl/log:check",
++        "absl/status",
+         "absl/strings",
+         "absl/strings:str_format",
+     ],
+--
+2.45.2
+

--- a/dependency_support/com_github_grpc_grpc/BUILD.bazel
+++ b/dependency_support/com_github_grpc_grpc/BUILD.bazel
@@ -1,0 +1,15 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/initialize_external.bzl
+++ b/dependency_support/initialize_external.bzl
@@ -1,0 +1,31 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#################################################################################
+# Stripped-down version of https://github.com/google/xls/blob/main/dependency_support/initialize_external.bzl,
+# taking only what is needed to get @rules_hdl working. Retains the XLS copyright notice.
+#################################################################################
+
+
+"""Provides helper that initializes external repositories with third-party code."""
+
+load("@project_python//:defs.bzl", python_interpreter_target = "interpreter")
+load("@rules_hdl//:init.bzl", rules_hdl_init = "init")
+load("@rules_hdl//dependency_support:dependency_support.bzl", rules_hdl_dependency_support = "dependency_support")
+
+def initialize_external_repositories():
+    """Calls set-up methods for external repositories that require that."""
+    rules_hdl_init(python_interpreter_target = python_interpreter_target)
+    rules_hdl_dependency_support()

--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -1,0 +1,77 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#################################################################################
+# Stripped-down version of https://github.com/google/xls/blob/main/dependency_support/load_external.bzl,
+# taking only what is needed to get @rules_hdl working. Retains the XLS copyright notice.
+#################################################################################
+
+"""Provides helper that loads external repositories with third-party code."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//dependency_support/boost:workspace.bzl", repo_boost = "repo")
+load("//dependency_support/rules_hdl:workspace.bzl", repo_rules_hdl = "repo")
+
+def load_external_repositories():
+    """Loads external repositories with third-party code."""
+
+    # Note: there are more direct dependencies than are explicitly listed here.
+    #
+    # By letting direct dependencies be satisfied by transitive WORKSPACE
+    # setups we let the transitive dependency versions "float" to satisfy their
+    # package requirements, so that we can bump our dependency versions here
+    # more easily without debugging/resolving unnecessary conflicts.
+    #
+    # This situation will change when Bedrock-RTL moves to bzlmod. See
+    # https://github.com/google/xls/issues/865 and
+    # https://github.com/google/xls/issues/931#issue-1667228764 for more
+    # information / background.
+
+    repo_boost()
+    repo_rules_hdl()
+
+    # Released on 2022-12-27.
+    # Current as of 2024-06-26 would be 6.0.2, but that does not work yet
+    # with rules_hdl (it assumes rules_proto_toolchains is in repositories.bzl)
+    # https://github.com/bazelbuild/rules_proto/releases/tag/5.3.0-21.7
+    http_archive(
+        name = "rules_proto",
+        sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+        strip_prefix = "rules_proto-5.3.0-21.7",
+        urls = [
+            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
+        ],
+    )
+
+    # Released on 2024-06-19, current as of 2024-06-26
+    http_archive(
+        name = "rules_python",
+        sha256 = "e3f1cc7a04d9b09635afb3130731ed82b5f58eadc8233d4efb59944d92ffc06f",
+        strip_prefix = "rules_python-0.33.2",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.33.2/rules_python-0.33.2.tar.gz",
+    )
+
+    # Released 2024-06-07, current as of 2024-06-26.
+    http_archive(
+        name = "com_github_grpc_grpc",
+        urls = ["https://github.com/grpc/grpc/archive/v1.64.2.tar.gz"],
+        patches = ["//dependency_support/com_github_grpc_grpc:0001-Add-absl-status-to-deps.patch"],
+        sha256 = "c682fc39baefc6e804d735e6b48141157b7213602cc66dbe0bf375b904d8b5f9",
+        strip_prefix = "grpc-1.64.2",
+        repo_mapping = {
+            "@local_config_python": "@project_python",
+            "@system_python": "@project_python",
+        },
+    )

--- a/dependency_support/rules_hdl/BUILD.bazel
+++ b/dependency_support/rules_hdl/BUILD.bazel
@@ -1,0 +1,15 @@
+# Copyright 2021 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Required to make this a package.

--- a/dependency_support/rules_hdl/workspace.bzl
+++ b/dependency_support/rules_hdl/workspace.bzl
@@ -1,0 +1,52 @@
+# Copyright 2021 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loads the rules_hdl package which contains Bazel rules for other tools that
+XLS uses."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def repo():
+    # Required to support rules_hdl, 0.7.0 release is current as of 2022-05-09.
+    http_archive(
+        name = "rules_pkg",
+        sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
+        urls = [
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
+        ],
+    )
+
+    # Required to support rules_hdl.
+    http_archive(
+        name = "rules_7zip",
+        strip_prefix = "rules_7zip-e00b15d3cb76b78ddc1c15e7426eb1d1b7ddaa3e",
+        urls = ["https://github.com/zaucy/rules_7zip/archive/e00b15d3cb76b78ddc1c15e7426eb1d1b7ddaa3e.zip"],
+        sha256 = "fd9e99f6ccb9e946755f9bc444abefbdd1eedb32c372c56dcacc7eb486aed178",
+    )
+
+    # Current as of 2024-04-01
+    git_hash = "3481036a33ea237c4c9c3baeffd5050eedd9f840"
+    archive_sha256 = "238020f945949459ca7d1ab7cb480e8d4a31048909d8674e564684f82dd0110a"
+
+    maybe(
+        http_archive,
+        name = "rules_hdl",
+        sha256 = archive_sha256,
+        strip_prefix = "bazel_rules_hdl-%s" % git_hash,
+        urls = [
+            "https://github.com/hdl/bazel_rules_hdl/archive/%s.tar.gz" % git_hash,
+        ],
+    )

--- a/enc/rtl/BUILD.bazel
+++ b/enc/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_test")
+load("//bazel:verible.bzl", "verible_lint_and_format_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -45,17 +45,17 @@ verilog_library(
 )
 
 ################ Verible lint tests ################
-verible_lint_test(
-    name = "br_enc_bin2onehot_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_enc_bin2onehot_verible_lint_and_format_test",
     srcs = ["br_enc_bin2onehot.sv"],
 )
 
-verible_lint_test(
-    name = "br_enc_onehot2bin_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_enc_onehot2bin_verible_lint_and_format_test",
     srcs = ["br_enc_onehot2bin.sv"],
 )
 
-verible_lint_test(
-    name = "br_enc_priority_encoder_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_enc_priority_encoder_verible_lint_and_format_test",
     srcs = ["br_enc_priority_encoder.sv"],
 )

--- a/enc/rtl/BUILD.bazel
+++ b/enc/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_and_format_test")
+load("//bazel:verible.bzl", "verible_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -44,18 +44,17 @@ verilog_library(
     ],
 )
 
-################ Verible lint tests ################
-verible_lint_and_format_test(
-    name = "br_enc_bin2onehot_verible_lint_and_format_test",
+verible_test(
+    name = "br_enc_bin2onehot_verible_test",
     srcs = ["br_enc_bin2onehot.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_enc_onehot2bin_verible_lint_and_format_test",
+verible_test(
+    name = "br_enc_onehot2bin_verible_test",
     srcs = ["br_enc_onehot2bin.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_enc_priority_encoder_verible_lint_and_format_test",
+verible_test(
+    name = "br_enc_priority_encoder_verible_test",
     srcs = ["br_enc_priority_encoder.sv"],
 )

--- a/enc/rtl/BUILD.bazel
+++ b/enc/rtl/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:verible.bzl", "verible_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -41,4 +42,20 @@ verilog_library(
         "//macros:br_registers",
         "//macros:br_asserts_internal",
     ],
+)
+
+################ Verible lint tests ################
+verible_lint_test(
+    name = "br_enc_bin2onehot_verible_lint_test",
+    srcs = ["br_enc_bin2onehot.sv"],
+)
+
+verible_lint_test(
+    name = "br_enc_onehot2bin_verible_lint_test",
+    srcs = ["br_enc_onehot2bin.sv"],
+)
+
+verible_lint_test(
+    name = "br_enc_priority_encoder_verible_lint_test",
+    srcs = ["br_enc_priority_encoder.sv"],
 )

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_and_format_test")
+load("//bazel:verible.bzl", "verible_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -107,58 +107,57 @@ verilog_library(
     ],
 )
 
-################ Verible lint tests ################
-verible_lint_and_format_test(
-    name = "br_flow_arb_fixed_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_arb_fixed_verible_test",
     srcs = ["br_flow_arb_fixed.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_arb_rr_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_arb_rr_verible_test",
     srcs = ["br_flow_arb_rr.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_demux_select_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_demux_select_verible_test",
     srcs = ["br_flow_demux_select.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_demux_select_unstable_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_demux_select_unstable_verible_test",
     srcs = ["br_flow_demux_select_unstable.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_fork_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_fork_verible_test",
     srcs = ["br_flow_fork.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_join_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_join_verible_test",
     srcs = ["br_flow_join.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_mux_select_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_mux_select_verible_test",
     srcs = ["br_flow_mux_select.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_mux_select_unstable_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_mux_select_unstable_verible_test",
     srcs = ["br_flow_mux_select_unstable.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_reg_both_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_reg_both_verible_test",
     srcs = ["br_flow_reg_both.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_reg_fwd_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_reg_fwd_verible_test",
     srcs = ["br_flow_reg_fwd.sv"],
 )
 
-verible_lint_and_format_test(
-    name = "br_flow_reg_rev_verible_lint_and_format_test",
+verible_test(
+    name = "br_flow_reg_rev_verible_test",
     srcs = ["br_flow_reg_rev.sv"],
 )

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:verible.bzl", "verible_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -104,4 +105,60 @@ verilog_library(
         "//macros:br_registers",
         "//macros:br_asserts_internal",
     ],
+)
+
+################ Verible lint tests ################
+verible_lint_test(
+    name = "br_flow_arb_fixed_verible_lint_test",
+    srcs = ["br_flow_arb_fixed.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_arb_rr_verible_lint_test",
+    srcs = ["br_flow_arb_rr.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_demux_select_verible_lint_test",
+    srcs = ["br_flow_demux_select.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_demux_select_unstable_verible_lint_test",
+    srcs = ["br_flow_demux_select_unstable.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_fork_verible_lint_test",
+    srcs = ["br_flow_fork.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_join_verible_lint_test",
+    srcs = ["br_flow_join.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_mux_select_verible_lint_test",
+    srcs = ["br_flow_mux_select.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_mux_select_unstable_verible_lint_test",
+    srcs = ["br_flow_mux_select_unstable.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_reg_both_verible_lint_test",
+    srcs = ["br_flow_reg_both.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_reg_fwd_verible_lint_test",
+    srcs = ["br_flow_reg_fwd.sv"],
+)
+
+verible_lint_test(
+    name = "br_flow_reg_rev_verible_lint_test",
+    srcs = ["br_flow_reg_rev.sv"],
 )

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_test")
+load("//bazel:verible.bzl", "verible_lint_and_format_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -108,57 +108,57 @@ verilog_library(
 )
 
 ################ Verible lint tests ################
-verible_lint_test(
-    name = "br_flow_arb_fixed_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_arb_fixed_verible_lint_and_format_test",
     srcs = ["br_flow_arb_fixed.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_arb_rr_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_arb_rr_verible_lint_and_format_test",
     srcs = ["br_flow_arb_rr.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_demux_select_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_demux_select_verible_lint_and_format_test",
     srcs = ["br_flow_demux_select.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_demux_select_unstable_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_demux_select_unstable_verible_lint_and_format_test",
     srcs = ["br_flow_demux_select_unstable.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_fork_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_fork_verible_lint_and_format_test",
     srcs = ["br_flow_fork.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_join_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_join_verible_lint_and_format_test",
     srcs = ["br_flow_join.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_mux_select_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_mux_select_verible_lint_and_format_test",
     srcs = ["br_flow_mux_select.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_mux_select_unstable_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_mux_select_unstable_verible_lint_and_format_test",
     srcs = ["br_flow_mux_select_unstable.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_reg_both_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_reg_both_verible_lint_and_format_test",
     srcs = ["br_flow_reg_both.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_reg_fwd_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_reg_fwd_verible_lint_and_format_test",
     srcs = ["br_flow_reg_fwd.sv"],
 )
 
-verible_lint_test(
-    name = "br_flow_reg_rev_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_flow_reg_rev_verible_lint_and_format_test",
     srcs = ["br_flow_reg_rev.sv"],
 )

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:verible.bzl", "verible_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -30,4 +31,20 @@ verilog_library(
 verilog_library(
     name = "br_registers",
     hdrs = ["br_registers.svh"],
+)
+
+################ Verible lint tests ################
+verible_lint_test(
+    name = "br_asserts_verible_lint_test",
+    srcs = ["br_asserts.svh"],
+)
+
+verible_lint_test(
+    name = "br_asserts_internal_verible_lint_test",
+    srcs = ["br_asserts_internal.svh"],
+)
+
+verible_lint_test(
+    name = "br_registers_verible_lint_test",
+    srcs = ["br_registers.svh"],
 )

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_test")
+load("//bazel:verible.bzl", "verible_lint_and_format_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -34,17 +34,17 @@ verilog_library(
 )
 
 ################ Verible lint tests ################
-verible_lint_test(
-    name = "br_asserts_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_asserts_verible_lint_and_format_test",
     srcs = ["br_asserts.svh"],
 )
 
-verible_lint_test(
-    name = "br_asserts_internal_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_asserts_internal_verible_lint_and_format_test",
     srcs = ["br_asserts_internal.svh"],
 )
 
-verible_lint_test(
-    name = "br_registers_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_registers_verible_lint_and_format_test",
     srcs = ["br_registers.svh"],
 )

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_and_format_test")
+load("//bazel:verible.bzl", "verible_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -33,18 +33,17 @@ verilog_library(
     hdrs = ["br_registers.svh"],
 )
 
-################ Verible lint tests ################
-verible_lint_and_format_test(
-    name = "br_asserts_verible_lint_and_format_test",
+verible_test(
+    name = "br_asserts_verible_test",
     srcs = ["br_asserts.svh"],
 )
 
-verible_lint_and_format_test(
-    name = "br_asserts_internal_verible_lint_and_format_test",
+verible_test(
+    name = "br_asserts_internal_verible_test",
     srcs = ["br_asserts_internal.svh"],
 )
 
-verible_lint_and_format_test(
-    name = "br_registers_verible_lint_and_format_test",
+verible_test(
+    name = "br_registers_verible_test",
     srcs = ["br_registers.svh"],
 )

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -91,4 +91,4 @@ end \
 endgenerate \
 `endif
 
-`endif // BR_ASSERTS_SVH
+`endif  // BR_ASSERTS_SVH

--- a/macros/br_asserts_internal.svh
+++ b/macros/br_asserts_internal.svh
@@ -119,4 +119,4 @@
 `BR_COVER_COMB(__name__, __expr__) \
 `endif
 
-`endif // BR_ASSERTS_INTERNAL_SVH
+`endif  // BR_ASSERTS_INTERNAL_SVH

--- a/macros/br_registers.svh
+++ b/macros/br_registers.svh
@@ -189,4 +189,4 @@ always_ff @(posedge __clk__) begin \
 end
 
 
-`endif // BR_REGISTERS_SVH
+`endif  // BR_REGISTERS_SVH

--- a/misc/rtl/BUILD.bazel
+++ b/misc/rtl/BUILD.bazel
@@ -13,10 +13,17 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:verible.bzl", "verible_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
 verilog_library(
     name = "br_misc_unused",
+    srcs = ["br_misc_unused.sv"],
+)
+
+################ Verible lint tests ################
+verible_lint_test(
+    name = "br_misc_unused_verible_lint_test",
     srcs = ["br_misc_unused.sv"],
 )

--- a/misc/rtl/BUILD.bazel
+++ b/misc/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_test")
+load("//bazel:verible.bzl", "verible_lint_and_format_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -23,7 +23,7 @@ verilog_library(
 )
 
 ################ Verible lint tests ################
-verible_lint_test(
-    name = "br_misc_unused_verible_lint_test",
+verible_lint_and_format_test(
+    name = "br_misc_unused_verible_lint_and_format_test",
     srcs = ["br_misc_unused.sv"],
 )

--- a/misc/rtl/BUILD.bazel
+++ b/misc/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verible.bzl", "verible_lint_and_format_test")
+load("//bazel:verible.bzl", "verible_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -22,8 +22,7 @@ verilog_library(
     srcs = ["br_misc_unused.sv"],
 )
 
-################ Verible lint tests ################
-verible_lint_and_format_test(
-    name = "br_misc_unused_verible_lint_and_format_test",
+verible_test(
+    name = "br_misc_unused_verible_test",
     srcs = ["br_misc_unused.sv"],
 )


### PR DESCRIPTION
- [X] Write new rules
  * `verible_lint_test`
  *  `verible_format_test`
- [X] Write new macro
  *  `verible_test` - expands to lint test and format test
- [X] Fix lint and format issues in sources
- [X] Copy over bazel stuff from https://github.com/google/xls (Apache 2.0-licensed) for getting `@rules_hdl` to work
  * (Needed for `verilog_library` targets that we will be using soon)
  * Retained original XLS copyright notices, and added comments to indicate when the original file had been changed.
- [X] Update `README.adoc`

Future work outlined in `//bazel:verible.bzl`:

```
# TODO(mgottscho): The lint and format rules here are not the ideal solution.
# We'd prefer to only run the linter and formatter on the changed lines in a
# git diff so that we can change the lint/format rules over time (if needed)
# and have the tests gradually ratchet over the codebase. I'm fine with this
# non-ideal solution for now, though, since we're setting this up on a fresh
# codebase and moving fast.
#
# The ideal solution would probably look like this:
#
# bazel run //:verible-format      # Test only changed lines
# bazel run //:verible-format-fix  # Test and fix changed lines in-place
#
# bazel run //:verible-format -- <file1.sv> <file2.sv>  # Run on specific files
# bazel run //:verible-format-fix -- <file1.sv> <file2.sv>  # Fix specific files
#
# bazel run //:verible-format -- --all      # Test all lines
# bazel run //:verible-format-fix -- --all  # Fix all lines
``` 