### PR TITLE
Fix some issues with br_fifo_test_harness and use for push credit test

### DIFF
--- a/cdc/sim/br_cdc_fifo_flops_tb.sv
+++ b/cdc/sim/br_cdc_fifo_flops_tb.sv
@@ -138,7 +138,10 @@ module br_cdc_fifo_flops_tb;
 
     timeout = 5000;
     td.wait_cycles();
-    while (timeout > 0 && !finished) td.wait_cycles();
+    while (timeout > 0 && !finished) begin
+      td.wait_cycles();
+      timeout = timeout - 1;
+    end
 
     td.check(timeout > 0, $sformatf("Test timed out"));
     td.check(error_count == 0, $sformatf("Errors in test"));

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -95,9 +95,11 @@ verilog_library(
     name = "br_fifo_flops_push_credit_tb",
     srcs = ["br_fifo_flops_push_credit_tb.sv"],
     deps = [
+        ":br_fifo_test_harness",
         "//credit/rtl:br_credit_sender",
         "//delay/rtl:br_delay_nr",
         "//fifo/rtl:br_fifo_flops_push_credit",
+        "//misc/sim:br_test_driver",
     ],
 )
 
@@ -109,11 +111,6 @@ verilog_elab_test(
 br_verilog_sim_test_suite(
     name = "br_fifo_flops_push_credit_vcs_test_suite",
     params = {
-        "Depth": [
-            "13",
-            "16",
-        ],
-        "Width": ["8"],
         "EnableBypass": [
             "0",
             "1",
@@ -127,6 +124,10 @@ br_verilog_sim_test_suite(
             "1",
             "2",
             "3",
+        ],
+        "RegisterPushCredit": [
+            "0",
+            "1",
         ],
     },
     tool = "vcs",


### PR DESCRIPTION
1. The handling of negedge/posedge in the testbench could cause some
spurious simulation failures. This change makes things more
consistent.
2. Use the br_fifo_test_harness to check br_fifo_flops_push_credit.
The Depth needs to be adjusted to allow full throughput as the test
harness expects.
3. Make sure the timeout counter is actually decrementing.

---

**Stack**:
- #212
- #211 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*