### PR TITLE
Add single-bit CDC synchronizer

### DIFF
--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -1,0 +1,43 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
+
+package(default_visibility = ["//visibility:public"])
+
+verilog_library(
+    name = "br_cdc_bit_toggle",
+    srcs = ["br_cdc_bit_toggle.sv"],
+    deps = [
+        "//gate/rtl:br_gate_behav",
+        "//macros:br_asserts",
+        "//macros:br_registers",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_cdc_bit_toggle_test_suite",
+    params = {
+        "NumStages": [
+            "2",
+            "3",
+        ],
+        "AddSourceFlop": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_cdc_bit_toggle"],
+)

--- a/cdc/rtl/br_cdc_bit_toggle.sv
+++ b/cdc/rtl/br_cdc_bit_toggle.sv
@@ -1,0 +1,67 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// CDC synchronizer for a single bit level signal.
+
+`include "br_registers.svh"
+`include "br_asserts.svh"
+
+module br_cdc_bit_toggle #(
+    // Number of synchronization stages. Must be at least 1.
+    // WARNING: Setting this parameter correctly is critical to
+    // ensuring a low probability of metastability.
+    // The recommended value is 3 for most technology nodes.
+    // Do not decrease below that unless you have a good reason.
+    parameter int NumStages = 3,
+    // If 1, add a flop on the source clock before the synchronizer
+    parameter bit AddSourceFlop = 1
+) (
+    // Used for simulation delay modeling only
+    // ri lint_check_waive INPUT_NOT_READ NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic src_clk,
+    // Used for assertion only
+    // ri lint_check_waive INPUT_NOT_READ NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic src_rst,
+    input logic src_bit,
+
+    input  logic dst_clk,
+    // Used for assertion only
+    // ri lint_check_waive INPUT_NOT_READ NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input  logic dst_rst,
+    output logic dst_bit
+);
+
+  // Integration Assertions
+  `BR_ASSERT_STATIC(num_stages_must_be_at_least_one_a, NumStages >= 1)
+
+  // Implementation
+  logic src_bit_internal;
+
+  if (AddSourceFlop) begin : gen_src_flop
+    `BR_REGNX(src_bit_internal, src_bit, src_clk)
+  end else begin : gen_src_passthrough
+    assign src_bit_internal = src_bit;
+  end
+
+  // TODO: Add simulation delay modeling
+
+  br_gate_cdc_sync #(
+      .NumStages(NumStages)
+  ) br_gate_cdc_sync (
+      .clk(dst_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .in(src_bit_internal),
+      .out(dst_bit)
+  );
+
+endmodule

--- a/gate/rtl/BUILD.bazel
+++ b/gate/rtl/BUILD.bazel
@@ -20,6 +20,7 @@ package(default_visibility = ["//visibility:public"])
 verilog_library(
     name = "br_gate_behav",
     srcs = ["br_gate_behav.sv"],
+    deps = ["//macros:br_registers"],
 )
 
 br_verilog_elab_and_lint_test_suite(
@@ -89,6 +90,20 @@ br_verilog_elab_and_lint_test_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_gate_icg_test_suite",
     top = "br_gate_icg",
+    deps = [
+        ":br_gate_behav",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_gate_cdc_sync_test_suite",
+    params = {
+        "NumStages": [
+            "2",
+            "3",
+        ],
+    },
+    top = "br_gate_cdc_sync",
     deps = [
         ":br_gate_behav",
     ],

--- a/gate/rtl/br_gate_behav.sv
+++ b/gate/rtl/br_gate_behav.sv
@@ -22,6 +22,8 @@
 // verilog_lint: waive-start module-filename
 // ri lint_check_off ONE_PER_FILE FILE_NAME
 
+`include "br_registers.svh"
+
 // Buffer
 module br_gate_buf (
     input  logic in,
@@ -132,5 +134,21 @@ module br_gate_icg (
 
 endmodule : br_gate_icg
 
+// Clock Domain Crossing Synchronizer
+module br_gate_cdc_sync #(
+    parameter int NumStages = 3
+) (
+    input  logic clk,
+    input  logic in,
+    output logic out
+);
+
+
+  logic [NumStages-1:0] in_d;
+
+  `BR_REGN(in_d, {in_d[NumStages-2:0], in})
+
+  assign out = in_d[NumStages-1];
+endmodule : br_gate_cdc_sync
 // verilog_lint: waive-stop module-filename
 // ri lint_check_on ONE_PER_FILE FILE_NAME


### PR DESCRIPTION
Behavioral model of basic CDC synchronizer cell goes in
br_gate_behav.sv.

Build bit-toggle CDC on top of this.

---

**Stack**:
- #183
- #207
- #180 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*