### PR TITLE
FPV: Add support for custom tcl

### DIFF
--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -67,6 +67,7 @@ br_verilog_fpv_test_suite(
     },
     tool = "jg",
     top = "br_arb_rr",
+    custom_tcl = "br_arb_rr_fpv.tcl",
     deps = [":br_arb_rr_fpv_monitor"],
 )
 

--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -59,6 +59,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_suite(
     name = "br_arb_rr_jg_test_suite",
+    custom_tcl = "br_arb_rr_fpv.tcl",
     params = {
         "NumRequesters": [
             "2",
@@ -67,7 +68,6 @@ br_verilog_fpv_test_suite(
     },
     tool = "jg",
     top = "br_arb_rr",
-    custom_tcl = "br_arb_rr_fpv.tcl",
     deps = [":br_arb_rr_fpv_monitor"],
 )
 

--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -59,7 +59,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_suite(
     name = "br_arb_rr_jg_test_suite",
-    custom_tcl = "br_arb_rr_fpv.tcl",
+    append_tcl = "br_arb_rr_fpv.tcl",
     params = {
         "NumRequesters": [
             "2",

--- a/arb/fpv/br_arb_rr_fpv.tcl
+++ b/arb/fpv/br_arb_rr_fpv.tcl
@@ -1,0 +1,5 @@
+clock clk
+reset rst
+get_design_info
+prove -all
+report

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -413,8 +413,8 @@ rule_verilog_fpv_test = rule(
         "tool": attr.string(
             doc = "Formal tool to use. If not provided, default is decided by the BAZEL_VERILOG_RUNNER_TOOL implementation.",
         ),
-        "custom_tcl": attr.label(
-            doc = "custom TCL script to run.",
+        "appendcustom_tcl": attr.label(
+            doc = "Custom TCL script to run after the elaboration step. Do not include Tcl commands that manipulate sources, headers, defines, or parameters, as those will be handled by the rule implementation.",
             allow_single_file = [".tcl"],
         ),
         "gui": attr.bool(

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -214,9 +214,9 @@ def _verilog_fpv_test_impl(ctx):
         extra_args.append("--elab_only")
     if ctx.attr.gui:
         extra_args.append("--gui")
-    if ctx.attr.custom_tcl:
-        extra_args.append("--custom_tcl=" + ctx.attr.custom_tcl.files.to_list()[0].short_path)
-        extra_runfiles += ctx.files.custom_tcl
+    if ctx.attr.append_tcl:
+        extra_args.append("--append_tcl=" + ctx.attr.append_tcl.files.to_list()[0].short_path)
+        extra_runfiles += ctx.files.append_tcl
     if len(ctx.attr.opts) > 0 and ctx.attr.tool == "":
         fail("If opts are provided, then tool must also be set.")
     for opt in ctx.attr.opts:
@@ -413,7 +413,7 @@ rule_verilog_fpv_test = rule(
         "tool": attr.string(
             doc = "Formal tool to use. If not provided, default is decided by the BAZEL_VERILOG_RUNNER_TOOL implementation.",
         ),
-        "appendcustom_tcl": attr.label(
+        "append_tcl": attr.label(
             doc = "Custom TCL script to run after the elaboration step. Do not include Tcl commands that manipulate sources, headers, defines, or parameters, as those will be handled by the rule implementation.",
             allow_single_file = [".tcl"],
         ),

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -209,10 +209,14 @@ def _verilog_sim_test_impl(ctx):
 def _verilog_fpv_test_impl(ctx):
     """Implementation of the verilog_fpv_test rule."""
     extra_args = []
+    extra_runfiles = []
     if ctx.attr.elab_only:
         extra_args.append("--elab_only")
     if ctx.attr.gui:
         extra_args.append("--gui")
+    if ctx.attr.custom_tcl:
+        extra_args.append("--custom_tcl=" + ctx.attr.custom_tcl.files.to_list()[0].short_path)
+        extra_runfiles += ctx.files.custom_tcl
     if len(ctx.attr.opts) > 0 and ctx.attr.tool == "":
         fail("If opts are provided, then tool must also be set.")
     for opt in ctx.attr.opts:
@@ -222,6 +226,7 @@ def _verilog_fpv_test_impl(ctx):
         ctx = ctx,
         subcmd = "fpv",
         extra_args = extra_args,
+        extra_runfiles = extra_runfiles,
     )
 
 def _verilog_sandbox_impl(ctx):
@@ -407,6 +412,10 @@ rule_verilog_fpv_test = rule(
         ),
         "tool": attr.string(
             doc = "Formal tool to use. If not provided, default is decided by the BAZEL_VERILOG_RUNNER_TOOL implementation.",
+        ),
+        "custom_tcl": attr.label(
+            doc = "custom TCL script to run.",
+            allow_single_file = [".tcl"],
         ),
         "gui": attr.bool(
             doc = "Enable GUI.",


### PR DESCRIPTION
Add a `custom_tcl` option to fpv test rule, the custom tcl will be sourced after the design is elaborated