### PR TITLE
Fix data loss bug in br_flow_reg_rev

### DIFF
--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
@@ -67,6 +67,15 @@ module br_cdc_fifo_ctrl_1r1w #(
     parameter int RamReadLatency = 0,
     // The number of synchronization stages to use for the gray counts.
     parameter int NumSyncStages = 3,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -134,7 +143,10 @@ module br_cdc_fifo_ctrl_1r1w #(
   br_cdc_fifo_push_ctrl #(
       .Depth(Depth),
       .Width(Width),
-      .RamWriteLatency(RamWriteLatency)
+      .RamWriteLatency(RamWriteLatency),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_cdc_fifo_push_ctrl (
       .clk              (push_clk),               // ri lint_check_waive SAME_CLOCK_NAME
       .rst              (push_rst),

--- a/cdc/rtl/br_cdc_fifo_flops.sv
+++ b/cdc/rtl/br_cdc_fifo_flops.sv
@@ -65,6 +65,15 @@ module br_cdc_fifo_flops #(
     // Number of pipeline register stages inserted along the read data path in the width dimension.
     // Must be at least 0.
     parameter int FlopRamReadDataWidthStages = 0,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
 
     // Internal computed parameters
     localparam int AddrWidth  = $clog2(Depth),
@@ -129,7 +138,10 @@ module br_cdc_fifo_flops #(
       .RegisterPopOutputs(RegisterPopOutputs),
       .RamWriteLatency(RamWriteLatency),
       .RamReadLatency(RamReadLatency),
-      .NumSyncStages(NumSyncStages)
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_cdc_fifo_ctrl_1r1w (
       .push_clk,
       .push_rst,

--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
@@ -20,6 +20,15 @@ module br_cdc_fifo_push_ctrl #(
     parameter int Depth = 2,
     parameter int Width = 1,
     parameter int RamWriteLatency = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = 1,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = 1,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -86,7 +95,10 @@ module br_cdc_fifo_push_ctrl #(
   br_fifo_push_ctrl_core #(
       .Depth(Depth),
       .Width(Width),
-      .EnableBypass(1'b0)  // Bypass is not enabled for CDC
+      .EnableBypass(1'b0),  // Bypass is not enabled for CDC
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_fifo_push_ctrl_core (
       .clk,
       .rst,

--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
@@ -125,7 +125,9 @@ module br_cdc_fifo_push_ctrl_credit #(
   br_fifo_push_ctrl_core #(
       .Depth(Depth),
       .Width(Width),
-      .EnableBypass(1'b0)  // Bypass is not enabled for CDC
+      .EnableBypass(1'b0),  // Bypass is not enabled for CDC
+      // The core push control should never be backpressured.
+      .EnableCoverPushBackpressure(0)
   ) br_fifo_push_ctrl_core (
       .clk,
       .rst,

--- a/credit/rtl/BUILD.bazel
+++ b/credit/rtl/BUILD.bazel
@@ -76,6 +76,7 @@ verilog_library(
     srcs = ["br_credit_sender.sv"],
     deps = [
         ":br_credit_counter",
+        "//flow/rtl:br_flow_checks_valid_data",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],

--- a/fifo/rtl/br_fifo_ctrl_1r1w.sv
+++ b/fifo/rtl/br_fifo_ctrl_1r1w.sv
@@ -78,6 +78,15 @@ module br_fifo_ctrl_1r1w #(
     // The number of cycles between when ram_rd_addr_valid is asserted and
     // ram_rd_data_valid is asserted.
     parameter int RamReadLatency = 0,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -146,7 +155,10 @@ module br_fifo_ctrl_1r1w #(
   br_fifo_push_ctrl #(
       .Depth(Depth),
       .Width(Width),
-      .EnableBypass(EnableBypass)
+      .EnableBypass(EnableBypass),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_fifo_push_ctrl (
       .clk,
       .rst,

--- a/fifo/rtl/br_fifo_flops.sv
+++ b/fifo/rtl/br_fifo_flops.sv
@@ -73,6 +73,15 @@ module br_fifo_flops #(
     // Number of pipeline register stages inserted along the read data path in the width dimension.
     // Must be at least 0.
     parameter int FlopRamReadDataWidthStages = 0,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
 
     // Internal computed parameters
     localparam int AddrWidth  = $clog2(Depth),
@@ -130,7 +139,10 @@ module br_fifo_flops #(
       .Width(Width),
       .EnableBypass(EnableBypass),
       .RegisterPopOutputs(RegisterPopOutputs),
-      .RamReadLatency(RamReadLatency)
+      .RamReadLatency(RamReadLatency),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_fifo_ctrl_1r1w (
       .clk,
       .rst,

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -22,6 +22,15 @@ module br_fifo_push_ctrl #(
     parameter int Depth = 2,
     parameter int Width = 1,
     parameter bit EnableBypass = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = 1,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = 1,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -65,6 +74,8 @@ module br_fifo_push_ctrl #(
 
   `BR_COVER_INTG(full_c, full)
 
+  // Other integration checks in submodules
+
   //------------------------------------------
   // Implementation
   //------------------------------------------
@@ -73,7 +84,10 @@ module br_fifo_push_ctrl #(
   br_fifo_push_ctrl_core #(
       .Depth(Depth),
       .Width(Width),
-      .EnableBypass(EnableBypass)
+      .EnableBypass(EnableBypass),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_fifo_push_ctrl_core (
       .clk,
       .rst,

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -108,7 +108,9 @@ module br_fifo_push_ctrl_credit #(
   br_fifo_push_ctrl_core #(
       .Depth(Depth),
       .Width(Width),
-      .EnableBypass(EnableBypass)
+      .EnableBypass(EnableBypass),
+      // The core push control should never be backpressured.
+      .EnableCoverPushBackpressure(0)
   ) br_fifo_push_ctrl_core (
       .clk,
       .rst,

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -18,6 +18,15 @@ load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
 package(default_visibility = ["//visibility:public"])
 
 verilog_library(
+    name = "br_flow_checks_valid_data",
+    srcs = ["br_flow_checks_valid_data.sv"],
+    deps = [
+        "//macros:br_asserts_internal",
+        "//macros:br_unused",
+    ],
+)
+
+verilog_library(
     name = "br_flow_arb_fixed",
     srcs = ["br_flow_arb_fixed.sv"],
     deps = [
@@ -62,19 +71,28 @@ verilog_library(
 verilog_library(
     name = "br_flow_demux_select_unstable",
     srcs = ["br_flow_demux_select_unstable.sv"],
-    deps = ["//macros:br_asserts_internal"],
+    deps = [
+        ":br_flow_checks_valid_data",
+        "//macros:br_asserts_internal",
+    ],
 )
 
 verilog_library(
     name = "br_flow_fork",
     srcs = ["br_flow_fork.sv"],
-    deps = ["//macros:br_asserts_internal"],
+    deps = [
+        ":br_flow_checks_valid_data",
+        "//macros:br_asserts_internal",
+    ],
 )
 
 verilog_library(
     name = "br_flow_join",
     srcs = ["br_flow_join.sv"],
-    deps = ["//macros:br_asserts_internal"],
+    deps = [
+        ":br_flow_checks_valid_data",
+        "//macros:br_asserts_internal",
+    ],
 )
 
 verilog_library(
@@ -90,7 +108,10 @@ verilog_library(
 verilog_library(
     name = "br_flow_mux_select_unstable",
     srcs = ["br_flow_mux_select_unstable.sv"],
-    deps = ["//macros:br_asserts_internal"],
+    deps = [
+        ":br_flow_checks_valid_data",
+        "//macros:br_asserts_internal",
+    ],
 )
 
 verilog_library(
@@ -139,6 +160,7 @@ verilog_library(
     name = "br_flow_reg_fwd",
     srcs = ["br_flow_reg_fwd.sv"],
     deps = [
+        ":br_flow_checks_valid_data",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],
@@ -148,9 +170,62 @@ verilog_library(
     name = "br_flow_reg_rev",
     srcs = ["br_flow_reg_rev.sv"],
     deps = [
+        ":br_flow_checks_valid_data",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_checks_valid_data_test_suite_valid_stable",
+    params = {
+        "NumFlows": [
+            "1",
+            "2",
+        ],
+        "EnableCoverBackpressure": [
+            "1",
+        ],
+        "EnableAssertValidStability": [
+            "1",
+        ],
+        "EnableAssertDataStability": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_flow_checks_valid_data"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_checks_valid_data_test_suite_valid_unstable",
+    params = {
+        "NumFlows": [
+            "1",
+            "2",
+        ],
+        "EnableCoverBackpressure": [
+            "1",
+        ],
+        "EnableAssertValidStability": [
+            "0",
+        ],
+    },
+    deps = [":br_flow_checks_valid_data"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_checks_valid_data_test_suite_no_backpressure",
+    params = {
+        "NumFlows": [
+            "1",
+            "2",
+        ],
+        "EnableCoverBackpressure": [
+            "0",
+        ],
+    },
+    deps = [":br_flow_checks_valid_data"],
 )
 
 br_verilog_elab_and_lint_test_suite(

--- a/flow/rtl/br_flow_arb_fixed.sv
+++ b/flow/rtl/br_flow_arb_fixed.sv
@@ -27,7 +27,13 @@
 
 module br_flow_arb_fixed #(
     // Must be at least 2
-    parameter int NumFlows = 2
+    parameter int NumFlows = 2,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure
 ) (
     // Only used for assertions
     // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ NOT_READ
@@ -62,7 +68,9 @@ module br_flow_arb_fixed #(
   );
 
   br_flow_arb_core #(
-      .NumFlows(NumFlows)
+      .NumFlows(NumFlows),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability)
   ) br_flow_arb_core (
       .clk,
       .rst,

--- a/flow/rtl/br_flow_arb_lru.sv
+++ b/flow/rtl/br_flow_arb_lru.sv
@@ -29,7 +29,13 @@
 
 module br_flow_arb_lru #(
     // Must be at least 2
-    parameter int NumFlows = 2
+    parameter int NumFlows = 2,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,
@@ -66,7 +72,9 @@ module br_flow_arb_lru #(
   );
 
   br_flow_arb_core #(
-      .NumFlows(NumFlows)
+      .NumFlows(NumFlows),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability)
   ) br_flow_arb_core (
       .clk,
       .rst,

--- a/flow/rtl/br_flow_arb_rr.sv
+++ b/flow/rtl/br_flow_arb_rr.sv
@@ -29,7 +29,13 @@
 
 module br_flow_arb_rr #(
     // Must be at least 2
-    parameter int NumFlows = 2
+    parameter int NumFlows = 2,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,
@@ -66,7 +72,9 @@ module br_flow_arb_rr #(
   );
 
   br_flow_arb_core #(
-      .NumFlows(NumFlows)
+      .NumFlows(NumFlows),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability)
   ) br_flow_arb_core (
       .clk,
       .rst,

--- a/flow/rtl/br_flow_checks_valid_data.sv
+++ b/flow/rtl/br_flow_checks_valid_data.sv
@@ -1,0 +1,97 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Inbound Ready-Valid Interface Checks
+//
+// This is an assertion-only module that can be reused in all
+// modules with inbound ready-valid interfaces.
+// It checks that the valid and data signals conform to the
+// ready-valid interface protocol.
+
+`include "br_asserts_internal.svh"
+`include "br_unused.svh"
+
+// ri lint_check_off NO_OUTPUT
+module br_flow_checks_valid_data #(
+    // The number of ready-valid flows. Must be at least 1.
+    parameter int NumFlows = 1,
+    // The width of the data signal. Must be at least 1.
+    parameter int Width = 1,
+    // If 1, cover that there is backpressure.
+    // If 0, assert that there is never backpressure.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableCoverBackpressure = 1,
+    // If 1, assert that valid is stable when backpressured.
+    // If 0, cover that valid can be unstable.
+    // Can only be enabled if EnableCoverBackpressure is also enabled.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableAssertValidStability = EnableCoverBackpressure,
+    // If 1, assert that data is stable when backpressured.
+    // If 0, cover that data can be unstable.
+    // Can only be enabled if EnableAssertValidStability is also enabled.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableAssertDataStability = EnableAssertValidStability
+) (
+    // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic clk,
+    input logic rst,
+    input logic [NumFlows-1:0] valid,
+    input logic [NumFlows-1:0] ready,
+    input logic [NumFlows-1:0][Width-1:0] data
+);
+
+  `BR_ASSERT_STATIC(legal_assert_valid_stability_a,
+                    !(EnableAssertValidStability && !EnableCoverBackpressure))
+  `BR_ASSERT_STATIC(legal_assert_data_stability_a,
+                    !(EnableAssertDataStability && !EnableAssertValidStability))
+
+`ifdef BR_ASSERT_ON
+`ifndef BR_DISABLE_INTG_CHECKS
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks
+    if (EnableCoverBackpressure) begin : gen_backpressure_checks
+      if (EnableAssertValidStability) begin : gen_valid_stability_checks
+        // Assert that under backpressure conditions, the upstream properly
+        // maintains the stability guarantee of the ready-valid protocol. That is,
+        // on any given cycle, if valid is 1 and ready is 0, then assert that on
+        // the following cycle valid is still 1 and data has not changed.
+        if (EnableAssertDataStability) begin : gen_valid_data_stability_checks
+          `BR_ASSERT_INTG(valid_data_stable_when_backpressured_a,
+                          !ready[i] && valid[i] |=> valid[i] && $stable(data[i]))
+        end else begin : gen_valid_only_stability_checks
+          // In some cases, the data may be expected to be unstable when
+          // backpressured. For instance, at the output of a br_flow_mux_*
+          // module. In this case, we still want to check that the valid
+          // is stable when backpressured.
+          `BR_ASSERT_INTG(valid_stable_when_backpressured_a, !ready[i] && valid[i] |=> valid[i])
+          `BR_COVER_INTG(data_unstable_c, ##1 $past(!ready[i] && valid[i]) && !$stable(data[i]))
+          // Assert that if valid is 1, then data must be known (not X).
+          // This is not strictly a required integration check, because most modules
+          // should still function correctly even if data is unknown (X).
+          // However, under the ready-valid protocol convention where data is stable while
+          // backpressured, unknown values are by definition not stable and therefore violate the
+          // protocol requirement.
+          `BR_ASSERT_INTG(data_known_a, valid[i] |-> !$isunknown(data[i]))
+        end
+      end else begin : gen_no_valid_stability_checks
+        // Cover that valid can be unstable when backpressured.
+        `BR_COVER_INTG(valid_unstable_c, ##1 $past(!ready[i] && valid[i]) && !valid[i])
+      end
+    end
+  end
+`endif
+`endif
+
+  `BR_UNUSED_NAMED(all_unused, {rst, valid, ready, data})
+endmodule
+// ri lint_check_on NO_OUTPUT

--- a/flow/rtl/br_flow_demux_select.sv
+++ b/flow/rtl/br_flow_demux_select.sv
@@ -32,7 +32,16 @@ module br_flow_demux_select #(
     // Must be at least 2
     parameter int NumFlows = 2,
     // Must be at least 1
-    parameter int Width = 1
+    parameter int Width = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability
 ) (
     input logic clk,
     input logic rst,  // Synchronous active-high
@@ -79,7 +88,10 @@ module br_flow_demux_select #(
 
   br_flow_demux_select_unstable #(
       .NumFlows(NumFlows),
-      .Width(Width)
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_flow_demux_select_unstable (
       .clk(clk),
       .rst(rst),

--- a/flow/rtl/br_flow_join.sv
+++ b/flow/rtl/br_flow_join.sv
@@ -22,7 +22,13 @@
 `include "br_asserts_internal.svh"
 
 module br_flow_join #(
-    parameter int NumFlows = 2  // Must be at least 2
+    parameter int NumFlows = 2,  // Must be at least 2
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure
 ) (
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,  // Used only for assertions
@@ -44,9 +50,21 @@ module br_flow_join #(
   //------------------------------------------
   `BR_ASSERT_STATIC(num_flows_gte2_a, NumFlows >= 2)
 
-  for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks
-    `BR_ASSERT_INTG(push_valid_stable_A, !push_ready[i] && push_valid[i] |=> push_valid[i])
-  end
+
+  br_flow_checks_valid_data #(
+      .NumFlows(NumFlows),
+      .Width(1),
+      .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertValidStability(EnableAssertPushValidStability),
+      // Data is always stable when valid is since it is constant.
+      .EnableAssertDataStability(EnableAssertPushValidStability)
+  ) br_flow_checks_valid_data (
+      .clk,
+      .rst,
+      .ready(push_ready),
+      .valid(push_valid),
+      .data ({NumFlows{1'b0}})
+  );
 
   //------------------------------------------
   // Implementation

--- a/flow/rtl/br_flow_mux_fixed.sv
+++ b/flow/rtl/br_flow_mux_fixed.sv
@@ -26,7 +26,16 @@
 
 module br_flow_mux_fixed #(
     parameter int NumFlows = 2,  // Must be at least 2
-    parameter int Width = 1  // Must be at least 1
+    parameter int Width = 1,  // Must be at least 1
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability
 ) (
     // ri lint_check_waive NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic                           clk,         // Only used for assertions
@@ -65,7 +74,10 @@ module br_flow_mux_fixed #(
 
   br_flow_mux_core #(
       .NumFlows(NumFlows),
-      .Width(Width)
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_flow_mux_core (
       .clk,
       .rst,

--- a/flow/rtl/br_flow_mux_lru.sv
+++ b/flow/rtl/br_flow_mux_lru.sv
@@ -25,7 +25,16 @@
 
 module br_flow_mux_lru #(
     parameter int NumFlows = 2,  // Must be at least 2
-    parameter int Width = 1  // Must be at least 1
+    parameter int Width = 1,  // Must be at least 1
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -66,7 +75,10 @@ module br_flow_mux_lru #(
 
   br_flow_mux_core #(
       .NumFlows(NumFlows),
-      .Width(Width)
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_flow_mux_core (
       .clk,
       .rst,

--- a/flow/rtl/br_flow_mux_rr.sv
+++ b/flow/rtl/br_flow_mux_rr.sv
@@ -25,7 +25,16 @@
 
 module br_flow_mux_rr #(
     parameter int NumFlows = 2,  // Must be at least 2
-    parameter int Width = 1  // Must be at least 1
+    parameter int Width = 1,  // Must be at least 1
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -66,7 +75,10 @@ module br_flow_mux_rr #(
 
   br_flow_mux_core #(
       .NumFlows(NumFlows),
-      .Width(Width)
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_flow_mux_core (
       .clk,
       .rst,

--- a/flow/rtl/br_flow_mux_select.sv
+++ b/flow/rtl/br_flow_mux_select.sv
@@ -32,7 +32,16 @@ module br_flow_mux_select #(
     // Must be at least 2
     parameter int NumFlows = 2,
     // Must be at least 1
-    parameter int Width = 1
+    parameter int Width = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability
 ) (
     input logic clk,
     input logic rst,  // Synchronous active-high
@@ -65,7 +74,10 @@ module br_flow_mux_select #(
 
   br_flow_mux_select_unstable #(
       .NumFlows(NumFlows),
-      .Width(Width)
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_flow_mux_select_unstable (
       .clk,
       .rst,

--- a/flow/rtl/br_flow_reg_fwd.sv
+++ b/flow/rtl/br_flow_reg_fwd.sv
@@ -28,7 +28,16 @@
 
 module br_flow_reg_fwd #(
     // Must be at least 1
-    parameter int Width = 1
+    parameter int Width = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = 1,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = 1
 ) (
     input logic clk,
     input logic rst,  // Synchronous active-high
@@ -47,23 +56,19 @@ module br_flow_reg_fwd #(
   //------------------------------------------
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
 
-  // Assert that under push-side backpressure conditions,
-  // the pipeline register correctly stalls upstream.
-  // That is, on any given cycle, if push_valid is 1 and push_ready
-  // is 0, then assert that on the following cycle push_valid is
-  // still 1 and push_data has not changed. In other words,
-  // we are checking that the input stimulus abides by the push-side
-  // ready-valid interface protocol.
-  `BR_ASSERT_INTG(push_backpressure_a, !push_ready && push_valid |=> push_valid && $stable
-                                       (push_data))
-
-  // Assert that if push_valid is 1, then push_data must be known (not X).
-  // This is not strictly a required integration check, because the module implementation
-  // will still function correctly even if push_data is unknown (X).
-  // However, under the ready-valid protocol convention where push_data is stable while
-  // backpressured, unknown values are by definition not stable and therefore violate the
-  // protocol requirement.
-  `BR_ASSERT_INTG(push_data_known_a, push_valid |-> !$isunknown(push_data))
+  br_flow_checks_valid_data #(
+      .NumFlows(1),
+      .Width(Width),
+      .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertValidStability(EnableAssertPushValidStability),
+      .EnableAssertDataStability(EnableAssertPushDataStability)
+  ) br_flow_checks_valid_data (
+      .clk,
+      .rst,
+      .ready(push_ready),
+      .valid(push_valid),
+      .data (push_data)
+  );
 
   //------------------------------------------
   // Implementation

--- a/flow/rtl/br_flow_reg_rev.sv
+++ b/flow/rtl/br_flow_reg_rev.sv
@@ -92,7 +92,8 @@ module br_flow_reg_rev #(
 
   // No reset necessary for reg_data because !push_ready qualifies the value of reg_data.
   // And push_ready resets to 1'b1, so the unknown value of reg_data doesn't matter.
-  `BR_REGLN(reg_data, push_data, !pop_ready && push_valid)
+  // Data is updated if it push data is accepted but cannot be forwarded to pop.
+  `BR_REGLN(reg_data, push_data, !pop_ready && push_ready && push_valid)
 
   //------------------------------------------
   // Implementation checks

--- a/flow/rtl/internal/BUILD.bazel
+++ b/flow/rtl/internal/BUILD.bazel
@@ -20,6 +20,7 @@ verilog_library(
     name = "br_flow_arb_core",
     srcs = ["br_flow_arb_core.sv"],
     deps = [
+        "//flow/rtl:br_flow_checks_valid_data",
         "//macros:br_asserts_internal",
         "//macros:br_unused",
     ],
@@ -30,6 +31,7 @@ verilog_library(
     srcs = ["br_flow_mux_core.sv"],
     deps = [
         ":br_flow_arb_core",
+        "//flow/rtl:br_flow_checks_valid_data",
         "//macros:br_asserts_internal",
         "//macros:br_unused",
         "//mux/rtl:br_mux_onehot",

--- a/flow/rtl/internal/br_flow_mux_core.sv
+++ b/flow/rtl/internal/br_flow_mux_core.sv
@@ -26,7 +26,16 @@
 
 module br_flow_mux_core #(
     parameter int NumFlows = 2,  // Must be at least 2
-    parameter int Width = 1  // Must be at least 1
+    parameter int Width = 1,  // Must be at least 1
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = 1,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = 1
 ) (
     // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
     input  logic                           clk,                     // Used for assertions only
@@ -52,7 +61,19 @@ module br_flow_mux_core #(
   `BR_ASSERT_STATIC(numflows_gte_2_a, NumFlows >= 2)
   `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
 
-  // Rely on submodule integration checks
+  br_flow_checks_valid_data #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertValidStability(EnableAssertPushValidStability),
+      .EnableAssertDataStability(EnableAssertPushDataStability)
+  ) br_flow_checks_valid_data (
+      .clk,
+      .rst,
+      .ready(push_ready),
+      .valid(push_valid),
+      .data (push_data)
+  );
 
   //------------------------------------------
   // Implementation


### PR DESCRIPTION
The load-enable for the data buffer was missing qualification
on push_ready, meaning that already buffered data would get overwritten
when a new push_valid came in.

---

**Stack**:
- #251
- #250 ⬅
- #249


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*