### PR TITLE
Add `defines` argument to `verilog_elab_test` and `verilog_lint_test`

### DIFF
--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -64,7 +64,7 @@ def _verilog_base_test_impl(ctx, tool, extra_args = [], extra_runfiles = []):
     hdrs = _get_transitive(ctx = ctx, srcs_not_hdrs = False).to_list()
     src_files = [src.path for src in srcs]
     hdr_files = [hdr.path for hdr in hdrs]
-    args = ["--hdr=" + hdr for hdr in hdr_files] + extra_args
+    args = ["--hdr=" + hdr for hdr in hdr_files] + ["--define=" + define for define in ctx.attr.defines] + extra_args
     cmd = " ".join([tool] + args + src_files)
     runfiles = ctx.runfiles(files = srcs + hdrs + extra_runfiles)
     executable_file = _write_executable_shell_script(
@@ -133,6 +133,7 @@ _verilog_elab_test = rule(
     attrs = {
         "deps": attr.label_list(allow_files = False),
         "top": attr.string(),
+        "defines": attr.string_list(default = ["SV_ASSERT_ON"]),
     },
     test = True,
 )
@@ -148,6 +149,7 @@ _verilog_lint_test = rule(
     implementation = _verilog_lint_test_impl,
     attrs = {
         "deps": attr.label_list(allow_files = False),
+        "defines": attr.string_list(default = ["SV_ASSERT_ON"]),
     },
     test = True,
 )

--- a/bazel/write_placeholder_tools.bzl
+++ b/bazel/write_placeholder_tools.bzl
@@ -47,7 +47,7 @@ def check_each_filename_suffix(filenames: List[str], suffices: List[str]) -> Non
             raise ValueError(f"Expected filename to end with any of {suffices}: {filename}")
 
 
-def verilog_elab_test(hdrs: Optional[List[str]], srcs: List[str], top: str) -> bool:
+def verilog_elab_test(hdrs: Optional[List[str]], defines: Optional[List[str]], srcs: List[str], top: str) -> bool:
     """Returns True if the top-level Verilog or SystemVerilog module is able to elaborate; may print to stdout and/or stderr."""
     # TODO: Implement this using your own tool.
     print("NOT IMPLEMENTED: Test vacuously passes.")
@@ -67,8 +67,14 @@ def main():
                         type=argparse.FileType("r"),
                         action="append",
                         default=[],
-                        help="Verilog headers (.vh) or SystemVerilog headers (.svh) to include. "
+                        help="Verilog header (.vh) or SystemVerilog header (.svh) to include. "
                              "Can be specified multiple times.",
+    )
+    parser.add_argument("--define",
+                        type=str,
+                        action="append",
+                        default=[],
+                        help="Verilog/SystemVerilog preprocessor define to use in compilation. Can be specified multiple times.",
     )
     parser.add_argument("srcs",
                         type=argparse.FileType("r"),
@@ -80,11 +86,12 @@ def main():
 
     hdrs = [hdr.name for hdr in args.hdr]
     srcs = [src.name for src in args.srcs]
+    defines = args.define
 
     check_each_filename_suffix(hdrs, [".vh", ".svh"])
     check_each_filename_suffix(srcs, [".v", ".sv"])
 
-    exit(0) if verilog_elab_test(hdrs, srcs, args.top) else exit(1)
+    exit(0) if verilog_elab_test(hdrs, defines, srcs, args.top) else exit(1)
 
 
 if __name__ == "__main__":
@@ -123,7 +130,7 @@ def check_each_filename_suffix(filenames: List[str], suffices: List[str]) -> Non
             raise ValueError(f"Expected filename to end with any of {suffices}: {filename}")
 
 
-def verilog_lint_test(hdrs: Optional[List[str]], srcs: List[str]) -> bool:
+def verilog_lint_test(hdrs: Optional[List[str]], defines: Optional[List[str]], srcs: List[str]) -> bool:
     """Returns True if the the Verilog/SystemVerilog sources pass a lint test; may print to stdout and/or stderr."""
     # TODO: Implement this using your own tool.
     print("NOT IMPLEMENTED: Test vacuously passes.")
@@ -138,8 +145,14 @@ def main():
                         type=argparse.FileType("r"),
                         action="append",
                         default=[],
-                        help="Verilog headers (.vh) or SystemVerilog headers (.svh) to include. "
+                        help="Verilog header (.vh) or SystemVerilog header (.svh) to include. "
                              "Can be specified multiple times.",
+    )
+    parser.add_argument("--define",
+                        type=str,
+                        action="append",
+                        default=[],
+                        help="Verilog/SystemVerilog preprocessor define to use in compilation. Can be specified multiple times.",
     )
     parser.add_argument("srcs",
                         type=argparse.FileType("r"),
@@ -150,11 +163,12 @@ def main():
 
     hdrs = [hdr.name for hdr in args.hdr]
     srcs = [src.name for src in args.srcs]
+    defines = args.define
 
     check_each_filename_suffix(hdrs, [".vh", ".svh"])
     check_each_filename_suffix(srcs, [".v", ".sv"])
 
-    exit(0) if verilog_lint_test(hdrs, srcs) else exit(1)
+    exit(0) if verilog_lint_test(hdrs, defines, srcs) else exit(1)
 
 
 if __name__ == "__main__":

--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -54,6 +54,11 @@ module br_delay #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_IMPL(delay_A, ##NumStages out == $past(in, NumStages))
+  if (NumStages == 0) begin : gen_zero_delay
+    `BR_ASSERT_IMPL(passthru_A, out == in)
+  end else begin : gen_pos_delay
+    `BR_ASSERT_IMPL(delay_A, ##NumStages out == $past(in, NumStages))
+  end
+
 
 endmodule : br_delay

--- a/delay/rtl/br_delay_nr.sv
+++ b/delay/rtl/br_delay_nr.sv
@@ -54,6 +54,11 @@ module br_delay_nr #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_IMPL(delay_A, ##NumStages out == $past(in, NumStages))
+  if (NumStages == 0) begin : gen_zero_delay
+    `BR_ASSERT_IMPL(passthru_A, out == in)
+  end else begin : gen_pos_delay
+    `BR_ASSERT_IMPL(delay_A, ##NumStages out == $past(in, NumStages))
+  end
+
 
 endmodule : br_delay_nr

--- a/delay/rtl/br_delay_valid.sv
+++ b/delay/rtl/br_delay_valid.sv
@@ -63,7 +63,11 @@ module br_delay_valid #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_IMPL(valid_delay_A, ##NumStages out_valid == $past(in_valid, NumStages))
-  `BR_ASSERT_IMPL(data_delay_A, in_valid |-> ##NumStages out_valid && out == $past(in, NumStages))
+  if (NumStages == 0) begin : gen_zero_delay
+    `BR_ASSERT_IMPL(passthru_A, out_valid == in_valid && out == in)
+  end else begin : gen_pos_delay
+    `BR_ASSERT_IMPL(valid_delay_A, ##NumStages out_valid == $past(in_valid, NumStages))
+    `BR_ASSERT_IMPL(data_delay_A, in_valid |-> ##NumStages out_valid && out == $past(in, NumStages))
+  end
 
 endmodule : br_delay_valid

--- a/delay/rtl/br_delay_valid_next.sv
+++ b/delay/rtl/br_delay_valid_next.sv
@@ -70,8 +70,13 @@ module br_delay_valid_next #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_IMPL(valid_next_delay_A, ##NumStages out_valid_next == $past(in_valid_next, NumStages))
-  `BR_ASSERT_IMPL(data_delay_A, in_valid_next |-> ##NumStages out_valid_next ##1 out == $past
-                                (in, NumStages))
+  if (NumStages == 0) begin : gen_zero_delay
+    `BR_ASSERT_IMPL(passthru_A, out_valid_next == in_valid_next && out == in)
+  end else begin : gen_pos_delay
+    `BR_ASSERT_IMPL(valid_next_delay_A,
+                    ##NumStages out_valid_next == $past(in_valid_next, NumStages))
+    `BR_ASSERT_IMPL(data_delay_A,
+                    in_valid_next |-> ##NumStages out_valid_next ##1 out == $past(in, NumStages))
+  end
 
 endmodule : br_delay_valid_next

--- a/delay/rtl/br_delay_valid_next_nr.sv
+++ b/delay/rtl/br_delay_valid_next_nr.sv
@@ -72,8 +72,13 @@ module br_delay_valid_next_nr #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_IMPL(valid_next_delay_A, ##NumStages out_valid_next == $past(in_valid_next, NumStages))
-  `BR_ASSERT_IMPL(data_delay_A, in_valid_next |-> ##NumStages out_valid_next ##1 out == $past
-                                (in, NumStages))
+  if (NumStages == 0) begin : gen_zero_delay
+    `BR_ASSERT_IMPL(passthru_A, out_valid_next == in_valid_next && out == in)
+  end else begin : gen_pos_delay
+    `BR_ASSERT_IMPL(valid_next_delay_A,
+                    ##NumStages out_valid_next == $past(in_valid_next, NumStages))
+    `BR_ASSERT_IMPL(data_delay_A,
+                    in_valid_next |-> ##NumStages out_valid_next ##1 out == $past(in, NumStages))
+  end
 
 endmodule : br_delay_valid_next_nr

--- a/flow/rtl/br_flow_fork.sv
+++ b/flow/rtl/br_flow_fork.sv
@@ -67,7 +67,7 @@ module br_flow_fork #(
   // Implementation checks
   //------------------------------------------
   for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks
-    `BR_COVER_IMPL(pop_valid_unstable_C, $stable(push_valid) && $fell(pop_valid[i]))
+    `BR_COVER_IMPL(pop_valid_unstable_C, $stable(push_valid) && $fell(pop_valid_unstable[i]))
   end
 
 endmodule : br_flow_fork

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -26,12 +26,14 @@
 // Static (elaboration-time) assertion macros
 ////////////////////////////////////////////////////////////////////////////////
 
+`ifdef SV_ASSERT_ON
 `define BR_ASSERT_STATIC(__name__, __expr__) \
-`ifdef SV_ASSERT_ON \
 if (!(__expr__)) begin : gen__``__name__ \
 __STATIC_ASSERT_FAILED__ __name__ (); \
-end \
-`endif
+end
+`else  // SV_ASSERT_ON
+`define BR_ASSERT_STATIC(__name__, __expr__) ;  // macro no-op; SV_ASSERT_ON not defined
+`endif  // SV_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
 // Concurrent assertion macros (evaluated on posedge of a clock and disabled during a reset)
@@ -39,28 +41,34 @@ end \
 
 // Clock: 'clk'
 // Reset: 'rst'
+`ifdef SV_ASSERT_ON
 `define BR_ASSERT(__name__, __expr__) \
-`ifdef SV_ASSERT_ON \
-__name__ : assert property (@(posedge clk) disable iff (rst) (__expr__)); \
-`endif
+__name__ : assert property (@(posedge clk) disable iff (rst) (__expr__));
+`else  // SV_ASSERT_ON
+`define BR_ASSERT(__name__, __expr__) ;  // macro no-op; SV_ASSERT_ON not defined
+`endif  // SV_ASSERT_ON
 
 // More expressive form of BR_ASSERT that allows the use of custom clock and reset signal names.
+`ifdef SV_ASSERT_ON
 `define BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) \
-`ifdef SV_ASSERT_ON \
-__name__ : assert property (@(posedge __clk__) disable iff (__rst__) (__expr__)); \
-`endif
+__name__ : assert property (@(posedge __clk__) disable iff (__rst__) (__expr__));
+`else  // SV_ASSERT_ON
+`define BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) ;  // macro no-op; SV_ASSERT_ON not defined
+`endif  // SV_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
 // Combinational assertion macros (evaluated continuously based on the expression sensitivity)
 ////////////////////////////////////////////////////////////////////////////////
+`ifdef SV_ASSERT_ON
 `define BR_ASSERT_COMB(__name__, __expr__) \
-`ifdef SV_ASSERT_ON \
 generate : __name__ \
 always_comb begin \
 assert property (__expr__); \
 end \
-endgenerate \
-`endif
+endgenerate
+`else  // SV_ASSERT_ON
+`define BR_ASSERT_COMB(__name__, __expr__) ;  // macro no-op; SV_ASSERT_ON not defined
+`endif  // SV_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
 // Concurrent cover macros (evaluated on posedge of a clock and disabled during a reset)
@@ -68,27 +76,34 @@ endgenerate \
 
 // Clock: 'clk'
 // Reset: 'rst'
+`ifdef SV_ASSERT_ON
 `define BR_COVER(__name__, __expr__) \
-`ifdef SV_ASSERT_ON \
-__name__ : cover property (@(posedge clk) disable iff (rst) (__expr__)); \
-`endif
+__name__ : cover property (@(posedge clk) disable iff (rst) (__expr__));
+`else  // SV_ASSERT_ON
+`define BR_COVER(__name__, __expr__) ;  // macro no-op; SV_ASSERT_ON not defined
+`endif  // SV_ASSERT_ON
 
 // More expressive form of BR_COVER that allows the use of custom clock and reset signal names.
+`ifdef SV_ASSERT_ON
 `define BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
-`ifdef SV_ASSERT_ON \
-__name__ : cover property (@(posedge __clk__) disable iff (__rst__) (__expr__)); \
-`endif
+__name__ : cover property (@(posedge __clk__) disable iff (__rst__) (__expr__));
+`else  // SV_ASSERT_ON
+`define BR_COVER_CR(__name__, __expr__, __clk__,
+                    __rst__) ;  // macro no-op; SV_ASSERT_ON not defined
+`endif  // SV_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
 // Combinational cover macros (evaluated continuously based on the expression sensitivity)
 ////////////////////////////////////////////////////////////////////////////////
+`ifdef SV_ASSERT_ON
 `define BR_COVER_COMB(__name__, __expr__) \
-`ifdef SV_ASSERT_ON \
 generate : __name__ \
 always_comb begin \
 cover property (__expr__); \
 end \
-endgenerate \
-`endif
+endgenerate
+`else  // SV_ASSERT_ON
+`define BR_COVER_COMB(__name__, __expr__) ;  // macro no-op; SV_ASSERT_ON not defined
+`endif  // SV_ASSERT_ON
 
 `endif  // BR_ASSERTS_SVH

--- a/macros/br_asserts_internal.svh
+++ b/macros/br_asserts_internal.svh
@@ -37,44 +37,58 @@
 // Concurrent assertion macros (evaluated on posedge of a clock and disabled during a reset)
 ////////////////////////////////////////////////////////////////////////////////
 
+// verilog_lint: disable line-length
+
 // Clock: 'clk'
 // Reset: 'rst'
+`ifndef BR_DISABLE_INTG_CHECKS
 `define BR_ASSERT_INTG(__name__, __expr__) \
-`ifndef BR_DISABLE_INTG_CHECKS \
-`BR_ASSERT(__name__, __expr__) \
-`endif
+`BR_ASSERT(__name__, __expr__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_INTG(__name__, __expr__) ;  // macro no-op; BR_DISABLE_INTG_CHECKS defined
+`endif  // BR_DISABLE_INTG_CHECKS
 
 // More expressive form of BR_ASSERT_INTG that allows the use of custom clock and reset signal names.
+`ifdef BR_DISABLE_INTG_CHECKS
 `define BR_ASSERT_CR_INTG(__name__, __expr__, __clk__, __rst__) \
-`ifdef BR_DISABLE_INTG_CHECKS \
-`BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) \
-`endif
+`BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_CR_INTG(__name__, __expr__, __clk__, __rst__) ;  // macro no-op; BR_DISABLE_INTG_CHECKS defined
+`endif  // BR_DISABLE_INTG_CHECKS
 
 // Clock: 'clk'
 // Reset: 'rst'
+`ifndef BR_ENABLE_IMPL_CHECKS
 `define BR_ASSERT_IMPL(__name__, __expr__) \
-`ifndef BR_ENABLE_IMPL_CHECKS \
-`BR_ASSERT(__name__, __expr__) \
-`endif
+`BR_ASSERT(__name__, __expr__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_IMPL(__name__, __expr__) ;  // macro no-op; BR_ENABLE_IMPL_CHECKS not defined
+`endif  // BR_ENABLE_IMPL_CHECKS
 
 // More expressive form of BR_ASSERT_IMPL that allows the use of custom clock and reset signal names.
+`ifdef BR_ENABLE_IMPL_CHECKS
 `define BR_ASSERT_CR_IMPL(__name__, __expr__, __clk__, __rst__) \
-`ifdef BR_ENABLE_IMPL_CHECKS \
-`BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) \
-`endif
+`BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_CR_IMPL(__name__, __expr__, __clk__, __rst__) ;  // macro no-op; BR_ENABLE_IMPL_CHECKS not defined
+`endif  // BR_ENABLE_IMPL_CHECKS
 
 ////////////////////////////////////////////////////////////////////////////////
 // Combinational assertion macros (evaluated continuously based on the expression sensitivity)
 ////////////////////////////////////////////////////////////////////////////////
+`ifndef BR_DISABLE_INTG_CHECKS
 `define BR_ASSERT_COMB_INTG(__name__, __expr__) \
-`ifndef BR_DISABLE_INTG_CHECKS \
-`BR_ASSERT_COMB(__name__, __expr__) \
-`endif
+`BR_ASSERT_COMB(__name__, __expr__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_COMB_INTG(__name__, __expr__) ;  // macro no-op; BR_DISABLE_INTG_CHECKS defined
+`endif  // BR_DISABLE_INTG_CHECKS
 
+`ifdef BR_ENABLE_IMPL_CHECKS
 `define BR_ASSERT_COMB_IMPL(__name__, __expr__) \
-`ifdef BR_ENABLE_IMPL_CHECKS \
-`BR_ASSERT_COMB(__name__, __expr__) \
-`endif
+`BR_ASSERT_COMB(__name__, __expr__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_COMB_IMPL(__name__, __expr__) ;  // macro no-op; BR_ENABLE_IMPL_CHECKS not defined
+`endif  // BR_ENABLE_IMPL_CHECKS
 
 ////////////////////////////////////////////////////////////////////////////////
 // Concurrent cover macros (evaluated on posedge of a clock and disabled during a reset)
@@ -82,41 +96,55 @@
 
 // Clock: 'clk'
 // Reset: 'rst'
+`ifndef BR_DISABLE_INTG_CHECKS
 `define BR_COVER_INTG(__name__, __expr__) \
-`ifndef BR_DISABLE_INTG_CHECKS \
-`BR_COVER(__name__, __expr__) \
-`endif
+`BR_COVER(__name__, __expr__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_COVER_INTG(__name__, __expr__) ;  // macro no-op; BR_DISABLE_INTG_CHECKS defined
+`endif  // BR_DISABLE_INTG_CHECKS
 
 // More expressive form of BR_COVER_INTG that allows the use of custom clock and reset signal names.
+`ifdef BR_DISABLE_INTG_CHECKS
 `define BR_COVER_CR_INTG(__name__, __expr__, __clk__, __rst__) \
-`ifdef BR_DISABLE_INTG_CHECKS \
-`BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
-`endif
+`BR_COVER_CR(__name__, __expr__, __clk__, __rst__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_COVER_CR_INTG(__name__, __expr__, __clk__, __rst__) ;  // macro no-op; BR_DISABLE_INTG_CHECKS defined
+`endif  // BR_DISABLE_INTG_CHECKS
 
 // Clock: 'clk'
 // Reset: 'rst'
+`ifndef BR_ENABLE_IMPL_CHECKS
 `define BR_COVER_IMPL(__name__, __expr__) \
-`ifndef BR_ENABLE_IMPL_CHECKS \
-`BR_COVER(__name__, __expr__) \
-`endif
+`BR_COVER(__name__, __expr__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_COVER_IMPL(__name__, __expr__) ;  // macro no-op; BR_ENABLE_IMPL_CHECKS not defined
+`endif  // BR_ENABLE_IMPL_CHECKS
 
 // More expressive form of BR_COVER_IMPL that allows the use of custom clock and reset signal names.
+`ifdef BR_ENABLE_IMPL_CHECKS
 `define BR_COVER_CR_IMPL(__name__, __expr__, __clk__, __rst__) \
-`ifdef BR_ENABLE_IMPL_CHECKS \
-`BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
-`endif
+`BR_COVER_CR(__name__, __expr__, __clk__, __rst__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_COVER_CR_IMPL(__name__, __expr__, __clk__, __rst__) ;  // macro no-op; BR_ENABLE_IMPL_CHECKS not defined
+`endif  // BR_ENABLE_IMPL_CHECKS
 
 ////////////////////////////////////////////////////////////////////////////////
 // Combinational cover macros (evaluated continuously based on the expression sensitivity)
 ////////////////////////////////////////////////////////////////////////////////
+`ifndef BR_DISABLE_INTG_CHECKS
 `define BR_COVER_COMB_INTG(__name__, __expr__) \
-`ifndef BR_DISABLE_INTG_CHECKS \
-`BR_COVER_COMB(__name__, __expr__) \
-`endif
+`BR_COVER_COMB(__name__, __expr__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_COVER_COMB_INTG(__name__, __expr__) ;  // macro no-op; BR_DISABLE_INTG_CHECKS defined
+`endif // BR_DISABLE_INTG_CHECKS
 
+`ifdef BR_ENABLE_IMPL_CHECKS
 `define BR_COVER_COMB_IMPL(__name__, __expr__) \
-`ifdef BR_ENABLE_IMPL_CHECKS \
-`BR_COVER_COMB(__name__, __expr__) \
-`endif
+`BR_COVER_COMB(__name__, __expr__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_COVER_COMB_IMPL(__name__, __expr__) ;  // macro no-op; BR_ENABLE_IMPL_CHECKS not defined
+`endif  // BR_ENABLE_IMPL_CHECKS
+
+// verilog_lint: enable line-length
 
 `endif  // BR_ASSERTS_INTERNAL_SVH

--- a/ram/rtl/br_ram_flops_1r1w.sv
+++ b/ram/rtl/br_ram_flops_1r1w.sv
@@ -54,7 +54,7 @@ module br_ram_flops_1r1w #(
   `BR_ASSERT_STATIC(BitWidth_gte1_A, BitWidth >= 1)
 
   `BR_ASSERT_INTG(wr_addr_in_range_A, wr_valid |-> wr_addr < Depth)
-  `BR_ASSERT_INTG(rd_addr_in_range_A, rd_valid |-> rd_addr < Depth)
+  `BR_ASSERT_INTG(rd_addr_in_range_A, rd_addr_valid |-> rd_addr < Depth)
 
   //------------------------------------------
   // Implementation


### PR DESCRIPTION
* Add `defines` argument to `verilog_elab_test` and `verilog_lint_test`.
  * Set the defaults to `SV_ASSERT_ON`.
* Fix `ifdef` ordering bugs in `br_asserts.svh` and `br_asserts_internal.svh`.
* Fix elaboration errors in RTL files exposed by turning assertions on in elab tests.