### PR TITLE
Allow priority encoder to produce multiple results

### DIFF
--- a/enc/rtl/BUILD.bazel
+++ b/enc/rtl/BUILD.bazel
@@ -41,6 +41,7 @@ verilog_library(
     deps = [
         "//macros:br_asserts_internal",
         "//macros:br_registers",
+        "//macros:br_unused",
     ],
 )
 
@@ -82,10 +83,17 @@ br_verilog_elab_and_lint_test_suite(
 
 br_verilog_elab_and_lint_test_suite(
     name = "br_enc_priority_encoder_test_suite",
-    params = {"NumRequesters": [
-        "2",
-        "15",
-    ]},
+    params = {
+        "NumRequesters": [
+            "4",
+            "15",
+        ],
+        "NumResults": [
+            "1",
+            "2",
+            "3",
+        ],
+    },
     deps = [":br_enc_priority_encoder"],
 )
 

--- a/enc/rtl/br_enc_priority_encoder.sv
+++ b/enc/rtl/br_enc_priority_encoder.sv
@@ -16,50 +16,163 @@
 //
 // Masks all but the highest priority active request in an input where the
 // lowest index is the highest priority.
+//
+// Can optionally produce more than one result if NumResults is greater than 1.
+// If so, out[0] will have the highest priority bit set, out[1] will have the
+// second highest priority bit set, etc.
 
 // TODO(mgottscho): Write spec
 
 `include "br_asserts_internal.svh"
+`include "br_unused.svh"
 
 module br_enc_priority_encoder #(
-    // Must be at least 2
-    parameter int NumRequesters = 2
+    // Must be at least 2 and greater than NumResults.
+    parameter int NumRequesters = 2,
+    // Number of onehot results to produce. Must be at least 1.
+    parameter int NumResults = 1
 ) (
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,  // Used only for assertions
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic rst,  // Used only for assertions
     input logic [NumRequesters-1:0] in,
-    output logic [NumRequesters-1:0] out
+    output logic [NumResults-1:0][NumRequesters-1:0] out
 );
 
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(num_requesters_at_least_two_a, NumRequesters >= 2)
+  `BR_ASSERT_STATIC(legal_num_results_a, NumResults >= 1)
+  `BR_ASSERT_STATIC(legal_num_requesters_a, NumRequesters > NumResults)
 
