### PR TITLE
Refactor br_fifo_ctrl_1r1w into two major submodules

### DIFF
--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -22,6 +22,8 @@ verilog_library(
     srcs = ["br_fifo_ctrl_1r1w.sv"],
     deps = [
         "//counter/rtl:br_counter_incr",
+        "//fifo/rtl/internal:br_fifo_pop_ctrl",
+        "//fifo/rtl/internal:br_fifo_push_ctrl",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
         "//misc/rtl:br_misc_unused",

--- a/fifo/rtl/br_fifo_flops.sv
+++ b/fifo/rtl/br_fifo_flops.sv
@@ -86,13 +86,13 @@ module br_fifo_flops #(
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  logic wr_valid;
-  logic [AddrWidth-1:0] wr_addr;
-  logic [BitWidth-1:0] wr_data;
-  logic rd_addr_valid;
-  logic [AddrWidth-1:0] rd_addr;
-  logic rd_data_valid;
-  logic [BitWidth-1:0] rd_data;
+  logic ram_wr_valid;
+  logic [AddrWidth-1:0] ram_wr_addr;
+  logic [BitWidth-1:0] ram_wr_data;
+  logic ram_rd_addr_valid;
+  logic [AddrWidth-1:0] ram_rd_addr;
+  logic ram_rd_data_valid;
+  logic [BitWidth-1:0] ram_rd_data;
 
   br_fifo_ctrl_1r1w #(
       .Depth(Depth),
@@ -115,13 +115,13 @@ module br_fifo_flops #(
       .empty_next,
       .items,
       .items_next,
-      .wr_valid,
-      .wr_addr,
-      .wr_data,
-      .rd_addr_valid,
-      .rd_addr,
-      .rd_data_valid,
-      .rd_data
+      .ram_wr_valid,
+      .ram_wr_addr,
+      .ram_wr_data,
+      .ram_rd_addr_valid,
+      .ram_rd_addr,
+      .ram_rd_data_valid,
+      .ram_rd_data
   );
 
   br_ram_flops_1r1w #(
@@ -132,13 +132,13 @@ module br_fifo_flops #(
   ) br_ram_flops_1r1w (
       .clk,
       .rst,
-      .wr_valid,
-      .wr_addr,
-      .wr_data,
-      .rd_addr_valid,
-      .rd_addr,
-      .rd_data_valid,
-      .rd_data
+      .wr_valid(ram_wr_valid),
+      .wr_addr(ram_wr_addr),
+      .wr_data(ram_wr_data),
+      .rd_addr_valid(ram_rd_addr_valid),
+      .rd_addr(ram_rd_addr),
+      .rd_data_valid(ram_rd_data_valid),
+      .rd_data(ram_rd_data)
   );
 
   //------------------------------------------

--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -1,0 +1,38 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_lint_test")
+
+package(default_visibility = ["//fifo/rtl:__subpackages__"])
+
+verilog_library(
+    name = "br_fifo_push_ctrl",
+    srcs = ["br_fifo_push_ctrl.sv"],
+    deps = [
+        "//counter/rtl:br_counter_incr",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_push_ctrl_elab_test",
+    deps = [":br_fifo_push_ctrl"],
+)
+
+verilog_lint_test(
+    name = "br_fifo_push_ctrl_lint_test",
+    deps = [":br_fifo_push_ctrl"],
+)

--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -24,6 +24,7 @@ verilog_library(
         "//counter/rtl:br_counter_incr",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
+        "//misc/rtl:br_misc_unused",
     ],
 )
 
