### PR TITLE
BR_UNUSED macro.

### DIFF
--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_lint_test")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -34,6 +34,29 @@ verilog_library(
     name = "br_registers",
     hdrs = ["br_registers.svh"],
     visibility = ["//visibility:public"],
+)
+
+verilog_library(
+    name = "br_unused",
+    hdrs = ["br_unused.svh"],
+    visibility = ["//visibility:public"],
+    deps = ["//misc/rtl:br_misc_unused"],
+)
+
+verilog_library(
+    name = "br_unused_tb",
+    srcs = ["br_unused_tb.sv"],
+    deps = [":br_unused"],
+)
+
+verilog_elab_test(
+    name = "br_unused_tb_elab_test",
+    deps = [":br_unused_tb"],
+)
+
+verilog_lint_test(
+    name = "br_unused_tb_lint_test",
+    deps = [":br_unused_tb"],
 )
 
 # Macro unit tests

--- a/macros/br_unused.svh
+++ b/macros/br_unused.svh
@@ -1,0 +1,21 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+`ifndef BR_UNUSED_SVH
+`define BR_UNUSED_SVH
+
+`define BR_UNUSED(
+    __x__) br_misc_unused #(.BitWidth($bits(__x__))) br_misc_unused__``__x__(.in(__x__));
+
+`endif  // BR_UNUSED_SVH

--- a/macros/br_unused_tb.sv
+++ b/macros/br_unused_tb.sv
@@ -1,0 +1,25 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Unit test for br_unused.svh macros
+
+`include "br_unused.svh"
+
+module br_unused_tb ();  // ri lint_check_waive NO_OUTPUT
+
+  wire foo = 1'b0;  // ri lint_check_waive CONST_ASSIGN
+
+  `BR_UNUSED(foo)
+
+endmodule : br_unused_tb

--- a/misc/rtl/br_misc_unused.sv
+++ b/misc/rtl/br_misc_unused.sv
@@ -19,7 +19,8 @@
 // synthesis tool.
 //
 // To automatically instantiate this at the bitwidth of local logic, by name,
-// users can opt to use the `BR_UNUSED(my_name) convenience macro.
+// users can opt to use the `BR_UNUSED(my_name) convenience macro defined in
+// macros/br_unused.svh.
 
 // ri lint_check_waive EMPTY_MOD NO_OUTPUT
 module br_misc_unused #(
@@ -32,5 +33,3 @@ module br_misc_unused #(
   assign unused = |in;
 
 endmodule : br_misc_unused
-
-`define BR_UNUSED(__x) br_misc_unused #(.BitWidth($bits(__x))) br_misc_unused__``__x(.in(__x))

--- a/misc/rtl/br_misc_unused.sv
+++ b/misc/rtl/br_misc_unused.sv
@@ -17,6 +17,9 @@
 // Sinks an unused signal and waives the corresponding lint errors internally.
 // It is expected that this logic will be automatically removed by the
 // synthesis tool.
+//
+// To automatically instantiate this at the bitwidth of local logic, by name,
+// users can opt to use the `BR_UNUSED(my_name) convenience macro.
 
 // ri lint_check_waive EMPTY_MOD NO_OUTPUT
 module br_misc_unused #(
@@ -29,3 +32,5 @@ module br_misc_unused #(
   assign unused = |in;
 
 endmodule : br_misc_unused
+
+`define BR_UNUSED(__x) br_misc_unused #(.BitWidth($bits(__x))) br_misc_unused__``__x(.in(__x))


### PR DESCRIPTION
Small style notes:
- double underscore prefix is used on the macro parameter to show more clearly if the name happened to escape macro usage.
- double underscore is used between the `br_misc_unused` pseudo-namespace and the name to avoid collisions with things explicitly named via single unscores, e.g. if a user defined `br_misc_unused_x` themselves.

(Both are fairly paranoid practices but that are not uncommon in C programming.)