### PR TITLE
Improve `BR_ASSERT_STATIC` for better logging

### DIFF
--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -35,7 +35,7 @@
 `ifdef SV_ASSERT_ON
 `define BR_ASSERT_STATIC(__name__, __expr__) \
 if (!(__expr__)) begin : gen__``__name__ \
-__STATIC_ASSERT_FAILED__ __STATIC_ASSERT_FAILED__``__name__ (); \
+__STATIC_ASSERT_FAILED__``__name__ __STATIC_ASSERT_FAILED__``__name__ (); \
 end
 `else  // SV_ASSERT_ON
 `define BR_ASSERT_STATIC(__name__, __expr__) \


### PR DESCRIPTION
Before:

```
instantiating unknown module '__STATIC_ASSERT_FAILED__'
```

After:

```
instantiating unknown module '__STATIC_ASSERT_FAILED__some_assert_a'
```