### PR TITLE
Rename `br_ram_flops_1r1w` to `br_ram_flops_1r1w_tile`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1120,7 +1120,7 @@ a| FIFO with internal flop RAM
 
 | `br_ram_flops_1r1w_tile`
 | One-tile flop-RAM with one read port and one write port
-| WIP
+| Yes
 |
 
 | `br_ram_flops_1r1w`

--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -46,7 +46,7 @@ verilog_library(
     srcs = ["br_fifo_flops.sv"],
     deps = [
         ":br_fifo_ctrl_1r1w",
-        "//ram/rtl:br_ram_flops_1r1w",
+        "//ram/rtl:br_ram_flops_1r1w_tile",
     ],
 )
 
@@ -55,7 +55,7 @@ verilog_library(
     srcs = ["br_fifo_flops_push_credit.sv"],
     deps = [
         ":br_fifo_ctrl_1r1w_push_credit",
-        "//ram/rtl:br_ram_flops_1r1w",
+        "//ram/rtl:br_ram_flops_1r1w_tile",
     ],
 )
 

--- a/fifo/rtl/br_fifo_flops.sv
+++ b/fifo/rtl/br_fifo_flops.sv
@@ -128,12 +128,13 @@ module br_fifo_flops #(
       .ram_rd_data
   );
 
-  br_ram_flops_1r1w #(
+  // TODO(https://github.com/xlsynth/bedrock-rtl/issues/136): switch to br_ram_flops_1r1w when ready
+  br_ram_flops_1r1w_tile #(
       .Depth(Depth),
       .BitWidth(BitWidth),
       .EnableBypass(EnableBypass),
       .EnableReset(0)
-  ) br_ram_flops_1r1w (
+  ) br_ram_flops_1r1w_tile (
       .clk,
       .rst,
       .wr_valid(ram_wr_valid),

--- a/fifo/rtl/br_fifo_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_flops_push_credit.sv
@@ -144,12 +144,13 @@ module br_fifo_flops_push_credit #(
       .ram_rd_data
   );
 
-  br_ram_flops_1r1w #(
+  // TODO(https://github.com/xlsynth/bedrock-rtl/issues/136): switch to br_ram_flops_1r1w when ready
+  br_ram_flops_1r1w_tile #(
       .Depth(Depth),
       .BitWidth(BitWidth),
       .EnableBypass(EnableBypass),
       .EnableReset(0)
-  ) br_ram_flops_1r1w (
+  ) br_ram_flops_1r1w_tile (
       .clk,
       .rst,
       .wr_valid(ram_wr_valid),

--- a/ram/rtl/BUILD.bazel
+++ b/ram/rtl/BUILD.bazel
@@ -18,8 +18,8 @@ load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
 package(default_visibility = ["//visibility:public"])
 
 verilog_library(
-    name = "br_ram_flops_1r1w",
-    srcs = ["br_ram_flops_1r1w.sv"],
+    name = "br_ram_flops_1r1w_tile",
+    srcs = ["br_ram_flops_1r1w_tile.sv"],
     deps = [
         "//macros:br_asserts_internal",
         "//macros:br_registers",
@@ -38,7 +38,7 @@ verilog_library(
 )
 
 br_verilog_elab_and_lint_test_suite(
-    name = "br_ram_flops_1r1w_test_suite",
+    name = "br_ram_flops_1r1w_tile_test_suite",
     params = {
         "Depth": [
             "2",
@@ -57,7 +57,7 @@ br_verilog_elab_and_lint_test_suite(
             "1",
         ],
     },
-    deps = [":br_ram_flops_1r1w"],
+    deps = [":br_ram_flops_1r1w_tile"],
 )
 
 br_verilog_elab_and_lint_test_suite(

--- a/ram/rtl/br_ram_flops_1r1w_tile.sv
+++ b/ram/rtl/br_ram_flops_1r1w_tile.sv
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Bedrock-RTL Flop-RAM (1R1W)
+// Bedrock-RTL Flop-RAM (1R1W) Tile
 //
-// A one-read/one-write (1R1W, also known as pseudo-dual-port) flop-based RAM.
+// A one-read/one-write (1R1W, also known as pseudo-dual-port) flop-based RAM tile.
 // Read latency is zero cycles. Write latency is one cycle.
 // By default, write-to-read latency is therefore one cycle.
 // If the bypass is enabled, then the write-to-read latency is zero cycles, but
@@ -24,7 +24,7 @@
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
 
-module br_ram_flops_1r1w #(
+module br_ram_flops_1r1w_tile #(
     parameter int Depth = 2,  // Must be at least 2
     parameter int BitWidth = 1,  // Must be at least 1
     // If 1, then if the read and write ports access the same address on the same cycle,
@@ -102,4 +102,4 @@ module br_ram_flops_1r1w #(
                     ))
   end
 
-endmodule : br_ram_flops_1r1w
+endmodule : br_ram_flops_1r1w_tile


### PR DESCRIPTION
Prep work for `br_ram_flops_1r1w` being the tiled version.