### PR TITLE
Allow any file type on `verilog_library` srcs and hdrs

### DIFF
--- a/dependency_support/rules_hdl/verilog/providers.bzl.patch
+++ b/dependency_support/rules_hdl/verilog/providers.bzl.patch
@@ -5,15 +5,14 @@
          "hdrs": attr.label_list(
              doc = "Verilog or SystemVerilog headers.",
 -            allow_files = [".vh", ".svh"],
-+            # Some vendor libraries include .h, .v, and .sv files rather than
-+            # following the .vh/.svh convention.
-+            allow_files = [".vh", ".svh", ".h", ".v", ".sv"],
++            # Normally we'd constrain the set of suffices, but some IP vendors use really weird conventions.
++            allow_files = True,
          ),
          "srcs": attr.label_list(
              doc = "Verilog or SystemVerilog sources.",
 -            allow_files = [".v", ".sv"],
-+            # .vp and .svp are encrypted files.
-+            allow_files = [".v", ".sv", ".vp", ".svp"],
++            # Normally we'd constrain the set of suffices, but some IP vendors use really weird conventions.
++            allow_files = True,
          ),
      },
  )

--- a/dependency_support/rules_hdl/verilog/providers.bzl.patch
+++ b/dependency_support/rules_hdl/verilog/providers.bzl.patch
@@ -1,6 +1,6 @@
 --- a/verilog/providers.bzl
 +++ b/verilog/providers.bzl
-@@ -124,11 +124,14 @@ verilog_library = rule(
+@@ -124,11 +124,13 @@ verilog_library = rule(
          ),
          "hdrs": attr.label_list(
              doc = "Verilog or SystemVerilog headers.",

--- a/python/verilog_runner/cli.py
+++ b/python/verilog_runner/cli.py
@@ -22,13 +22,15 @@ from util import check_filename_extension
 
 def verilog_file(filename: str) -> str:
     # .vp and .svp are encrypted files.
-    return check_filename_extension(filename, (".v", ".sv", ".vp", ".svp"))
+    return check_filename_extension(filename, (".v", ".sv", ".vp", ".svp"), error=False)
 
 
 def verilog_header_file(filename: str) -> str:
     # Some vendor libraries include .h, .v, and .sv files rather than
     # following the .vh/.svh convention.
-    return check_filename_extension(filename, (".vh", ".svh", ".h", ".v", ".sv"))
+    return check_filename_extension(
+        filename, (".vh", ".svh", ".h", ".v", ".sv"), error=False
+    )
 
 
 def tcl_file(filename: str) -> str:

--- a/python/verilog_runner/util.py
+++ b/python/verilog_runner/util.py
@@ -109,12 +109,27 @@ def print_summary(
     logger.info(f"Summary:\n{SEPARATOR}\n{summary_text}\n{SEPARATOR}\n")
 
 
-def check_filename_extension(filename: str, allowed_extensions: Tuple[str]) -> str:
+def check_filename_extension(
+    filename: str,
+    allowed_extensions: Tuple[str],
+    logger: logging.Logger = None,
+    error: bool = True,
+) -> str:
     """Checks if a filename has one of the allowed extensions and returns it as-is."""
     if not filename.endswith(allowed_extensions):
-        raise argparse.ArgumentTypeError(
-            f"File '{filename}' must have one of the extensions: {allowed_extensions}"
-        )
+        if error:
+            raise argparse.ArgumentTypeError(
+                f"File '{filename}' must have one of the extensions: {allowed_extensions}"
+            )
+        else:
+            if logger:
+                logger.warning(
+                    f"File '{filename}' has an atypical extension. Expected one of: {allowed_extensions}"
+                )
+            else:
+                logging.warn(
+                    f"File '{filename}' has an atypical extension. Expected one of: {allowed_extensions}"
+                )
     return filename
 
 

--- a/python/verilog_runner/util_test.py
+++ b/python/verilog_runner/util_test.py
@@ -63,6 +63,9 @@ class TestUtilFunctions(unittest.TestCase):
         self.assertEqual(check_filename_extension("test.v", (".v", ".sv")), "test.v")
         with self.assertRaises(argparse.ArgumentTypeError):
             check_filename_extension("test.txt", (".v", ".sv"))
+        self.assertEqual(
+            check_filename_extension("test.foo", (".v", ".sv"), error=False), "test.foo"
+        )
 
     def test_gen_file_header(self):
         header = gen_file_header("test.v", "test_tool")


### PR DESCRIPTION
Some vendors have unusual filename suffices. Relax `verilog_library` to permit this. `verilog_runner.py` will now warn of unusual src/hdr suffices rather than error. Some tool plugins could still barf on nonstandard extensions.