### PR TITLE
Fix FIFO testbenches after stability assertion addition

### DIFF
--- a/cdc/sim/br_cdc_fifo_flops_push_credit_tb.sv
+++ b/cdc/sim/br_cdc_fifo_flops_push_credit_tb.sv
@@ -105,7 +105,10 @@ module br_cdc_fifo_flops_push_credit_tb ();
 
   br_credit_sender #(
       .Width(Width),
-      .MaxCredit(Depth)
+      .MaxCredit(Depth),
+      // The test harness causes instability on the push_valid,
+      // so need to disable the stability check
+      .EnableAssertPushValidStability(0)
   ) br_credit_sender (
       .clk,
       .rst,

--- a/cdc/sim/br_cdc_fifo_flops_tb.sv
+++ b/cdc/sim/br_cdc_fifo_flops_tb.sv
@@ -57,7 +57,10 @@ module br_cdc_fifo_flops_tb;
       .NumSyncStages(NumSyncStages),
       .RegisterPopOutputs(RegisterPopOutputs),
       .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
-      .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages)
+      .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages),
+      // The test harness causes instability on the push_valid,
+      // so need to disable the stability check
+      .EnableAssertPushValidStability(0)
   ) dut (
       .push_clk(clk),  // ri lint_check_waive SAME_CLOCK_NAME
       .push_rst(rst),

--- a/fifo/sim/br_fifo_flops_push_credit_tb.sv
+++ b/fifo/sim/br_fifo_flops_push_credit_tb.sv
@@ -95,7 +95,10 @@ module br_fifo_flops_push_credit_tb ();
 
   br_credit_sender #(
       .Width(Width),
-      .MaxCredit(Depth)
+      .MaxCredit(Depth),
+      // The test harness causes instability on the push_valid,
+      // so need to disable the stability check
+      .EnableAssertPushValidStability(0)
   ) br_credit_sender (
       .clk,
       .rst,

--- a/fifo/sim/br_fifo_flops_tb.sv
+++ b/fifo/sim/br_fifo_flops_tb.sv
@@ -57,7 +57,10 @@ module br_fifo_flops_tb;
       .Width(Width),
       .RegisterPopOutputs(RegisterPopOutputs),
       .EnableBypass(EnableBypass),
-      .FlopRamAddressDepthStages(FlopRamAddressDepthStages)
+      .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
+      // The test harness causes instability on the push_valid,
+      // so need to disable the stability check
+      .EnableAssertPushValidStability(0)
   ) dut (
       .clk(clk),
       .rst(rst),


### PR DESCRIPTION
The change adding the valid stability assertions broke the
testbenches since the test harness causes instability after
attempting to push to full FIFO. Just disable the assertion
on the DUT for now.

---

**Stack**:
- #256
- #255 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*