### PR TITLE
Enable `BR_ASSERT_STATIC` unconditionally; canonicalize fail strings

### DIFF
--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -43,7 +43,7 @@ end
 typedef enum logic [1:0] { \
     __BR_ASSERT_STATIC_IN_PACKAGE_OK__``__name__ = ((__expr__) ? 1 : 0), \
     __BR_ASSERT_STATIC_IN_PACKAGE_FAILED__``__name__ = 0 \
-} __static_assert_enum__``__name__;
+} __br_static_assert_enum__``__name__;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Concurrent assertion macros (evaluated on posedge of a clock and disabled during a synchronous active-high reset)

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -32,22 +32,15 @@
 // Static (elaboration-time) assertion macros
 ////////////////////////////////////////////////////////////////////////////////
 
-`define BR_NOOP
-
-`ifdef BR_ASSERT_ON
 `define BR_ASSERT_STATIC(__name__, __expr__) \
 if (!(__expr__)) begin : gen__``__name__ \
-__STATIC_ASSERT_FAILED__``__name__ __STATIC_ASSERT_FAILED__``__name__ (); \
+__BR_ASSERT_STATIC_FAILED__``__name__ __BR_ASSERT_STATIC_FAILED__``__name__ (); \
 end
-`else  // BR_ASSERT_ON
-`define BR_ASSERT_STATIC(__name__, __expr__) \
-`BR_NOOP
-`endif  // BR_ASSERT_ON
 
 `define BR_ASSERT_STATIC_IN_PACKAGE(__name__, __expr__) \
 typedef enum logic [1:0] { \
-    __STATIC_ASSERT_OK__``__name__ = ((__expr__) ? 1 : 0), \
-    __STATIC_ASSERT_FAILED__``__name__ = 0 \
+    __BR_ASSERT_STATIC_IN_PACKAGE_OK__``__name__ = ((__expr__) ? 1 : 0), \
+    __BR_ASSERT_STATIC_IN_PACKAGE_FAILED__``__name__ = 0 \
 } __static_assert_enum__``__name__;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -32,6 +32,8 @@
 // Static (elaboration-time) assertion macros
 ////////////////////////////////////////////////////////////////////////////////
 
+`define BR_NOOP
+
 `define BR_ASSERT_STATIC(__name__, __expr__) \
 if (!(__expr__)) begin : gen__``__name__ \
 __BR_ASSERT_STATIC_FAILED__``__name__ __BR_ASSERT_STATIC_FAILED__``__name__ (); \


### PR DESCRIPTION
Fixes #177 