### PR TITLE
arbs: adjust priority update behavior

### DIFF
--- a/arb/rtl/br_arb_fixed.sv
+++ b/arb/rtl/br_arb_fixed.sv
@@ -16,8 +16,6 @@
 //
 // Grants a single request at a time with fixed (strict) priority
 // where the lowest index requester has the highest priority.
-//
-// An enable signal controls whether any grant can be made.
 
 `include "br_asserts_internal.svh"
 
@@ -29,7 +27,6 @@ module br_arb_fixed #(
     input logic clk,  // Only used for assertions
     // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic rst,  // Only used for assertions
-    input logic enable,
     input logic [NumRequesters-1:0] request,
     output logic [NumRequesters-1:0] grant
 );
@@ -42,18 +39,14 @@ module br_arb_fixed #(
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  logic [NumRequesters-1:0] grant_internal;
-
   br_enc_priority_encoder #(
       .NumRequesters(NumRequesters)
   ) br_enc_priority_encoder (
       .clk,
       .rst,
       .in (request),
-      .out(grant_internal)
+      .out(grant)
   );
-
-  assign grant = {NumRequesters{enable}} & grant_internal;
 
   //------------------------------------------
   // Implementation checks
@@ -61,7 +54,7 @@ module br_arb_fixed #(
   // Rely on submodule implementation checks
 
   `BR_ASSERT_IMPL(grant_onehot0_A, $onehot0(grant))
+  `BR_ASSERT_IMPL(always_grant_a, |request |-> |grant)
   `BR_ASSERT_IMPL(grant_implies_request_A, (grant & request) == grant)
-  `BR_ASSERT_IMPL(grant_only_when_enabled_A, |grant |-> enable)
 
 endmodule : br_arb_fixed

--- a/flow/rtl/br_flow_arb_fixed.sv
+++ b/flow/rtl/br_flow_arb_fixed.sv
@@ -58,7 +58,6 @@ module br_flow_arb_fixed #(
   ) br_arb_fixed (
       .clk,
       .rst,
-      .enable (pop_ready),
       .request(push_valid),
       .grant
   );
@@ -68,7 +67,7 @@ module br_flow_arb_fixed #(
   // for the same flow.
   for (genvar i = 0; i < NumFlows; i++) begin : gen_push_ready
     always_comb begin
-      push_ready[i] = 1'b1;
+      push_ready[i] = pop_ready;
       for (int j = 0; j < NumFlows; j++) begin
         if (i != j) begin
           push_ready[i] &= !grant[j];

--- a/flow/rtl/br_flow_arb_lru.sv
+++ b/flow/rtl/br_flow_arb_lru.sv
@@ -56,7 +56,7 @@ module br_flow_arb_lru #(
   ) br_arb_lru (
       .clk,
       .rst,
-      .enable (pop_ready),
+      .enable_priority_update(pop_ready),
       .request(push_valid),
       .grant
   );

--- a/flow/rtl/br_flow_arb_rr.sv
+++ b/flow/rtl/br_flow_arb_rr.sv
@@ -56,7 +56,7 @@ module br_flow_arb_rr #(
   ) br_arb_rr (
       .clk,
       .rst,
-      .enable (pop_ready),
+      .enable_priority_update(pop_ready),
       .request(push_valid),
       .grant
   );


### PR DESCRIPTION
Rename arbiter `enable` port to `enable_priority_update` and fix the functionality to match the intent. Requests will always result in grants, regardless of the value of `enable_priority_update`. Since the behavior has changed, `br_arb_fixed` no longer has the corresponding port (it would be meaningless).

Adjust asserts and covers to match.
