### PR TITLE
Clean up elab and lint rules; add formatters to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: detect-private-key
       - id: debug-statements
+      - id: mixed-line-ending
+
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.8.0
+    hooks:
+      - id: black
+        language_version: python3.12
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,12 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: detect-private-key
       - id: debug-statements
+
+  - repo: local
+    hooks:
+      - id: verible-verilog-format
+        name: verible-verilog-format
+        entry: verible-verilog-format --inplace
+        language: system
+        files: \.(v|vh|sv|svh)$
+        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,14 @@ repos:
       - id: debug-statements
       - id: mixed-line-ending
 
+  # Format Python files
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.8.0
     hooks:
       - id: black
         language_version: python3.12
 
+  # Format Verilog files
   - repo: local
     hooks:
       - id: verible-verilog-format
@@ -38,3 +40,15 @@ repos:
         files: \.(v|vh|sv|svh)$
         pass_filenames: true
         types: [text]
+
+  # Format Bazel files
+  - repo: local
+    hooks:
+    - id: buildifier
+      name: format bazel files
+      entry: buildifier
+      args: [--mode=fix, --lint=warn]
+      language: system
+      files: (\.(bzl|bazel|bzlmod)$)|WORKSPACE|MODULE|BUILD|\.bazelrc|\.bazelversion
+      pass_filenames: true
+      types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,10 @@ repos:
   - repo: local
     hooks:
       - id: verible-verilog-format
-        name: verible-verilog-format
-        entry: verible-verilog-format --inplace
+        name: format verilog files
+        entry: verible-verilog-format
+        args: [--inplace]
         language: system
         files: \.(v|vh|sv|svh)$
         pass_filenames: true
+        types: [text]

--- a/arb/rtl/BUILD.bazel
+++ b/arb/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verilog.bzl", "verible_test", "verilog_elab_test", "verilog_lint_test")
+load("//bazel:verilog.bzl", "verible_lint_test", "verilog_elab_test", "verilog_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -79,17 +79,17 @@ verilog_lint_test(
     deps = [":br_arb_rr"],
 )
 
