### PR TITLE
FPV: Fix FPV sandbox issue

### DIFF
--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bedrock-rtl//bazel:verilog.bzl", "rule_verilog_sandbox")
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_fpv_test_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
@@ -91,6 +92,21 @@ br_verilog_fpv_test_suite(
             "2",
             "3",
         ],
+    },
+    tool = "jg",
+    top = "br_arb_lru",
+    deps = [":br_arb_lru_fpv_monitor"],
+)
+
+rule_verilog_sandbox(
+    name = "br_arb_lru_sandbox",
+    defines = [
+        "BR_ASSERT_ON",
+        "BR_ENABLE_IMPL_CHECKS",
+    ],
+    kind = "fpv",
+    params = {
+        "NumRequesters": "2",
     },
     tool = "jg",
     top = "br_arb_lru",

--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -99,7 +99,7 @@ br_verilog_fpv_test_suite(
 )
 
 rule_verilog_sandbox(
-    name = "br_arb_lru_sandbox",
+    name = "br_arb_lru_jg_sandbox",
     defines = [
         "BR_ASSERT_ON",
         "BR_ENABLE_IMPL_CHECKS",

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -142,15 +142,12 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
         )
 
         # Run generator script
-
         ctx.actions.run(
             inputs = generator_inputs + [generator_executable_file],
             outputs = [ctx.outputs.tarball],
             executable = generator_executable_file,
             arguments = [],
-            env = {
-                "VERILOG_RUNNER_PLUGIN_PATH": env.get("VERILOG_RUNNER_PLUGIN_PATH"),
-            },
+            use_default_shell_env=True,
         )
 
         # Write runner script (but don't run it)

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -117,7 +117,7 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
     else:
         # Generator I/O
         generator_inputs = srcs + hdrs + extra_runfiles
-        generator_outputs = [tcl, script]
+        generator_outputs = [tcl, script, filelist]
 
         # Tarball inputs
         tar_inputs = []
@@ -142,11 +142,15 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
         )
 
         # Run generator script
+
         ctx.actions.run(
             inputs = generator_inputs + [generator_executable_file],
             outputs = [ctx.outputs.tarball],
             executable = generator_executable_file,
             arguments = [],
+            env = {
+                "VERILOG_RUNNER_PLUGIN_PATH": env.get("VERILOG_RUNNER_PLUGIN_PATH"),
+            },
         )
 
         # Write runner script (but don't run it)

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -147,7 +147,7 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
             outputs = [ctx.outputs.tarball],
             executable = generator_executable_file,
             arguments = [],
-            use_default_shell_env=True,
+            use_default_shell_env = True,
         )
 
         # Write runner script (but don't run it)


### PR DESCRIPTION
- Added missing filelist in the runfile
- Explicitly pass `VERILOG_RUNNER_PLUGIN_PATH` to sandbox generation step as `ctx.actions.run` doesn't inherit environment variables automatically
- Added a sample FPV sandbox target

Verify it works within bedrock, need to test hw-1p repo bedrock file path issue separately