### PR TITLE
Issue #108: `BR_UNUSED_NAMED. And deploy unused macros in bedrock

### DIFF
--- a/arb/rtl/BUILD.bazel
+++ b/arb/rtl/BUILD.bazel
@@ -32,7 +32,7 @@ verilog_library(
     deps = [
         "//macros:br_asserts_internal",
         "//macros:br_registers",
-        "//misc/rtl:br_misc_unused",
+        "//macros:br_unused",
     ],
 )
 

--- a/arb/rtl/br_arb_lru.sv
+++ b/arb/rtl/br_arb_lru.sv
@@ -21,6 +21,7 @@
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
+`include "br_unused.svh"
 
 module br_arb_lru #(
     // Must be at least 2
@@ -93,18 +94,14 @@ module br_arb_lru #(
         // Tie-off unused signals
         assign state_reg_next[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
         assign state_reg[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
-        br_misc_unused br_misc_unused_state_reg_next (.in(state_reg_next[i][j]));
-        br_misc_unused br_misc_unused_state_reg (.in(state_reg[i][j]));
+        `BR_UNUSED(state_reg_next, state_reg_next[i][j])
+        `BR_UNUSED(state_reg, state_reg[i][j])
 
         // The diagonal is unused. Tie off signals.
       end else begin : gen_diag
         // ri lint_check_waive CONST_ASSIGN
         assign {state_reg_next[i][j], state_reg[i][j], state[i][j]} = '0;
-        br_misc_unused #(
-            .BitWidth(3)
-        ) br_misc_unused (
-            .in({state_reg_next[i][j], state_reg[i][j], state[i][j]})
-        );
+        `BR_UNUSED(states, {state_reg_next[i][j], state_reg[i][j], state[i][j]})
       end
     end
   end

