### PR TITLE
Support for multiple allocation ports in br_tracker_freelist

### DIFF
--- a/tracker/rtl/BUILD.bazel
+++ b/tracker/rtl/BUILD.bazel
@@ -32,8 +32,12 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_tracker_freelist_test_suite",
     params = {
         "NumEntries": [
-            "4",
-            "6",
+            "5",
+            "8",
+        ],
+        "NumAllocPorts": [
+            "1",
+            "2",
         ],
         "NumDeallocPorts": [
             "1",

--- a/tracker/sim/BUILD.bazel
+++ b/tracker/sim/BUILD.bazel
@@ -36,7 +36,12 @@ br_verilog_sim_test_suite(
     name = "br_tracker_freelist_vcs_test_suite",
     params = {
         "NumEntries": [
-            "16",
+            "12",
+        ],
+        "NumAllocPorts": [
+            "1",
+            "2",
+            "3",
         ],
         "NumDeallocPorts": [
             "1",
@@ -44,6 +49,5 @@ br_verilog_sim_test_suite(
         ],
     },
     tool = "vcs",
-    waves = True,
     deps = [":br_tracker_freelist_tb"],
 )

--- a/tracker/sim/br_tracker_freelist_tb.sv
+++ b/tracker/sim/br_tracker_freelist_tb.sv
@@ -15,8 +15,9 @@
 module br_tracker_freelist_tb;
 
   parameter int NumEntries = 16;
+  parameter int NumAllocPorts = 1;
   parameter int NumDeallocPorts = 1;
-  parameter int NumAllocations = 100;
+  parameter int NumAllocations = 100 / NumAllocPorts;
   parameter int MaxDelay = 10;
 
   localparam int EntryIdWidth = $clog2(NumEntries);
@@ -35,9 +36,9 @@ module br_tracker_freelist_tb;
   logic clk;
   logic rst;
 
-  logic alloc_valid;
-  logic alloc_ready;
-  logic [EntryIdWidth-1:0] alloc_entry_id;
+  logic [NumAllocPorts-1:0] alloc_valid;
+  logic [NumAllocPorts-1:0] alloc_ready;
+  logic [NumAllocPorts-1:0][EntryIdWidth-1:0] alloc_entry_id;
 
   logic [NumDeallocPorts-1:0] dealloc_valid;
   logic [NumDeallocPorts-1:0][EntryIdWidth-1:0] dealloc_entry_id;
@@ -51,6 +52,7 @@ module br_tracker_freelist_tb;
 
   br_tracker_freelist #(
       .NumEntries(NumEntries),
+      .NumAllocPorts(NumAllocPorts),
       .NumDeallocPorts(NumDeallocPorts)
   ) dut (
       .clk,
@@ -67,22 +69,29 @@ module br_tracker_freelist_tb;
   // Allocate all entries at the beginning without deallocation
   // and check that they come out in the expected order.
   task automatic init_allocate_entries();
-    alloc_ready = 1;
-    for (int i = 0; i < NumEntries; i++) begin
+    alloc_ready = '1;
+
+    // The entries are going to be allocated to the ports in round-robin
+    // fashion initially.
+    for (int i = 0; i < NumEntries; i += NumAllocPorts) begin
       @(posedge clk);
-      td.check(alloc_valid, "Cannot allocate an initial entry");
-      td.check_integer(alloc_entry_id, i, "Allocated entry ID is incorrect");
-      free_entries[i] = 1;
-      entry_queues[0].push_back(i);
+      for (int j = 0; j < NumAllocPorts; j++) begin
+        td.check(alloc_valid[j], "Cannot allocate an initial entry");
+        td.check_integer(alloc_entry_id[j], i + j, "Allocated entry ID is incorrect");
+        free_entries[i+j] = 1;
+        entry_queues[0].push_back(i + j);
+      end
     end
     @(negedge clk);
-    alloc_ready = 0;
+    alloc_ready = '0;
   endtask
 
   // Randomly allocate entries to queues
-  task automatic random_allocate_entries();
+  task automatic random_allocate_entries(int aid);
     int delay;
     int qid;
+
+    $display("Randomly allocating entries for alloc port %0d", aid);
 
     for (int i = 0; i < NumAllocations; i++) begin
       int timeout;
@@ -90,26 +99,26 @@ module br_tracker_freelist_tb;
       delay = $urandom_range(MaxDelay);
       td.wait_cycles(delay);
 
-      alloc_ready = 1;
+      alloc_ready[aid] = 1;
       @(posedge clk);
 
-      timeout = 100;
-      while (!alloc_valid && timeout > 0) begin
+      timeout = (MaxDelay + 1) * (NumAllocPorts - 1) * NumAllocations;
+      while (!alloc_valid[aid] && timeout > 0) begin
         @(posedge clk);
         timeout--;
       end
 
-      td.check(timeout > 0, "Timeout waiting for allocation");
+      td.check(alloc_valid[aid], $sformatf("Timeout waiting for allocation on %0d", aid));
 
-      td.check(free_entries[alloc_entry_id], $sformatf(
-               "Allocated entry %0d is not free", alloc_entry_id));
+      td.check(free_entries[alloc_entry_id[aid]], $sformatf(
+               "Allocated entry %0d is not free", alloc_entry_id[aid]));
 
       qid = $urandom_range(NumDeallocPorts - 1);
-      entry_queues[qid].push_back(alloc_entry_id);
-      free_entries[alloc_entry_id] = 0;
+      entry_queues[qid].push_back(alloc_entry_id[aid]);
+      free_entries[alloc_entry_id[aid]] = 0;
 
       @(negedge clk);
-      alloc_ready = 0;
+      alloc_ready[aid] = 0;
     end
   endtask
 
@@ -182,8 +191,20 @@ module br_tracker_freelist_tb;
       join_none
     end
 
-    $display("Randomly allocating entries");
-    random_allocate_entries();
+    fork
+      begin
+        // Need to wait for all the allocation threads to finish,
+        // but don't want to wait for the deallocation threads.
+        for (int i = 0; i < NumAllocPorts; i++) begin
+          automatic int aid;
+          aid = i;
+          fork
+            random_allocate_entries(aid);
+          join_none
+        end
+        wait fork;
+      end
+    join
 
     td.wait_cycles(1);
 


### PR DESCRIPTION
For each allocation port, instantiate separate priority encoder,
onehot2bin encoder, and staging buffer. To avoid collisions,
mask off the next-to-alloc entry from one port if it is ready to
be accepted.