### PR TITLE
Encapsulate available credits in credit counter with decr_ready signal

### DIFF
--- a/credit/rtl/BUILD.bazel
+++ b/credit/rtl/BUILD.bazel
@@ -93,6 +93,10 @@ br_verilog_elab_and_lint_test_suite(
             "1",
             "16",
         ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
     },
     deps = [":br_credit_sender"],
 )
@@ -117,6 +121,10 @@ br_verilog_elab_and_lint_test_suite(
         "BitWidth": [
             "1",
             "16",
+        ],
+        "RegisterPushCredit": [
+            "0",
+            "1",
         ],
     },
     deps = [":br_credit_receiver"],

--- a/credit/rtl/br_credit_receiver.sv
+++ b/credit/rtl/br_credit_receiver.sv
@@ -70,9 +70,7 @@ module br_credit_receiver #(
     // Dynamically withhold credits from circulation
     input  logic [CounterWidth-1:0] credit_withhold,
     // Credit counter state before increment/decrement/withhold.
-    output logic [CounterWidth-1:0] credit_count,
-    // Dynamic amount of available credit.
-    output logic [CounterWidth-1:0] credit_available
+    output logic [CounterWidth-1:0] credit_count
 );
 
   //------------------------------------------
@@ -88,6 +86,9 @@ module br_credit_receiver #(
   //------------------------------------------
   // Implementation
   //------------------------------------------
+  logic credit_decr_valid;
+  logic credit_decr_ready;
+
   br_credit_counter #(
       .MaxValue (MaxCredit),
       .MaxChange(1)
@@ -96,15 +97,16 @@ module br_credit_receiver #(
       .rst,
       .incr_valid(pop_credit),
       .incr(1'b1),
-      .decr_valid(push_credit),
+      .decr_ready(credit_decr_ready),
+      .decr_valid(credit_decr_valid),
       .decr(1'b1),
       .initial_value(credit_initial),
       .withhold(credit_withhold),
-      .value(credit_count),
-      .available(credit_available)
+      .value(credit_count)
   );
 
-  assign push_credit = !push_credit_stall && (credit_available > 0);
+  assign credit_decr_valid = !push_credit_stall;
+  assign push_credit = credit_decr_valid && credit_decr_ready;
   assign pop_valid = push_valid;
   assign pop_data = push_data;
 

--- a/credit/rtl/br_credit_sender.sv
+++ b/credit/rtl/br_credit_sender.sv
@@ -78,9 +78,7 @@ module br_credit_sender #(
     // Dynamically withhold credits from circulation
     input  logic [CounterWidth-1:0] credit_withhold,
     // Credit counter state before increment/decrement/withhold.
-    output logic [CounterWidth-1:0] credit_count,
-    // Dynamic amount of available credit.
-    output logic [CounterWidth-1:0] credit_available
+    output logic [CounterWidth-1:0] credit_count
 );
 
   //------------------------------------------
