### PR TITLE
New guard: `BR_ENABLE_ASSERT_COMB`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -372,6 +372,7 @@ These assertion macros are intended for use by the user in their own designs.
 They are guarded (enabled) by the following defines:
 
 * `ifdef BR_ASSERT_ON`
+* `ifdef BR_ENABLE_ASSERT_COMB` - only for guarding `BR_ASSERT_COMB` (off by default).
 
 IMPORTANT: Clocks are always positive-edge triggered.
 Resets are always active-high.

--- a/bazel/br_verilog.bzl
+++ b/bazel/br_verilog.bzl
@@ -38,14 +38,14 @@ def br_verilog_elab_and_lint_test_suite(name, **kwargs):
 
     verilog_elab_and_lint_test_suite(
         name = name,
-        defines = ["BR_ASSERT_ON"],
+        defines = ["BR_ASSERT_ON", "BR_ENABLE_ASSERT_COMB"],
         tags = ["assert"],
         **kwargs
     )
 
     verilog_elab_and_lint_test_suite(
         name = name + "_allassert",
-        defines = ["BR_ASSERT_ON", "BR_ENABLE_IMPL_CHECKS"],
+        defines = ["BR_ASSERT_ON", "BR_ENABLE_ASSERT_COMB", "BR_ENABLE_IMPL_CHECKS"],
         tags = ["allassert"],
         **kwargs
     )
@@ -80,7 +80,7 @@ def br_verilog_sim_test_suite(name, tool, opts = [], **kwargs):
         name = name,
         tool = tool,
         opts = opts,
-        defines = ["BR_ASSERT_ON", "BR_ENABLE_IMPL_CHECKS"],
+        defines = ["BR_ASSERT_ON", "BR_ENABLE_ASSERT_COMB", "BR_ENABLE_IMPL_CHECKS"],
         **kwargs
     )
 
@@ -99,6 +99,7 @@ def br_verilog_fpv_test_suite(name, **kwargs):
 
     verilog_fpv_test_suite(
         name = name,
+        # No BR_ENABLE_ASSERT_COMB for fpv tools, they may not support it.
         defines = ["BR_ASSERT_ON", "BR_ENABLE_IMPL_CHECKS"],
         **kwargs
     )

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -77,11 +77,19 @@ __name__ : assert property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || 
 // Combinational assertion macros (evaluated continuously based on the expression sensitivity).
 // Also pass if the expression is unknown.
 ////////////////////////////////////////////////////////////////////////////////
+
+// BR_ASSERT_COMB is guarded with BR_ENABLE_ASSERT_COMB because some tools don't like immediate assertions,
+// and/or $isunknown in combinational blocks, even when it's used inside of an assert statement.
 `ifdef BR_ASSERT_ON
+`ifdef BR_ENABLE_ASSERT_COMB
 `define BR_ASSERT_COMB(__name__, __expr__) \
 always_comb begin  : gen_``__name__ \
 assert ($isunknown(__expr__) || (__expr__)); \
 end
+`else  // BR_ENABLE_COMB_CHECKS
+`define BR_ASSERT_COMB(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ENABLE_COMB_CHECKS
 `else  // BR_ASSERT_ON
 `define BR_ASSERT_COMB(__name__, __expr__) \
 `BR_NOOP


### PR DESCRIPTION
New guard needed because some tools really don't like seeing immediate assertions in `always_comb` blocks or they might not like seeing `$isunknown` there specifically.