### PR TITLE
Some bug fixes and refactors for FIFOs

### DIFF
--- a/fifo/rtl/br_fifo_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_flops_push_credit.sv
@@ -114,6 +114,8 @@ module br_fifo_flops_push_credit #(
     output logic [CountWidth-1:0] items,
     output logic [CountWidth-1:0] items_next
 );
+  localparam int RamReadLatency =
+      FlopRamAddressDepthStages + FlopRamReadDataDepthStages + FlopRamReadDataWidthStages;
 
   //------------------------------------------
   // Integration checks
@@ -138,7 +140,7 @@ module br_fifo_flops_push_credit #(
       .MaxCredit(MaxCredit),
       .RegisterPushCredit(RegisterPushCredit),
       .RegisterPopOutputs(RegisterPopOutputs),
-      .RamReadLatency(0)  // TODO(zhemao): Update this if flop RAM adds pipeline stages
+      .RamReadLatency(RamReadLatency)
   ) br_fifo_ctrl_1r1w_push_credit (
       .clk,
       .rst,

--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -18,11 +18,20 @@ load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
 package(default_visibility = ["//fifo/rtl:__subpackages__"])
 
 verilog_library(
+    name = "br_fifo_push_ctrl_core",
+    srcs = ["br_fifo_push_ctrl_core.sv"],
+    deps = [
+        "//counter/rtl:br_counter_incr",
+        "//macros:br_unused",
+    ],
+)
+
+verilog_library(
     name = "br_fifo_push_ctrl",
     srcs = ["br_fifo_push_ctrl.sv"],
     deps = [
+        ":br_fifo_push_ctrl_core",
         "//counter/rtl:br_counter",
-        "//counter/rtl:br_counter_incr",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
         "//macros:br_unused",
@@ -52,8 +61,8 @@ verilog_library(
     name = "br_fifo_push_ctrl_credit",
     srcs = ["br_fifo_push_ctrl_credit.sv"],
     deps = [
+        ":br_fifo_push_ctrl_core",
         "//counter/rtl:br_counter",
-        "//counter/rtl:br_counter_incr",
         "//credit/rtl:br_credit_receiver",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
@@ -85,11 +94,21 @@ br_verilog_elab_and_lint_test_suite(
 )
 
 verilog_library(
-    name = "br_fifo_pop_ctrl",
-    srcs = ["br_fifo_pop_ctrl.sv"],
+    name = "br_fifo_pop_ctrl_core",
+    srcs = ["br_fifo_pop_ctrl_core.sv"],
     deps = [
         ":br_fifo_staging_buffer",
         "//counter/rtl:br_counter_incr",
+        "//macros:br_unused",
+    ],
+)
+
+verilog_library(
+    name = "br_fifo_pop_ctrl",
+    srcs = ["br_fifo_pop_ctrl.sv"],
+    deps = [
+        ":br_fifo_pop_ctrl_core",
+        "//counter/rtl:br_counter",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
         "//macros:br_unused",

--- a/fifo/rtl/internal/br_fifo_pop_ctrl_core.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl_core.sv
@@ -1,0 +1,155 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Core FIFO pop control logic that will be reused across different variants.
+// Contains just the bypass and RAM read logic, leaving occupancy tracking up to
+// the instantiating module.
+
+`include "br_unused.svh"
+
+module br_fifo_pop_ctrl_core #(
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter bit EnableBypass = 1,
+    parameter int RamReadLatency = 0,
+    parameter bit RegisterPopOutputs = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    // Posedge-triggered clock.
+    input logic clk,
+    // Synchronous active-high reset.
+    input logic rst,
+
+    // Pop-side interface.
+    input  logic             pop_ready,
+    output logic             pop_valid,
+    output logic [Width-1:0] pop_data,
+
+    // Bypass interface
+    // Bypass is only used when EnableBypass is 1, hence lint waivers.
+    output logic bypass_ready,
+    input logic bypass_valid_unstable,  // ri lint_check_waive INEFFECTIVE_NET
+    input logic [Width-1:0] bypass_data_unstable,  // ri lint_check_waive INEFFECTIVE_NET
+
+    // RAM interface
+    output logic                 ram_rd_addr_valid,
+    output logic [AddrWidth-1:0] ram_rd_addr,
+    input  logic                 ram_rd_data_valid,  // ri lint_check_waive INEFFECTIVE_NET
+    input  logic [    Width-1:0] ram_rd_data,
+
+    input  logic                  empty,    // ri lint_check_waive INEFFECTIVE_NET
+    input  logic [CountWidth-1:0] items,    // ri lint_check_waive INEFFECTIVE_NET
+    output logic                  pop_beat
+);
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  // Flow control
+  assign pop_beat = pop_ready && pop_valid;
+
+  // RAM path
+  br_counter_incr #(
+      .MaxValue(Depth - 1),
+      .MaxIncrement(1)
+  ) br_counter_incr_rd_addr (
+      .clk,
+      .rst,
+      .reinit(1'b0),  // unused
+      .initial_value(AddrWidth'(1'b0)),
+      .incr_valid(ram_rd_addr_valid),
+      .incr(1'b1),
+      .value(ram_rd_addr),
+      .value_next()  // unused
+  );
+
+  // Datapath
+  if (RamReadLatency == 0) begin : gen_zero_rd_lat
+    logic             internal_pop_valid;
+    logic             internal_pop_ready;
+    logic [Width-1:0] internal_pop_data;
+    logic             internal_empty;
+
+    if (EnableBypass) begin : gen_bypass
+      assign bypass_ready = internal_empty && internal_pop_ready;
+      assign internal_pop_valid = !internal_empty || bypass_valid_unstable;
+      assign internal_pop_data = internal_empty ? bypass_data_unstable : ram_rd_data;
+      assign ram_rd_addr_valid = internal_pop_valid && internal_pop_ready && !internal_empty;
+    end else begin : gen_no_bypass
+      // TODO(zhemao, #157): Replace this with BR_TIEOFF macros once they are fixed
+      assign bypass_ready = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
+      assign internal_pop_valid = !internal_empty;
+      assign internal_pop_data = ram_rd_data;
+      assign ram_rd_addr_valid = internal_pop_valid && internal_pop_ready;
+
+      `BR_UNUSED_NAMED(bypass_signals, {bypass_valid_unstable, bypass_data_unstable})
+    end
+    `BR_UNUSED(ram_rd_data_valid)  // implied
+
+    if (RegisterPopOutputs) begin : gen_reg_pop
+      br_flow_reg_fwd #(
+          .Width(Width)
+      ) br_flow_reg_fwd_pop (
+          .clk,
+          .rst,
+          .push_valid(internal_pop_valid),
+          .push_ready(internal_pop_ready),
+          .push_data (internal_pop_data),
+          .pop_valid,
+          .pop_ready,
+          .pop_data
+      );
+      // internal_empty is true if there are no items or if there is one item
+      // and it is already in the staging register
+      assign internal_empty = empty || ((items == 1'b1) && pop_valid);
+    end else begin : gen_noreg_pop
+      assign internal_empty = empty;
+      assign pop_valid = internal_pop_valid;
+      assign pop_data = internal_pop_data;
+      assign internal_pop_ready = pop_ready;
+      `BR_UNUSED(items)
+    end
+  end else begin : gen_nonzero_rd_lat
+    br_fifo_staging_buffer #(
+        .EnableBypass      (EnableBypass),
+        .TotalDepth        (Depth),
+        .RamReadLatency    (RamReadLatency),
+        .Width             (Width),
+        .RegisterPopOutputs(RegisterPopOutputs)
+    ) br_fifo_staging_buffer (
+        .clk,
+        .rst,
+
+        // If bypass is disabled, bypass_ready will be driven by constant
+        // TODO(zhemao, #157): Remove this once lint waiver issue is fixed
+        .bypass_ready,  // ri lint_check_waive CONST_OUTPUT
+        .bypass_valid_unstable,
+        .bypass_data_unstable,
+
+        .total_items(items),
+
+        .ram_rd_addr_valid,
+        .ram_rd_data_valid,
+        .ram_rd_data,
+
+        .pop_ready,
+        .pop_valid,
+        .pop_data
+    );
+    `BR_UNUSED(empty)
+  end
+
+endmodule : br_fifo_pop_ctrl_core

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -69,41 +69,30 @@ module br_fifo_push_ctrl #(
   // Implementation
   //------------------------------------------
 
-  // Flow control
-  assign push_beat  = push_ready && push_valid;
-  assign push_ready = !full;
-
-  // RAM path
-  br_counter_incr #(
-      .MaxValue(Depth - 1),
-      .MaxIncrement(1)
-  ) br_counter_incr_wr_addr (
+  // Core flow-control logic
+  br_fifo_push_ctrl_core #(
+      .Depth(Depth),
+      .Width(Width),
+      .EnableBypass(EnableBypass)
+  ) br_fifo_push_ctrl_core (
       .clk,
       .rst,
-      .reinit(1'b0),  // unused
-      .initial_value(AddrWidth'(1'b0)),
-      .incr_valid(ram_wr_valid),
-      .incr(1'b1),
-      .value(ram_wr_addr),
-      .value_next()  // unused
+
+      .push_ready,
+      .push_valid,
+      .push_data,
+
+      .bypass_ready,
+      .bypass_valid_unstable,  // ri lint_check_waive CONST_OUTPUT
+      .bypass_data_unstable,  // ri lint_check_waive CONST_OUTPUT
+
+      .ram_wr_valid,
+      .ram_wr_addr,
+      .ram_wr_data,
+
+      .full,
+      .push_beat
   );
-
-  // Datapath
-  if (EnableBypass) begin : gen_bypass
-    assign bypass_valid_unstable = push_valid;
-    assign bypass_data_unstable = push_data;
-
-    assign ram_wr_valid = push_beat && !bypass_ready;
-    assign ram_wr_data = push_data;
-  end else begin : gen_no_bypass
-    `BR_UNUSED(bypass_ready)
-    // TODO(zhemao, #157): Replace this with BR_TIEOFF macros once they are fixed
-    assign bypass_valid_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
-    assign bypass_data_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
-
-    assign ram_wr_valid = push_beat;
-    assign ram_wr_data = push_data;
-  end
 
   // Status flags
   br_counter #(

--- a/fifo/rtl/internal/br_fifo_push_ctrl_core.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_core.sv
@@ -1,0 +1,93 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Core FIFO push control logic that will be reused across different variants.
+// Contains just the bypass and RAM write logic, leaving occupancy tracking up to
+// the instantiating module.
+
+`include "br_unused.svh"
+
+module br_fifo_push_ctrl_core #(
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter bit EnableBypass = 1,
+    localparam int AddrWidth = $clog2(Depth)
+) (
+    // Posedge-triggered clock.
+    input logic clk,
+    // Synchronous active-high reset.
+    input logic rst,
+
+    // Push-side interface.
+    output logic             push_ready,
+    input  logic             push_valid,
+    input  logic [Width-1:0] push_data,
+
+    // Bypass interface
+    // Bypass is only used when EnableBypass is 1, hence lint waiver.
+    input  logic             bypass_ready,           // ri lint_check_waive INEFFECTIVE_NET
+    output logic             bypass_valid_unstable,
+    output logic [Width-1:0] bypass_data_unstable,
+
+    // RAM interface
+    output logic                 ram_wr_valid,
+    output logic [AddrWidth-1:0] ram_wr_addr,
+    output logic [    Width-1:0] ram_wr_data,
+
+    // Signals to/from internal logic
+    input  logic full,
+    output logic push_beat
+);
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  // Flow control
+  assign push_beat  = push_ready && push_valid;
+  assign push_ready = !full;
+
+  // RAM path
+  br_counter_incr #(
+      .MaxValue(Depth - 1),
+      .MaxIncrement(1)
+  ) br_counter_incr_wr_addr (
+      .clk,
+      .rst,
+      .reinit(1'b0),  // unused
+      .initial_value(AddrWidth'(1'b0)),
+      .incr_valid(ram_wr_valid),
+      .incr(1'b1),
+      .value(ram_wr_addr),
+      .value_next()  // unused
+  );
+
+  // Datapath
+  if (EnableBypass) begin : gen_bypass
+    assign bypass_valid_unstable = push_valid;
+    assign bypass_data_unstable = push_data;
+
+    assign ram_wr_valid = push_beat && !bypass_ready;
+    assign ram_wr_data = push_data;
+  end else begin : gen_no_bypass
+    `BR_UNUSED(bypass_ready)
+    // TODO(zhemao, #157): Replace this with BR_TIEOFF macros once they are fixed
+    assign bypass_valid_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
+    assign bypass_data_unstable = '0;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
+
+    assign ram_wr_valid = push_beat;
+    assign ram_wr_data = push_data;
+  end
+
+endmodule

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -122,6 +122,12 @@ br_verilog_sim_test_suite(
             "0",
             "1",
         ],
+        "FlopRamAddressDepthStages": [
+            "0",
+            "1",
+            "2",
+            "3",
+        ],
     },
     tool = "vcs",
     deps = [":br_fifo_flops_push_credit_tb"],


### PR DESCRIPTION
1. Fix RamReadLatency in br_fifo_flops_push_credit
2. Pull some core functionality of br_fifo push and pop ctrl into separate modules.
This will help with reusability when implementing the CDC FIFOs.

git-pr-chain: fifo_fixes

---

**Stack**:
- #183
- #182
- #181
- #180
- #179 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*