### PR TITLE
FPV: Add FPV enrivornment for arbiters

### DIFF
--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -1,0 +1,97 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_fpv_test_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# Fixed priority arbiter
+
+verilog_library(
+    name = "br_arb_fixed_fpv_monitor",
+    srcs = ["br_arb_fixed_fpv_monitor.sv"],
+    deps = ["//arb/rtl:br_arb_fixed"],
+)
+
+verilog_elab_test(
+    name = "br_arb_fixed_fpv_monitor_elab_test",
+    deps = [":br_arb_fixed_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_arb_fixed_jg_test_suite",
+    params = {
+        "NumRequesters": [
+            "2",
+            "3",
+        ],
+    },
+    tool = "jg",
+    top = "br_arb_fixed",
+    deps = [":br_arb_fixed_fpv_monitor"],
+)
+
+# Round robin arbiter
+
+verilog_library(
+    name = "br_arb_rr_fpv_monitor",
+    srcs = ["br_arb_rr_fpv_monitor.sv"],
+    deps = ["//arb/rtl:br_arb_rr"],
+)
+
+verilog_elab_test(
+    name = "br_arb_rr_fpv_monitor_elab_test",
+    deps = [":br_arb_rr_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_arb_rr_jg_test_suite",
+    params = {
+        "NumRequesters": [
+            "2",
+            "3",
+        ],
+    },
+    tool = "jg",
+    top = "br_arb_rr",
+    deps = [":br_arb_rr_fpv_monitor"],
+)
+
+# LRU arbiter
+
+verilog_library(
+    name = "br_arb_lru_fpv_monitor",
+    srcs = ["br_arb_lru_fpv_monitor.sv"],
+    deps = ["//arb/rtl:br_arb_lru"],
+)
+
+verilog_elab_test(
+    name = "br_arb_lru_fpv_monitor_elab_test",
+    deps = [":br_arb_lru_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_arb_lru_jg_test_suite",
+    params = {
+        "NumRequesters": [
+            "2",
+            "3",
+        ],
+    },
+    tool = "jg",
+    top = "br_arb_lru",
+    deps = [":br_arb_lru_fpv_monitor"],
+)

--- a/arb/fpv/br_arb_fixed_fpv_monitor.sv
+++ b/arb/fpv/br_arb_fixed_fpv_monitor.sv
@@ -14,19 +14,17 @@
 
 // Bedrock-RTL Fixed-Priority Arbiter FPV monitor
 
+`include "br_asserts.svh"
+
 module br_arb_fixed_fpv_monitor #(
     // Must be at least 2
     parameter int NumRequesters = 2
 ) (
-    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input logic clk,  // Only used for assertions
-    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input logic rst,  // Only used for assertions
+    input logic clk,
+    input logic rst,
     input logic [NumRequesters-1:0] request,
     input logic [NumRequesters-1:0] grant
 );
-
-  `include "br_asserts.svh"
 
    `BR_ASSERT(must_grant_a, request != 0 |-> grant != 0)
    `BR_ASSERT(onehot_grant_a, $countones(grant) <= 1)

--- a/arb/fpv/br_arb_fixed_fpv_monitor.sv
+++ b/arb/fpv/br_arb_fixed_fpv_monitor.sv
@@ -1,0 +1,44 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Fixed-Priority Arbiter FPV monitor
+
+module br_arb_fixed_fpv_monitor #(
+    // Must be at least 2
+    parameter int NumRequesters = 2
+) (
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic clk,  // Only used for assertions
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic rst,  // Only used for assertions
+    input logic [NumRequesters-1:0] request,
+    input logic [NumRequesters-1:0] grant
+);
+
+  `include "br_asserts.svh"
+
+   `BR_ASSERT(must_grant_a, request != 0 |-> grant != 0)
+   `BR_ASSERT(onehot_grant_a, $countones(grant) <= 1)
+   `BR_COVER(all_request_c, request == '1)
+
+   for (genvar i = 0; i < NumRequesters - 1; i++) begin : gen_high
+     `BR_ASSERT(grant_active_req_a, grant[i] |-> request[i])
+     for (genvar j = i + 1; j < NumRequesters; j++) begin : gen_low
+       `BR_ASSERT(arb_priority_a, grant[j] |-> !request[i])
+     end
+   end
+
+endmodule : br_arb_fixed_fpv_monitor
+
+bind br_arb_fixed br_arb_fixed_fpv_monitor#(.NumRequesters(NumRequesters)) monitor (.*);

--- a/arb/fpv/br_arb_lru_fpv_monitor.sv
+++ b/arb/fpv/br_arb_lru_fpv_monitor.sv
@@ -41,6 +41,7 @@ module br_arb_lru_fpv_monitor #(
 
   for (genvar i = 0; i < NumRequesters; i++) begin : gen_req_0
     // Request must be hold until granted
+    // TODO: Remove below assumption and fix other liveness assrtion
     `BR_ASSUME(hold_request_until_grant_m, request[i] && !grant[i] |=> request[i])
     // Grant must be given to an active requester
     `BR_ASSERT(grant_active_req_a, grant[i] |-> request[i])

--- a/arb/fpv/br_arb_lru_fpv_monitor.sv
+++ b/arb/fpv/br_arb_lru_fpv_monitor.sv
@@ -36,7 +36,7 @@ module br_arb_lru_fpv_monitor #(
   end
 
   `BR_ASSERT(must_grant_a, request != 0 |-> grant != 0)
-  `BR_ASSERT(onehot_grant_a, $countones(grant) <= 1)
+  `BR_ASSERT(onehot_grant_a, $onehot0(grant))
   `BR_COVER(all_request_c, request == '1)
 
   for (genvar i = 0; i < NumRequesters; i++) begin : gen_req_0

--- a/arb/fpv/br_arb_lru_fpv_monitor.sv
+++ b/arb/fpv/br_arb_lru_fpv_monitor.sv
@@ -31,7 +31,7 @@ module br_arb_lru_fpv_monitor #(
   for (genvar i = 0; i < NumRequesters; i++) begin : gen_priority
      // The granted request will have priority reset to the lowest
      // All other requesters bump up their priority
-    `BR_REGL(arb_priority[i], grant[i] ? 0 : arb_priority[i] + 1'b1, grant != 0)
+    `BR_REGL(arb_priority[i], grant[i] ? 0 : arb_priority[i] + request[i], grant != 0)
   end
 
   `BR_ASSERT(must_grant_a, request != 0 |-> grant != 0)

--- a/arb/fpv/br_arb_lru_fpv_monitor.sv
+++ b/arb/fpv/br_arb_lru_fpv_monitor.sv
@@ -32,7 +32,6 @@ module br_arb_lru_fpv_monitor #(
      // The granted request will have priority reset to the lowest
      // All other requesters bump up their priority
     `BR_REGL(arb_priority[i], grant[i] ? 0 : arb_priority[i] + 1'b1, grant != 0)
-    end
   end
 
   `BR_ASSERT(must_grant_a, request != 0 |-> grant != 0)
@@ -53,8 +52,8 @@ module br_arb_lru_fpv_monitor #(
       if (i != j) begin
         `BR_ASSERT(arb_priority_a, grant[j] |->
           !request[i] || (arb_priority[i] < arb_priority[j]) ||
-          // TODO: when two requests have the same priority, the
-          // lower index request should be granted first?
+          // When two requests have the same priority, the
+          // lower index request should be granted
           (arb_priority[i] == arb_priority[j] && (i < j))
          )
        end

--- a/arb/fpv/br_arb_lru_fpv_monitor.sv
+++ b/arb/fpv/br_arb_lru_fpv_monitor.sv
@@ -15,6 +15,7 @@
 // Bedrock-RTL LRU Arbiter FPV monitor
 
 `include "br_asserts.svh"
+`include "br_registers.svh"
 
 module br_arb_lru_fpv_monitor #(
     // Must be at least 2

--- a/arb/fpv/br_arb_lru_fpv_monitor.sv
+++ b/arb/fpv/br_arb_lru_fpv_monitor.sv
@@ -1,0 +1,72 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL LRU Arbiter FPV monitor
+
+module br_arb_lru_fpv_monitor #(
+    // Must be at least 2
+    parameter int NumRequesters = 2
+) (
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic clk,  // Only used for assertions
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic rst,  // Only used for assertions
+    input logic [NumRequesters-1:0] request,
+    input logic [NumRequesters-1:0] grant
+);
+
+  `include "br_asserts.svh"
+
+  logic [NumRequesters-1:0][$clog2(NumRequesters)-1:0] arb_priority;
+
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_priority
+    always_ff @(posedge clk) begin
+      if (rst) begin
+        arb_priority[i] <= 0;
+      end if (grant != 0) begin
+        // The granted request will have priority reset to the lowest
+        // All other requesters bump up their priority
+        arb_priority[i] <= grant[i] ? 0 : arb_priority[i] + 1'b1;
+      end
+    end
+  end
+
+  `BR_ASSERT(must_grant_a, request != 0 |-> grant != 0)
+  `BR_ASSERT(onehot_grant_a, $countones(grant) <= 1)
+  `BR_COVER(all_request_c, request == '1)
+
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_req_0
+    // Request must be hold until granted
+    `BR_ASSUME(hold_request_until_grant_m, request[i] && !grant[i] |=> request[i])
+    // Grant must be given to an active requester
+    `BR_ASSERT(grant_active_req_a, grant[i] |-> request[i])
+    // Grant must be returned to the requester after all other requesters are granted once
+    `BR_ASSERT(grant_latency_a, request[i] && !grant[i] |-> ##[1:NumRequesters] grant[i])
+    // High priority request must be grant the same cycle
+    `BR_ASSERT(high_priority_grant_a, request[i] && (arb_priority[i] == NumRequesters - 1) |-> grant[i])
+    for (genvar j = 0; j < NumRequesters; j++) begin : gen_req_1
+      if (i != j) begin
+        `BR_ASSERT(arb_priority_a, grant[j] |->
+          !request[i] || (arb_priority[i] < arb_priority[j]) ||
+          // TODO: when two requests have the same priority, the
+          // lower index request should be granted first?
+          (arb_priority[i] == arb_priority[j] && (i < j))
+         )
+       end
+     end
+   end
+
+endmodule : br_arb_lru_fpv_monitor
+
+bind br_arb_lru br_arb_lru_fpv_monitor#(.NumRequesters(NumRequesters)) monitor (.*);

--- a/arb/fpv/br_arb_lru_fpv_monitor.sv
+++ b/arb/fpv/br_arb_lru_fpv_monitor.sv
@@ -29,14 +29,9 @@ module br_arb_lru_fpv_monitor #(
   logic [NumRequesters-1:0][$clog2(NumRequesters)-1:0] arb_priority;
 
   for (genvar i = 0; i < NumRequesters; i++) begin : gen_priority
-    always_ff @(posedge clk) begin
-      if (rst) begin
-        arb_priority[i] <= 0;
-      end if (grant != 0) begin
-        // The granted request will have priority reset to the lowest
-        // All other requesters bump up their priority
-        arb_priority[i] <= grant[i] ? 0 : arb_priority[i] + 1'b1;
-      end
+     // The granted request will have priority reset to the lowest
+     // All other requesters bump up their priority
+    `BR_REGL(arb_priority[i], grant[i] ? 0 : arb_priority[i] + 1'b1, grant != 0)
     end
   end
 

--- a/arb/fpv/br_arb_lru_fpv_monitor.sv
+++ b/arb/fpv/br_arb_lru_fpv_monitor.sv
@@ -14,19 +14,17 @@
 
 // Bedrock-RTL LRU Arbiter FPV monitor
 
+`include "br_asserts.svh"
+
 module br_arb_lru_fpv_monitor #(
     // Must be at least 2
     parameter int NumRequesters = 2
 ) (
-    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input logic clk,  // Only used for assertions
-    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input logic rst,  // Only used for assertions
+    input logic clk,
+    input logic rst,
     input logic [NumRequesters-1:0] request,
     input logic [NumRequesters-1:0] grant
 );
-
-  `include "br_asserts.svh"
 
   logic [NumRequesters-1:0][$clog2(NumRequesters)-1:0] arb_priority;
 

--- a/arb/fpv/br_arb_rr_fpv_monitor.sv
+++ b/arb/fpv/br_arb_rr_fpv_monitor.sv
@@ -15,6 +15,7 @@
 // Bedrock-RTL Round Robin Priority Arbiter FPV monitor
 
 `include "br_asserts.svh"
+`include "br_registers.svh"
 
 module br_arb_rr_fpv_monitor #(
     // Must be at least 2

--- a/arb/fpv/br_arb_rr_fpv_monitor.sv
+++ b/arb/fpv/br_arb_rr_fpv_monitor.sv
@@ -14,19 +14,17 @@
 
 // Bedrock-RTL Round Robin Priority Arbiter FPV monitor
 
+`include "br_asserts.svh"
+
 module br_arb_rr_fpv_monitor #(
     // Must be at least 2
     parameter int NumRequesters = 2
 ) (
-    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input logic clk,  // Only used for assertions
-    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
-    input logic rst,  // Only used for assertions
+    input logic clk,
+    input logic rst,
     input logic [NumRequesters-1:0] request,
     input logic [NumRequesters-1:0] grant
 );
-
-  `include "br_asserts.svh"
 
   `BR_ASSERT(must_grant_a, request != 0 |-> grant != 0)
   `BR_ASSERT(onehot_grant_a, $countones(grant) <= 1)

--- a/arb/fpv/br_arb_rr_fpv_monitor.sv
+++ b/arb/fpv/br_arb_rr_fpv_monitor.sv
@@ -42,6 +42,7 @@ module br_arb_rr_fpv_monitor #(
 
   for (genvar i = 0; i < NumRequesters; i++) begin : gen_req_0
     // Request must be hold until granted
+    // TODO: Remove below assumption and fix other liveness assrtion
     `BR_ASSUME(hold_request_until_grant_m, request[i] && !grant[i] |=> request[i])
     // Grant must be given to an active requester
     `BR_ASSERT(grant_active_req_a, grant[i] |-> request[i])

--- a/arb/fpv/br_arb_rr_fpv_monitor.sv
+++ b/arb/fpv/br_arb_rr_fpv_monitor.sv
@@ -1,0 +1,71 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Round Robin Priority Arbiter FPV monitor
+
+module br_arb_rr_fpv_monitor #(
+    // Must be at least 2
+    parameter int NumRequesters = 2
+) (
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic clk,  // Only used for assertions
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic rst,  // Only used for assertions
+    input logic [NumRequesters-1:0] request,
+    input logic [NumRequesters-1:0] grant
+);
+
+  `include "br_asserts.svh"
+
+  `BR_ASSERT(must_grant_a, request != 0 |-> grant != 0)
+  `BR_ASSERT(onehot_grant_a, $countones(grant) <= 1)
+  `BR_COVER(all_request_c, request == '1)
+
+   logic [NumRequesters-1:0] high_priority_request;
+
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      high_priority_request <= 1;
+    end if (grant != 0) begin
+      high_priority_request <= (grant == 1 << NumRequesters) ? 1 : grant << 1;
+    end
+  end
+
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_req_0
+    // Request must be hold until granted
+    `BR_ASSUME(hold_request_until_grant_m, request[i] && !grant[i] |=> request[i])
+    // Grant must be given to an active requester
+    `BR_ASSERT(grant_active_req_a, grant[i] |-> request[i])
+    // Grant must be returned to the requester after all other requesters are granted once
+    `BR_ASSERT(grant_latency_a, request[i] && !grant[i] |-> ##[1:NumRequesters] grant[i])
+    // High priority request must be grant the same cycle
+    `BR_ASSERT(high_priority_grant_a, request[i] && (2 ** i == high_priority_request) |-> grant[i])
+    for (genvar j = 0; j < NumRequesters; j++) begin : gen_req_1
+      if (i != j) begin
+        `BR_ASSERT(arb_priority_a, grant[j] |->
+          !request[i] ||
+          // high_priority ... j ... i
+          ((2 ** j >= high_priority_request) && (2 ** i > high_priority_request) && (j < i)) ||
+          // i ... high_priority ... j
+          ((2 ** j >= high_priority_request) && (2 ** i < high_priority_request)) ||
+          // j ... i ... high_priority ...
+          ((2 ** j <= high_priority_request) && (2 ** i < high_priority_request) && (j < i))
+        )
+      end
+    end
+  end
+
+endmodule : br_arb_rr_fpv_monitor
+
+bind br_arb_rr br_arb_rr_fpv_monitor#(.NumRequesters(NumRequesters)) monitor (.*);

--- a/arb/fpv/br_arb_rr_fpv_monitor.sv
+++ b/arb/fpv/br_arb_rr_fpv_monitor.sv
@@ -32,13 +32,7 @@ module br_arb_rr_fpv_monitor #(
 
    logic [NumRequesters-1:0] high_priority_request;
 
-  always_ff @(posedge clk) begin
-    if (rst) begin
-      high_priority_request <= 1;
-    end if (grant != 0) begin
-      high_priority_request <= (grant == 1 << NumRequesters) ? 1 : grant << 1;
-    end
-  end
+  `BR_REGL(high_priority_request, (grant == 1 << NumRequesters) ? 1 : grant << 1, grant != 0)
 
   for (genvar i = 0; i < NumRequesters; i++) begin : gen_req_0
     // Request must be hold until granted


### PR DESCRIPTION
Add FPV environment for fixed/rr/lru arbiter

Status:
----------------
fixed_arb : full proof
rr_arb: cex found, need further debugging 
lru_ab: cex found, need further debugging 


Note: I did not use symbol variables because the current fpv has some issue with undriven nets