### PR TITLE
Fix bypass cut-through latency assertion

### DIFF
--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -141,8 +141,14 @@ module br_fifo_pop_ctrl #(
 
   // Flow control and latency
   if (EnableBypass) begin : gen_bypass_cut_through_latency_check
+    // If a RAM read is inflight when the bypass occurs, pop_valid will not
+    // be asserted until the RAM read completes. So the range of the latency
+    // from bypass to the input of the final register stage is
+    // 0 to RamReadLatency.
     `BR_ASSERT_IMPL(bypass_cut_through_latency_a,
-                    (bypass_valid_unstable && bypass_ready) |-> ##(RegisterPopOutputs) pop_valid)
+                    (bypass_valid_unstable && bypass_ready)
+                    |->
+                    ##[RegisterPopOutputs:RegisterPopOutputs+RamReadLatency] pop_valid)
   end
   `BR_ASSERT_IMPL(
       non_bypass_cut_through_latency_a,


### PR DESCRIPTION
The assertion previously assumed that bypassed data would always
go directly to the output or the final staging flop.
However, this might not be true if there are reads to the data storage
still in flight. In this case, the bypass data sits in the staging
buffer and will not go through until all the inflight read data has
gone through.