### PR TITLE
Revert "Rename `SV_ASSERT_ON to `BR_ASSERT_ON`; split `BR_COVER_ON` (#80)"

### DIFF
--- a/bazel/br_verilog.bzl
+++ b/bazel/br_verilog.bzl
@@ -21,12 +21,12 @@ def br_verilog_elab_and_lint_test_suite(name, **kwargs):
 
     Not intended to be called by Bedrock users.
 
-    (1) The first instance defines "BR_ASSERT_ON" and "BR_COVER_ON" and uses the provided name.
+    (1) The first instance defines "SV_ASSERT_ON" and uses the provided name.
         This is to test the design is elab/lint clean when it will be integrated into a user's design.
-    (2) The second instance defines "BR_ASSERT_ON", "BR_COVER_ON", and "BR_ENABLE_IMPL_CHECKS".
-        This is to test the design is elab/lint clean with all Bedrock-internal assertions/covers enabled.
+    (2) The second instance defines "SV_ASSERT_ON" and "BR_ENABLE_IMPL_CHECKS".
+        This is to test the design is elab/lint clean with all Bedrock-internal assertions enabled.
     (3) The third instance has no defines.
-        This is to test the design is elab/lint clean without any assertions or covers.
+        This is to test the design is elab/lint clean without any assertions.
 
     Args:
         name (str): The base name of the test suite.
@@ -38,13 +38,13 @@ def br_verilog_elab_and_lint_test_suite(name, **kwargs):
 
     verilog_elab_and_lint_test_suite(
         name = name,
-        defines = ["BR_ASSERT_ON", "BR_COVER_ON"],
+        defines = ["SV_ASSERT_ON"],
         **kwargs
     )
 
     verilog_elab_and_lint_test_suite(
         name = name + "_allassert",
-        defines = ["BR_ASSERT_ON", "BR_COVER_ON", "BR_ENABLE_IMPL_CHECKS"],
+        defines = ["SV_ASSERT_ON", "BR_ENABLE_IMPL_CHECKS"],
         **kwargs
     )
 

--- a/credit/rtl/br_credit_counter.sv
+++ b/credit/rtl/br_credit_counter.sv
@@ -80,7 +80,7 @@ module br_credit_counter #(
   `BR_ASSERT_INTG(decr_in_range_a, decr_valid |-> (decr <= MaxChange))
 
   // Assertion-only helper logic for overflow/underflow detection
-`ifdef BR_ASSERT_ON
+`ifdef SV_ASSERT_ON
 `ifndef BR_DISABLE_INTG_CHECKS
   localparam int CalcWidth = ValueWidth + 1;
   logic [CalcWidth-1:0] value_extended_next;
@@ -96,7 +96,7 @@ module br_credit_counter #(
   end
 
 `endif  // BR_DISABLE_INTG_CHECKS
-`endif  // BR_ASSERT_ON
+`endif  // SV_ASSERT_ON
 
   `BR_ASSERT_INTG(no_overflow_or_underflow_a, value_extended_next <= MaxValue)
 