--- a/arb/rtl/br_arb_lru.sv
+++ b/arb/rtl/br_arb_lru.sv
@@ -94,14 +94,14 @@ module br_arb_lru #(
         // Tie-off unused signals
         assign state_reg_next[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
         assign state_reg[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
-        `BR_UNUSED(state_reg_next, state_reg_next[i][j])
-        `BR_UNUSED(state_reg, state_reg[i][j])
+        `BR_UNUSED_NAMED(state_reg_next, state_reg_next[i][j])
+        `BR_UNUSED_NAMED(state_reg, state_reg[i][j])
 
         // The diagonal is unused. Tie off signals.
       end else begin : gen_diag
         // ri lint_check_waive CONST_ASSIGN
         assign {state_reg_next[i][j], state_reg[i][j], state[i][j]} = '0;
-        `BR_UNUSED(states, {state_reg_next[i][j], state_reg[i][j], state[i][j]})
+        `BR_UNUSED_NAMED(states, {state_reg_next[i][j], state_reg[i][j], state[i][j]})
       end
     end
   end

--- a/arb/rtl/br_arb_lru.sv
+++ b/arb/rtl/br_arb_lru.sv
@@ -94,8 +94,7 @@ module br_arb_lru #(
         // Tie-off unused signals
         assign state_reg_next[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
         assign state_reg[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
-        `BR_UNUSED_NAMED(state_reg_next, state_reg_next[i][j])
-        `BR_UNUSED_NAMED(state_reg, state_reg[i][j])
+        `BR_UNUSED_NAMED(states, {state_reg_next[i][j], state_reg[i][j]})
 
         // The diagonal is unused. Tie off signals.
       end else begin : gen_diag

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -274,3 +274,5 @@ Useful for having Bazel self-throttle test actions that require a finite number 
 | :------------- | :------------- | :------------- |
 | <a id="verilog_sim_test-tags"></a>tags |  <p align="center"> - </p>   |  `[]` |
 | <a id="verilog_sim_test-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+

--- a/counter/rtl/BUILD.bazel
+++ b/counter/rtl/BUILD.bazel
@@ -23,7 +23,7 @@ verilog_library(
     deps = [
         "//macros:br_asserts_internal",
         "//macros:br_registers",
-        "//misc/rtl:br_misc_unused",
+        "//macros:br_unused",
     ],
 )
 

--- a/counter/rtl/br_counter_incr.sv
+++ b/counter/rtl/br_counter_incr.sv
@@ -42,6 +42,7 @@
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
+`include "br_unused.svh"
 
 module br_counter_incr #(
     parameter int MaxValue = 1,  // Must be at least 1. Inclusive.
@@ -102,11 +103,7 @@ module br_counter_incr #(
         value_temp[ValueWidth-1:0];  // ri lint_check_waive FULL_RANGE
 
     if (TempWidth > ValueWidth) begin : gen_unused
-      br_misc_unused #(
-          .BitWidth(TempWidth - ValueWidth)
-      ) br_misc_unused_value_temp_wrapped_msbs (
-          .in(value_temp_wrapped[TempWidth-1:ValueWidth])
-      );
+      `BR_UNUSED(value_temp_wrapped_msbs, value_temp_wrapped[TempWidth-1:ValueWidth])
     end
   end
 

--- a/counter/rtl/br_counter_incr.sv
+++ b/counter/rtl/br_counter_incr.sv
@@ -103,7 +103,7 @@ module br_counter_incr #(
         value_temp[ValueWidth-1:0];  // ri lint_check_waive FULL_RANGE
 
     if (TempWidth > ValueWidth) begin : gen_unused
-      `BR_UNUSED(value_temp_wrapped_msbs, value_temp_wrapped[TempWidth-1:ValueWidth])
+      `BR_UNUSED_NAMED(value_temp_wrapped_msbs, value_temp_wrapped[TempWidth-1:ValueWidth])
     end
   end
 

--- a/enc/rtl/BUILD.bazel
+++ b/enc/rtl/BUILD.bazel
@@ -32,7 +32,7 @@ verilog_library(
     deps = [
         "//macros:br_asserts_internal",
         "//macros:br_registers",
-        "//misc/rtl:br_misc_unused",
+        "//macros:br_unused",
     ],
 )
 

--- a/enc/rtl/br_enc_onehot2bin.sv
+++ b/enc/rtl/br_enc_onehot2bin.sv
@@ -85,7 +85,7 @@ module br_enc_onehot2bin #(
     end
   end
 
-  `BR_UNUSED(in0, in[0])
+  `BR_UNUSED_NAMED(in0, in[0])
 
   //------------------------------------------
   // Implementation checks

--- a/enc/rtl/br_enc_onehot2bin.sv
+++ b/enc/rtl/br_enc_onehot2bin.sv
@@ -46,6 +46,7 @@
 // ...
 
 `include "br_asserts_internal.svh"
+`include "br_unused.svh"
 
 module br_enc_onehot2bin #(
     parameter int NumValues = 2,  // Must be at least 2
@@ -84,7 +85,7 @@ module br_enc_onehot2bin #(
     end
   end
 
-  br_misc_unused br_misc_unused (.in(in[0]));
+  `BR_UNUSED(in0, in[0])
 
   //------------------------------------------
   // Implementation checks

--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -25,7 +25,7 @@ verilog_library(
         "//fifo/rtl/internal:br_fifo_push_ctrl",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
-        "//misc/rtl:br_misc_unused",
+        "//macros:br_unused",
     ],
 )
 
@@ -37,7 +37,7 @@ verilog_library(
         "//fifo/rtl/internal:br_fifo_push_ctrl_credit",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
-        "//misc/rtl:br_misc_unused",
+        "//macros:br_unused",
     ],
 )
 

--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -24,7 +24,7 @@ verilog_library(
         "//counter/rtl:br_counter_incr",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
-        "//misc/rtl:br_misc_unused",
+        "//macros:br_unused",
     ],
 )
 
@@ -55,7 +55,7 @@ verilog_library(
         "//credit/rtl:br_credit_receiver",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
-        "//misc/rtl:br_misc_unused",
+        "//macros:br_unused",
     ],
 )
 
@@ -89,7 +89,7 @@ verilog_library(
         "//counter/rtl:br_counter_incr",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
-        "//misc/rtl:br_misc_unused",
+        "//macros:br_unused",
     ],
 )
 

--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -114,9 +114,10 @@ module br_fifo_pop_ctrl #(
     assign pop_valid = !empty;
     assign pop_data = ram_rd_data;
     assign ram_pop = pop;
-    `BR_UNUSED(bypass, {bypass_valid_unstable, bypass_data_unstable})
+    `BR_UNUSED(bypass_valid_unstable)
+    `BR_UNUSED(bypass_data_unstable)
   end
-  `BR_UNUSED(ram_rd_data_valid, ram_rd_data_valid)  // implied
+  `BR_UNUSED(ram_rd_data_valid)  // implied
 
   // Status flags
   assign items_next = ram_push && !ram_pop ? items + 1 : !ram_push && ram_pop ? items - 1 : items;

--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -16,6 +16,7 @@
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
+`include "br_unused.svh"
 
 module br_fifo_pop_ctrl #(
     parameter int Depth = 2,
