### PR TITLE
Refactor arbiter library to create internal versions with can_grant signal

### DIFF
--- a/arb/rtl/br_arb_fixed.sv
+++ b/arb/rtl/br_arb_fixed.sv
@@ -23,9 +23,9 @@ module br_arb_fixed #(
     // Must be at least 2
     parameter int NumRequesters = 2
 ) (
-    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
     input logic clk,  // Only used for assertions
-    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
     input logic rst,  // Only used for assertions
     input logic [NumRequesters-1:0] request,
     output logic [NumRequesters-1:0] grant
@@ -34,24 +34,22 @@ module br_arb_fixed #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  // Rely on submodule integration checks
+  `BR_COVER_INTG(request_multihot_c, !$onehot0(request))
 
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  br_enc_priority_encoder #(
+  br_arb_fixed_internal #(
       .NumRequesters(NumRequesters)
-  ) br_enc_priority_encoder (
-      .clk,
-      .rst,
-      .in (request),
-      .out(grant)
+  ) br_arb_fixed_internal (
+      .request,
+      .can_grant(),  // Unused internal signal
+      .grant
   );
 
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  // Rely on submodule implementation checks
 
   `BR_ASSERT_IMPL(grant_onehot0_A, $onehot0(grant))
   `BR_ASSERT_IMPL(always_grant_a, |request |-> |grant)

--- a/arb/rtl/br_arb_lru.sv
+++ b/arb/rtl/br_arb_lru.sv
@@ -37,92 +37,22 @@ module br_arb_lru #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  // Rely on submodule integration checks
 
-  // TODO(mgottscho): add checks
+  `BR_COVER_INTG(request_multihot_c, !$onehot0(request))
 
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  // Whenever a requester is granted, it becomes the *most* recently used, and therefore
-  // it becomes the lowest priority.
-  //
-  // To ensure fairness, we need to maintain a total order of least recently used requesters.
-  // We do this with a priority state matrix, where state[i][j] == 1'b1 means that requester
-  // i is less recently used than requester j (otherwise, i is more recently used than j and
-  // has lower priority). This scheme is based on the matrix arbiter as described in Chapter
-  // 18.5 of "Principles and Practices of Interconnection Networks" by Dally and Towles.
-  //
-  // Therefore, requester i can only be granted if (!req[j] || state[i][j]) for all j where i != j.
-  // If priorities are tied, the lower-index requester wins.
-  //
-  // State update occurs whenever enable_priority_update is 1 and there is any valid request
-  // (because it will always result in a grant).
-  // * Whenever a grant occurs for requester i, on the next cycle we fill 0s into state[i][j]
-  //   for all j where i != j. This indicates that requester i is used more recently (lower
-  //   priority) than all requesters j.
-  // * Whenever a grant occurs for requester j, on the next cycle we fill 1s into state[i][j]
-  //   for all i where i != j. This indicates that all requesters i are used less recently
-  //   (higher priority) than requester j.
-  //
-  // The advantage of this implementation is that we can update and search all the priorities
-  // in parallel, which is good for timing. However, the priority state contains some redundancy,
-  // costing extra flip-flops.
-
-
-  // Implement the state matrix. We only need to maintain the upper triangular state (exclusive of
-  // diagonal) in registers because the lower triangle is its complement. The diagonal is undefined
-  // and unused (because we never need to compare the priority of a requester with itself).
-  // There are NumRequesters * (NumRequesters - 1) / 2 flip-flops of priority state.
-  logic [NumRequesters-1:0][NumRequesters-1:0] state;
-  logic [NumRequesters-1:0][NumRequesters-1:0] state_reg;
-  logic [NumRequesters-1:0][NumRequesters-1:0] state_reg_next;
-
-  for (genvar i = 0; i < NumRequesters; i++) begin : gen_state_row
-    for (genvar j = 0; j < NumRequesters; j++) begin : gen_state_col
-      // Upper triangle
-      if (i < j) begin : gen_upper_tri
-        // All bits in upper triangle init to 1'b1 (lowest numbered req wins)
-        assign state_reg_next[i][j] = grant[i] ? 1'b0 : grant[j] ? 1'b1 : state[i][j];
-        `BR_REGIL(state_reg[i][j], state_reg_next[i][j], enable_priority_update && |request, 1'b1)
-        assign state[i][j] = state_reg[i][j];
-
-        // Lower triangle is the inverse of upper triangle
-      end else if (i > j) begin : gen_lower_tri
-        assign state[i][j] = !state_reg[j][i];
-
-        // Tie-off unused signals
-        assign state_reg_next[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
-        assign state_reg[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
-        `BR_UNUSED_NAMED(states, {state_reg_next[i][j], state_reg[i][j]})
-
-        // The diagonal is unused. Tie off signals.
-      end else begin : gen_diag
-        // ri lint_check_waive CONST_ASSIGN
-        assign {state_reg_next[i][j], state_reg[i][j], state[i][j]} = '0;
-        `BR_UNUSED_NAMED(states, {state_reg_next[i][j], state_reg[i][j], state[i][j]})
-      end
-    end
-  end
-
-
-  // Compute the grant.
-  // * A requester can only be granted if there are no higher priority active requesters.
-  // * A requester i is higher priority than a requester j if state[i][j] is 1.
-  logic [NumRequesters-1:0] can_grant;
-
-  always_comb begin
-    for (int i = 0; i < NumRequesters; i++) begin
-      can_grant[i] = 1'b1;
-      for (int j = 0; j < NumRequesters; j++) begin
-        if (i != j) begin  // Diagonal is unused
-          can_grant[i] &= !request[j] || state[i][j];
-        end
-      end
-    end
-  end
-
-  assign grant = request & can_grant;
+  br_arb_lru_internal #(
+      .NumRequesters(NumRequesters)
+  ) br_arb_lru_internal (
+      .clk,
+      .rst,
+      .enable_priority_update,
+      .request,
+      .can_grant(),  // Unused internal signal
+      .grant
+  );
 
   //------------------------------------------
   // Implementation checks

--- a/arb/rtl/internal/BUILD.bazel
+++ b/arb/rtl/internal/BUILD.bazel
@@ -13,24 +13,21 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
 
-package(default_visibility = ["//arb/rtl:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 verilog_library(
-    name = "br_arb_fixed",
-    srcs = ["br_arb_fixed.sv"],
+    name = "br_arb_fixed_internal",
+    srcs = ["br_arb_fixed_internal.sv"],
     deps = [
-        "//arb/rtl/internal:br_arb_fixed_internal",
         "//macros:br_asserts_internal",
     ],
 )
 
 verilog_library(
-    name = "br_arb_lru",
-    srcs = ["br_arb_lru.sv"],
+    name = "br_arb_lru_internal",
+    srcs = ["br_arb_lru_internal.sv"],
     deps = [
-        "//arb/rtl/internal:br_arb_lru_internal",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
         "//macros:br_unused",
@@ -38,38 +35,12 @@ verilog_library(
 )
 
 verilog_library(
-    name = "br_arb_rr",
-    srcs = ["br_arb_rr.sv"],
+    name = "br_arb_rr_internal",
+    srcs = ["br_arb_rr_internal.sv"],
     deps = [
-        "//arb/rtl/internal:br_arb_rr_internal",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],
 )
 
-br_verilog_elab_and_lint_test_suite(
-    name = "br_arb_fixed_test_suite",
-    params = {"NumRequesters": [
-        "2",
-        "5",
-    ]},
-    deps = [":br_arb_fixed"],
-)
-
-br_verilog_elab_and_lint_test_suite(
-    name = "br_arb_lru_test_suite",
-    params = {"NumRequesters": [
-        "2",
-        "5",
-    ]},
-    deps = [":br_arb_lru"],
-)
-
-br_verilog_elab_and_lint_test_suite(
-    name = "br_arb_rr_test_suite",
-    params = {"NumRequesters": [
-        "2",
-        "5",
-    ]},
-    deps = [":br_arb_rr"],
-)
+# Elab/Lint tests done on public modules

--- a/arb/rtl/internal/br_arb_fixed_internal.sv
+++ b/arb/rtl/internal/br_arb_fixed_internal.sv
@@ -1,0 +1,44 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Fixed-Priority Arbiter Internal Module
+//
+// Grants a single request at a time with fixed (strict) priority
+// where the lowest index requester has the highest priority.
+//
+// This internal module exposes a 'can_grant' that is high if there are no
+// requests of higher priority.  The final grant signal is equivalent to
+// 'can_grant & request'.
+
+`include "br_asserts_internal.svh"
+
+module br_arb_fixed_internal #(
+    // Must be at least 2
+    parameter int NumRequesters = 2
+) (
+    input  logic [NumRequesters-1:0] request,
+    output logic [NumRequesters-1:0] can_grant,
+    output logic [NumRequesters-1:0] grant
+);
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  assign can_grant[0] = 1'b1;  // ri lint_check_waive CONST_ASSIGN CONST_OUTPUT
+  for (genvar i = 1; i < NumRequesters; i++) begin : gen_can_grant_upper
+    assign can_grant[i] = !(|request[i-1:0]);
+  end
+  assign grant = request & can_grant;
+
+endmodule : br_arb_fixed_internal

