### PR TITLE
Refactor br_flow_mux_* and make available for use

### DIFF
--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -94,6 +94,39 @@ verilog_library(
 )
 
 verilog_library(
+    name = "br_flow_mux_fixed",
+    srcs = ["br_flow_mux_fixed.sv"],
+    deps = [
+        "//arb/rtl/internal:br_arb_fixed_internal",
+        "//flow/rtl/internal:br_flow_mux_core",
+        "//macros:br_asserts_internal",
+        "//macros:br_unused",
+    ],
+)
+
+verilog_library(
+    name = "br_flow_mux_rr",
+    srcs = ["br_flow_mux_rr.sv"],
+    deps = [
+        "//arb/rtl/internal:br_arb_rr_internal",
+        "//flow/rtl/internal:br_flow_mux_core",
+        "//macros:br_asserts_internal",
+        "//macros:br_unused",
+    ],
+)
+
+verilog_library(
+    name = "br_flow_mux_lru",
+    srcs = ["br_flow_mux_lru.sv"],
+    deps = [
+        "//arb/rtl/internal:br_arb_lru_internal",
+        "//flow/rtl/internal:br_flow_mux_core",
+        "//macros:br_asserts_internal",
+        "//macros:br_unused",
+    ],
+)
+
+verilog_library(
     name = "br_flow_reg_both",
     srcs = ["br_flow_reg_both.sv"],
     deps = [
@@ -233,6 +266,51 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_flow_mux_select_unstable"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_mux_fixed_test_suite",
+    params = {
+        "NumFlows": [
+            "2",
+            "3",
+        ],
+        "Width": [
+            "1",
+            "2",
+        ],
+    },
+    deps = [":br_flow_mux_fixed"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_mux_rr_test_suite",
+    params = {
+        "NumFlows": [
+            "2",
+            "3",
+        ],
+        "Width": [
+            "1",
+            "2",
+        ],
+    },
+    deps = [":br_flow_mux_rr"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_mux_lru_test_suite",
+    params = {
+        "NumFlows": [
+            "2",
+            "3",
+        ],
+        "Width": [
+            "1",
+            "2",
+        ],
+    },
+    deps = [":br_flow_mux_lru"],
 )
 
 br_verilog_elab_and_lint_test_suite(

--- a/flow/rtl/br_flow_mux_lru.sv
+++ b/flow/rtl/br_flow_mux_lru.sv
@@ -24,57 +24,63 @@
 `include "br_asserts.svh"
 
 module br_flow_mux_lru #(
-    parameter int NumFlows  = 2,  // Must be at least 2
-    parameter int DataWidth = 1   // Must be at least 1
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1  // Must be at least 1
 ) (
-    input  logic                                clk,
-    input  logic                                rst,
-    output logic [ NumFlows-1:0]                push_ready,
-    input  logic [ NumFlows-1:0]                push_valid,
-    input  logic [ NumFlows-1:0][DataWidth-1:0] push_data,
-    input  logic                                pop_ready,
-    output logic                                pop_valid,
-    output logic [DataWidth-1:0]                pop_data
+    input  logic                           clk,
+    input  logic                           rst,
+    output logic [NumFlows-1:0]            push_ready,
+    input  logic [NumFlows-1:0]            push_valid,
+    input  logic [NumFlows-1:0][Width-1:0] push_data,
+    input  logic                           pop_ready,
+    output logic                           pop_valid,
+    output logic [   Width-1:0]            pop_data
 );
 
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(numflows_gte_2_a, NumFlows >= 2)
-  `BR_ASSERT_STATIC(datawidth_gte_1_a, DataWidth >= 1)
+  `BR_ASSERT_STATIC(num_requesters_gte_2_a, NumFlows >= 2)
+  `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
 
   // Rely on submodule integration checks
 
   //------------------------------------------
   // Implementation
   //------------------------------------------
+  logic [NumFlows-1:0] request;
+  logic [NumFlows-1:0] can_grant;
+  logic [NumFlows-1:0] grant;
+  logic enable_priority_update;
 
-  br_flow_arb_lru #(
-      .NumFlows(NumFlows)
-  ) br_flow_arb_lru (
+  br_arb_lru_internal #(
+      .NumRequesters(NumFlows)
+  ) br_arb_lru_internal (
       .clk,
       .rst,
-      .push_ready,
-      .push_valid,
-      .pop_ready,
-      .pop_valid
+      .request,
+      .can_grant,
+      .grant,
+      .enable_priority_update
   );
 
-  // Determine the index of the granted flow
-  logic [$clog2(NumFlows)-1:0] grant_idx;
-
-  always_comb begin
-    grant_idx = '0;
-    for (int i = 0; i < NumFlows; i++) begin
-      if (push_ready[i] && push_valid[i]) begin
-        grant_idx = i;
-        break;  // push_ready & push_valid is guaranteed onehot0 by br_flow_arb_fixed
-      end
-    end
-  end
-
-  // Mux to the output
-  assign pop_data = push_data[grant_idx];
+  br_flow_mux_core #(
+      .NumFlows(NumFlows),
+      .Width(Width)
+  ) br_flow_mux_core (
+      .clk,
+      .rst,
+      .request,
+      .can_grant,
+      .grant,
+      .enable_priority_update,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
 
   //------------------------------------------
   // Implementation checks

--- a/flow/rtl/internal/BUILD.bazel
+++ b/flow/rtl/internal/BUILD.bazel
@@ -24,3 +24,14 @@ verilog_library(
         "//macros:br_unused",
     ],
 )
+
+verilog_library(
+    name = "br_flow_mux_core",
+    srcs = ["br_flow_mux_core.sv"],
+    deps = [
+        ":br_flow_arb_core",
+        "//macros:br_asserts_internal",
+        "//macros:br_unused",
+        "//mux/rtl:br_mux_onehot",
+    ],
+)


### PR DESCRIPTION
1. Build br_flow_mux_core using br_flow_arb_core
2. Change the br_flow_mux_* modules to instantiate br_flow_mux_core
and br_arb_*_internal directly
3. Change 'DataWidth' to 'Width' for consistency with other modules
4. Add bazel verilog_library rules