-  // TODO(mgottscho): Write a cover point that multiple inputs are concurrently active
+`ifdef BR_ASSERT_ON
+`ifndef BR_DISABLE_INTG_CHECKS
+  logic [$clog2(NumRequesters+1)-1:0] num_in_hot;
+
+  always_comb begin
+    num_in_hot = '0;
+    for (int i = 0; i < NumRequesters; i++) begin
+      num_in_hot += in[i];
+    end
+  end
+
+  `BR_COVER_INTG(more_in_hot_than_num_results_c, num_in_hot > NumResults)
+`endif
+`endif
 
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  always_comb begin
-    out = '0;
-    for (int i = 0; i < NumRequesters; i++) begin
-      // Lowest index is highest priority
-      if (in[i]) begin
-        out[i] = 1'b1;
-        break;
+
+  // Each result is a separate priority search on the input
+  // with the bits selected by previous results masked off.
+  for (genvar out_idx = 0; out_idx < NumResults; out_idx++) begin : gen_out
+    logic [NumRequesters-1:0] in_masked;
+
+    // Generated the masked input
+    // Any bit that was set in a previous result
+    // should be cleared in the masked input.
+    always_comb begin
+      in_masked = in;
+      // This for loop won't be entered if out_idx is 0
+      // This is expected since we just want in_masked to be in
+      // ri lint_check_waive LOOP_NOT_ENTERED
+      for (int prev_idx = 0; prev_idx < out_idx; prev_idx++) begin
+        in_masked &= ~out[prev_idx];
       end
+    end
+
+    // in_masked[out_idx-1:0] will always be zero since
+    // they would have been claimed by a previous result.
+    // out[out_idx][out_idx-1:0] must always be zero
+    if (out_idx > 0) begin : gen_out_masked_lsb_tieoff
+      // ri lint_check_waive CONST_OUTPUT
+      assign out[out_idx][out_idx-1:0] = '0;
+      `BR_UNUSED(in_masked[out_idx-1:0])
+      `BR_ASSERT_IMPL(in_masked_lsb_zero_a, in_masked[out_idx-1:0] == '0)
+    end
+
+    // Generate the onehot result for this stage
+    // LSB is highest priority and is set unconditionally
+    // if the masked input bit is set.
+    assign out[out_idx][out_idx] = in_masked[out_idx];
+    for (genvar in_idx = out_idx + 1; in_idx < NumRequesters; in_idx++) begin : gen_out_bit
+      // Output is set if the corresponding input bit is set and all lower index
+      // bits of the masked input are not set.
+      assign out[out_idx][in_idx] = in_masked[in_idx] && (in_masked[in_idx-1:out_idx] == '0);
     end
   end
 
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_IMPL(out_onehot0_a, $onehot0(out))
-  `BR_ASSERT_IMPL(out_lowest_max_priority_a, in[0] == out[0])
-  `BR_ASSERT_IMPL(out_highest_min_priority_a,
-                  out[NumRequesters-1] |-> in[NumRequesters-1] && (|in[NumRequesters-2:0] == '0))
+
+`ifdef BR_ASSERT_ON
+`ifdef BR_ENABLE_IMPL_CHECKS
+  // prev_out[i] is the bitwise OR of all out from 0 to i-1
+  logic [NumResults-1:0][NumRequesters-1:0] prev_out;
+  // num_prev_out[i] is the number of bits set in prev_out[i]
+  logic [NumResults-1:0][$clog2(NumRequesters+1)-1:0] num_prev_out;
+
+  for (genvar out_idx = 0; out_idx < NumResults; out_idx++) begin : gen_out_impl_checks
+    always_comb begin
+      prev_out[out_idx] = '0;
+      num_prev_out[out_idx] = '0;
+      // ri lint_check_waive LOOP_NOT_ENTERED
+      for (int i = 0; i < out_idx; i++) begin
+        prev_out[out_idx] |= out[i];
+        num_prev_out[out_idx] += |out[i];
+      end
+    end
+
+    // Each output needs to be onehot
+    `BR_ASSERT_IMPL(out_onehot0_a, $onehot0(out[out_idx]))
+    // The highest priority bit of the output must be set if the corresponding
+    // input bit is set and it was not taken by a previous result.
+    `BR_ASSERT_IMPL(out_lowest_max_priority_a,
+                    (in[out_idx] && !prev_out[out_idx][out_idx]) |-> out[out_idx][out_idx])
+    for (
+        genvar in_idx = out_idx + 1; in_idx < NumRequesters; in_idx++
+    ) begin : gen_msb_input_impl_checks
+      // A bit in out can only be set if the higher priority bits of the input
+      // are not set or were taken by a higher priority output.
+      `BR_ASSERT_IMPL(
+          no_out_if_higher_prio_in_a,
+          out[out_idx][in_idx] |-> ((in[in_idx-1:0] & ~prev_out[out_idx][in_idx-1:0]) == '0))
+    end
+
+    if (out_idx > 0) begin : gen_secondary_out_impl_checks
+      // For each result, there cannot be a bit set if there weren't bits set in
+      // all previous results.
+      `BR_ASSERT_IMPL(no_out_without_prev_out_a,
+                      (|out[out_idx]) |-> (num_prev_out[out_idx] == out_idx))
+
+      for (
+          genvar in_idx = out_idx; in_idx < (NumRequesters - 1); in_idx++
+      ) begin : gen_secondary_out_per_input_impl_checks
+        // If a bit is set in a secondary output, the higher priority outputs
+        // must not have taken an input of lower priority.
+        `BR_ASSERT_IMPL(
+            out_lower_prio_than_prev_out_a,
+            out[out_idx][in_idx] |-> (prev_out[out_idx][NumRequesters-1:in_idx+1] == '0))
+      end
+    end
+  end
+
+  if (NumResults > 1) begin : gen_no_collision_check
+    logic [NumRequesters-1:0] out_intersect;
+
+    always_comb begin
+      out_intersect = out[0];
+      for (int i = 1; i < NumResults; i++) begin
+        out_intersect &= out[i];
+      end
+    end
+
+    `BR_ASSERT_IMPL(no_out_collision_a, out_intersect == '0)
+  end
+`endif
+`endif
 
 endmodule : br_enc_priority_encoder

--- a/enc/sim/BUILD.bazel
+++ b/enc/sim/BUILD.bazel
@@ -35,6 +35,15 @@ verilog_library(
     ],
 )
 
+verilog_library(
+    name = "br_enc_priority_encoder_tb",
+    srcs = ["br_enc_priority_encoder_tb.sv"],
+    deps = [
+        "//enc/rtl:br_enc_priority_encoder",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
 verilog_elab_test(
     name = "br_enc_bin2onehot_tb_elab_test",
     deps = [":br_enc_bin2onehot_tb"],
@@ -65,4 +74,22 @@ br_verilog_sim_test_suite(
     ]},
     tool = "vcs",
     deps = [":br_enc_gray_tb"],
+)
+
+verilog_elab_test(
+    name = "br_enc_priority_encoder_tb_elab_test",
+    deps = [":br_enc_priority_encoder_tb"],
+)
+
+br_verilog_sim_test_suite(
+    name = "br_enc_priority_encoder_vcs_test_suite",
+    params = {
+        "NumRequesters": ["7"],
+        "NumResults": [
+            "1",
+            "3",
+        ],
+    },
+    tool = "vcs",
+    deps = [":br_enc_priority_encoder_tb"],
 )

--- a/enc/sim/br_enc_priority_encoder_tb.sv
+++ b/enc/sim/br_enc_priority_encoder_tb.sv
@@ -1,0 +1,85 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Priority Encoder Testbench
+//
+// Since this is a purely combinational block with just one input,
+// we can just exhaustively test all possible input values.
+
+module br_enc_priority_encoder_tb;
+  parameter int NumRequesters = 8;
+  parameter int NumResults = 3;
+  localparam int MaxInValue = (2 ** NumRequesters) - 1;
+
+  logic clk;
+  logic rst;
+
+  logic [NumRequesters-1:0] in;
+  logic [NumResults-1:0][NumRequesters-1:0] out;
+
+  br_test_driver driver (
+      .clk,
+      .rst
+  );
+
+  br_enc_priority_encoder #(
+      .NumRequesters(NumRequesters),
+      .NumResults(NumResults)
+  ) dut (
+      .clk,
+      .rst,
+      .in,
+      .out
+  );
+
+  function automatic logic [NumResults-1:0][NumRequesters-1:0] calc_expected_out(input int fin);
+    int res_idx = 0;
+    logic [NumResults-1:0][NumRequesters-1:0] fout;
+
+    fout = '0;
+    for (int i = 0; i < NumRequesters; i++) begin
+      // Once we find an input bit set, just set it on the current
+      // output and then move on to the next output.
+      if (fin[i]) begin
+        fout[res_idx][i] = 1;
+        res_idx++;
+        // We're done once we've found a set bit for each output.
+        if (res_idx == NumResults) break;
+      end
+    end
+    return fout;
+  endfunction
+
+  initial begin
+    logic [NumResults-1:0][NumRequesters-1:0] expected_out;
+
+    in = '0;
+
+    driver.reset_dut();
+
+    // Exhaustively test all possible input values
+    for (int i = 0; i <= MaxInValue; i++) begin
+      @(negedge clk);
+      in = i;
+      expected_out = calc_expected_out(i);
+      @(posedge clk);
+      driver.check_integer(out, expected_out, $sformatf("Output mismatch for input %0d", i));
+    end
+
+    @(negedge clk);
+
+    driver.finish();
+  end
+
+endmodule


### PR DESCRIPTION
Each secondary output is the result of another priority to onehot
encoder on the input with previously found values masked off.

Add a unit test that exhaustively checks all possible inputs.