@@ -35,4 +36,25 @@ verilog_elab_test(
 verilog_lint_test(
     name = "br_fifo_push_ctrl_lint_test",
     deps = [":br_fifo_push_ctrl"],
+)
+
+verilog_library(
+    name = "br_fifo_pop_ctrl",
+    srcs = ["br_fifo_pop_ctrl.sv"],
+    deps = [
+        "//counter/rtl:br_counter_incr",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+        "//misc/rtl:br_misc_unused",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_pop_ctrl_elab_test",
+    deps = [":br_fifo_pop_ctrl"],
+)
+
+verilog_lint_test(
+    name = "br_fifo_pop_ctrl_lint_test",
+    deps = [":br_fifo_pop_ctrl"],
 )

--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -1,0 +1,141 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL FIFO Pop Controller (Ready/Valid)
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+
+module br_fifo_pop_ctrl #(
+    parameter int Depth = 2,
+    parameter int BitWidth = 1,
+    parameter bit EnableBypass = 1,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input logic clk,
+    input logic rst,  // Synchronous active-high
+
+    input  logic                pop_ready,
+    output logic                pop_valid,
+    output logic [BitWidth-1:0] pop_data,
+
+    // Pop-side status flags
+    output logic                  empty,
+    output logic                  empty_next,
+    output logic [CountWidth-1:0] items,
+    output logic [CountWidth-1:0] items_next,
+
+    // Bypass interface
+    output logic bypass_ready,
+    input logic bypass_valid,
+    input logic [BitWidth-1:0] bypass_data,
+
+    // RAM interface
+    output logic                 ram_rd_addr_valid,
+    output logic [AddrWidth-1:0] ram_rd_addr,
+    input  logic                 ram_rd_data_valid,
+    input  logic [ BitWidth-1:0] ram_rd_data,
+
+    // Internal handshakes between push and pop controllers
+    input  logic ram_push,
+    output logic ram_pop
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
+  `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, BitWidth >= 1)
+
+  `BR_ASSERT_INTG(ram_rd_latency_zero_a, ram_rd_addr_valid |-> ram_rd_data_valid)
+
+  // Internal integration checks
+  `BR_ASSERT_IMPL(bypass_backpressure_a, !bypass_ready && bypass_valid |=> bypass_valid && $stable
+                                         (bypass_data))
+  // This is not the tightest possible check, because we are planning to
+  // support pipelined RAM access and CDC use cases that require supporting
+  // delays between the push controller and pop controller.
+  // The tightest possible check is slots == 0 |-> !ram_push.
+  // This one is looser because items == Depth |-> slots == 0 (but the
+  // converse is not true).
+  `BR_ASSERT_IMPL(no_ram_push_when_all_items_a, items == Depth |-> !ram_push)
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  // Flow control
+  logic pop;
+  assign pop = pop_ready && pop_valid;
+
+  // RAM path
+  br_counter_incr #(
+      .MaxValue(Depth - 1),
+      .MaxIncrement(1)
+  ) br_counter_incr_rd_addr (
+      .clk,
+      .rst,
+      .incr_valid(ram_rd_addr_valid),
+      .incr(1'b1),
+      .value(ram_rd_addr),
+      .value_next()  // unused
+  );
+
+  // Datapath
+  assign ram_rd_addr_valid = ram_pop;
+  if (EnableBypass) begin : gen_bypass
+    assign bypass_ready = empty && pop_ready;
+    assign pop_valid = bypass_valid || !empty;
+    assign pop_data = bypass_valid ? bypass_data : ram_rd_data;
+    assign ram_pop = pop && !bypass_valid;
+  end else begin : gen_no_bypass
+    assign bypass_ready = '0;
+    assign pop_valid = !empty;
+    assign pop_data = ram_rd_data;
+    assign ram_pop = pop;
+    br_misc_unused br_misc_unused_bypass_valid (.in(bypass_valid));
+    br_misc_unused #(.BitWidth(BitWidth)) br_misc_unused_bypass_data (.in(bypass_data));
+  end
+  br_misc_unused br_misc_unused_ram_rd_data_valid (.in(ram_rd_data_valid));  // implied
+
+  // Status flags
+  assign items_next = ram_push && !ram_pop ? items + 1 : !ram_push && ram_pop ? items - 1 : items;
+  assign empty_next = items_next == 0;
+
+  `BR_REGL(items, items_next, ram_push || ram_pop)
+  `BR_REGIL(empty, empty_next, ram_push || ram_pop, 1'b1)
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  `BR_ASSERT_IMPL(ram_rd_addr_in_range_a, ram_rd_addr_valid |-> ram_rd_addr < Depth)
+
+  // Flow control and latency
+  `BR_ASSERT_IMPL(pop_invalid_when_empty_a, empty |-> !pop_valid)
+  `BR_ASSERT_IMPL(cutthrough_latency_1_cycle_a, empty && ram_push |=> !empty && pop_valid)
+  `BR_ASSERT_IMPL(bypass_ready_only_when_empty_and_pop_ready_a, bypass_ready |-> empty && pop_ready)
+
+  // RAM
+  `BR_ASSERT_IMPL(ram_read_a, ram_pop |-> ram_rd_data_valid && ram_rd_data == pop_data)
+
+  // Flags
+  `BR_ASSERT_IMPL(items_in_range_a, items <= Depth)
+  `BR_ASSERT_IMPL(items_next_a, ##1 items == $past(items_next))
+  `BR_ASSERT_IMPL(push_and_pop_items_a, ram_push && ram_pop |-> items_next == items)
+  `BR_ASSERT_IMPL(push_items_a, ram_push && !ram_pop |-> items_next == items + 1)
+  `BR_ASSERT_IMPL(pop_items_a, !ram_push && ram_pop |-> items_next == items - 1)
+  `BR_ASSERT_IMPL(empty_a, empty == (items == 0))
+
+endmodule : br_fifo_pop_ctrl

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -1,0 +1,147 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL FIFO Push Controller (Ready/Valid)
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+
+module br_fifo_push_ctrl #(
+    parameter int Depth = 2,
+    parameter int BitWidth = 1,
+    parameter bit EnableBypass = 1,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input logic clk,
+    input logic rst,  // Synchronous active-high
+
+    output logic                push_ready,
+    input  logic                push_valid,
+    input  logic [BitWidth-1:0] push_data,
+
+    // Push-side status flags
+    output logic                  full,
+    output logic                  full_next,
+    output logic [CountWidth-1:0] slots,
+    output logic [CountWidth-1:0] slots_next,
+
+    // Bypass interface
+    input  logic bypass_ready,
+    output logic bypass_valid,
+    output logic bypass_data,
+
+    // RAM interface
+    output logic                 ram_wr_valid,
+    output logic [AddrWidth-1:0] ram_wr_addr,
+    output logic [ BitWidth-1:0] ram_wr_data,
+
+    // Internal event signal from pop controller.
+    // Must only fire when an item is actually
+    // popped from the RAM (not when the bypass
+    // is used).
+    input logic ram_pop
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
+  `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, BitWidth >= 1)
+
+  // TODO(mgottscho): Do we really want this? It's ready-valid
+  // checker but the FIFO implementation correctness does not depend on it.
+  `BR_ASSERT_INTG(push_backpressure_a, !push_ready && push_valid |=> push_valid && $stable
+                                       (push_data))
+  `BR_ASSERT_INTG(full_c, full)
+
+  // Pop control
+
+  // This is not the tightest possible check, because we are planning to
+  // support pipelined RAM access and CDC use cases that require supporting
+  // delays between the push controller and pop controller.
+  // The tightest possible check is items == 0 |-> !ram_pop.
+  // This one is looser because slots == Depth |-> items == 0 (but the
+  // converse is not true).
+  `BR_ASSERT_INTG(no_ram_pop_when_all_slots_a, slots == Depth |-> !ram_pop)
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  // Flow control
+  logic push, ram_push;
+  assign push_ready = !full;
+  assign push = push_ready && push_valid;
+
+  // RAM path
+  br_counter_incr #(
+      .MaxValue(Depth - 1),
+      .MaxIncrement(1)
+  ) br_counter_incr_wr_addr (
+      .clk,
+      .rst,
+      .incr_valid(ram_wr_valid),
+      .incr(1'b1),
+      .value(ram_wr_addr),
+      .value_next()  // unused
+  );
+
+  // Datapath
+  assign ram_wr_valid = ram_push;
+  if (EnableBypass) begin : gen_bypass
+    assign bypass_valid = push && bypass_ready;
+    assign bypass_data = push_data;
+
+    assign ram_push = push && !bypass_ready;
+    assign ram_wr_data = push_data;
+  end else begin : gen_no_bypass
+    br_misc_unused br_misc_unused_bypass_ready (.in(bypass_ready));
+    assign bypass_valid = '0;
+    assign bypass_data = '0;
+
+    assign ram_push = push;
+    assign ram_wr_data = push_data;
+  end
+
+  // Status flags
+  assign slots_next = ram_push && !ram_pop ? slots + 1 : !ram_push && ram_pop ? slots - 1 : slots;
+  assign full_next  = slots_next == 0;
+
+  `BR_REGIL(slots, slots_next, ram_push || ram_pop, Depth)
+  `BR_REGL(full, full_next, ram_push || ram_pop)
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  `BR_ASSERT_IMPL(ram_wr_addr_in_range_a, ram_wr_valid |-> ram_wr_addr < Depth)
+
+  // Flow control and latency
+  `BR_ASSERT_IMPL(push_backpressure_when_full_a, full |-> !push_ready)
+  `BR_ASSERT_IMPL(backpressure_latency_1_cycle_a, full && ram_pop |=> !full && push_ready)
+  `BR_ASSERT_IMPL(bypass_backpressure_a, !bypass_ready && bypass_valid |=> bypass_valid && $stable
+                                         (bypass_data))
+
+  // RAM
+  `BR_ASSERT_IMPL(ram_write_a, ram_push |-> ram_wr_valid && ram_wr_data == push_data)
+
+  // Flags
+  `BR_ASSERT_IMPL(slots_in_range_a, slots <= Depth)
+  `BR_ASSERT_IMPL(slots_next_a, ##1 slots == $past(slots_next))
+  `BR_ASSERT_IMPL(push_and_pop_slots_a, ram_push && ram_pop |-> slots_next == slots)
+  `BR_ASSERT_IMPL(push_slots_a, ram_push && !ram_pop |-> slots_next == slots + 1)
+  `BR_ASSERT_IMPL(pop_slots_a, !ram_push && ram_pop |-> slots_next == slots - 1)
+  `BR_ASSERT_IMPL(full_a, full == (slots == 0))
+
+endmodule : br_fifo_push_ctrl


### PR DESCRIPTION
Planning ahead for various combinations of FIFO features:
* CDC
* Push credit/valid
* Pop credit/valid
* Pipelined RAM access

Refactored br_fifo_ctrl_1r1w to move in this direction.

A general theme among the above feature variants is that we need to decouple push and pop FSM logic. In a CDC FIFO they are on different clock domains and there is latency to communicate between them. Decided to start making that communication channel structurally obvious, though right now it is overkill.

Additionally, this will make things easier when we swap out push or pop controller for a credit-valid version.

Unfortunately, there is significant complexity needed to support key optimizations in the common case. Right now we have redundant flop state in a synchronous FIFO with 0 latency between push and pop controllers.