@@ -104,18 +102,17 @@ module br_credit_sender #(
       .rst,
       .incr_valid(pop_credit),
       .incr(1'b1),
-      .decr_valid(pop_valid),
+      .decr_ready(push_ready),
+      .decr_valid(push_valid),
       .decr(1'b1),
       .initial_value(credit_initial),
       .withhold(credit_withhold),
-      .value(credit_count),
-      .available(credit_available)
+      .value(credit_count)
   );
 
   `BR_REGI(pop_credit_stall, 1'b0, 1'b1)
-  assign push_ready = credit_available > 0;
-  assign pop_valid  = push_ready && push_valid;
-  assign pop_data   = push_data;
+  assign pop_valid = push_ready && push_valid;
+  assign pop_data  = push_data;
 
   //------------------------------------------
   // Implementation checks

--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -97,6 +97,10 @@ br_verilog_elab_and_lint_test_suite(
             "4",
             "16",
         ],
+        "RegisterPushCredit": [
+            "0",
+            "1",
+        ],
     },
     deps = [":br_fifo_ctrl_1r1w_push_credit"],
 )
@@ -138,6 +142,10 @@ br_verilog_elab_and_lint_test_suite(
         "MaxCredit": [
             "4",
             "16",
+        ],
+        "RegisterPushCredit": [
+            "0",
+            "1",
         ],
     },
     deps = [":br_fifo_flops_push_credit"],

--- a/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
+++ b/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
@@ -55,6 +55,10 @@ module br_fifo_ctrl_1r1w_push_credit #(
     // Overriding may be convenient if having a consistent credit counter register width
     // (say, 16-bit) throughout a design is deemed useful.
     parameter int MaxCredit = Depth,
+    // If 1, add a retiming stage to the push_credit signal so that it is
+    // driven directly from a flop. This comes at the expense of one additional
+    // cycle of credit loop latency.
+    parameter bit RegisterPushCredit = 0,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int CreditWidth = $clog2(MaxCredit + 1)
@@ -121,7 +125,8 @@ module br_fifo_ctrl_1r1w_push_credit #(
       .Depth(Depth),
       .BitWidth(BitWidth),
       .EnableBypass(EnableBypass),
-      .MaxCredit(MaxCredit)
+      .MaxCredit(MaxCredit),
+      .RegisterPushCredit(RegisterPushCredit)
   ) br_fifo_push_ctrl_credit (
       .clk,
       .rst,

--- a/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
+++ b/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
@@ -91,7 +91,6 @@ module br_fifo_ctrl_1r1w_push_credit #(
     input  logic [CreditWidth-1:0] credit_initial_push,
     input  logic [CreditWidth-1:0] credit_withhold_push,
     output logic [CreditWidth-1:0] credit_count_push,
-    output logic [CreditWidth-1:0] credit_available_push,
 
     // 1R1W RAM interface
     output logic                 ram_wr_valid,
@@ -141,7 +140,6 @@ module br_fifo_ctrl_1r1w_push_credit #(
       .credit_initial_push,
       .credit_withhold_push,
       .credit_count_push,
-      .credit_available_push,
       .ram_wr_valid,
       .ram_wr_addr,
       .ram_wr_data,

--- a/fifo/rtl/br_fifo_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_flops_push_credit.sv
@@ -48,6 +48,10 @@ module br_fifo_flops_push_credit #(
     // Overriding may be convenient if having a consistent credit counter register width
     // (say, 16-bit) throughout a design is deemed useful.
     parameter int MaxCredit = Depth,
+    // If 1, add a retiming stage to the push_credit signal so that it is
+    // driven directly from a flop. This comes at the expense of one additional
+    // cycle of credit loop latency.
+    parameter bit RegisterPushCredit = 0,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int CreditWidth = $clog2(MaxCredit + 1)
@@ -106,7 +110,8 @@ module br_fifo_flops_push_credit #(
       .Depth(Depth),
       .BitWidth(BitWidth),
       .EnableBypass(EnableBypass),
-      .MaxCredit(MaxCredit)
+      .MaxCredit(MaxCredit),
+      .RegisterPushCredit(RegisterPushCredit)
   ) br_fifo_ctrl_1r1w_push_credit (
       .clk,
       .rst,

--- a/fifo/rtl/br_fifo_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_flops_push_credit.sv
@@ -78,7 +78,6 @@ module br_fifo_flops_push_credit #(
     input  logic [CreditWidth-1:0] credit_initial_push,
     input  logic [CreditWidth-1:0] credit_withhold_push,
     output logic [CreditWidth-1:0] credit_count_push,
-    output logic [CreditWidth-1:0] credit_available_push,
 
     // Pop-side status flags
     output logic empty,
@@ -129,7 +128,6 @@ module br_fifo_flops_push_credit #(
       .credit_initial_push,
       .credit_withhold_push,
       .credit_count_push,
-      .credit_available_push,
       .ram_wr_valid,
       .ram_wr_addr,
       .ram_wr_data,

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -48,7 +48,6 @@ module br_fifo_push_ctrl_credit #(
     input  logic [CreditWidth-1:0] credit_initial_push,
     input  logic [CreditWidth-1:0] credit_withhold_push,
     output logic [CreditWidth-1:0] credit_count_push,
-    output logic [CreditWidth-1:0] credit_available_push,
 
     // Bypass interface
     // Bypass is only used when EnableBypass is 1, hence lint waiver.
@@ -109,8 +108,7 @@ module br_fifo_push_ctrl_credit #(
       .pop_data(internal_data),
       .credit_initial(credit_initial_push),
       .credit_withhold(credit_withhold_push),
-      .credit_count(credit_count_push),
-      .credit_available(credit_available_push)
+      .credit_count(credit_count_push)
   );
 
   // RAM path

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -23,6 +23,7 @@ module br_fifo_push_ctrl_credit #(
     parameter int BitWidth = 1,
     parameter bit EnableBypass = 0,
     parameter int MaxCredit = Depth,
+    parameter bit RegisterPushCredit = 0,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int CreditWidth = $clog2(MaxCredit + 1)
@@ -94,8 +95,9 @@ module br_fifo_push_ctrl_credit #(
   logic [BitWidth-1:0] internal_data;
 
   br_credit_receiver #(
-      .BitWidth (BitWidth),
-      .MaxCredit(MaxCredit)
+      .BitWidth          (BitWidth),
+      .MaxCredit         (MaxCredit),
+      .RegisterPushCredit(RegisterPushCredit)
   ) br_credit_receiver (
       .clk,
       .rst,


### PR DESCRIPTION
Fixes #123 

Additionally add parameters to control retiming of outputs of credit_receiver and credit_sender.