@@ -113,14 +114,9 @@ module br_fifo_pop_ctrl #(
     assign pop_valid = !empty;
     assign pop_data = ram_rd_data;
     assign ram_pop = pop;
-    br_misc_unused br_misc_unused_bypass_valid_unstable (.in(bypass_valid_unstable));
-    br_misc_unused #(
-        .BitWidth(BitWidth)
-    ) br_misc_unused_bypass_data_unstable (
-        .in(bypass_data_unstable)
-    );
+    `BR_UNUSED(bypass, {bypass_valid_unstable, bypass_data_unstable})
   end
-  br_misc_unused br_misc_unused_ram_rd_data_valid (.in(ram_rd_data_valid));  // implied
+  `BR_UNUSED(ram_rd_data_valid, ram_rd_data_valid)  // implied
 
   // Status flags
   assign items_next = ram_push && !ram_pop ? items + 1 : !ram_push && ram_pop ? items - 1 : items;

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -16,6 +16,7 @@
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
+`include "br_unused.svh"
 
 module br_fifo_push_ctrl #(
     parameter int Depth = 2,
@@ -108,7 +109,7 @@ module br_fifo_push_ctrl #(
     assign ram_push = push && !bypass_ready;
     assign ram_wr_data = push_data;
   end else begin : gen_no_bypass
-    br_misc_unused br_misc_unused_bypass_ready (.in(bypass_ready));
+    `BR_UNUSED(bypass_ready, bypass_ready)
     assign bypass_valid_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
     assign bypass_data_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
 

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -109,7 +109,7 @@ module br_fifo_push_ctrl #(
     assign ram_push = push && !bypass_ready;
     assign ram_wr_data = push_data;
   end else begin : gen_no_bypass
-    `BR_UNUSED(bypass_ready, bypass_ready)
+    `BR_UNUSED(bypass_ready)
     assign bypass_valid_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
     assign bypass_data_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
 

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -16,6 +16,7 @@
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
+`include "br_unused.svh"
 
 module br_fifo_push_ctrl_credit #(
     parameter int Depth = 2,
@@ -136,7 +137,7 @@ module br_fifo_push_ctrl_credit #(
     assign ram_push = internal_valid && !bypass_ready;
     assign ram_wr_data = internal_data;
   end else begin : gen_no_bypass
-    br_misc_unused br_misc_unused_bypass_ready (.in(bypass_ready));
+    `BR_UNUSED(bypass_ready, bypass_ready)
     assign bypass_valid_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
     assign bypass_data_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
 

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -137,7 +137,7 @@ module br_fifo_push_ctrl_credit #(
     assign ram_push = internal_valid && !bypass_ready;
     assign ram_wr_data = internal_data;
   end else begin : gen_no_bypass
-    `BR_UNUSED(bypass_ready, bypass_ready)
+    `BR_UNUSED(bypass_ready)
     assign bypass_valid_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
     assign bypass_data_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
 

--- a/macros/br_unused.svh
+++ b/macros/br_unused.svh
@@ -15,7 +15,17 @@
 `ifndef BR_UNUSED_SVH
 `define BR_UNUSED_SVH
 
-`define BR_UNUSED(__name__, __x__) \
+// Use this macro when __x__ is just a plain signal name.
+`define BR_UNUSED(__x__) \
+br_misc_unused #( \
+    .BitWidth($bits(__x__))) \
+br_misc_unused_``__x__ ( \
+    .in(__x__) \
+);
+
+// Use this macro when a custom instance name suffix is required or desired.
+// For example, use when __x__ is a complex expression (e.g., concatenation like {foo, bar}).
+`define BR_UNUSED_NAMED(__name__, __x__) \
 br_misc_unused #( \
     .BitWidth($bits(__x__))) \
 br_misc_unused_``__name__ ( \

--- a/macros/br_unused.svh
+++ b/macros/br_unused.svh
@@ -15,19 +15,11 @@
 `ifndef BR_UNUSED_SVH
 `define BR_UNUSED_SVH
 
-// ri lint_check_off LINE_LENGTH
-// verilog_lint: waive-start line-length
-// verilog_format: off
-
 `define BR_UNUSED(__name__, __x__) \
 br_misc_unused #( \
     .BitWidth($bits(__x__))) \
 br_misc_unused_``__name__ ( \
     .in(__x__) \
 );