--- a/enc/sim/BUILD.bazel
+++ b/enc/sim/BUILD.bazel
@@ -31,7 +31,7 @@ verilog_elab_test(
 verilog_sim_test(
     name = "br_enc_bin2onehot_sim_test",
     defines = [
-        "BR_ASSERT_ON",
+        "SV_ASSERT_ON",
         "BR_ENABLE_IMPL_CHECKS",
     ],
     deps = [":br_enc_bin2onehot_tb"],

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -46,10 +46,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_asserts_elab_test",
-    defines = [
-        "BR_ASSERT_ON",
-        "BR_COVER_ON",
-    ],
+    defines = ["SV_ASSERT_ON"],
     deps = [":br_asserts_test"],
 )
 
@@ -68,8 +65,7 @@ verilog_library(
 verilog_elab_test(
     name = "br_asserts_elab_internal_test",
     defines = [
-        "BR_ASSERT_ON",
-        "BR_COVER_ON",
+        "SV_ASSERT_ON",
         "BR_ENABLE_IMPL_CHECKS",
     ],
     deps = [":br_asserts_internal_test"],

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -32,15 +32,15 @@
 
 `define BR_NOOP
 
-`ifdef BR_ASSERT_ON
+`ifdef SV_ASSERT_ON
 `define BR_ASSERT_STATIC(__name__, __expr__) \
 if (!(__expr__)) begin : gen__``__name__ \
 __STATIC_ASSERT_FAILED__ __STATIC_ASSERT_FAILED__``__name__ (); \
 end
-`else  // BR_ASSERT_ON
+`else  // SV_ASSERT_ON
 `define BR_ASSERT_STATIC(__name__, __expr__) \
 `BR_NOOP
-`endif  // BR_ASSERT_ON
+`endif  // SV_ASSERT_ON
 
 `define BR_ASSERT_STATIC_IN_PACKAGE(__name__, __expr__) \
 typedef enum logic [1:0] { \
@@ -54,35 +54,35 @@ typedef enum logic [1:0] { \
 
 // Clock: 'clk'
 // Reset: 'rst'
-`ifdef BR_ASSERT_ON
+`ifdef SV_ASSERT_ON
 `define BR_ASSERT(__name__, __expr__) \
 __name__ : assert property (@(posedge clk) disable iff (rst) (__expr__));
-`else  // BR_ASSERT_ON
+`else  // SV_ASSERT_ON
 `define BR_ASSERT(__name__, __expr__) \
 `BR_NOOP
-`endif  // BR_ASSERT_ON
+`endif  // SV_ASSERT_ON
 
 // More expressive form of BR_ASSERT that allows the use of custom clock and reset signal names.
-`ifdef BR_ASSERT_ON
+`ifdef SV_ASSERT_ON
 `define BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) \
 __name__ : assert property (@(posedge __clk__) disable iff (__rst__) (__expr__));
-`else  // BR_ASSERT_ON
+`else  // SV_ASSERT_ON
 `define BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) \
 `BR_NOOP
-`endif  // BR_ASSERT_ON
+`endif  // SV_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
 // Combinational assertion macros (evaluated continuously based on the expression sensitivity)
 ////////////////////////////////////////////////////////////////////////////////
-`ifdef BR_ASSERT_ON
+`ifdef SV_ASSERT_ON
 `define BR_ASSERT_COMB(__name__, __expr__) \
 always_comb begin  : gen_``__name__ \
 assert (__expr__); \
 end
-`else  // BR_ASSERT_ON
+`else  // SV_ASSERT_ON
 `define BR_ASSERT_COMB(__name__, __expr__) \
 `BR_NOOP
-`endif  // BR_ASSERT_ON
+`endif  // SV_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
 // Concurrent cover macros (evaluated on posedge of a clock and disabled during a reset)
@@ -90,35 +90,35 @@ end
 
 // Clock: 'clk'
 // Reset: 'rst'
-`ifdef BR_COVER_ON
+`ifdef SV_ASSERT_ON
 `define BR_COVER(__name__, __expr__) \
 __name__ : cover property (@(posedge clk) disable iff (rst) (__expr__));
-`else  // BR_COVER_ON
+`else  // SV_ASSERT_ON
 `define BR_COVER(__name__, __expr__) \
 `BR_NOOP
-`endif  // BR_COVER_ON
+`endif  // SV_ASSERT_ON
 
 // More expressive form of BR_COVER that allows the use of custom clock and reset signal names.
-`ifdef BR_COVER_ON
+`ifdef SV_ASSERT_ON
 `define BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
 __name__ : cover property (@(posedge __clk__) disable iff (__rst__) (__expr__));
-`else  // BR_COVER_ON
+`else  // SV_ASSERT_ON
 `define BR_COVER_CR(__name__, __expr__, __clk__, __rst__) \
 `BR_NOOP
-`endif  // BR_COVER_ON
+`endif  // SV_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
 // Combinational cover macros (evaluated continuously based on the expression sensitivity)
 ////////////////////////////////////////////////////////////////////////////////
-`ifdef BR_COVER_ON
+`ifdef SV_ASSERT_ON
 `define BR_COVER_COMB(__name__, __expr__) \
 always_comb begin  : gen_``__name__ \
 cover (__expr__); \
 end
-`else  // BR_COVER_ON
+`else  // SV_ASSERT_ON
 `define BR_COVER_COMB(__name__, __expr__) \
 `BR_NOOP
-`endif  // BR_COVER_ON
+`endif  // SV_ASSERT_ON
 
 // verilog_format: on
 // verilog_lint: waive-stop line-length


### PR DESCRIPTION
This reverts commit 82599a16b2b099ba1a4917b37aaefe54c51bb053.