-verible_test(
-    name = "br_arb_fixed_verible_test",
+verible_lint_test(
+    name = "br_arb_fixed_verible_lint_test",
     srcs = ["br_arb_fixed.sv"],
 )
 
-verible_test(
-    name = "br_arb_lru_verible_test",
+verible_lint_test(
+    name = "br_arb_lru_verible_lint_test",
     srcs = ["br_arb_lru.sv"],
 )
 
-verible_test(
-    name = "br_arb_rr_verible_test",
+verible_lint_test(
+    name = "br_arb_rr_verible_lint_test",
     srcs = ["br_arb_rr.sv"],
 )

--- a/bazel/util.py
+++ b/bazel/util.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+from typing import List
 
-exports_files([
-    "verilog_elab_test.py",
-    "verilog_lint_test.py",
-    "util.py",
-])
+def check_each_filename_suffix(filenames: List[str], suffices: List[str]) -> None:
+    """Raises ValueError if there is any filename in the list that doesn't end with any of the expected suffices."""
+    for filename in filenames:
+        match = False
+        for suffix in suffices:
+            if filename.endswith(suffix):
+                match = True
+                break
+        if not match:
+            raise ValueError(f"Expected filename to end with any of {suffices}: {filename}")

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -89,8 +89,8 @@ def _verilog_lint_test_impl(ctx):
         extra_args=ctx.attr.tool_args,
     )
 
-def _verible_impl(ctx):
-    """Implementation of the verible_lint_test and verible_format_test rules."""
+def _verible_lint_test_impl(ctx):
+    """Implementation of the verible_lint_test rule."""
     # TODO(mgottscho): refactor this to share more code with other rules
     srcs = ctx.files.srcs + _get_transitive(ctx=ctx, srcs_not_hdrs=True).to_list()
     hdrs = _get_transitive(ctx=ctx, srcs_not_hdrs=False).to_list()
@@ -139,26 +139,9 @@ verilog_lint_test = rule(
     test = True,
 )
 
-# TODO(mgottscho): The verible lint and format rules here are not the ideal solution.
-# We'd prefer to only run the linter and formatter on the changed lines in a
-# git diff so that we can change the lint/format rules over time (if needed)
-# and have the tests gradually ratchet over the codebase. I'm fine with this
-# non-ideal solution for now, though, since we're setting this up on a fresh
-# codebase and moving fast.
-#
-# The ideal solution would probably look like this:
-#
-# bazel run //:verible-format      # Test only changed lines
-# bazel run //:verible-format-fix  # Test and fix changed lines in-place
-#
-# bazel run //:verible-format -- <file1.sv> <file2.sv>  # Run on specific files
-# bazel run //:verible-format-fix -- <file1.sv> <file2.sv>  # Fix specific files
-#
-# bazel run //:verible-format -- --all      # Test all lines
-# bazel run //:verible-format-fix -- --all  # Fix all lines
 verible_lint_test = rule(
     doc = "Tests that the given source files don't have syntax errors or Verible lint errors.",
-    implementation = _verible_impl,
+    implementation = _verible_lint_test_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),
         "deps": attr.label_list(allow_files=False),
@@ -169,36 +152,3 @@ verible_lint_test = rule(
     },
     test = True,
 )
-
-verible_format_test = rule(
-    doc = "Tests that the given source files don't have syntax errors or Verible formatting errors.",
-    implementation = _verible_impl,
-    attrs = {
-        "srcs": attr.label_list(allow_files = [".v", ".sv", ".svh"]),
-        "deps": attr.label_list(allow_files=False),
-        # By default, expect to find the tool in the system $PATH.
-        # TODO(mgottscho): It would be better to do this hermetically.
-        "tool": attr.string(default = "verible-verilog-format"),
-        "tool_args": attr.string_list(default = ["--verify=true"]),
-    },
-    test = True,
-)
-
-def verible_test(name, lint_tool = "verible-verilog-lint", format_tool = "verible-verilog-format", **kwargs):
-    """Expands to a pair of test targets that check for Verible lint and formatting issues."""
-    if not name.endswith("_verible_test"):
-        fail("verible_test target names must end with '_verible_test'")
-
-    name = name.removesuffix("_verible_test")
-
-    verible_lint_test(
-        name = name + "_verible_lint_test",
-        tool = lint_tool,
-        **kwargs
-    )
-
-    verible_format_test(
-        name = name + "_verible_format_test",
-        tool = format_tool,
-        **kwargs
-    )

--- a/bazel/verilog_elab_test.py
+++ b/bazel/verilog_elab_test.py
@@ -13,18 +13,8 @@
 # limitations under the License.
 
 import argparse
+from util import check_each_filename_suffix
 from typing import List, Optional
-
-def check_each_filename_suffix(filenames: List[str], suffices: List[str]) -> None:
-    """Raises ValueError if there is any filename in the list that doesn't end with any of the expected suffices."""
-    for filename in filenames:
-        match = False
-        for suffix in suffices:
-            if filename.endswith(suffix):
-                match = True
-                break
-        if not match:
-            raise ValueError(f"Expected filename to end with any of {suffices}: {filename}")
 
 
 def verilog_elab_test(hdrs: Optional[List[str]], srcs: List[str], top: str) -> bool:

--- a/bazel/verilog_elab_test.py
+++ b/bazel/verilog_elab_test.py
@@ -20,6 +20,7 @@ from typing import List, Optional
 def verilog_elab_test(hdrs: Optional[List[str]], srcs: List[str], top: str) -> bool:
     """Returns True if the top-level Verilog or SystemVerilog module is able to elaborate; may print to stdout and/or stderr."""
     # TODO: Implement this using your own tool.
+    print("NOT IMPLEMENTED: Test vacuously passes.")
     return True
 
 

--- a/bazel/verilog_lint_test.py
+++ b/bazel/verilog_lint_test.py
@@ -13,19 +13,8 @@
 # limitations under the License.
 
 import argparse
+from util import check_each_filename_suffix
 from typing import List, Optional
-
-def check_each_filename_suffix(filenames: List[str], suffices: List[str]) -> None:
-    """Raises ValueError if there is any filename in the list that doesn't end with any of the expected suffices."""
-    for filename in filenames:
-        match = False
-        for suffix in suffices:
-            if filename.endswith(suffix):
-                match = True
-                break
-        if not match:
-            raise ValueError(f"Expected filename to end with any of {suffices}: {filename}")
-
 
 def verilog_lint_test(hdrs: Optional[List[str]], srcs: List[str]) -> bool:
     """Returns True if the the Verilog/SystemVerilog sources pass a lint test; may print to stdout and/or stderr."""

--- a/bazel/verilog_lint_test.py
+++ b/bazel/verilog_lint_test.py
@@ -19,6 +19,7 @@ from typing import List, Optional
 def verilog_lint_test(hdrs: Optional[List[str]], srcs: List[str]) -> bool:
     """Returns True if the the Verilog/SystemVerilog sources pass a lint test; may print to stdout and/or stderr."""
     # TODO: Implement this using your own tool.
+    print("NOT IMPLEMENTED: Test vacuously passes.")
     return True
 
 

--- a/bazel/verilog_lint_test.py
+++ b/bazel/verilog_lint_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import argparse
-from typing import List
+from typing import List, Optional
 
 def check_each_filename_suffix(filenames: List[str], suffices: List[str]) -> None:
     """Raises ValueError if there is any filename in the list that doesn't end with any of the expected suffices."""
@@ -27,25 +27,37 @@ def check_each_filename_suffix(filenames: List[str], suffices: List[str]) -> Non
             raise ValueError(f"Expected filename to end with any of {suffices}: {filename}")
 
 
-def verilog_lint_test(srcs: List[str]) -> bool:
+def verilog_lint_test(hdrs: Optional[List[str]], srcs: List[str]) -> bool:
     """Returns True if the the Verilog/SystemVerilog sources pass a lint test; may print to stdout and/or stderr."""
     # TODO: Implement this using your own tool.
     return True
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Test that a top-level Verilog or SystemVerilog module is able to pass lint checks.",
+    parser = argparse.ArgumentParser(description="Test that Verilog or SystemVerilog modules are able to pass lint checks.",
                                      allow_abbrev=False,
+    )
+    parser.add_argument("--hdr",
+                        type=argparse.FileType("r"),
+                        nargs="*",
+                        default=[],
+                        help="Verilog headers (.vh) or SystemVerilog headers (.svh) to include. "
+                             "Can be specified multiple times.",
     )
     parser.add_argument("srcs",
                         type=argparse.FileType("r"),
                         nargs="+",
-                        help="One or more Verilog/SystemVerilog source files (.v/.vh/.sv/.svh)",
+                        help="One or more Verilog (.h) or SystemVerilog (.sv) source files",
     )
     args = parser.parse_args()
+
+    hdrs = [hdr.name for hdr in args.hdr]
     srcs = [src.name for src in args.srcs]
-    check_each_filename_suffix(srcs, [".v", ".sv", ".vh", ".svh"])
-    exit(0) if verilog_lint_test(srcs) else exit(1)
+
+    check_each_filename_suffix(hdrs, [".vh", ".svh"])
+    check_each_filename_suffix(srcs, [".v", ".sv"])
+
+    exit(0) if verilog_lint_test(hdrs, srcs) else exit(1)
 
 
 if __name__ == "__main__":

--- a/counter/rtl/BUILD.bazel
+++ b/counter/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verilog.bzl", "verible_test", "verilog_elab_test", "verilog_lint_test")
+load("//bazel:verilog.bzl", "verible_lint_test", "verilog_elab_test", "verilog_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -57,12 +57,12 @@ verilog_lint_test(
     deps = [":br_counter_decr"],
 )
 
-verible_test(
-    name = "br_counter_incr_verible_test",
+verible_lint_test(
+    name = "br_counter_incr_verible_lint_test",
     srcs = ["br_counter_incr.sv"],
 )
 
-verible_test(
-    name = "br_counter_decr_verible_test",
+verible_lint_test(
+    name = "br_counter_decr_verible_lint_test",
     srcs = ["br_counter_decr.sv"],
 )

--- a/delay/rtl/BUILD.bazel
+++ b/delay/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verilog.bzl", "verible_test", "verilog_elab_test", "verilog_lint_test")
+load("//bazel:verilog.bzl", "verible_lint_test", "verilog_elab_test", "verilog_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -62,28 +62,28 @@ verilog_library(
     ],
 )
 
-verible_test(
-    name = "br_delay_verible_test",
+verible_lint_test(
+    name = "br_delay_verible_lint_test",
     srcs = ["br_delay.sv"],
 )
 
-verible_test(
-    name = "br_delay_nr_verible_test",
+verible_lint_test(
+    name = "br_delay_nr_verible_lint_test",
     srcs = ["br_delay_nr.sv"],
 )
 
-verible_test(
-    name = "br_delay_valid_verible_test",
+verible_lint_test(
+    name = "br_delay_valid_verible_lint_test",
     srcs = ["br_delay_valid.sv"],
 )
 
-verible_test(
-    name = "br_delay_valid_next_verible_test",
+verible_lint_test(
+    name = "br_delay_valid_next_verible_lint_test",
     srcs = ["br_delay_valid_next.sv"],
 )
 
-verible_test(
-    name = "br_delay_valid_next_nr_verible_test",
+verible_lint_test(
+    name = "br_delay_valid_next_nr_verible_lint_test",
     srcs = ["br_delay_valid_next_nr.sv"],
 )
 

--- a/enc/rtl/BUILD.bazel
+++ b/enc/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verilog.bzl", "verible_test", "verilog_elab_test", "verilog_lint_test")
+load("//bazel:verilog.bzl", "verible_lint_test", "verilog_elab_test", "verilog_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -77,17 +77,17 @@ verilog_lint_test(
     deps = [":br_enc_priority_encoder"],
 )
 
-verible_test(
-    name = "br_enc_bin2onehot_verible_test",
+verible_lint_test(
+    name = "br_enc_bin2onehot_verible_lint_test",
     srcs = ["br_enc_bin2onehot.sv"],
 )
 
-verible_test(
-    name = "br_enc_onehot2bin_verible_test",
+verible_lint_test(
+    name = "br_enc_onehot2bin_verible_lint_test",
     srcs = ["br_enc_onehot2bin.sv"],
 )
 
-verible_test(
-    name = "br_enc_priority_encoder_verible_test",
+verible_lint_test(
+    name = "br_enc_priority_encoder_verible_lint_test",
     srcs = ["br_enc_priority_encoder.sv"],
 )

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verilog.bzl", "verible_test", "verilog_elab_test", "verilog_lint_test")
+load("//bazel:verilog.bzl", "verible_lint_test", "verilog_elab_test", "verilog_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -249,77 +249,77 @@ verilog_lint_test(
     deps = [":br_flow_reg_rev"],
 )
 
-verible_test(
-    name = "br_flow_arb_fixed_verible_test",
+verible_lint_test(
+    name = "br_flow_arb_fixed_verible_lint_test",
     srcs = ["br_flow_arb_fixed.sv"],
 )
 
-verible_test(
-    name = "br_flow_arb_rr_verible_test",
+verible_lint_test(
+    name = "br_flow_arb_rr_verible_lint_test",
     srcs = ["br_flow_arb_rr.sv"],
 )
 
-verible_test(
-    name = "br_flow_arb_lru_verible_test",
+verible_lint_test(
+    name = "br_flow_arb_lru_verible_lint_test",
     srcs = ["br_flow_arb_lru.sv"],
 )
 
-verible_test(
-    name = "br_flow_demux_select_verible_test",
+verible_lint_test(
+    name = "br_flow_demux_select_verible_lint_test",
     srcs = ["br_flow_demux_select.sv"],
 )
 
-verible_test(
-    name = "br_flow_demux_select_unstable_verible_test",
+verible_lint_test(
+    name = "br_flow_demux_select_unstable_verible_lint_test",
     srcs = ["br_flow_demux_select_unstable.sv"],
 )
 
-verible_test(
-    name = "br_flow_fork_verible_test",
+verible_lint_test(
+    name = "br_flow_fork_verible_lint_test",
     srcs = ["br_flow_fork.sv"],
 )
 
-verible_test(
-    name = "br_flow_join_verible_test",
+verible_lint_test(
+    name = "br_flow_join_verible_lint_test",
     srcs = ["br_flow_join.sv"],
 )
 
-verible_test(
-    name = "br_flow_mux_fixed_verible_test",
+verible_lint_test(
+    name = "br_flow_mux_fixed_verible_lint_test",
     srcs = ["br_flow_mux_fixed.sv"],
 )
 
-verible_test(
-    name = "br_flow_mux_rr_verible_test",
+verible_lint_test(
+    name = "br_flow_mux_rr_verible_lint_test",
     srcs = ["br_flow_mux_rr.sv"],
 )
 
-verible_test(
-    name = "br_flow_mux_lru_verible_test",
+verible_lint_test(
+    name = "br_flow_mux_lru_verible_lint_test",
     srcs = ["br_flow_mux_lru.sv"],
 )
 
-verible_test(
-    name = "br_flow_mux_select_verible_test",
+verible_lint_test(
+    name = "br_flow_mux_select_verible_lint_test",
     srcs = ["br_flow_mux_select.sv"],
 )
 
-verible_test(
-    name = "br_flow_mux_select_unstable_verible_test",
+verible_lint_test(
+    name = "br_flow_mux_select_unstable_verible_lint_test",
     srcs = ["br_flow_mux_select_unstable.sv"],
 )
 
-verible_test(
-    name = "br_flow_reg_both_verible_test",
+verible_lint_test(
+    name = "br_flow_reg_both_verible_lint_test",
     srcs = ["br_flow_reg_both.sv"],
 )
 
-verible_test(
-    name = "br_flow_reg_fwd_verible_test",
+verible_lint_test(
+    name = "br_flow_reg_fwd_verible_lint_test",
     srcs = ["br_flow_reg_fwd.sv"],
 )
 
-verible_test(
-    name = "br_flow_reg_rev_verible_test",
+verible_lint_test(
+    name = "br_flow_reg_rev_verible_lint_test",
     srcs = ["br_flow_reg_rev.sv"],
 )

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verilog.bzl", "verible_test")
+load("//bazel:verilog.bzl", "verible_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -33,17 +33,17 @@ verilog_library(
     hdrs = ["br_registers.svh"],
 )
 
-verible_test(
-    name = "br_asserts_verible_test",
+verible_lint_test(
+    name = "br_asserts_verible_lint_test",
     srcs = ["br_asserts.svh"],
 )
 
-verible_test(
-    name = "br_asserts_internal_verible_test",
+verible_lint_test(
+    name = "br_asserts_internal_verible_lint_test",
     srcs = ["br_asserts_internal.svh"],
 )
 
-verible_test(
-    name = "br_registers_verible_test",
+verible_lint_test(
+    name = "br_registers_verible_lint_test",
     srcs = ["br_registers.svh"],
 )

--- a/misc/rtl/BUILD.bazel
+++ b/misc/rtl/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verilog.bzl", "verible_test", "verilog_elab_test", "verilog_lint_test")
+load("//bazel:verilog.bzl", "verible_lint_test", "verilog_elab_test", "verilog_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -33,7 +33,7 @@ verilog_lint_test(
     deps = [":br_misc_unused"],
 )
 
-verible_test(
-    name = "br_misc_unused_verible_test",
+verible_lint_test(
+    name = "br_misc_unused_verible_lint_test",
     srcs = ["br_misc_unused.sv"],
 )


### PR DESCRIPTION
* Refactor some shared code across different rules.
* Add Verilog pre-commit formatter with Verible.
* Add Python pre-commit formatter with Black.
* Add Bazel pre-commit formatter with Buildifier.
* Add mixed line-ending pre-commit checks.
* Drop `verible_format_test` rule.