### PR TITLE
Add placeholder rules for elab tests

### DIFF
--- a/arb/rtl/BUILD.bazel
+++ b/arb/rtl/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:verible.bzl", "verible_test")
+load("//bazel:sv_elab_test.bzl", "sv_elab_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -40,6 +41,24 @@ verilog_library(
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],
+)
+
+sv_elab_test(
+    name = "br_arb_fixed_elab_test",
+    deps = [":br_arb_fixed"],
+    top = "br_arb_fixed",
+)
+
+sv_elab_test(
+    name = "br_arb_lru_elab_test",
+    deps = [":br_arb_lru"],
+    top = "br_arb_lru",
+)
+
+sv_elab_test(
+    name = "br_arb_rr_elab_test",
+    deps = [":br_arb_rr"],
+    top = "br_arb_rr",
 )
 
 verible_test(

--- a/counter/rtl/BUILD.bazel
+++ b/counter/rtl/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:verible.bzl", "verible_test")
+load("//bazel:sv_elab_test.bzl", "sv_elab_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -33,6 +34,18 @@ verilog_library(
         "//macros:br_registers",
         "//macros:br_asserts_internal",
     ],
+)
+
+sv_elab_test(
+    name = "br_counter_incr_elab_test",
+    deps = [":br_counter_incr"],
+    top = "br_counter_incr",
+)
+
+sv_elab_test(
+    name = "br_counter_decr_elab_test",
+    deps = [":br_counter_decr"],
+    top = "br_counter_decr",
 )
 
 verible_test(

--- a/delay/rtl/BUILD.bazel
+++ b/delay/rtl/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:verible.bzl", "verible_test")
+load("//bazel:sv_elab_test.bzl", "sv_elab_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -85,4 +86,34 @@ verible_test(
 verible_test(
     name = "br_delay_valid_next_nr_verible_test",
     srcs = ["br_delay_valid_next_nr.sv"],
+)
+
+sv_elab_test(
+    name = "br_delay_elab_test",
+    deps = [":br_delay"],
+    top = "br_delay",
+)
+
+sv_elab_test(
+    name = "br_delay_nr_elab_test",
+    deps = [":br_delay_nr"],
+    top = "br_delay_nr",
+)
+
+sv_elab_test(
+    name = "br_delay_valid_elab_test",
+    deps = [":br_delay_valid"],
+    top = "br_delay_valid",
+)
+
+sv_elab_test(
+    name = "br_delay_valid_next_elab_test",
+    deps = [":br_delay_valid_next"],
+    top = "br_delay_valid_next",
+)
+
+sv_elab_test(
+    name = "br_delay_valid_next_nr_elab_test",
+    deps = [":br_delay_valid_next_nr"],
+    top = "br_delay_valid_next_nr",
 )

--- a/enc/rtl/BUILD.bazel
+++ b/enc/rtl/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:verible.bzl", "verible_test")
+load("//bazel:sv_elab_test.bzl", "sv_elab_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -42,6 +43,24 @@ verilog_library(
         "//macros:br_registers",
         "//macros:br_asserts_internal",
     ],
+)
+
+sv_elab_test(
+    name = "br_enc_bin2onehot_elab_test",
+    deps = [":br_enc_bin2onehot"],
+    top = "br_enc_bin2onehot",
+)
+
+sv_elab_test(
+    name = "br_enc_onehot2bin_elab_test",
+    deps = [":br_enc_onehot2bin"],
+    top = "br_enc_onehot2bin",
+)
+
+sv_elab_test(
+    name = "br_enc_priority_encoder_elab_test",
+    deps = [":br_enc_priority_encoder"],
+    top = "br_enc_priority_encoder",
 )
 
 verible_test(

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:verible.bzl", "verible_test")
+load("//bazel:sv_elab_test.bzl", "sv_elab_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -115,6 +116,78 @@ verilog_library(
         "//macros:br_registers",
         "//macros:br_asserts_internal",
     ],
+)
+
+sv_elab_test(
+    name = "br_flow_arb_fixed_elab_test",
+    deps = [":br_flow_arb_fixed"],
+    top = "br_flow_arb_fixed",
+)
+
+sv_elab_test(
+    name = "br_flow_arb_rr_elab_test",
+    deps = [":br_flow_arb_rr"],
+    top = "br_flow_arb_rr",
+)
+
+sv_elab_test(
+    name = "br_flow_arb_lru_elab_test",
+    deps = [":br_flow_arb_lru"],
+    top = "br_flow_arb_lru",
+)
+
+sv_elab_test(
+    name = "br_flow_demux_select_elab_test",
+    deps = [":br_flow_demux_select"],
+    top = "br_flow_demux_select",
+)
+
+sv_elab_test(
+    name = "br_flow_demux_select_unstable_elab_test",
+    deps = [":br_flow_demux_select_unstable"],
+    top = "br_flow_demux_select_unstable",
+)
+
+sv_elab_test(
+    name = "br_flow_fork_elab_test",
+    deps = [":br_flow_fork"],
+    top = "br_flow_fork",
+)
+
+sv_elab_test(
+    name = "br_flow_join_elab_test",
+    deps = [":br_flow_join"],
+    top = "br_flow_join",
+)
+
+sv_elab_test(
+    name = "br_flow_mux_select_elab_test",
+    deps = [":br_flow_mux_select"],
+    top = "br_flow_mux_select",
+)
+
+sv_elab_test(
+    name = "br_flow_mux_select_unstable_elab_test",
+    deps = [":br_flow_mux_select_unstable"],
+    top = "br_flow_mux_select_unstable",
+)
+
+sv_elab_test(
+    name = "br_flow_reg_both_elab_test",
+    deps = [":br_flow_reg_both"],
+    top = "br_flow_reg_both",
+)
+
+sv_elab_test(
+    name = "br_flow_reg_fwd_elab_test",
+    deps = [":br_flow_reg_fwd"],
+    top = "br_flow_reg_fwd",
+)
+
+sv_elab_test(
+    name = "br_flow_reg_rev_elab_test",
+    deps = [":br_flow_reg_rev"],
+    top = "br_flow_reg_rev",
 )
 
 verible_test(

--- a/misc/rtl/BUILD.bazel
+++ b/misc/rtl/BUILD.bazel
@@ -14,12 +14,19 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:verible.bzl", "verible_test")
+load("//bazel:sv_elab_test.bzl", "sv_elab_test")
 
 package(default_visibility = ["//visibility:public"])
 
 verilog_library(
     name = "br_misc_unused",
     srcs = ["br_misc_unused.sv"],
+)
+
+sv_elab_test(
+    name = "br_misc_unused_elab_test",
+    deps = [":br_misc_unused"],
+    top = "br_misc_unused",
 )
 
 verible_test(


### PR DESCRIPTION
Bazel won't build with this PR, because the implementation of these rules is not yet provided (coming soon).