### PR TITLE
br_delay: add new output port out_stage (#79)

### DIFF
--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -35,9 +35,9 @@ module br_delay #(
     input  logic [BitWidth-1:0] in,
     // Output of last delay stage (delayed by NumStages cycles).
     output logic [BitWidth-1:0] out,
-    // Output of each delay stage. Note that out_stage[0] == in, and
-    // out_stage[NumStages] == out.
-    output logic [NumStages:0][BitWidth-1:0] out_stage
+    // Output of each delay stage. Note that out_stages[0] == in, and
+    // out_stages[NumStages] == out.
+    output logic [NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------
@@ -57,8 +57,8 @@ module br_delay #(
     `BR_REG(stages[i], stages[i-1])
   end
 
-  assign out       = stages[NumStages];
-  assign out_stage = stages;
+  assign out = stages[NumStages];
+  assign out_stages = stages;
 
   //------------------------------------------
   // Implementation checks

--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -28,16 +28,16 @@ module br_delay #(
 ) (
     // Positive edge-triggered. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                clk,
+    input  logic                              clk,
     // Synchronous active-high. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                rst,
-    input  logic [BitWidth-1:0] in,
+    input  logic                              rst,
+    input  logic [BitWidth-1:0]               in,
     // Output of last delay stage (delayed by NumStages cycles).
-    output logic [BitWidth-1:0] out,
+    output logic [BitWidth-1:0]               out,
     // Output of each delay stage. Note that out_stages[0] == in, and
     // out_stages[NumStages] == out.
-    output logic [NumStages:0][BitWidth-1:0] out_stages
+    output logic [ NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------

--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -33,7 +33,11 @@ module br_delay #(
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic                rst,
     input  logic [BitWidth-1:0] in,
-    output logic [BitWidth-1:0] out
+    // Output of last delay stage (delayed by NumStages cycles).
+    output logic [BitWidth-1:0] out,
+    // Output of each delay stage. Note that out_stage[0] == in, and
+    // out_stage[NumStages] == out.
+    output logic [NumStages:0][BitWidth-1:0] out_stage
 );
 
   //------------------------------------------
@@ -53,7 +57,8 @@ module br_delay #(
     `BR_REG(stages[i], stages[i-1])
   end
 
-  assign out = stages[NumStages];
+  assign out       = stages[NumStages];
+  assign out_stage = stages;
 
   //------------------------------------------
   // Implementation checks

--- a/delay/rtl/br_delay_nr.sv
+++ b/delay/rtl/br_delay_nr.sv
@@ -28,16 +28,16 @@ module br_delay_nr #(
 ) (
     // Positive edge-triggered. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                clk,
+    input  logic                              clk,
     // Synchronous active-high. Only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                rst,
-    input  logic [BitWidth-1:0] in,
+    input  logic                              rst,
+    input  logic [BitWidth-1:0]               in,
     // Output of last delay stage (delayed by NumStages cycles).
-    output logic [BitWidth-1:0] out,
+    output logic [BitWidth-1:0]               out,
     // Output of each delay stage. Note that out_stages[0] == in, and
     // out_stages[NumStages] == out.
-    output logic [NumStages:0][BitWidth-1:0] out_stages
+    output logic [ NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------

--- a/delay/rtl/br_delay_nr.sv
+++ b/delay/rtl/br_delay_nr.sv
@@ -33,7 +33,11 @@ module br_delay_nr #(
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic                rst,
     input  logic [BitWidth-1:0] in,
-    output logic [BitWidth-1:0] out
+    // Output of last delay stage (delayed by NumStages cycles).
+    output logic [BitWidth-1:0] out,
+    // Output of each delay stage. Note that out_stages[0] == in, and
+    // out_stages[NumStages] == out.
+    output logic [NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------
@@ -54,6 +58,7 @@ module br_delay_nr #(
   end
 
   assign out = stages[NumStages];
+  assign out_stages = stages;
 
   //------------------------------------------
   // Implementation checks

--- a/delay/rtl/br_delay_valid.sv
+++ b/delay/rtl/br_delay_valid.sv
@@ -38,6 +38,8 @@ module br_delay_valid #(
     output logic                              out_valid,
     // Output of last delay stage (delayed by NumStages cycles).
     output logic [BitWidth-1:0]               out,
+    // Indicates the valid status of each delay stage.
+    output logic [ NumStages:0]               out_valid_stages, 
     // Output of each delay stage. Note that out_stages[0] == in, and
     // out_stages[NumStages] == out.
     output logic [ NumStages:0][BitWidth-1:0] out_stages
@@ -67,6 +69,7 @@ module br_delay_valid #(
 
   assign out_valid = stage_valid[NumStages];
   assign out = stage[NumStages];
+  assign out_valid_stages = stage_valid;
   assign out_stages = stage;
 
   //------------------------------------------

--- a/delay/rtl/br_delay_valid.sv
+++ b/delay/rtl/br_delay_valid.sv
@@ -29,18 +29,18 @@ module br_delay_valid #(
 ) (
     // Positive edge-triggered. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                clk,
+    input  logic                              clk,
     // Synchronous active-high. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                rst,
-    input  logic                in_valid,
-    input  logic [BitWidth-1:0] in,
-    output logic                out_valid,
+    input  logic                              rst,
+    input  logic                              in_valid,
+    input  logic [BitWidth-1:0]               in,
+    output logic                              out_valid,
     // Output of last delay stage (delayed by NumStages cycles).
-    output logic [BitWidth-1:0] out,
+    output logic [BitWidth-1:0]               out,
     // Output of each delay stage. Note that out_stages[0] == in, and
     // out_stages[NumStages] == out.
-    output logic [NumStages:0][BitWidth-1:0] out_stages
+    output logic [ NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------

--- a/delay/rtl/br_delay_valid.sv
+++ b/delay/rtl/br_delay_valid.sv
@@ -36,7 +36,11 @@ module br_delay_valid #(
     input  logic                in_valid,
     input  logic [BitWidth-1:0] in,
     output logic                out_valid,
-    output logic [BitWidth-1:0] out
+    // Output of last delay stage (delayed by NumStages cycles).
+    output logic [BitWidth-1:0] out,
+    // Output of each delay stage. Note that out_stages[0] == in, and
+    // out_stages[NumStages] == out.
+    output logic [NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------
@@ -63,6 +67,7 @@ module br_delay_valid #(
 
   assign out_valid = stage_valid[NumStages];
   assign out = stage[NumStages];
+  assign out_stages = stage;
 
   //------------------------------------------
   // Implementation checks

--- a/delay/rtl/br_delay_valid.sv
+++ b/delay/rtl/br_delay_valid.sv
@@ -39,7 +39,7 @@ module br_delay_valid #(
     // Output of last delay stage (delayed by NumStages cycles).
     output logic [BitWidth-1:0]               out,
     // Indicates the valid status of each delay stage.
-    output logic [ NumStages:0]               out_valid_stages, 
+    output logic [ NumStages:0]               out_valid_stages,
     // Output of each delay stage. Note that out_stages[0] == in, and
     // out_stages[NumStages] == out.
     output logic [ NumStages:0][BitWidth-1:0] out_stages

--- a/delay/rtl/br_delay_valid_next.sv
+++ b/delay/rtl/br_delay_valid_next.sv
@@ -41,7 +41,10 @@ module br_delay_valid_next #(
     input  logic                in_valid_next,
     input  logic [BitWidth-1:0] in,
     output logic                out_valid_next,
-    output logic [BitWidth-1:0] out
+    output logic [BitWidth-1:0] out,
+    // Output of each delay stage. Note that out_stages[0] == in, and
+    // out_stages[NumStages] == out.
+    output logic [NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------
@@ -70,6 +73,7 @@ module br_delay_valid_next #(
 
   assign out_valid_next = stage_valid_next[NumStages];
   assign out = stage[NumStages];
+  assign out_stages = stage;
 
   //------------------------------------------
   // Implementation checks

--- a/delay/rtl/br_delay_valid_next.sv
+++ b/delay/rtl/br_delay_valid_next.sv
@@ -42,6 +42,8 @@ module br_delay_valid_next #(
     input  logic [BitWidth-1:0]               in,
     output logic                              out_valid_next,
     output logic [BitWidth-1:0]               out,
+    // Indicates the valid_next signal at each stage.
+    output logic [ NumStages:0]               out_valid_next_stages,
     // Output of each delay stage. Note that out_stages[0] == in, and
     // out_stages[NumStages] == out.
     output logic [ NumStages:0][BitWidth-1:0] out_stages
@@ -73,6 +75,7 @@ module br_delay_valid_next #(
 
   assign out_valid_next = stage_valid_next[NumStages];
   assign out = stage[NumStages];
+  assign out_valid_next_stages = stage_valid_next;
   assign out_stages = stage;
 
   //------------------------------------------

--- a/delay/rtl/br_delay_valid_next.sv
+++ b/delay/rtl/br_delay_valid_next.sv
@@ -34,17 +34,17 @@ module br_delay_valid_next #(
 ) (
     // Positive edge-triggered. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                clk,
+    input  logic                              clk,
     // Synchronous active-high. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                rst,
-    input  logic                in_valid_next,
-    input  logic [BitWidth-1:0] in,
-    output logic                out_valid_next,
-    output logic [BitWidth-1:0] out,
+    input  logic                              rst,
+    input  logic                              in_valid_next,
+    input  logic [BitWidth-1:0]               in,
+    output logic                              out_valid_next,
+    output logic [BitWidth-1:0]               out,
     // Output of each delay stage. Note that out_stages[0] == in, and
     // out_stages[NumStages] == out.
-    output logic [NumStages:0][BitWidth-1:0] out_stages
+    output logic [ NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------

--- a/delay/rtl/br_delay_valid_next_nr.sv
+++ b/delay/rtl/br_delay_valid_next_nr.sv
@@ -79,7 +79,7 @@ module br_delay_valid_next_nr #(
   assign out_valid_next = stage_valid_next[NumStages];
   assign out = stage[NumStages];
   assign out_valid_next_stages = stage_valid_next;
-  assign out_stages = stages;
+  assign out_stages = stage;
 
   //------------------------------------------
   // Implementation checks

--- a/delay/rtl/br_delay_valid_next_nr.sv
+++ b/delay/rtl/br_delay_valid_next_nr.sv
@@ -45,6 +45,8 @@ module br_delay_valid_next_nr #(
     output logic                              out_valid_next,
     // Output of last delay stage (delayed by NumStages cycles).
     output logic [BitWidth-1:0]               out,
+    // Indicates the valid_next state of each delay stage.
+    output logic [ NumStages:0]               out_valid_next_stages,
     // Output of each delay stage. Note that out_stages[0] == in, and
     // out_stages[NumStages] == out.
     output logic [ NumStages:0][BitWidth-1:0] out_stages
@@ -76,6 +78,7 @@ module br_delay_valid_next_nr #(
 
   assign out_valid_next = stage_valid_next[NumStages];
   assign out = stage[NumStages];
+  assign out_valid_next_stages = stage_valid_next;
   assign out_stages = stages;
 
   //------------------------------------------

--- a/delay/rtl/br_delay_valid_next_nr.sv
+++ b/delay/rtl/br_delay_valid_next_nr.sv
@@ -36,18 +36,18 @@ module br_delay_valid_next_nr #(
 ) (
     // Positive edge-triggered. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                clk,
+    input  logic                              clk,
     // Synchronous active-high. Only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input  logic                rst,
-    input  logic                in_valid_next,
-    input  logic [BitWidth-1:0] in,
-    output logic                out_valid_next,
+    input  logic                              rst,
+    input  logic                              in_valid_next,
+    input  logic [BitWidth-1:0]               in,
+    output logic                              out_valid_next,
     // Output of last delay stage (delayed by NumStages cycles).
-    output logic [BitWidth-1:0] out,
+    output logic [BitWidth-1:0]               out,
     // Output of each delay stage. Note that out_stages[0] == in, and
     // out_stages[NumStages] == out.
-    output logic [NumStages:0][BitWidth-1:0] out_stages
+    output logic [ NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------

--- a/delay/rtl/br_delay_valid_next_nr.sv
+++ b/delay/rtl/br_delay_valid_next_nr.sv
@@ -43,7 +43,11 @@ module br_delay_valid_next_nr #(
     input  logic                in_valid_next,
     input  logic [BitWidth-1:0] in,
     output logic                out_valid_next,
-    output logic [BitWidth-1:0] out
+    // Output of last delay stage (delayed by NumStages cycles).
+    output logic [BitWidth-1:0] out,
+    // Output of each delay stage. Note that out_stages[0] == in, and
+    // out_stages[NumStages] == out.
+    output logic [NumStages:0][BitWidth-1:0] out_stages
 );
 
   //------------------------------------------
@@ -72,6 +76,7 @@ module br_delay_valid_next_nr #(
 
   assign out_valid_next = stage_valid_next[NumStages];
   assign out = stage[NumStages];
+  assign out_stages = stages;
 
   //------------------------------------------
   // Implementation checks

--- a/fifo/sim/br_fifo_flops_push_credit_tb.sv
+++ b/fifo/sim/br_fifo_flops_push_credit_tb.sv
@@ -107,8 +107,9 @@ module br_fifo_flops_push_credit_tb ();
   ) br_delay_nr_to_fifo (
       .clk,
       .rst,
-      .in ({cv_push_valid, cv_push_data, cv_push_credit_stall}),
-      .out({cv_push_valid_d, cv_push_data_d, cv_push_credit_stall_d})
+      .in({cv_push_valid, cv_push_data, cv_push_credit_stall}),
+      .out({cv_push_valid_d, cv_push_data_d, cv_push_credit_stall_d}),
+      .out_stages()  // ri lint_check_waive OPEN_OUTPUT
   );
 
   br_delay_nr #(
@@ -117,8 +118,9 @@ module br_fifo_flops_push_credit_tb ();
   ) br_delay_nr_from_fifo (
       .clk,
       .rst,
-      .in (cv_push_credit),
-      .out(cv_push_credit_d)
+      .in(cv_push_credit),
+      .out(cv_push_credit_d),
+      .out_stages()  // ri lint_check_waive OPEN_OUTPUT
   );
 
   // Clock generation


### PR DESCRIPTION
Adds a new output port "out_stage" which includes the output of each stage in a delay chain. This allows the module to be used as a simple delay element or as a shift register.

Note that out_stage[0] == in, out_stage[NumStages] == out.

fixes #79