### PR TITLE
Implement CDC FIFOs

### DIFF
--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -41,3 +41,147 @@ br_verilog_elab_and_lint_test_suite(
     },
     deps = [":br_cdc_bit_toggle"],
 )
+
+verilog_library(
+    name = "br_cdc_fifo_ctrl_1r1w",
+    srcs = ["br_cdc_fifo_ctrl_1r1w.sv"],
+    deps = [
+        ":br_cdc_bit_toggle",
+        "//cdc/rtl/internal:br_cdc_fifo_gray_count_sync",
+        "//cdc/rtl/internal:br_cdc_fifo_pop_ctrl",
+        "//cdc/rtl/internal:br_cdc_fifo_push_ctrl",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_cdc_fifo_ctrl_1r1w_test_suite",
+    params = {
+        "Depth": [
+            "5",
+            "8",
+        ],
+        "Width": ["8"],
+        "RamWriteLatency": [
+            "1",
+            "2",
+        ],
+        "RamReadLatency": [
+            "0",
+            "1",
+            "2",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    top = "br_cdc_fifo_ctrl_1r1w",
+    deps = [":br_cdc_fifo_ctrl_1r1w"],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_ctrl_1r1w_push_credit",
+    srcs = ["br_cdc_fifo_ctrl_1r1w_push_credit.sv"],
+    deps = [
+        ":br_cdc_bit_toggle",
+        "//cdc/rtl/internal:br_cdc_fifo_gray_count_sync",
+        "//cdc/rtl/internal:br_cdc_fifo_pop_ctrl",
+        "//cdc/rtl/internal:br_cdc_fifo_push_ctrl_credit",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_cdc_fifo_ctrl_1r1w_push_credit_test_suite",
+    params = {
+        "Depth": [
+            "5",
+            "8",
+        ],
+        "Width": ["8"],
+        "RamWriteLatency": [
+            "1",
+            "2",
+        ],
+        "RamReadLatency": [
+            "0",
+            "1",
+            "2",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    top = "br_cdc_fifo_ctrl_1r1w_push_credit",
+    deps = [":br_cdc_fifo_ctrl_1r1w_push_credit"],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_flops",
+    srcs = ["br_cdc_fifo_flops.sv"],
+    deps = [
+        ":br_cdc_fifo_ctrl_1r1w",
+        "//ram/rtl:br_ram_flops_1r1w",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_cdc_fifo_flops_test_suite",
+    params = {
+        "Depth": [
+            "5",
+            "8",
+        ],
+        "Width": ["8"],
+        "RamWriteLatency": [
+            "1",
+            "2",
+        ],
+        "RamReadLatency": [
+            "0",
+            "1",
+            "2",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    top = "br_cdc_fifo_flops",
+    deps = [":br_cdc_fifo_flops"],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_flops_push_credit",
+    srcs = ["br_cdc_fifo_flops_push_credit.sv"],
+    deps = [
+        ":br_cdc_fifo_ctrl_1r1w_push_credit",
+        "//ram/rtl:br_ram_flops_1r1w",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_cdc_fifo_flops_push_credit_test_suite",
+    params = {
+        "Depth": [
+            "5",
+            "8",
+        ],
+        "Width": ["8"],
+        "RamWriteLatency": [
+            "1",
+            "2",
+        ],
+        "RamReadLatency": [
+            "0",
+            "1",
+            "2",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    top = "br_cdc_fifo_flops_push_credit",
+    deps = [":br_cdc_fifo_flops_push_credit"],
+)

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
@@ -1,0 +1,238 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL CDC FIFO Controller (1R1W, Push Ready/Valid, Pop Ready/Valid Variant)
+//
+// A one-read/one-write (1R1W) asynchronous FIFO controller that uses the
+// AMBA-inspired ready-valid handshake protocol for synchronizing pipeline
+// stages and stalling when encountering backpressure hazards.
+//
+// This module does not include any internal RAM. Instead, it exposes
+// read and write ports to an external 1R1W (pseudo-dual-port)
+// RAM module, which could be implemented in flops or SRAM.
+//
+// Data progresses from one stage to another when both
+// the corresponding ready signal and valid signal are
+// both 1 on the same cycle. Otherwise, the stage is stalled.
+//
+// The FIFO controller can work with RAMs of arbitrary fixed read latency.
+// If the latency is non-zero, a FLOP-based staging buffer is kept in the
+// controller so that a synchronous ready/valid interface can be maintained
+// at the pop interface.
+//
+// The RegisterPopOutputs parameter can be set to 1 to add an additional br_flow_reg_fwd
+// before the pop interface of the FIFO. This may improve timing of paths dependent on
+// the pop interface at the expense of an additional pop cycle of cut-through latency.
+
+// The cut-through latency (push_valid to pop_valid latency) and backpressure
+// latency (pop_ready to push_ready) can be calculated as follows:
+//
+// Let PushT and PopT be the push period and pop period, respectively.
+//
+// The cut-through latency is max(2, RamWriteLatency + 1) * PushT +
+// (NumSyncStages + 1 + RamReadLatency + RegisterPopOutputs) * PopT.
+
+// The backpressure latency is 2 * PopT + (NumSyncStages + 1) * PushT.
+//
+// To achieve full bandwidth, the depth of the FIFO must be at least
+// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+
+`include "br_asserts_internal.svh"
+
+module br_cdc_fifo_ctrl_1r1w #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    // If 1, then ensure pop_valid/pop_data always come directly from a register
+    // at the cost of an additional pop cycle of cut-through latency.
+    // If 0, pop_valid/pop_data can come directly from the push interface
+    // (if bypass is enabled), the RAM read interface, and/or an internal staging
+    // buffer (if RAM read latency is >0).
+    parameter bit RegisterPopOutputs = 0,
+    // The number of push cycles after ram_wr_valid is asserted at which
+    // it is safe to read the newly written data.
+    parameter int RamWriteLatency = 1,
+    // The number of pop cycles between when ram_rd_addr_valid is asserted and
+    // ram_rd_data_valid is asserted.
+    parameter int RamReadLatency = 0,
+    // The number of synchronization stages to use for the gray counts.
+    parameter int NumSyncStages = 3,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    // Posedge-triggered clock.
+    input logic push_clk,
+    // Synchronous active-high reset.
+    input logic push_rst,
+
+    // Push-side interface
+    output logic             push_ready,
+    input  logic             push_valid,
+    input  logic [Width-1:0] push_data,
+
+    // Push-side status flags
+    output logic                  push_full,
+    output logic                  push_full_next,
+    output logic [CountWidth-1:0] push_slots,
+    output logic [CountWidth-1:0] push_slots_next,
+
+    // Push-side RAM write interface
+    output logic                 push_ram_wr_valid,
+    output logic [AddrWidth-1:0] push_ram_wr_addr,
+    output logic [    Width-1:0] push_ram_wr_data,
+
+    // Posedge-triggered clock.
+    input logic pop_clk,
+    // Synchronous active-high reset.
+    input logic pop_rst,
+
+    // Pop-side interface
+    input  logic             pop_ready,
+    output logic             pop_valid,
+    output logic [Width-1:0] pop_data,
+
+    // Pop-side status flags
+    output logic                  pop_empty,
+    output logic                  pop_empty_next,
+    output logic [CountWidth-1:0] pop_items,
+    output logic [CountWidth-1:0] pop_items_next,
+
+    // Pop-side RAM read interface
+    output logic                 pop_ram_rd_addr_valid,
+    output logic [AddrWidth-1:0] pop_ram_rd_addr,
+    input  logic                 pop_ram_rd_data_valid,
+    input  logic [    Width-1:0] pop_ram_rd_data
+);
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  // Rely on submodule integration checks
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  logic [CountWidth-1:0] push_push_count_gray;
+  logic [CountWidth-1:0] pop_push_count_gray;
+  logic [CountWidth-1:0] push_pop_count_gray;
+  logic [CountWidth-1:0] pop_pop_count_gray;
+  logic                  push_reset_active_pop;
+  logic                  push_reset_active_push;
+  logic                  pop_reset_active_pop;
+  logic                  pop_reset_active_push;
+
+  br_cdc_fifo_push_ctrl #(
+      .Depth(Depth),
+      .Width(Width),
+      .RamWriteLatency(RamWriteLatency)
+  ) br_cdc_fifo_push_ctrl (
+      .clk              (push_clk),               // ri lint_check_waive SAME_CLOCK_NAME
+      .rst              (push_rst),
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .full             (push_full),
+      .full_next        (push_full_next),
+      .slots            (push_slots),
+      .slots_next       (push_slots_next),
+      .ram_wr_valid     (push_ram_wr_valid),
+      .ram_wr_addr      (push_ram_wr_addr),
+      .ram_wr_data      (push_ram_wr_data),
+      .push_count_gray  (push_push_count_gray),
+      .pop_count_gray   (push_pop_count_gray),
+      .reset_active_pop (push_reset_active_pop),
+      .reset_active_push(push_reset_active_push)
+  );
+
+  br_cdc_fifo_gray_count_sync #(
+      .CountWidth(CountWidth),
+      .NumStages (NumSyncStages)
+  ) br_cdc_fifo_gray_count_sync_push2pop (
+      .src_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .src_rst(push_rst),
+      .src_count_gray(push_push_count_gray),
+      .dst_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .dst_rst(pop_rst),
+      .dst_count_gray(pop_push_count_gray)
+  );
+
+  br_cdc_fifo_gray_count_sync #(
+      .CountWidth(CountWidth),
+      .NumStages (NumSyncStages)
+  ) br_cdc_fifo_gray_count_sync_pop2push (
+      .src_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .src_rst(pop_rst),
+      .src_count_gray(pop_pop_count_gray),
+      .dst_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .dst_rst(push_rst),
+      .dst_count_gray(push_pop_count_gray)
+  );
+
+  br_cdc_bit_toggle #(
+      .NumStages(NumSyncStages),
+      .AddSourceFlop(0)
+  ) br_cdc_bit_toggle_reset_active_push (
+      .src_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .src_rst(push_rst),
+      .src_bit(push_reset_active_push),
+      .dst_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .dst_rst(pop_rst),
+      .dst_bit(pop_reset_active_push)
+  );
+
+  br_cdc_bit_toggle #(
+      .NumStages(NumSyncStages),
+      .AddSourceFlop(0)
+  ) br_cdc_bit_toggle_reset_active_pop (
+      .src_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .src_rst(pop_rst),
+      .src_bit(pop_reset_active_pop),
+      .dst_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .dst_rst(push_rst),
+      .dst_bit(push_reset_active_pop)
+  );
+
+  br_cdc_fifo_pop_ctrl #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RamReadLatency(RamReadLatency)
+  ) br_cdc_fifo_pop_ctrl (
+      .clk              (pop_clk),                // ri lint_check_waive SAME_CLOCK_NAME
+      .rst              (pop_rst),
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .empty            (pop_empty),
+      .empty_next       (pop_empty_next),
+      .items            (pop_items),
+      .items_next       (pop_items_next),
+      .ram_rd_addr_valid(pop_ram_rd_addr_valid),
+      .ram_rd_addr      (pop_ram_rd_addr),
+      .ram_rd_data_valid(pop_ram_rd_data_valid),
+      .ram_rd_data      (pop_ram_rd_data),
+      .push_count_gray  (pop_push_count_gray),
+      .pop_count_gray   (pop_pop_count_gray),
+      .reset_active_pop (pop_reset_active_pop),
+      .reset_active_push(pop_reset_active_push)
+  );
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  `BR_ASSERT_CR_IMPL(no_pop_valid_when_empty_a, pop_empty |-> !pop_valid, pop_clk, pop_rst)
+
+  // Check that the FIFO backpressures when it is full.
+  `BR_ASSERT_CR_IMPL(push_backpressure_when_full_a, push_full |-> !push_ready, push_clk, push_rst)
+
+endmodule : br_cdc_fifo_ctrl_1r1w

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
@@ -1,0 +1,259 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL CDC FIFO Controller (1R1W, Push Ready/Valid, Pop Credit/Valid Variant)
+//
+// A one-read/one-write (1R1W) asynchronous FIFO controller that uses a
+// credit-valid push interface and an AMBA-inspired ready-valid pop interface
+// for synchronizing pipeline stages and stalling when encountering backpressure hazards.
+//
+// This module does not include any internal RAM. Instead, it exposes
+// read and write ports to an external 1R1W (pseudo-dual-port)
+// RAM module, which could be implemented in flops or SRAM.
+//
+// Data progresses from one stage to another when both
+// the corresponding ready signal and valid signal are
+// both 1 on the same cycle. Otherwise, the stage is stalled.
+//
+// The FIFO controller can work with RAMs of arbitrary fixed read latency.
+// If the latency is non-zero, a FLOP-based staging buffer is kept in the
+// controller so that a synchronous ready/valid interface can be maintained
+// at the pop interface.
+//
+// The RegisterPopOutputs parameter can be set to 1 to add an additional br_flow_reg_fwd
+// before the pop interface of the FIFO. This may improve timing of paths dependent on
+// the pop interface at the expense of an additional pop cycle of cut-through latency.
+
+// The cut-through latency (push_valid to pop_valid latency) and backpressure
+// latency (pop_ready to push_ready) can be calculated as follows:
+//
+// Let PushT and PopT be the push period and pop period, respectively.
+//
+// The cut-through latency is max(2, RamWriteLatency + 1) * PushT +
+// (NumSyncStages + 1 + RamReadLatency + RegisterPopOutputs) * PopT.
+
+// The backpressure latency is 2 * PopT + (NumSyncStages + 1 + RegisterPushCredit) * PushT.
+//
+// To achieve full bandwidth, the depth of the FIFO must be at least
+// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+
+`include "br_asserts_internal.svh"
+
+module br_cdc_fifo_ctrl_1r1w_push_credit #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    // If 1, then ensure pop_valid/pop_data always come directly from a register
+    // at the cost of an additional pop cycle of cut-through latency.
+    // If 0, pop_valid/pop_data can come directly from the push interface
+    // (if bypass is enabled), the RAM read interface, and/or an internal staging
+    // buffer (if RAM read latency is >0).
+    parameter bit RegisterPopOutputs = 0,
+    // The number of push cycles after ram_wr_valid is asserted at which
+    // it is safe to read the newly written data.
+    parameter int RamWriteLatency = 1,
+    // The number of pop cycles between when ram_rd_addr_valid is asserted and
+    // ram_rd_data_valid is asserted.
+    parameter int RamReadLatency = 0,
+    // The number of synchronization stages to use for the gray counts.
+    parameter int NumSyncStages = 3,
+    // Maximum credit for the internal credit counter. Must be at least Depth.
+    // Recommended to not override the default because it is the smallest viable size.
+    // Overriding may be convenient if having a consistent credit counter register width
+    // (say, 16-bit) throughout a design is deemed useful.
+    parameter int MaxCredit = Depth,
+    // If 1, add a retiming stage to the push_credit signal so that it is
+    // driven directly from a flop. This comes at the expense of one additional
+    // push cycle of credit loop latency.
+    parameter bit RegisterPushCredit = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1),
+    localparam int CreditWidth = $clog2(MaxCredit + 1)
+) (
+    // Posedge-triggered clock.
+    input logic push_clk,
+    // Synchronous active-high reset.
+    input logic push_rst,
+
+    // Push-side interface
+    input  logic             push_credit_stall,
+    output logic             push_credit,
+    input  logic             push_valid,
+    input  logic [Width-1:0] push_data,
+
+    // Push-side status flags
+    output logic                  push_full,
+    output logic                  push_full_next,
+    output logic [CountWidth-1:0] push_slots,
+    output logic [CountWidth-1:0] push_slots_next,
+
+    // Push-side credits
+    input  logic [CreditWidth-1:0] credit_initial_push,
+    input  logic [CreditWidth-1:0] credit_withhold_push,
+    output logic [CreditWidth-1:0] credit_count_push,
+    output logic [CreditWidth-1:0] credit_available_push,
+
+    // Push-side RAM write interface
+    output logic                 push_ram_wr_valid,
+    output logic [AddrWidth-1:0] push_ram_wr_addr,
+    output logic [    Width-1:0] push_ram_wr_data,
+
+    // Posedge-triggered clock.
+    input logic pop_clk,
+    // Synchronous active-high reset.
+    input logic pop_rst,
+
+    // Pop-side interface
+    input  logic             pop_ready,
+    output logic             pop_valid,
+    output logic [Width-1:0] pop_data,
+
+    // Pop-side status flags
+    output logic                  pop_empty,
+    output logic                  pop_empty_next,
+    output logic [CountWidth-1:0] pop_items,
+    output logic [CountWidth-1:0] pop_items_next,
+
+    // Pop-side RAM read interface
+    output logic                 pop_ram_rd_addr_valid,
+    output logic [AddrWidth-1:0] pop_ram_rd_addr,
+    input  logic                 pop_ram_rd_data_valid,
+    input  logic [    Width-1:0] pop_ram_rd_data
+);
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  // Rely on submodule integration checks
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  logic [CountWidth-1:0] push_push_count_gray;
+  logic [CountWidth-1:0] pop_push_count_gray;
+  logic [CountWidth-1:0] push_pop_count_gray;
+  logic [CountWidth-1:0] pop_pop_count_gray;
+  logic                  push_reset_active_pop;
+  logic                  push_reset_active_push;
+  logic                  pop_reset_active_pop;
+  logic                  pop_reset_active_push;
+
+  br_cdc_fifo_push_ctrl_credit #(
+      .Depth(Depth),
+      .Width(Width),
+      .RamWriteLatency(RamWriteLatency),
+      .RegisterPushCredit(RegisterPushCredit),
+      .MaxCredit(MaxCredit)
+  ) br_cdc_fifo_push_ctrl_credit (
+      .clk              (push_clk),               // ri lint_check_waive SAME_CLOCK_NAME
+      .rst              (push_rst),
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .push_data,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push,
+      .full             (push_full),
+      .full_next        (push_full_next),
+      .slots            (push_slots),
+      .slots_next       (push_slots_next),
+      .ram_wr_valid     (push_ram_wr_valid),
+      .ram_wr_addr      (push_ram_wr_addr),
+      .ram_wr_data      (push_ram_wr_data),
+      .push_count_gray  (push_push_count_gray),
+      .pop_count_gray   (push_pop_count_gray),
+      .reset_active_pop (push_reset_active_pop),
+      .reset_active_push(push_reset_active_push)
+  );
+
+  br_cdc_fifo_gray_count_sync #(
+      .CountWidth(CountWidth),
+      .NumStages (NumSyncStages)
+  ) br_cdc_fifo_gray_count_sync_push2pop (
+      .src_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .src_rst(push_rst),
+      .src_count_gray(push_push_count_gray),
+      .dst_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .dst_rst(pop_rst),
+      .dst_count_gray(pop_push_count_gray)
+  );
+
+  br_cdc_fifo_gray_count_sync #(
+      .CountWidth(CountWidth),
+      .NumStages (NumSyncStages)
+  ) br_cdc_fifo_gray_count_sync_pop2push (
+      .src_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .src_rst(pop_rst),
+      .src_count_gray(pop_pop_count_gray),
+      .dst_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .dst_rst(push_rst),
+      .dst_count_gray(push_pop_count_gray)
+  );
+
+  br_cdc_bit_toggle #(
+      .NumStages(NumSyncStages),
+      .AddSourceFlop(0)
+  ) br_cdc_bit_toggle_reset_active_push (
+      .src_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .src_rst(push_rst),
+      .src_bit(push_reset_active_push),
+      .dst_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .dst_rst(pop_rst),
+      .dst_bit(pop_reset_active_push)
+  );
+
+  br_cdc_bit_toggle #(
+      .NumStages(NumSyncStages),
+      .AddSourceFlop(0)
+  ) br_cdc_bit_toggle_reset_active_pop (
+      .src_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .src_rst(pop_rst),
+      .src_bit(pop_reset_active_pop),
+      .dst_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .dst_rst(push_rst),
+      .dst_bit(push_reset_active_pop)
+  );
+
+  br_cdc_fifo_pop_ctrl #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RamReadLatency(RamReadLatency)
+  ) br_cdc_fifo_pop_ctrl (
+      .clk              (pop_clk),                // ri lint_check_waive SAME_CLOCK_NAME
+      .rst              (pop_rst),
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .empty            (pop_empty),
+      .empty_next       (pop_empty_next),
+      .items            (pop_items),
+      .items_next       (pop_items_next),
+      .ram_rd_addr_valid(pop_ram_rd_addr_valid),
+      .ram_rd_addr      (pop_ram_rd_addr),
+      .ram_rd_data_valid(pop_ram_rd_data_valid),
+      .ram_rd_data      (pop_ram_rd_data),
+      .push_count_gray  (pop_push_count_gray),
+      .pop_count_gray   (pop_pop_count_gray),
+      .reset_active_pop (pop_reset_active_pop),
+      .reset_active_push(pop_reset_active_push)
+  );
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  `BR_ASSERT_CR_IMPL(no_pop_valid_when_empty_a, pop_empty |-> !pop_valid, pop_clk, pop_rst)
+
+endmodule : br_cdc_fifo_ctrl_1r1w_push_credit

--- a/cdc/rtl/br_cdc_fifo_flops.sv
+++ b/cdc/rtl/br_cdc_fifo_flops.sv
@@ -1,0 +1,190 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL CDC FIFO (Internal 1R1W Flop-RAM, Push Ready/Valid, Pop Ready/Valid Variant)
+//
+// A one-read/one-write (1R1W) asynchronous FIFO that uses the AMBA-inspired
+// ready-valid handshake protocol for synchronizing pipeline stages and stalling
+// when encountering backpressure hazards.
+//
+// This module includes an internal flop-RAM.
+//
+// Data progresses from one stage to another when both
+// the corresponding ready signal and valid signal are
+// both 1 on the same cycle. Otherwise, the stage is stalled.
+//
+// The RegisterPopOutputs parameter can be set to 1 to add an additional br_flow_reg_fwd
+// before the pop interface of the FIFO. This may improve timing of paths dependent on
+// the pop interface at the expense of an additional pop cycle of cut-through latency.
+
+// The cut-through latency (push_valid to pop_valid latency) and backpressure
+// latency (pop_ready to push_ready) can be calculated as follows:
+//
+// Let PushT and PopT be the push period and pop period, respectively.
+//
+// The cut-through latency is max(2, FlopRamAddressDepthStages + 2) * PushT +
+// (NumSyncStages + 1 + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
+// FlopRamReadDataWidthStages + RegisterPopOutputs) * PopT.
+
+// The backpressure latency is 2 * PopT + (NumSyncStages + 1) * PushT.
+//
+// To achieve full bandwidth, the depth of the FIFO must be at least
+// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+
+module br_cdc_fifo_flops #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    // If 1, then ensure pop_valid/pop_data always come directly from a register
+    // at the cost of an additional pop cycle of cut-through latency.
+    // If 0, pop_valid/pop_data comes directly from push_valid (if bypass is enabled)
+    // and/or ram_wr_data.
+    parameter bit RegisterPopOutputs = 0,
+    // Number of synchronization stages to use for the gray counts. Must be >=2.
+    parameter int NumSyncStages = 3,
+    // Number of tiles in the depth (address) dimension. Must be at least 1 and evenly divide Depth.
+    parameter int FlopRamDepthTiles = 1,
+    // Number of tiles along the width (data) dimension. Must be at least 1 and evenly divide Width.
+    parameter int FlopRamWidthTiles = 1,
+    // Number of pipeline register stages inserted along the write address and read address paths
+    // in the depth dimension. Must be at least 0.
+    parameter int FlopRamAddressDepthStages = 0,
+    // Number of pipeline register stages inserted along the read data path in the depth dimension.
+    // Must be at least 0.
+    parameter int FlopRamReadDataDepthStages = 0,
+    // Number of pipeline register stages inserted along the read data path in the width dimension.
+    // Must be at least 0.
+    parameter int FlopRamReadDataWidthStages = 0,
+
+    // Internal computed parameters
+    localparam int AddrWidth  = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    // Posedge-triggered clock.
+    input logic push_clk,
+    // Synchronous active-high reset.
+    input logic push_rst,
+
+    // Push-side interface.
+    output logic             push_ready,
+    input  logic             push_valid,
+    input  logic [Width-1:0] push_data,
+
+    // Posedge-triggered clock.
+    input logic pop_clk,
+    // Synchronous active-high reset.
+    input logic pop_rst,
+
+    // Pop-side interface.
+    input  logic             pop_ready,
+    output logic             pop_valid,
+    output logic [Width-1:0] pop_data,
+
+    // Push-side status flags
+    output logic push_full,
+    output logic push_full_next,
+    output logic [CountWidth-1:0] push_slots,
+    output logic [CountWidth-1:0] push_slots_next,
+
+    // Pop-side status flags
+    output logic pop_empty,
+    output logic pop_empty_next,
+    output logic [CountWidth-1:0] pop_items,
+    output logic [CountWidth-1:0] pop_items_next
+);
+
+  localparam int RamReadLatency =
+      FlopRamAddressDepthStages + FlopRamReadDataDepthStages + FlopRamReadDataWidthStages;
+  localparam int RamWriteLatency = FlopRamAddressDepthStages + 1;
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  // Rely on submodule integration checks
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  logic push_ram_wr_valid;
+  logic [AddrWidth-1:0] push_ram_wr_addr;
+  logic [Width-1:0] push_ram_wr_data;
+  logic pop_ram_rd_addr_valid;
+  logic [AddrWidth-1:0] pop_ram_rd_addr;
+  logic pop_ram_rd_data_valid;
+  logic [Width-1:0] pop_ram_rd_data;
+
+  br_cdc_fifo_ctrl_1r1w #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency),
+      .NumSyncStages(NumSyncStages)
+  ) br_cdc_fifo_ctrl_1r1w (
+      .push_clk,
+      .push_rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_full_next,
+      .push_slots,
+      .push_slots_next,
+      .pop_empty,
+      .pop_empty_next,
+      .pop_items,
+      .pop_items_next,
+      .push_ram_wr_valid,
+      .push_ram_wr_addr,
+      .push_ram_wr_data,
+      .pop_ram_rd_addr_valid,
+      .pop_ram_rd_addr,
+      .pop_ram_rd_data_valid,
+      .pop_ram_rd_data
+  );
+
+  br_ram_flops_1r1w #(
+      .Depth(Depth),
+      .Width(Width),
+      .DepthTiles(FlopRamDepthTiles),
+      .WidthTiles(FlopRamWidthTiles),
+      .AddressDepthStages(FlopRamAddressDepthStages),
+      .ReadDataDepthStages(FlopRamReadDataDepthStages),
+      .ReadDataWidthStages(FlopRamReadDataWidthStages),
+      // Flops don't need to be reset, since uninitialized cells will never be read
+      .EnableMemReset(0)
+  ) br_ram_flops_1r1w (
+      .wr_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .wr_rst(push_rst),
+      .wr_valid(push_ram_wr_valid),
+      .wr_addr(push_ram_wr_addr),
+      .wr_data(push_ram_wr_data),
+      .rd_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .rd_rst(pop_rst),
+      .rd_addr_valid(pop_ram_rd_addr_valid),
+      .rd_addr(pop_ram_rd_addr),
+      .rd_data_valid(pop_ram_rd_data_valid),
+      .rd_data(pop_ram_rd_data)
+  );
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  // Rely on submodule implementation checks
+
+endmodule : br_cdc_fifo_flops

--- a/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
@@ -1,0 +1,210 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL CDC FIFO (Internal 1R1W Flop-RAM, Push Credit/Valid, Pop Ready/Valid Variant)
+//
+// A one-read/one-write (1R1W) asynchronous FIFO controller that uses a credit-valid
+// push interface and an AMBA-inspired ready-valid pop interface
+// for synchronizing pipeline stages and stalling
+// when encountering backpressure hazards.
+//
+// This module includes an internal flop-RAM.
+//
+// The RegisterPopOutputs parameter can be set to 1 to add an additional br_flow_reg_fwd
+// before the pop interface of the FIFO. This may improve timing of paths dependent on
+// the pop interface at the expense of an additional pop cycle of cut-through latency.
+
+// The cut-through latency (push_valid to pop_valid latency) and backpressure
+// latency (pop_ready to push_ready) can be calculated as follows:
+//
+// Let PushT and PopT be the push period and pop period, respectively.
+//
+// The cut-through latency is max(2, FlopRamAddressDepthStages + 2) * PushT +
+// (NumSyncStages + 1 + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
+// FlopRamReadDataWidthStages + RegisterPopOutputs) * PopT.
+
+// The backpressure latency is 2 * PopT + (NumSyncStages + 1 + RegisterPushCredit) * PushT.
+//
+// To achieve full bandwidth, the depth of the FIFO must be at least
+// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+
+
+module br_cdc_fifo_flops_push_credit #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    // Maximum credit for the internal credit counter. Must be at least Depth.
+    // Recommended to not override the default because it is the smallest viable size.
+    // Overriding may be convenient if having a consistent credit counter register width
+    // (say, 16-bit) throughout a design is deemed useful.
+    parameter int MaxCredit = Depth,
+    // If 1, add a retiming stage to the push_credit signal so that it is
+    // driven directly from a flop. This comes at the expense of one additional
+    // push cycle of credit loop latency.
+    parameter bit RegisterPushCredit = 0,
+    // If 1, then ensure pop_valid/pop_data always come directly from a register
+    // at the cost of an additional pop cycle of cut-through latency.
+    // If 0, pop_valid/pop_data comes directly from push_valid (if bypass is enabled)
+    // and/or ram_wr_data.
+    parameter bit RegisterPopOutputs = 1,
+    // Number of synchronization stages to use for the gray counts. Must be >=2.
+    parameter int NumSyncStages = 3,
+    // Number of tiles in the depth (address) dimension. Must be at least 1 and evenly divide Depth.
+    parameter int FlopRamDepthTiles = 1,
+    // Number of tiles along the width (data) dimension. Must be at least 1 and evenly divide Width.
+    parameter int FlopRamWidthTiles = 1,
+    // Number of pipeline register stages inserted along the write address and read address paths
+    // in the depth dimension. Must be at least 0.
+    parameter int FlopRamAddressDepthStages = 0,
+    // Number of pipeline register stages inserted along the read data path in the depth dimension.
+    // Must be at least 0.
+    parameter int FlopRamReadDataDepthStages = 0,
+    // Number of pipeline register stages inserted along the read data path in the width dimension.
+    // Must be at least 0.
+    parameter int FlopRamReadDataWidthStages = 0,
+
+    // Internal computed parameters
+    localparam int AddrWidth   = $clog2(Depth),
+    localparam int CountWidth  = $clog2(Depth + 1),
+    localparam int CreditWidth = $clog2(MaxCredit + 1)
+) (
+    // Push-side posedge-triggered clock.
+    input logic push_clk,
+    // Push-side synchronous active-high reset.
+    input logic push_rst,
+    // Pop-side posedge-triggered clock.
+    input logic pop_clk,
+    // Pop-side synchronous active-high reset.
+    input logic pop_rst,
+
+    // Push-side interface
+    input  logic             push_credit_stall,
+    output logic             push_credit,
+    input  logic             push_valid,
+    input  logic [Width-1:0] push_data,
+
+    // Pop-side interface.
+    input  logic             pop_ready,
+    output logic             pop_valid,
+    output logic [Width-1:0] pop_data,
+
+    // Push-side status flags
+    output logic push_full,
+    output logic push_full_next,
+    output logic [CountWidth-1:0] push_slots,
+    output logic [CountWidth-1:0] push_slots_next,
+
+    // Push-side credits
+    input  logic [CreditWidth-1:0] credit_initial_push,
+    input  logic [CreditWidth-1:0] credit_withhold_push,
+    output logic [CreditWidth-1:0] credit_count_push,
+    output logic [CreditWidth-1:0] credit_available_push,
+
+    // Pop-side status flags
+    output logic pop_empty,
+    output logic pop_empty_next,
+    output logic [CountWidth-1:0] pop_items,
+    output logic [CountWidth-1:0] pop_items_next
+);
+  localparam int RamReadLatency =
+      FlopRamAddressDepthStages + FlopRamReadDataDepthStages + FlopRamReadDataWidthStages;
+  localparam int RamWriteLatency = FlopRamAddressDepthStages + 1;
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  // Rely on submodule integration checks
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  logic push_ram_wr_valid;
+  logic [AddrWidth-1:0] push_ram_wr_addr;
+  logic [Width-1:0] push_ram_wr_data;
+  logic pop_ram_rd_addr_valid;
+  logic [AddrWidth-1:0] pop_ram_rd_addr;
+  logic pop_ram_rd_data_valid;
+  logic [Width-1:0] pop_ram_rd_data;
+
+  br_cdc_fifo_ctrl_1r1w_push_credit #(
+      .Depth(Depth),
+      .Width(Width),
+      .MaxCredit(MaxCredit),
+      .RegisterPushCredit(RegisterPushCredit),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency),
+      .NumSyncStages(NumSyncStages)
+  ) br_cdc_fifo_ctrl_1r1w_push_credit (
+      .push_clk,
+      .push_rst,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_full_next,
+      .push_slots,
+      .push_slots_next,
+      .pop_empty,
+      .pop_empty_next,
+      .pop_items,
+      .pop_items_next,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push,
+      .push_ram_wr_valid,
+      .push_ram_wr_addr,
+      .push_ram_wr_data,
+      .pop_ram_rd_addr_valid,
+      .pop_ram_rd_addr,
+      .pop_ram_rd_data_valid,
+      .pop_ram_rd_data
+  );
+
+  br_ram_flops_1r1w #(
+      .Depth(Depth),
+      .Width(Width),
+      .DepthTiles(FlopRamDepthTiles),
+      .WidthTiles(FlopRamWidthTiles),
+      .AddressDepthStages(FlopRamAddressDepthStages),
+      .ReadDataDepthStages(FlopRamReadDataDepthStages),
+      .ReadDataWidthStages(FlopRamReadDataWidthStages),
+      // Flops don't need to be reset, since uninitialized cells will never be read
+      .EnableMemReset(0)
+  ) br_ram_flops_1r1w (
+      .wr_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .wr_rst(push_rst),
+      .rd_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .rd_rst(pop_rst),
+      .wr_valid(push_ram_wr_valid),
+      .wr_addr(push_ram_wr_addr),
+      .wr_data(push_ram_wr_data),
+      .rd_addr_valid(pop_ram_rd_addr_valid),
+      .rd_addr(pop_ram_rd_addr),
+      .rd_data_valid(pop_ram_rd_data_valid),
+      .rd_data(pop_ram_rd_data)
+  );
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  // Rely on submodule implementation checks
+
+endmodule : br_cdc_fifo_flops_push_credit

--- a/cdc/rtl/internal/BUILD.bazel
+++ b/cdc/rtl/internal/BUILD.bazel
@@ -1,0 +1,168 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
+
+package(default_visibility = ["//cdc/rtl:__subpackages__"])
+
+verilog_library(
+    name = "br_cdc_fifo_push_flag_mgr",
+    srcs = ["br_cdc_fifo_push_flag_mgr.sv"],
+    deps = [
+        "//counter/rtl:br_counter_incr",
+        "//delay/rtl:br_delay",
+        "//delay/rtl:br_delay_nr",
+        "//enc/rtl:br_enc_bin2gray",
+        "//enc/rtl:br_enc_gray2bin",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+        "//pkg:br_math_pkg",
+    ],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_push_ctrl",
+    srcs = ["br_cdc_fifo_push_ctrl.sv"],
+    deps = [
+        ":br_cdc_fifo_push_flag_mgr",
+        "//fifo/rtl/internal:br_fifo_push_ctrl_core",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_cdc_fifo_push_ctrl_test_suite",
+    params = {
+        "Depth": [
+            "5",
+            "8",
+        ],
+        "Width": [
+            "8",
+        ],
+        "RamWriteLatency": [
+            "1",
+            "2",
+        ],
+    },
+    deps = [":br_cdc_fifo_push_ctrl"],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_push_ctrl_credit",
+    srcs = ["br_cdc_fifo_push_ctrl_credit.sv"],
+    deps = [
+        ":br_cdc_fifo_push_flag_mgr",
+        "//credit/rtl:br_credit_receiver",
+        "//fifo/rtl/internal:br_fifo_push_ctrl_core",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_cdc_fifo_push_ctrl_credit_test_suite",
+    params = {
+        "Depth": [
+            "5",
+            "8",
+        ],
+        "Width": [
+            "8",
+        ],
+        "RamWriteLatency": [
+            "1",
+            "2",
+        ],
+        "RegisterPushCredit": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_cdc_fifo_push_ctrl_credit"],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_pop_flag_mgr",
+    srcs = ["br_cdc_fifo_pop_flag_mgr.sv"],
+    deps = [
+        "//counter/rtl:br_counter_incr",
+        "//delay/rtl:br_delay",
+        "//delay/rtl:br_delay_nr",
+        "//enc/rtl:br_enc_bin2gray",
+        "//enc/rtl:br_enc_gray2bin",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+    ],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_pop_ctrl",
+    srcs = ["br_cdc_fifo_pop_ctrl.sv"],
+    deps = [
+        ":br_cdc_fifo_pop_flag_mgr",
+        "//fifo/rtl/internal:br_fifo_pop_ctrl_core",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_cdc_fifo_pop_ctrl_test_suite",
+    params = {
+        "Depth": [
+            "5",
+            "8",
+        ],
+        "Width": [
+            "8",
+        ],
+        "RamReadLatency": [
+            "0",
+            "1",
+            "2",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_cdc_fifo_pop_ctrl"],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_gray_count_sync",
+    srcs = ["br_cdc_fifo_gray_count_sync.sv"],
+    deps = [
+        "//cdc/rtl:br_cdc_bit_toggle",
+        "//macros:br_asserts_internal",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_cdc_fifo_gray_count_sync_test_suite",
+    params = {
+        "CountWidth": [
+            "3",
+            "4",
+        ],
+        "NumStages": [
+            "2",
+            "3",
+        ],
+    },
+    deps = [":br_cdc_fifo_gray_count_sync"],
+)

--- a/cdc/rtl/internal/br_cdc_fifo_gray_count_sync.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_gray_count_sync.sv
@@ -1,0 +1,63 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Synchronizer for gray-encoded counts that adds some useful integration
+// assertions.
+
+`include "br_asserts_internal.svh"
+
+module br_cdc_fifo_gray_count_sync #(
+    // Width of the gray-encoded count. Must be at least 2.
+    parameter int CountWidth = 2,
+    // Number of synchronization stages. Must be at least 1.
+    parameter int NumStages  = 3
+) (
+    // Used for assertions only
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic src_clk,
+    // Used for assertions only
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic src_rst,
+    input logic [CountWidth-1:0] src_count_gray,
+
+    input logic dst_clk,
+    // Used for assertions only
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic dst_rst,
+    output logic [CountWidth-1:0] dst_count_gray
+);
+  // Integration Assertions
+
+  `BR_ASSERT_STATIC(legal_count_width_a, CountWidth >= 2)
+  `BR_ASSERT_STATIC(legal_num_stages_a, NumStages >= 1)
+
+  `BR_ASSERT_CR_IMPL(single_bit_change_a, $onehot0(src_count_gray ^ $past(src_count_gray)),
+                     src_clk, src_rst)
+
+  // Implementation
+  for (genvar i = 0; i < CountWidth; i++) begin : gen_cdc_sync
+    br_cdc_bit_toggle #(
+        .AddSourceFlop(0),  // Assume flopped externally
+        .NumStages(NumStages)
+    ) br_cdc_bit_toggle_inst (
+        .src_clk,
+        .src_rst,
+        .src_bit(src_count_gray[i]),
+        .dst_clk,
+        .dst_rst,
+        .dst_bit(dst_count_gray[i])
+    );
+  end
+
+endmodule : br_cdc_fifo_gray_count_sync

--- a/cdc/rtl/internal/br_cdc_fifo_pop_ctrl.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_pop_ctrl.sv
@@ -1,0 +1,131 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL FIFO Pop Controller (Ready/Valid)
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+`include "br_unused.svh"
+
+module br_cdc_fifo_pop_ctrl #(
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter int RamReadLatency = 0,
+    parameter bit RegisterPopOutputs = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    // Posedge-triggered clock.
+    input logic clk,
+    // Synchronous active-high reset.
+    input logic rst,
+
+    // Pop-side interface.
+    input  logic             pop_ready,
+    output logic             pop_valid,
+    output logic [Width-1:0] pop_data,
+
+    // Pop-side status flags
+    output logic                  empty,
+    output logic                  empty_next,
+    output logic [CountWidth-1:0] items,
+    output logic [CountWidth-1:0] items_next,
+
+    // RAM interface
+    output logic                 ram_rd_addr_valid,
+    output logic [AddrWidth-1:0] ram_rd_addr,
+    // Not used except for assertions in some configurations.
+    // ri lint_check_waive INEFFECTIVE_NET
+    input  logic                 ram_rd_data_valid,
+    input  logic [    Width-1:0] ram_rd_data,
+
+    // Signals synchronized from/to the push side
+    input  logic [CountWidth-1:0] push_count_gray,
+    output logic [CountWidth-1:0] pop_count_gray,
+    input  logic                  reset_active_push,
+    output logic                  reset_active_pop
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
+  `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
+
+  `BR_ASSERT_INTG(ram_rd_latency_matches_a,
+                  ram_rd_addr_valid |-> ##RamReadLatency ram_rd_data_valid)
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  // Core flow-control logic
+
+  logic pop_beat;
+
+  br_fifo_pop_ctrl_core #(
+      .Depth(Depth),
+      .Width(Width),
+      .EnableBypass(1'b0),  // Bypass is not used for CDC
+      .RamReadLatency(RamReadLatency),
+      .RegisterPopOutputs(RegisterPopOutputs)
+  ) br_fifo_pop_ctrl_core (
+      .clk,
+      .rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .bypass_ready(),  // Not used
+      .bypass_valid_unstable(1'b0),  // Not used
+      .bypass_data_unstable(Width'(1'b0)),  // Not used
+      .ram_rd_addr_valid,
+      .ram_rd_addr,
+      .ram_rd_data_valid,
+      .ram_rd_data,
+      .empty,
+      .items,
+      .pop_beat
+  );
+
+  // Status flags
+  br_cdc_fifo_pop_flag_mgr #(
+      .Depth(Depth)
+  ) br_cdc_fifo_pop_flag_mgr (
+      .clk,
+      .rst,
+      .pop_beat,
+      .push_count_gray,
+      .pop_count_gray,
+      .items_next,
+      .items,
+      .empty_next,
+      .empty,
+      .reset_active_push,
+      .reset_active_pop
+  );
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  `BR_ASSERT_IMPL(ram_rd_addr_in_range_a, ram_rd_addr_valid |-> ram_rd_addr < Depth)
+
+  // Flow control
+  `BR_ASSERT_IMPL(no_pop_valid_on_empty_a, pop_valid |-> !empty)
+
+  // Flags
+  `BR_ASSERT_IMPL(items_in_range_a, items <= Depth)
+  `BR_ASSERT_IMPL(pop_items_a, (items_next < items) |-> pop_beat)
+  `BR_ASSERT_IMPL(empty_a, empty == (items == 0))
+
+endmodule : br_cdc_fifo_pop_ctrl

--- a/cdc/rtl/internal/br_cdc_fifo_pop_flag_mgr.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_pop_flag_mgr.sv
@@ -1,0 +1,131 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This module manages the pop-side flags for a CDC FIFO.
+// It takes in the push count as a gray code, decodes it to binary,
+// and compares it to the internal pop count to determine the number of
+// items in the FIFO.
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+`include "br_unused.svh"
+
+module br_cdc_fifo_pop_flag_mgr #(
+    parameter int Depth = 2,
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input  logic                  clk,
+    input  logic                  rst,
+    input  logic                  pop_beat,
+    input  logic [CountWidth-1:0] push_count_gray,
+    output logic [CountWidth-1:0] pop_count_gray,
+    output logic [CountWidth-1:0] items_next,
+    output logic [CountWidth-1:0] items,
+    output logic                  empty_next,
+    output logic                  empty,
+    input  logic                  reset_active_push,
+    output logic                  reset_active_pop
+);
+  `BR_ASSERT_STATIC(legal_depth_A, Depth >= 2)
+
+  localparam int MaxCountP1 = 1 << CountWidth;
+  localparam int MaxCount = MaxCountP1 - 1;
+  localparam int ResetActiveDelay = 1;
+  // Need to make sure that on pop reset, the updated pop_count is not visible
+  // to the push side before reset_active is.
+  localparam int PopCountDelay = ResetActiveDelay + 1;
+
+  logic [CountWidth-1:0] pop_count_next;
+  logic [CountWidth-1:0] pop_count_next_gray;
+  logic [CountWidth-1:0] push_count;
+  logic [CountWidth-1:0] push_count_saved;
+  logic [CountWidth-1:0] push_count_visible;
+
+  br_counter_incr #(
+      .MaxValue(MaxCount)
+  ) br_counter_incr_pop_count (
+      .clk,
+      .rst,
+      .reinit(1'b0),  // unused
+      .initial_value(CountWidth'(1'b0)),
+      .incr_valid(pop_beat),
+      .incr(1'b1),
+      .value(),
+      .value_next(pop_count_next)
+  );
+
+  br_enc_gray2bin #(
+      .Width(CountWidth)
+  ) br_enc_gray2bin_inst (
+      .gray(push_count_gray),
+      .bin (push_count)
+  );
+
+  br_enc_bin2gray #(
+      .Width(CountWidth)
+  ) br_enc_bin2gray_inst (
+      .bin (pop_count_next),
+      .gray(pop_count_next_gray)
+  );
+
+  br_delay_nr #(
+      .Width(1),
+      .NumStages(ResetActiveDelay)
+  ) br_delay_nr_reset_active_pop (
+      .clk,
+      .rst(1'b0),  // unused
+      .in(rst),
+      .out(reset_active_pop),
+      .out_stages()
+  );
+
+  br_delay #(
+      .Width(CountWidth),
+      .NumStages(PopCountDelay)
+  ) br_delay_pop_count_gray (
+      .clk,
+      .rst,
+      .in(pop_count_next_gray),
+      .out(pop_count_gray),
+      .out_stages()
+  );
+
+  // Extended versions of the counts to allow for overflow
+  logic [CountWidth:0] pop_count_next_ext;
+  logic [CountWidth:0] push_count_visible_ext;
+  logic [CountWidth:0] items_next_ext;  // ri lint_check_waive INEFFECTIVE_NET
+  logic [CountWidth:0] items_wrap_offset;
+  logic [CountWidth:0] push_count_adjusted;
+
+  assign push_count_visible = reset_active_push ? push_count_saved : push_count;
+  assign pop_count_next_ext = {1'b0, pop_count_next};
+  assign push_count_visible_ext = {1'b0, push_count_visible};
+  assign items_wrap_offset = MaxCountP1;
+  assign push_count_adjusted = push_count_visible_ext + items_wrap_offset;
+  assign items_next_ext = (push_count_visible_ext >= pop_count_next_ext) ?
+      (push_count_visible_ext - pop_count_next_ext) :
+      (push_count_adjusted - pop_count_next_ext);
+  assign items_next = items_next_ext[CountWidth-1:0];
+  assign empty_next = (items_next == '0);
+
+  `BR_REGL(push_count_saved, push_count, !reset_active_push)
+  `BR_REGL(items, items_next, pop_beat || !reset_active_push)
+  `BR_REGIL(empty, empty_next, pop_beat || !reset_active_push, 1'b1)
+
+  `BR_UNUSED_NAMED(items_next_ext_msb, items_next_ext[CountWidth])
+
+  // Implementation checks
+  `BR_ASSERT_IMPL(no_items_overflow_A, items_next_ext <= Depth)
+
+endmodule : br_cdc_fifo_pop_flag_mgr

--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
@@ -1,0 +1,124 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Push Controller for CDC FIFO with Ready/Valid interface
+
+`include "br_asserts_internal.svh"
+
+module br_cdc_fifo_push_ctrl #(
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter int RamWriteLatency = 1,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    // Posedge-triggered clock.
+    input logic clk,
+    // Synchronous active-high reset.
+    input logic rst,
+
+    // Push-side interface.
+    output logic             push_ready,
+    input  logic             push_valid,
+    input  logic [Width-1:0] push_data,
+
+    // Push-side status flags
+    output logic                  full,
+    output logic                  full_next,
+    output logic [CountWidth-1:0] slots,
+    output logic [CountWidth-1:0] slots_next,
+
+    // RAM interface
+    output logic                 ram_wr_valid,
+    output logic [AddrWidth-1:0] ram_wr_addr,
+    output logic [    Width-1:0] ram_wr_data,
+
+    // Signals to/from pop controller
+    input  logic [CountWidth-1:0] pop_count_gray,
+    output logic [CountWidth-1:0] push_count_gray,
+    input  logic                  reset_active_pop,
+    output logic                  reset_active_push
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
+  `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
+  `BR_COVER_INTG(full_c, full)
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  logic push_beat;
+
+  br_cdc_fifo_push_flag_mgr #(
+      .Depth(Depth),
+      .RamWriteLatency(RamWriteLatency)
+  ) br_cdc_fifo_push_flag_mgr (
+      .clk,
+      .rst,
+      .push_beat,
+      .push_count_gray,
+      .pop_count_gray,
+      .pop_count_delta(),
+      .slots_next,
+      .slots,
+      .full_next,
+      .full,
+      .reset_active_push,
+      .reset_active_pop
+  );
+
+  // Core flow-control logic
+  br_fifo_push_ctrl_core #(
+      .Depth(Depth),
+      .Width(Width),
+      .EnableBypass(1'b0)  // Bypass is not enabled for CDC
+  ) br_fifo_push_ctrl_core (
+      .clk,
+      .rst,
+
+      .push_ready,
+      .push_valid,
+      .push_data,
+
+      .bypass_ready(1'b0),  // Bypass not used
+      .bypass_valid_unstable(),  // Bypass not used
+      .bypass_data_unstable(),  // Bypass not used
+
+      .ram_wr_valid,
+      .ram_wr_addr,
+      .ram_wr_data,
+
+      .full,
+      .push_beat
+  );
+
+  // Implementation checks
+  // Implementation checks
+  `BR_ASSERT_IMPL(ram_wr_addr_in_range_a, ram_wr_valid |-> ram_wr_addr < Depth)
+
+  // Flow control and latency
+  `BR_ASSERT_IMPL(push_backpressure_when_full_a, full |-> !push_ready)
+
+  // Flags
+  `BR_ASSERT_IMPL(slots_in_range_a, slots <= Depth)
+  `BR_ASSERT_IMPL(slots_next_a, ##1 slots == $past(slots_next))
+  // Slots should only decrease on a push
+  `BR_ASSERT_IMPL(push_slots_a, (slots_next < slots) |-> push_beat)
+  `BR_ASSERT_IMPL(full_a, full == (slots == 0))
+
+endmodule : br_cdc_fifo_push_ctrl

--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
@@ -1,0 +1,162 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Push Controller for CDC FIFO with Credit/Valid interface
+
+`include "br_asserts_internal.svh"
+
+module br_cdc_fifo_push_ctrl_credit #(
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter int RamWriteLatency = 1,
+    parameter int MaxCredit = Depth,
+    parameter bit RegisterPushCredit = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1),
+    localparam int CreditWidth = $clog2(MaxCredit + 1)
+) (
+    // Posedge-triggered clock.
+    input logic clk,
+    // Synchronous active-high reset.
+    input logic rst,
+
+    // Push-side interface.
+    input  logic             push_credit_stall,
+    output logic             push_credit,
+    input  logic             push_valid,
+    input  logic [Width-1:0] push_data,
+
+    // Push-side status flags
+    output logic                  full,
+    output logic                  full_next,
+    output logic [CountWidth-1:0] slots,
+    output logic [CountWidth-1:0] slots_next,
+
+    // Push-side credits
+    input  logic [CreditWidth-1:0] credit_initial_push,
+    input  logic [CreditWidth-1:0] credit_withhold_push,
+    output logic [CreditWidth-1:0] credit_count_push,
+    output logic [CreditWidth-1:0] credit_available_push,
+
+    // RAM interface
+    output logic                 ram_wr_valid,
+    output logic [AddrWidth-1:0] ram_wr_addr,
+    output logic [    Width-1:0] ram_wr_data,
+
+    // Signals to/from pop controller
+    input  logic [CountWidth-1:0] pop_count_gray,
+    output logic [CountWidth-1:0] push_count_gray,
+    input  logic                  reset_active_pop,
+    output logic                  reset_active_push
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
+  `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
+  `BR_COVER_INTG(full_c, full)
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  // Flow control
+  logic internal_valid;
+  logic [Width-1:0] internal_data;
+  logic push_beat;
+  // The amount of credit to return on a cycle is the amount that pop_count has changed.
+  // The most conservative maximum for this is Depth, but it is likely much smaller.
+  // However, calculating a smaller bound would require knowing the cut-through latency
+  // and relatively clock speeds, which we want to avoid.
+  logic [CountWidth-1:0] pop_count_delta;
+
+  br_credit_receiver #(
+      .Width             (Width),
+      .MaxCredit         (MaxCredit),
+      .RegisterPushCredit(RegisterPushCredit),
+      .PopCreditMaxChange(Depth)
+  ) br_credit_receiver (
+      .clk,
+      .rst,
+      .push_credit_stall(push_credit_stall),
+      .push_credit(push_credit),
+      .push_valid(push_valid),
+      .push_data(push_data),
+      .pop_credit(pop_count_delta),
+      .pop_valid(internal_valid),
+      .pop_data(internal_data),
+      .credit_initial(credit_initial_push),
+      .credit_withhold(credit_withhold_push),
+      .credit_count(credit_count_push),
+      .credit_available(credit_available_push)
+  );
+
+  br_cdc_fifo_push_flag_mgr #(
+      .Depth(Depth),
+      .RamWriteLatency(RamWriteLatency)
+  ) br_cdc_fifo_push_flag_mgr (
+      .clk,
+      .rst,
+      .push_beat,
+      .push_count_gray,
+      .pop_count_gray,
+      .pop_count_delta,
+      .slots_next,
+      .slots,
+      .full_next,
+      .full,
+      .reset_active_push,
+      .reset_active_pop
+  );
+
+  // Core flow-control logic
+  br_fifo_push_ctrl_core #(
+      .Depth(Depth),
+      .Width(Width),
+      .EnableBypass(1'b0)  // Bypass is not enabled for CDC
+  ) br_fifo_push_ctrl_core (
+      .clk,
+      .rst,
+
+      .push_ready(),
+      .push_valid(internal_valid),
+      .push_data (internal_data),
+
+      .bypass_ready(1'b0),  // Bypass not used
+      .bypass_valid_unstable(),  // Bypass not used
+      .bypass_data_unstable(),  // Bypass not used
+
+      .ram_wr_valid,
+      .ram_wr_addr,
+      .ram_wr_data,
+
+      .full,
+      .push_beat
+  );
+
+  // Implementation checks
+  `BR_ASSERT_IMPL(ram_wr_addr_in_range_a, ram_wr_valid |-> ram_wr_addr < Depth)
+
+  // Flow control and latency
+  `BR_ASSERT_IMPL(no_overflow_a, internal_valid |-> !full)
+
+  // Flags
+  `BR_ASSERT_IMPL(slots_in_range_a, slots <= Depth)
+  `BR_ASSERT_IMPL(slots_next_a, ##1 slots == $past(slots_next))
+  // Slots should only decrease on a push
+  `BR_ASSERT_IMPL(push_slots_a, (slots_next < slots) |-> push_beat)
+  `BR_ASSERT_IMPL(full_a, full == (slots == 0))
+
+endmodule : br_cdc_fifo_push_ctrl_credit

--- a/cdc/rtl/internal/br_cdc_fifo_push_flag_mgr.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_flag_mgr.sv
@@ -1,0 +1,134 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This module manages the push-side flags for a CDC FIFO.
+// It takes in the pop count as a gray code, decodes it to binary,
+// and compares it to the internal push count to determine the number of
+// slots remaining in the FIFO.
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+`include "br_unused.svh"
+
+module br_cdc_fifo_push_flag_mgr #(
+    parameter int Depth = 2,
+    parameter int RamWriteLatency = 1,
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input  logic                  clk,
+    input  logic                  rst,
+    input  logic                  push_beat,
+    output logic [CountWidth-1:0] push_count_gray,
+    input  logic [CountWidth-1:0] pop_count_gray,
+    output logic [CountWidth-1:0] pop_count_delta,
+    output logic [CountWidth-1:0] slots_next,
+    output logic [CountWidth-1:0] slots,
+    output logic                  full_next,
+    output logic                  full,
+    output logic                  reset_active_push,
+    input  logic                  reset_active_pop
+);
+  `BR_ASSERT_STATIC(legal_depth_A, Depth >= 2)
+  `BR_ASSERT_STATIC(legal_ram_write_latency_A, RamWriteLatency >= 1)
+
+  localparam int MaxCountP1 = 1 << CountWidth;
+  localparam int MaxCount = MaxCountP1 - 1;
+  localparam int ResetActiveDelay = 1;
+  // Need to make sure that on push reset, the updated push_count is not visible
+  // to the pop side before reset_active is.
+  localparam int PushCountDelay = br_math::max2(ResetActiveDelay + 1, RamWriteLatency);
+
+  logic [CountWidth-1:0] push_count_next;
+  logic [CountWidth-1:0] push_count_next_gray;
+  logic [CountWidth-1:0] pop_count;
+  logic [CountWidth-1:0] pop_count_saved;
+  logic [CountWidth-1:0] pop_count_visible;
+
+  br_counter_incr #(
+      .MaxValue(MaxCount)
+  ) br_counter_incr_push_count (
+      .clk,
+      .rst,
+      .reinit(1'b0),  // unused
+      .initial_value(CountWidth'(1'b0)),
+      .incr_valid(push_beat),
+      .incr(1'b1),
+      .value(),
+      .value_next(push_count_next)
+  );
+
+  br_enc_gray2bin #(
+      .Width(CountWidth)
+  ) br_enc_gray2bin_inst (
+      .gray(pop_count_gray),
+      .bin (pop_count)
+  );
+
+  br_enc_bin2gray #(
+      .Width(CountWidth)
+  ) br_enc_bin2gray_inst (
+      .bin (push_count_next),
+      .gray(push_count_next_gray)
+  );
+
+  br_delay_nr #(
+      .Width(1),
+      .NumStages(ResetActiveDelay)
+  ) br_delay_nr_reset_active_push (
+      .clk,
+      .rst(1'b0),  // unused
+      .in(rst),
+      .out(reset_active_push),
+      .out_stages()
+  );
+
+  br_delay #(
+      .Width(CountWidth),
+      .NumStages(PushCountDelay)
+  ) br_delay_push_count_gray (
+      .clk,
+      .rst,
+      .in(push_count_next_gray),
+      .out(push_count_gray),
+      .out_stages()
+  );
+
+  // Extended versions of the counts to allow for overflow
+  logic [CountWidth:0] push_count_next_ext;
+  logic [CountWidth:0] pop_count_visible_ext;
+  logic [CountWidth:0] items_wrap_offset;
+  logic [CountWidth:0] push_count_adjusted;
+  logic [CountWidth:0] items_next;  // ri lint_check_waive INEFFECTIVE_NET
+
+  assign pop_count_visible = reset_active_pop ? pop_count_saved : pop_count;
+  assign pop_count_delta = reset_active_pop ? '0 : (pop_count - pop_count_saved);
+  assign push_count_next_ext = {1'b0, push_count_next};
+  assign pop_count_visible_ext = {1'b0, pop_count_visible};
+  assign items_wrap_offset = MaxCountP1;
+  assign push_count_adjusted = push_count_next_ext + items_wrap_offset;
+  assign items_next = (push_count_next_ext >= pop_count_visible_ext) ?
+      (push_count_next_ext - pop_count_visible_ext) :
+      (push_count_adjusted - pop_count_visible_ext);
+  assign slots_next = Depth - items_next[CountWidth-1:0];
+  assign full_next = (slots_next == '0);
+
+  `BR_REGL(pop_count_saved, pop_count, !reset_active_pop)
+  `BR_REGIL(slots, slots_next, push_beat || !reset_active_pop, Depth)
+  `BR_REGL(full, full_next, push_beat || !reset_active_pop)
+
+  `BR_UNUSED_NAMED(items_next_msb, items_next[CountWidth])
+
+  // Implementation checks
+  `BR_ASSERT_IMPL(no_overflow_a, items_next <= Depth)
+endmodule : br_cdc_fifo_push_flag_mgr

--- a/cdc/sim/BUILD.bazel
+++ b/cdc/sim/BUILD.bazel
@@ -1,0 +1,65 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:public"])
+
+verilog_library(
+    name = "br_cdc_fifo_flops_tb",
+    srcs = ["br_cdc_fifo_flops_tb.sv"],
+    deps = [
+        "//cdc/rtl:br_cdc_fifo_flops",
+        "//fifo/sim:br_fifo_test_harness",
+        "//misc/sim:br_test_driver",
+        "//pkg:br_math_pkg",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_fifo_flops_tb_elab_test",
+    deps = [":br_cdc_fifo_flops_tb"],
+)
+
+br_verilog_sim_test_suite(
+    name = "br_cdc_fifo_flops_vcs_test_suite",
+    params = {
+        "Depth": [
+            # Minimum depth needed for full bandwidth at the maximum cut-through and backpressure latencies
+            "15",
+        ],
+        "Width": ["8"],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "FlopRamAddressDepthStages": [
+            "0",
+            "1",
+        ],
+        "FlopRamReadDataDepthStages": [
+            "0",
+            "1",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+        ],
+    },
+    tool = "vcs",
+    waves = True,
+    deps = [":br_cdc_fifo_flops_tb"],
+)

--- a/cdc/sim/br_cdc_fifo_flops_tb.sv
+++ b/cdc/sim/br_cdc_fifo_flops_tb.sv
@@ -1,0 +1,149 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+`timescale 1ns / 1ps
+
+module br_cdc_fifo_flops_tb;
+
+  // Parameters
+  parameter int Depth = 13;
+  parameter int Width = 8;
+  parameter int RegisterPopOutputs = 0;
+  parameter int FlopRamAddressDepthStages = 0;
+  parameter int FlopRamReadDataDepthStages = 0;
+  parameter int NumSyncStages = 3;
+
+  // Clock and Reset
+  // Same clock for both push and pop side for now
+  // TODO(zhemao): Test with different push and pop frequencies
+  reg clk;
+  reg rst;
+
+  logic start;
+  logic finished;
+  logic [31:0] error_count;
+
+  // Push Interface
+  wire push_ready;
+  reg push_valid;
+  reg [Width-1:0] push_data;
+
+  // Pop Interface
+  reg pop_ready;
+  wire pop_valid;
+  wire [Width-1:0] pop_data;
+
+  // Status Outputs
+  wire empty;
+  wire full;
+  wire [$clog2(Depth+1)-1:0] items;
+  wire [$clog2(Depth+1)-1:0] slots;
+
+  // Instantiate the FIFO
+  br_cdc_fifo_flops #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
+      .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages)
+  ) dut (
+      .push_clk(clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .push_rst(rst),
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .push_slots(slots),
+      .push_slots_next(),
+      .push_full(full),
+      .push_full_next(),
+      .pop_clk(clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .pop_rst(rst),
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .pop_empty(empty),
+      .pop_empty_next(),
+      .pop_items(items),
+      .pop_items_next()
+  );
+
+  localparam int ResetActiveDelay = 1;
+  localparam int RamWriteLatency = FlopRamAddressDepthStages + 1;
+  localparam int RamReadLatency = FlopRamReadDataDepthStages;
+  localparam int CutThroughLatency =
+  // Push-side retiming
+  br_math::max2(
+      RamWriteLatency, ResetActiveDelay + 1
+  ) +
+  // Gray count CDC
+  NumSyncStages +
+  // Pop-side retiming
+  1 + RamReadLatency + RegisterPopOutputs;
+  localparam int BackpressureLatency = ResetActiveDelay + 1 +  // Pop-side
+  NumSyncStages + 1;  // Push-side
+
+  // Hook up the test harness
+  br_fifo_test_harness #(
+      .Depth(Depth),
+      .Width(Width),
+      .CutThroughLatency(CutThroughLatency),
+      .BackpressureLatency(BackpressureLatency)
+  ) br_fifo_test_harness (
+      .clk,
+      .rst,
+      .start      (start),
+      .finished   (finished),
+      .error_count(error_count),
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .empty,
+      .full,
+      .items,
+      .slots
+  );
+
+  br_test_driver #(
+      .ResetCycles(10)
+  ) td (
+      .clk,
+      .rst
+  );
+
+  // Test Sequence
+  initial begin
+    integer timeout;
+
+    start = 0;
+
+    td.reset_dut();
+
+    $display("Starting test");
+
+    start   = 1'b1;
+
+    timeout = 5000;
+    td.wait_cycles();
+    while (timeout > 0 && !finished) td.wait_cycles();
+
+    td.check(timeout > 0, $sformatf("Test timed out"));
+    td.check(error_count == 0, $sformatf("Errors in test"));
+
+    td.finish();
+  end
+
+endmodule

--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -15,7 +15,10 @@
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
 
-package(default_visibility = ["//fifo/rtl:__subpackages__"])
+package(default_visibility = [
+    "//cdc/rtl:__subpackages__",
+    "//fifo/rtl:__subpackages__",
+])
 
 verilog_library(
     name = "br_fifo_push_ctrl_core",

--- a/fifo/sim/br_fifo_test_harness.sv
+++ b/fifo/sim/br_fifo_test_harness.sv
@@ -16,7 +16,9 @@
 
 module br_fifo_test_harness #(
     parameter int Width = 1,
-    parameter int Depth = 2
+    parameter int Depth = 2,
+    parameter int CutThroughLatency = 1,
+    parameter int BackpressureLatency = 1
 ) (
     input  logic        clk,
     input  logic        rst,
@@ -76,7 +78,7 @@ module br_fifo_test_harness #(
     push_valid = 0;
 
     // Check if FIFO is full
-    @(negedge clk);
+    repeat (CutThroughLatency) @(negedge clk);
     if (full && !empty && (items == Depth))
       $display("FIFO is full as expected with %0d items.", items);
     else begin
@@ -115,7 +117,7 @@ module br_fifo_test_harness #(
     pop_ready = 0;
 
     // Check if FIFO is empty
-    @(posedge clk);
+    repeat (BackpressureLatency) @(posedge clk);
     if (empty && !full && (items == 0))
       $display("FIFO is empty as expected with %0d items.", items);
     else begin


### PR DESCRIPTION
This PR adds support for CDC FIFOs using gray-encoded counters for
synchronization between the push and pop controller. To implement the
FIFOs, added the following components:

1. br_cdc_fifo_ctrl_1r1w/br_cdc_fifo_ctrl_1r1w_push_credit - External
memory controller for CDC FIFO.
2. br_cdc_fifo_flops/br_cdc_fifo_flops_push_credit - CDC FIFO using
br_ram_flops_1r1w for internal storage.
3. br_cdc_fifo_flops_tb - testbench for CDC FIFO using same clock for
push and pop