--- a/arb/rtl/internal/br_arb_lru_internal.sv
+++ b/arb/rtl/internal/br_arb_lru_internal.sv
@@ -1,0 +1,119 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Least-Recently-Used (LRU) Arbiter
+//
+// Grants a single request at a time with a fair least-recently-used policy.
+//
+// The enable_priority_update signal allows the priority state to update when a grant is made.
+// If low, grants can still be made, but the priority will remain unchanged for the next cycle.
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+`include "br_unused.svh"
+
+module br_arb_lru_internal #(
+    // Must be at least 2
+    parameter int NumRequesters = 2
+) (
+    input logic clk,
+    input logic rst,  // Synchronous active-high
+    input logic enable_priority_update,
+    input logic [NumRequesters-1:0] request,
+    output logic [NumRequesters-1:0] can_grant,
+    output logic [NumRequesters-1:0] grant
+);
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  // Whenever a requester is granted, it becomes the *most* recently used, and therefore
+  // it becomes the lowest priority.
+  //
+  // To ensure fairness, we need to maintain a total order of least recently used requesters.
+  // We do this with a priority state matrix, where state[i][j] == 1'b1 means that requester
+  // i is less recently used than requester j (otherwise, i is more recently used than j and
+  // has lower priority). This scheme is based on the matrix arbiter as described in Chapter
+  // 18.5 of "Principles and Practices of Interconnection Networks" by Dally and Towles.
+  //
+  // Therefore, requester i can only be granted if (!req[j] || state[i][j]) for all j where i != j.
+  // If priorities are tied, the lower-index requester wins.
+  //
+  // State update occurs whenever enable_priority_update is 1 and there is any valid request
+  // (because it will always result in a grant).
+  // * Whenever a grant occurs for requester i, on the next cycle we fill 0s into state[i][j]
+  //   for all j where i != j. This indicates that requester i is used more recently (lower
+  //   priority) than all requesters j.
+  // * Whenever a grant occurs for requester j, on the next cycle we fill 1s into state[i][j]
+  //   for all i where i != j. This indicates that all requesters i are used less recently
+  //   (higher priority) than requester j.
+  //
+  // The advantage of this implementation is that we can update and search all the priorities
+  // in parallel, which is good for timing. However, the priority state contains some redundancy,
+  // costing extra flip-flops.
+
+
+  // Implement the state matrix. We only need to maintain the upper triangular state (exclusive of
+  // diagonal) in registers because the lower triangle is its complement. The diagonal is undefined
+  // and unused (because we never need to compare the priority of a requester with itself).
+  // There are NumRequesters * (NumRequesters - 1) / 2 flip-flops of priority state.
+  logic [NumRequesters-1:0][NumRequesters-1:0] state;
+  logic [NumRequesters-1:0][NumRequesters-1:0] state_reg;
+  logic [NumRequesters-1:0][NumRequesters-1:0] state_reg_next;
+
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_state_row
+    for (genvar j = 0; j < NumRequesters; j++) begin : gen_state_col
+      // Upper triangle
+      if (i < j) begin : gen_upper_tri
+        // All bits in upper triangle init to 1'b1 (lowest numbered req wins)
+        assign state_reg_next[i][j] = grant[i] ? 1'b0 : grant[j] ? 1'b1 : state[i][j];
+        `BR_REGIL(state_reg[i][j], state_reg_next[i][j], enable_priority_update && |request, 1'b1)
+        assign state[i][j] = state_reg[i][j];
+
+        // Lower triangle is the inverse of upper triangle
+      end else if (i > j) begin : gen_lower_tri
+        assign state[i][j] = !state_reg[j][i];
+
+        // Tie-off unused signals
+        assign state_reg_next[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
+        assign state_reg[i][j] = 1'b0;  // ri lint_check_waive CONST_ASSIGN
+        `BR_UNUSED_NAMED(states, {state_reg_next[i][j], state_reg[i][j]})
+
+        // The diagonal is unused. Tie off signals.
+      end else begin : gen_diag
+        // ri lint_check_waive CONST_ASSIGN
+        assign {state_reg_next[i][j], state_reg[i][j], state[i][j]} = '0;
+        `BR_UNUSED_NAMED(states, {state_reg_next[i][j], state_reg[i][j], state[i][j]})
+      end
+    end
+  end
+
+
+  // Compute the grant.
+  // * A requester can only be granted if there are no higher priority active requesters.
+  // * A requester i is higher priority than a requester j if state[i][j] is 1.
+  always_comb begin
+    for (int i = 0; i < NumRequesters; i++) begin
+      can_grant[i] = 1'b1;
+      for (int j = 0; j < NumRequesters; j++) begin
+        if (i != j) begin  // Diagonal is unused
+          can_grant[i] &= !request[j] || state[i][j];
+        end
+      end
+    end
+  end
+
+  assign grant = request & can_grant;
+
+endmodule : br_arb_lru_internal

--- a/arb/rtl/internal/br_arb_rr_internal.sv
+++ b/arb/rtl/internal/br_arb_rr_internal.sv
@@ -1,0 +1,130 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Round-Robin Arbiter
+//
+// Grants a single request at a time using round-robin priority. Requester 0
+// initializes as the highest priority. On the cycle after a grant, the granted
+// index becomes the lowest priority and the next higher index (modulo NumRequesters)
+// becomes the highest priority.
+//
+// On average, round-robin arbitration is fair to all requesters so long as each requester
+// does not withdraw its request until it is granted.
+//
+// The update_priority signal causes the priority state to update and should
+// only be true if there is a grant.
+//
+// There is zero latency from request to grant.
+
+// This internal module exposes a 'can_grant' that is high if there are no
+// requests of higher priority.  The final grant signal is equivalent to
+// 'can_grant & request'.
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+
+module br_arb_rr_internal #(
+    // Must be at least 2
+    parameter int NumRequesters = 2
+) (
+    input logic clk,
+    input logic rst,  // Synchronous active-high
+    input logic enable_priority_update,
+    input logic [NumRequesters-1:0] request,
+    output logic [NumRequesters-1:0] can_grant,
+    output logic [NumRequesters-1:0] grant
+);
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  // last_grant is the only state in the design. The requester with the last grant
+  // is the lowest priority, so the next highest index (modulo NumRequesters) is the
+  // highest priority.
+  //
+  // We use two priority encoders to handle the modulo indexing.
+  // * The first encoder uses a masked request vector to find the highest priority request
+  // (if any exists) before wrapping around.
+  // * The second encoder uses the unmasked request vector to find the highest priority request
+  // after the wraparound index.
+  //
+  // If the masked request vector is not zero, then we use the grant from the first encoder;
+  // otherwise we use the grant from the second encoder.
+  //
+  // The last_grant gets updated on the next cycle with grant, so that the
+  // priority rotates in a round-robin fashion.
+  // last_grant initializes to NumRequesters'b100....0 such that index 0 is the highest priority
+  // out of reset.
+
+  logic [NumRequesters-1:0] priority_mask;
+  logic [NumRequesters-1:0] request_high;
+  logic [NumRequesters-1:0] last_grant;
+  logic [NumRequesters-1:0] last_grant_init;
+
+  // priority_mask selects all bits at or below the last grant.
+  // e.g. if last grant is 001, then priority_mask is 001
+  //      if last grant is 010, then priority_mask is 011
+  //      if last grant is 100, then priority_mask is 111
+  // priority_mask[0] is thus always 1.
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_priority_mask
+    // For i = NumRequesters - 1, the full range will be selected
+    // ri lint_check_waive FULL_RANGE
+    assign priority_mask[i] = |last_grant[NumRequesters-1:i];
+  end
+
+  // request_high[0] is constant 0
+  // ri lint_check_waive CONST_ASSIGN
+  assign request_high = request & ~priority_mask;
+
+  // If priority_mask[i] is 0, can_grant[i] looks at request_high[i-1:0]
+  // If priority_mask[i] is 1, can_grant[i] looks at
+  // request_high[NumRequesters-1:i+1] and request[i-1:0].
+  // This avoids having can_grant[i] depend on request[i].
+  // To make this a little easier to reason about,
+  // we create the NxN matrix, request_priority, where
+  // request_priority[i][j] means that request[j] is set and
+  // of higher priority than request[i].
+  // The diagonal, request_priority[i][i], is always 0.
+  // Then can_grant[i] is equivalent to !(|request_priority[i]).
+  logic [NumRequesters-1:0][NumRequesters-1:0] request_priority;
+
+  // For i = 0, priority_mask[i] is never 0,
+  assign request_priority[0] = {request_high[NumRequesters-1:1], 1'b0};
+  assign request_priority[NumRequesters-1] =
+      priority_mask[NumRequesters-1] ? {1'b0, request[NumRequesters-2:0]}
+                                     : {1'b0, request_high[NumRequesters-2:0]};
+
+  for (genvar i = 1; i < (NumRequesters - 1); i++) begin : gen_request_priority
+    // The diagonal is always 0
+    assign request_priority[i][i] = 1'b0;
+    // For j < i, request[j] |-> request_priority[i][j] iff both are masked or both are unmasked
+    assign request_priority[i][i-1:0] = priority_mask[i] ? request[i-1:0] : request_high[i-1:0];
+    // For j > i, request[j] |-> request_priority[i][j] iff i is masked but j is not
+    assign request_priority[i][NumRequesters-1:i+1] =
+        priority_mask[i] ? request_high[NumRequesters-1:i+1] : '0;
+  end
+
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_can_grant
+    assign can_grant[i] = !(|request_priority[i]);
+  end
+
+  assign grant = request & can_grant;
+  // ri lint_check_waive CONST_ASSIGN
+  assign last_grant_init[NumRequesters-1] = 1'b1;
+  // ri lint_check_waive CONST_ASSIGN
+  assign last_grant_init[NumRequesters-2:0] = '0;
+
+  `BR_REGIL(last_grant, grant, enable_priority_update && |request, last_grant_init)
+
+endmodule : br_arb_rr_internal


### PR DESCRIPTION
This can_grant signal is true if there are no requesters of lower
priority. This means grant = request & can_grant.

This will later be used by the br_flow_arb_* modules to avoid
combinational dependency of push_ready[i] and push_valid[i].

---

**Stack**:
- #218
- #217
- #216 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*