### PR TITLE
fpv/bazel: Add custom elab_opts and analysis_opts to jg

### DIFF
--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -214,6 +214,10 @@ def _verilog_fpv_test_impl(ctx):
         fail("If opts are provided, then tool must also be set.")
     for opt in ctx.attr.opts:
         extra_args.append("--opt='" + opt + "'")
+    for opt in ctx.attr.elab_opts:
+        extra_args.append("--elab_opt='" + opt + "'")
+    for opt in ctx.attr.analysis_opts:
+        extra_args.append("--analysis_opt='" + opt + "'")
 
     return _verilog_base_impl(
         ctx = ctx,
@@ -437,6 +441,12 @@ rule_verilog_fpv_test = rule(
         ),
         "opts": attr.string_list(
             doc = "Tool-specific options not covered by other arguments. If provided, then 'tool' must also be set.",
+        ),
+        "elab_opts": attr.string_list(
+            doc = "custom elab options",
+        ),
+        "analysis_opts": attr.string_list(
+            doc = "custom analysis options",
         ),
         "elab_only": attr.bool(
             doc = "Only run elaboration.",

--- a/python/verilog_runner/cli.py
+++ b/python/verilog_runner/cli.py
@@ -251,3 +251,17 @@ class Fpv(Subcommand):
             action="store_true",
             help="Run with GUI",
         )
+        parser.add_argument(
+            "--elab_opt",
+            type=str,
+            action="append",
+            default=[],
+            help="elab options",
+        )
+        parser.add_argument(
+            "--analysis_opt",
+            type=str,
+            action="append",
+            default=[],
+            help="analysis options",
+        )


### PR DESCRIPTION
Add custom elab_opts and analysis_opts to jg. This is needed to allow users to add custom elab/analysis opts to tcl without changing the rest of analsysi/elab command