-
-// ri lint_check_on LINE_LENGTH
-// verilog_lint: waive-stop line-length
-// verilog_format: on
 
 `endif  // BR_UNUSED_SVH

--- a/macros/br_unused.svh
+++ b/macros/br_unused.svh
@@ -19,7 +19,7 @@
 // verilog_lint: waive-start line-length
 // verilog_format: off
 
-`define BR_UNUSED(__x__) br_misc_unused #(.BitWidth($bits(__x__))) br_misc_unused__``__x__(.in(__x__));
+`define BR_UNUSED(__name__, __x__) br_misc_unused #(.BitWidth($bits(__x__))) br_misc_unused_``__name__(.in(__x__));
 
 // ri lint_check_on LINE_LENGTH
 // verilog_lint: waive-stop line-length

--- a/macros/br_unused.svh
+++ b/macros/br_unused.svh
@@ -15,14 +15,6 @@
 `ifndef BR_UNUSED_SVH
 `define BR_UNUSED_SVH
 
-// Use this macro when __x__ is just a plain signal name.
-`define BR_UNUSED(__x__) \
-br_misc_unused #( \
-    .BitWidth($bits(__x__))) \
-br_misc_unused_``__x__ ( \
-    .in(__x__) \
-);
-
 // Use this macro when a custom instance name suffix is required or desired.
 // For example, use when __x__ is a complex expression (e.g., concatenation like {foo, bar}).
 `define BR_UNUSED_NAMED(__name__, __x__) \
@@ -31,5 +23,8 @@ br_misc_unused #( \
 br_misc_unused_``__name__ ( \
     .in(__x__) \
 );
+
+// Use this macro when __x__ is just a plain signal name.
+`define BR_UNUSED(__x__) `BR_UNUSED_NAMED(__x__, __x__)
 
 `endif  // BR_UNUSED_SVH

--- a/macros/br_unused.svh
+++ b/macros/br_unused.svh
@@ -15,7 +15,14 @@
 `ifndef BR_UNUSED_SVH
 `define BR_UNUSED_SVH
 
-`define BR_UNUSED(
-    __x__) br_misc_unused #(.BitWidth($bits(__x__))) br_misc_unused__``__x__(.in(__x__));
+// ri lint_check_off LINE_LENGTH
+// verilog_lint: waive-start line-length
+// verilog_format: off
+
+`define BR_UNUSED(__x__) br_misc_unused #(.BitWidth($bits(__x__))) br_misc_unused__``__x__(.in(__x__));
+
+// ri lint_check_on LINE_LENGTH
+// verilog_lint: waive-stop line-length
+// verilog_format: on
 
 `endif  // BR_UNUSED_SVH

--- a/macros/br_unused.svh
+++ b/macros/br_unused.svh
@@ -19,7 +19,12 @@
 // verilog_lint: waive-start line-length
 // verilog_format: off
 
-`define BR_UNUSED(__name__, __x__) br_misc_unused #(.BitWidth($bits(__x__))) br_misc_unused_``__name__(.in(__x__));
+`define BR_UNUSED(__name__, __x__) \
+br_misc_unused #( \
+    .BitWidth($bits(__x__))) \
+br_misc_unused_``__name__ ( \
+    .in(__x__) \
+);
 
 // ri lint_check_on LINE_LENGTH
 // verilog_lint: waive-stop line-length

--- a/macros/br_unused_tb.sv
+++ b/macros/br_unused_tb.sv
@@ -18,8 +18,10 @@
 
 module br_unused_tb ();  // ri lint_check_waive NO_OUTPUT
 
-  wire foo = 1'b0;  // ri lint_check_waive CONST_ASSIGN
+  wire [1:0] foo = 2'b01;  // ri lint_check_waive CONST_ASSIGN
+  wire bar = foo[0];  // ri lint_check_waive CONST_ASSIGN
 
-  `BR_UNUSED(foo)
+  `BR_UNUSED(bar)
+  `BR_UNUSED_NAMED(foo1, foo[1])
 
 endmodule : br_unused_tb

--- a/misc/rtl/br_misc_unused.sv
+++ b/misc/rtl/br_misc_unused.sv
@@ -18,9 +18,9 @@
 // It is expected that this logic will be automatically removed by the
 // synthesis tool.
 //
-// To automatically instantiate this at the bitwidth of local logic, by name,
-// users can opt to use the `BR_UNUSED(my_name) convenience macro defined in
-// macros/br_unused.svh.
+// To automatically instantiate this at the bitwidth of local logic,
+// users can opt to use the `BR_UNUSED(signal) or `BR_UNUSED_NAMED(name, expression)
+// convenience macros defined in macros/br_unused.svh.
 
 // ri lint_check_waive EMPTY_MOD NO_OUTPUT
 module br_misc_unused #(


### PR DESCRIPTION
Fixes #108 