### PR TITLE
br_delay: add new output port out_stage (#79)

### DIFF
--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -28,12 +28,16 @@ module br_delay #(
 ) (
     // Positive edge-triggered. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                clk,
+    input  logic                             clk,
     // Synchronous active-high. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                rst,
-    input  logic [BitWidth-1:0] in,
-    output logic [BitWidth-1:0] out
+    input  logic                             rst,
+    input  logic [BitWidth-1:0]              in,
+    // Output of last delay stage (delayed by NumStages cycles).
+    output logic [BitWidth-1:0]              out,
+    // Output of each delay stage. Note that out_stage[0] == in, and
+    // out_stage[NumStages] == out.
+    output logic [NumStages:0][BitWidth-1:0] out_stage
 );
 
   //------------------------------------------
@@ -53,7 +57,8 @@ module br_delay #(
     `BR_REG(stages[i], stages[i-1])
   end
 
-  assign out = stages[NumStages];
+  assign out       = stages[NumStages];
+  assign out_stage = stages;
 
   //------------------------------------------
   // Implementation checks

--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -28,13 +28,13 @@ module br_delay #(
 ) (
     // Positive edge-triggered. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                             clk,
+    input  logic                clk,
     // Synchronous active-high. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                             rst,
-    input  logic [BitWidth-1:0]              in,
+    input  logic                rst,
+    input  logic [BitWidth-1:0] in,
     // Output of last delay stage (delayed by NumStages cycles).
-    output logic [BitWidth-1:0]              out,
+    output logic [BitWidth-1:0] out,
     // Output of each delay stage. Note that out_stage[0] == in, and
     // out_stage[NumStages] == out.
     output logic [NumStages:0][BitWidth-1:0] out_stage


### PR DESCRIPTION
Adds a new output port "out_stage" which includes the output of each stage in a delay chain. This allows the module to be used as a simple delay element or as a shift register.

Note that out_stage[0] == in, out_stage[NumStages] == out.

fixes #79