### PR TITLE
Refactoring br_flow_arb_* modules for reusability and timing

### DIFF
--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -21,7 +21,8 @@ verilog_library(
     name = "br_flow_arb_fixed",
     srcs = ["br_flow_arb_fixed.sv"],
     deps = [
-        "//arb/rtl:br_arb_fixed",
+        "//arb/rtl/internal:br_arb_fixed_internal",
+        "//flow/rtl/internal:br_flow_arb_core",
         "//macros:br_asserts_internal",
     ],
 )
@@ -30,7 +31,8 @@ verilog_library(
     name = "br_flow_arb_rr",
     srcs = ["br_flow_arb_rr.sv"],
     deps = [
-        "//arb/rtl:br_arb_rr",
+        "//arb/rtl/internal:br_arb_rr_internal",
+        "//flow/rtl/internal:br_flow_arb_core",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],
@@ -40,7 +42,8 @@ verilog_library(
     name = "br_flow_arb_lru",
     srcs = ["br_flow_arb_lru.sv"],
     deps = [
-        "//arb/rtl:br_arb_lru",
+        "//arb/rtl/internal:br_arb_lru_internal",
+        "//flow/rtl/internal:br_flow_arb_core",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],

--- a/flow/rtl/br_flow_arb_rr.sv
+++ b/flow/rtl/br_flow_arb_rr.sv
@@ -49,40 +49,40 @@ module br_flow_arb_rr #(
   //------------------------------------------
   // Implementation
   //------------------------------------------
+  logic [NumFlows-1:0] request;
+  logic [NumFlows-1:0] can_grant;
   logic [NumFlows-1:0] grant;
+  logic enable_priority_update;
 
-  br_arb_rr #(
+  br_arb_rr_internal #(
       .NumRequesters(NumFlows)
-  ) br_arb_rr (
+  ) br_arb_rr_internal (
       .clk,
       .rst,
-      .enable_priority_update(pop_ready),
-      .request(push_valid),
+      .enable_priority_update,
+      .request,
+      .can_grant,
       .grant
   );
 
-  // We could just make push_ready[i] == grant[i], but then push_ready[i] will always
-  // depend on push_valid[i]. It is nicer to indicate ready independently of the valid
-  // for the same flow.
-  for (genvar i = 0; i < NumFlows; i++) begin : gen_push_ready
-    always_comb begin
-      push_ready[i] = 1'b1;
-      for (int j = 0; j < NumFlows; j++) begin
-        if (i != j) begin
-          push_ready[i] &= !grant[j];
-        end
-      end
-    end
-  end
-
-  assign pop_valid = |push_valid;
+  br_flow_arb_core #(
+      .NumFlows(NumFlows)
+  ) br_flow_arb_core (
+      .clk,
+      .rst,
+      .request,
+      .can_grant,
+      .grant,
+      .enable_priority_update,
+      .push_ready,
+      .push_valid,
+      .pop_ready,
+      .pop_valid
+  );
 
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
   // Rely on submodule implementation checks
-
-  `BR_ASSERT_IMPL(grant_onehot0_a, $onehot0(grant))
-  `BR_ASSERT_IMPL(grant_equals_push_ready_and_valid_a, grant == (push_ready & push_valid))
 
 endmodule : br_flow_arb_rr

--- a/flow/rtl/internal/BUILD.bazel
+++ b/flow/rtl/internal/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright 2024 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+
+package(default_visibility = ["//flow/rtl:__subpackages__"])
+
+verilog_library(
+    name = "br_flow_arb_core",
+    srcs = ["br_flow_arb_core.sv"],
+    deps = [
+        "//macros:br_asserts_internal",
+        "//macros:br_unused",
+    ],
+)

--- a/flow/rtl/internal/br_flow_arb_core.sv
+++ b/flow/rtl/internal/br_flow_arb_core.sv
@@ -1,0 +1,80 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow-Controlled Arbiter Core
+//
+// This module is intended to work with one of the br_arb_* modules
+// to implement a flow-controlled arbiter. Given two or more sets of
+// ready-valid signals, it will arbitrate between them, granting one
+// request per cycle if pop_ready is true.
+
+`include "br_asserts_internal.svh"
+`include "br_unused.svh"
+
+module br_flow_arb_core #(
+    // Must be at least 2
+    parameter int NumFlows = 2
+) (
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
+    input logic clk,  // Only used for assertions
+    // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
+    input logic rst,  // Only used for assertions
+    // Interface to base arbiter
+    output logic [NumFlows-1:0] request,
+    input logic [NumFlows-1:0] can_grant,
+    input logic [NumFlows-1:0] grant,
+    output logic enable_priority_update,
+    // External-facing signals
+    output logic [NumFlows-1:0] push_ready,
+    input logic [NumFlows-1:0] push_valid,
+    input logic pop_ready,
+    output logic pop_valid
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+
+  // TODO(mgottscho): Add checks
+  `BR_COVER_INTG(push_backpressure_a, |push_valid && !pop_ready)
+
+  // Internal integration checks
+  `BR_ASSERT_IMPL(request_implies_grant_a, |request |-> |grant)
+  `BR_ASSERT_IMPL(grant_onehot0_a, $onehot0(grant))
+  `BR_ASSERT_IMPL(grant_is_request_and_can_grant_a, grant == (request & can_grant))
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  assign request = push_valid;
+  // only allow priority update if we actually grant
+  assign enable_priority_update = pop_ready;
+  assign push_ready = {NumFlows{pop_ready}} & can_grant;
+  assign pop_valid = |push_valid;
+
+  // grant is only used for assertions
+  `BR_UNUSED(grant)
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+
+  `BR_ASSERT_IMPL(push_handshake_onehot0_a, $onehot0(push_valid & push_ready))
+  `BR_ASSERT_IMPL(pop_ready_equals_push_ready_or_a, pop_ready == |push_ready)
+  `BR_ASSERT_IMPL(push_handshake_implies_pop_handshake_a,
+                  |(push_valid & push_ready) |-> (pop_valid & pop_ready))
+  `BR_ASSERT_IMPL(grant_equals_push_ready_and_valid_a, grant == (push_ready & push_valid))
+
+endmodule : br_flow_arb_core


### PR DESCRIPTION
Factor out the policy-independent logic br_flow_arb into
br_flow_arb_core module that interfaces to the br_arb_*_internal module
at a higher level.

Use the can_grant signal from br_arb_*_internal so that push_ready[i] is
not combinationally dependent on push_valid[i].

---

**Stack**:
- #218
- #217 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*