### PR TITLE
Small optimization for credit counter when MaxChange=1

### DIFF
--- a/credit/rtl/br_credit_counter.sv
+++ b/credit/rtl/br_credit_counter.sv
@@ -139,8 +139,13 @@ module br_credit_counter #(
 
   // Withhold and available: don't use the decrement in the calculation of
   // available credits because that would cause a combinational loop
-  assign available  = value_plus_incr > withhold ? value_plus_incr - withhold : '0;
-  assign decr_ready = ValueWidth'(decr_internal) <= available;
+  assign available = value_plus_incr > withhold ? value_plus_incr - withhold : '0;
+
+  if (MaxChange == 1) begin : gen_decr_ready_one
+    assign decr_ready = available > '0;
+  end else begin : gen_decr_ready_gt_one
+    assign decr_ready = ValueWidth'(decr_internal) <= available;
+  end
 
   //------------------------------------------
   // Implementation checks


### PR DESCRIPTION
For the common case where credit only increments one at a time, we don't need to check the decrement amount again available. Just need to check that available is non-zero.

We assume there's no reason we would want to decrement with decr=0 while available is 0.