### PR TITLE
Implement `br_flow_serializer` and `br_flow_deserializer`

### DIFF
--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -176,6 +176,19 @@ verilog_library(
     ],
 )
 
+verilog_library(
+    name = "br_flow_serializer",
+    srcs = ["br_flow_serializer.sv"],
+    deps = [
+        ":br_flow_checks_valid_data",
+        ":br_flow_reg_fwd",
+        "//counter/rtl:br_counter_incr",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+        "//mux/rtl:br_mux_bin",
+    ],
+)
+
 br_verilog_elab_and_lint_test_suite(
     name = "br_flow_checks_valid_data_test_suite_valid_stable",
     params = {
@@ -419,4 +432,26 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_flow_reg_rev"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_serializer_test_suite",
+    params = {
+        "PushWidth": [
+            "8",
+            "12",
+        ],
+        "PopWidth": [
+            "4",
+        ],
+        "SerializeMostSignificantFirst": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_flow_serializer"],
 )

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -181,8 +181,8 @@ verilog_library(
     srcs = ["br_flow_serializer.sv"],
     deps = [
         ":br_flow_checks_valid_data",
-        ":br_flow_reg_fwd",
         "//counter/rtl:br_counter_incr",
+        "//delay/rtl:br_delay_nr",
         "//macros:br_asserts",
         "//macros:br_asserts_internal",
         "//mux/rtl:br_mux_bin",

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -456,6 +456,9 @@ br_verilog_elab_and_lint_test_suite(
         "PopWidth": [
             "4",
         ],
+        "MetadataWidth": [
+            "1",
+        ],
         "SerializeMostSignificantFirst": [
             "0",
             "1",

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -194,10 +194,12 @@ verilog_library(
     srcs = ["br_flow_deserializer.sv"],
     deps = [
         ":br_flow_checks_valid_data",
-        ":br_flow_demux_select_unstable",
-        ":br_flow_reg_fwd",
+        "//counter/rtl:br_counter_incr",
+        "//demux/rtl:br_demux_bin",
         "//macros:br_asserts",
         "//macros:br_asserts_internal",
+        "//macros:br_registers",
+        "//mux/rtl:br_mux_bin",
     ],
 )
 
@@ -476,6 +478,9 @@ br_verilog_elab_and_lint_test_suite(
         "PopWidth": [
             "8",
             "12",
+        ],
+        "MetadataWidth": [
+            "1",
         ],
         "DeserializeMostSignificantFirst": [
             "0",

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -183,9 +183,21 @@ verilog_library(
         ":br_flow_checks_valid_data",
         ":br_flow_reg_fwd",
         "//counter/rtl:br_counter_incr",
+        "//macros:br_asserts",
         "//macros:br_asserts_internal",
-        "//macros:br_registers",
         "//mux/rtl:br_mux_bin",
+    ],
+)
+
+verilog_library(
+    name = "br_flow_deserializer",
+    srcs = ["br_flow_deserializer.sv"],
+    deps = [
+        ":br_flow_checks_valid_data",
+        ":br_flow_demux_select_unstable",
+        ":br_flow_reg_fwd",
+        "//macros:br_asserts",
+        "//macros:br_asserts_internal",
     ],
 )
 
@@ -454,4 +466,26 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_flow_serializer"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_deserializer_test_suite",
+    params = {
+        "PushWidth": [
+            "4",
+        ],
+        "PopWidth": [
+            "8",
+            "12",
+        ],
+        "DeserializeMostSignificantFirst": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_flow_deserializer"],
 )

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -185,6 +185,7 @@ verilog_library(
         "//delay/rtl:br_delay_nr",
         "//macros:br_asserts",
         "//macros:br_asserts_internal",
+        "//macros:br_unused",
         "//mux/rtl:br_mux_bin",
     ],
 )
@@ -199,6 +200,7 @@ verilog_library(
         "//macros:br_asserts",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
+        "//macros:br_tieoff",
         "//mux/rtl:br_mux_bin",
     ],
 )
@@ -452,6 +454,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_flow_serializer_test_suite",
     params = {
         "PushWidth": [
+            "4",
             "8",
             "12",
         ],
@@ -476,6 +479,7 @@ br_verilog_elab_and_lint_test_suite(
             "4",
         ],
         "PopWidth": [
+            "4",
             "8",
             "12",
         ],

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -482,10 +482,6 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
-        "RegisterPopOutputs": [
-            "0",
-            "1",
-        ],
     },
     deps = [":br_flow_deserializer"],
 )

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -460,10 +460,6 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
-        "RegisterPopOutputs": [
-            "0",
-            "1",
-        ],
     },
     deps = [":br_flow_serializer"],
 )

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -182,7 +182,6 @@ verilog_library(
     deps = [
         ":br_flow_checks_valid_data",
         "//counter/rtl:br_counter_incr",
-        "//delay/rtl:br_delay_nr",
         "//macros:br_asserts",
         "//macros:br_asserts_internal",
         "//macros:br_unused",

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -14,44 +14,68 @@
 
 // Bedrock-RTL Flow Deserializer
 //
-// This module deserializes an input packet consisting of multiple narrower flits into a single wider flit.
-// Data flows from pop-side to push-side using ready-valid handshakes on both sides.
+// This module deserializes packet flits from a narrow bus onto a wider bus.
+// Data flows from push-side to pop-side using ready-valid handshakes on both sides.
 //
 // The push and pop bitwidths are parameterized; the PopWidth must be a positive integer
 // that is greater than PushWidth and is also divisible by PushWidth.
-// The number of deserialized flits per packet is a constant given by PopWidth / PushWidth.
+// The flit deserialization ratio is given by DeserializationRatio = PopWidth / PushWidth, i.e.,
+// the ratio of bus widths is DeserializationRatio:1 for some integer DeserializationRatio > 1 and the
+// maximum number of push flits per pop flit is DeserializationRatio.
 //
-// The deserialization order is configured by DeserializeMostSignificantFirst. If 1, then the first flit
-// is placed in the most significant bits of the pop data; otherwise, the last flit is placed there.
-// The order of bits within each push flit is always maintained on the pop side.
+// The deserialization order is configured by DeserializeMostSignificantFirst. If 1, then the most-significant
+// bits of the pop flit are reconstructed first from incoming push flits; otherwise, the least-significant bits
+// are reconstructed first. The order of bits within each reconstructed pop flit matches the concatenation order
+// of the individual push flits.
 //
-// Although the number of push flits per packet is constant, each push flit is accompanied by a
-// push_id sideband signal. This is useful for any logic that needs to directly operate on data within the
-// serialized flow. For convenience, a push_last signal is also provided in case the user only needs to know
-// when a deserialized packet is complete (equivalent to push_id == (NumPushFlits-1)).
+// Each pop flit is accompanied by a pop_metadata sideband signal that is formed by sampling the push_metadata
+// associated with the set of push flits that compose that pop flit. The module does not care about the contents
+// of push_metadata. The push_metadata is required to be constant across every push flit in matching the same pop flit,
+// and so the deserializer samples it only on the last push flit of the packet.
 //
-// The push_valid and push_data must be held stable until push_ready is 1.
+// The push interface has a push_last signal that indicates the last flit of a packet on the push side.
+// Up to DeserializationRatio push flits combine to form one pop flit. The pop flit is greedily constructed
+// until either the pop flit is full (DeserializationRatio push flits have been consumed) or push_last is 1.
+// When push_last is 1, then the number of push flits that were consumed to form the last pop flit can vary between 1
+// and DeserializationRatio.
 //
-// The throughput of this module is 1 push flit per cycle; equivalently, a packet output interval of
-// 1 packet per (PushWidth / PopWidth) cycles.
+// The pop interface sets pop_last to 1 when the packet deserialization is complete (as indicated by push_last).
+// If the total number of push flits in the packet is not divisible by DeserializationRatio (i.e., push_last comes
+// "early"), then the last pop flit is partially populated and the remaining space is filled with zeros.
+// If DeserializeMostSignificantFirst is 1, then the zero-filled values occupy the least-significant portion of
+// the final pop flit; otherwise, they occupy the most-significant portion.
 //
-// Examples(where the ready and valid signals are not shown:
+// The push_valid, push_data, push_last, and push_metadata must be held stable until push_ready is 1.
 //
-//     PushWidth = 8, PopWidth = 64, DeserializeMostSignificantFirst = 1
-//     Cycle | push_data | push_id | push_last | pop_data
-//     ------|-----------|---------|-----------|--------------
-//     0     | 8'hBA     | 2'd0    | 1'b0      | 64'hBAxxxxxx
-//     1     | 8'hAD     | 2'd1    | 1'b0      | 64'hBAADxxxx
-//     2     | 8'hF0     | 2'd2    | 1'b0      | 64'hBAADF0xx
-//     3     | 8'h0D     | 2'd3    | 1'b1      | 64'hBAADF00D
+// The throughput of this module is 1 pop flit per DeserializationRatio cycles; equivalently, a packet initiation interval of
+// 1 packet per DeserializationRatio cycles. The throughput can increase if push_last is used to send packets that are
+// not evenly divisible by DeserializationRatio, because the push-side stream is compressed.
 //
-//     PushWidth = 8, PopWidth = 64, DeserializeMostSignificantFirst = 0
-//     Cycle | push_data | push_id | push_last | pop_data
-//     ------|-----------|---------|-----------|--------------
-//     0     | 8'h0D     | 2'd0    | 1'b0      | 64'hxxxxxx0D
-//     1     | 8'hF0     | 2'd1    | 1'b0      | 64'hxxxxF00D
-//     2     | 8'hAD     | 2'd2    | 1'b0      | 64'hxxADF00D
-//     3     | 8'hBA     | 2'd3    | 1'b1      | 64'hBAADF00D
+// The latency from the first push flit valid to the pop flit being valid varies from 0 cycles (when push_last is 1 on the first flit)
+// up to (DeserializationRatio - 1) cycles (when push_last is 1 on the last flit or not set at all).
+//
+// Examples (where the ready signals are not shown and are assumed to always be 1; X denotes an unknown value when pop_valid is 0):
+//
+//     Packet length = 32 bits (4 push flits)
+//     PushWidth = 8, PopWidth = 32, MetadataWidth = 3, (DeserializationRatio = 4), DeserializeMostSignificantFirst = 1
+//     Cycle | push_valid | push_data | push_last | push_metadata | pop_valid | pop_data     | pop_last | pop_metadata
+//     ------|------------|-----------|-----------|---------------|-----------|--------------|----------|-------------
+//     0     | 1'b1       | 8'hBA     | 1'b0      | 3'd6          | 1'b0      | 32'hXXXXXXXX | 1'bX     | 3'dX
+//     1     | 1'b1       | 8'hAD     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 3'dX
+//     2     | 1'b1       | 8'hF0     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 3'dX
+//     3     | 1'b1       | 8'h0D     | 1'b0      | stable        | 1'b1      | 32'hBAADF00D | 1'b0     | 3'd6
+//
+//     Packet length = 56 bits (7 push flits)
+//     PushWidth = 8, PopWidth = 32, MetadataWidth = 3, (DeserializationRatio = 4), DeserializeMostSignificantFirst = 0
+//     Cycle | push_valid | push_data | push_last | push_metadata | pop_valid | pop_data     | pop_last | pop_metadata
+//     ------|------------|-----------|-----------|---------------|-----------|--------------|----------|-------------
+//     0     | 1'b1       | 8'h67     | 1'b0      | 3'd2          | 1'b0      | 32'hXXXXXXXX | 1'bX     | 3'dX
+//     1     | 1'b1       | 8'h45     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 3'dX
+//     2     | 1'b1       | 8'h23     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 3'dX
+//     3     | 1'b1       | 8'h01     | 1'b0      | stable        | 1'b1      | 32'h01234567 | 1'b0     | 3'd2
+//     4     | 1'b1       | 8'h0D     | 1'b0      | 3'd5          | 1'b0      | 32'hXXXXXXXX | 1'bX     | 3'dX
+//     5     | 1'b1       | 8'hF0     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 3'dX
+//     6     | 1'b1       | 8'hAD     | 1'b1      | stable        | 1'b1      | 32'hXXADF00D | 1'b1     | 3'd5
 
 `include "br_asserts.svh"
 `include "br_asserts_internal.svh"
@@ -62,30 +86,38 @@ module br_flow_deserializer #(
     // Width of the pop side packet. Must be greater than PushWidth
     // and evenly divisible by PushWidth.
     parameter int PopWidth = 2,
+    // Width of the sideband metadata (not serialized). Must be at least 1.
+    parameter int MetadataWidth = 1,
     // If 1, the most significant bits of the packet are received first.
     // If 0, the least significant bits are received first.
     // The order of bits within each flit is always the same that they
     // appear on the push interface.
     parameter bit DeserializeMostSignificantFirst = 1,
-    localparam int NumPushFlits = PopWidth / PushWidth,
-    localparam int PushFlitIdWidth = $clog2(NumPushFlits)
+    localparam int DeserializationRatio = PopWidth / PushWidth
 ) (
     // Posedge-triggered clock
     input logic clk,
     // Synchronous active-high reset
     input logic rst,
 
-    // Push-side interface (narrow, serialized)
-    output logic                       push_ready,
-    input  logic                       push_valid,
-    input  logic [      PushWidth-1:0] push_data,
-    input  logic [PushFlitIdWidth-1:0] push_id,
-    input  logic                       push_last,
+    // Push-side interface (narrow, serialized flits).
+    output logic                     push_ready,
+    input  logic                     push_valid,
+    input  logic [    PushWidth-1:0] push_data,
+    // Indicates the last push flit in the packet. Safe to tie to 0
+    // if you don't need to keep track of this in external logic.
+    input  logic                     push_last,
+    // Constant packet metadata carried alongside each push flit;
+    // passed directly to the pop interface.
+    input  logic [MetadataWidth-1:0] push_metadata,
 
-    // Pop-side interface (wide)
-    input  logic                pop_ready,
-    output logic                pop_valid,
-    output logic [PopWidth-1:0] pop_data
+    // Pop-side interface (wide flits).
+    input  logic                     pop_ready,
+    output logic                     pop_valid,
+    output logic [     PopWidth-1:0] pop_data,
+    // Indicates that this is the last pop flit of a packet.
+    output logic                     pop_last,
+    output logic [MetadataWidth-1:0] pop_metadata
 );
 
   //------------------------------------------
@@ -95,15 +127,12 @@ module br_flow_deserializer #(
 
   `BR_ASSERT_STATIC(push_width_gte_1_a, PushWidth >= 1)
   `BR_ASSERT_STATIC(pop_width_multiple_of_push_width_a, (PopWidth % PushWidth) == 0)
-  `BR_ASSERT_STATIC(pop_width_greater_than_push_width_a, PopWidth > PushWidth)
-
-  `BR_ASSERT_INTG(push_id_in_range_a, push_valid |-> push_id < NumPushFlits)
-  // TODO(mgottscho): check that push_id always increments by 1 and wraps around as expected.
-  `BR_ASSERT_INTG(push_last_a, push_valid && push_id == NumPushFlitsMinus1 |-> push_last)
+  `BR_ASSERT_STATIC(metadata_width_gte_1_a, MetadataWidth >= 1)
+  `BR_ASSERT_STATIC(deserialization_ratio_gt_1_a, DeserializationRatio > 1)
 
   br_flow_checks_valid_data #(
       .NumFlows(1),
-      .Width(PushWidth + PushFlitIdWidth + 1),
+      .Width(PushWidth + 1 + MetadataWidth),
       // Push ready/valid stability is required for the deserializer to work correctly.
       // That's because it serially receives the valid push data until the entire packet
       // has been received. If the push data is unstable during reception, then the data
@@ -116,73 +145,84 @@ module br_flow_deserializer #(
       .rst,
       .ready(push_ready),
       .valid(push_valid),
-      .data ({push_data, push_id, push_last})
+      .data ({push_data, push_last, push_metadata})
   );
 
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  logic [NumPushFlits-1:0] internal_ready;
-  logic [NumPushFlits-1:0] internal_valid;
-  logic [NumPushFlits-1:0][PushWidth-1:0] internal_data;
 
-  logic [NumPushFlits-1:0] internal_pop_ready;
-  logic [NumPushFlits-1:0] internal_pop_valid;
-  logic [NumPushFlits-1:0][PushWidth-1:0] internal_pop_data;
+  //------
+  // FSM is just an incrementing counter that keeps track of the push flit ID.
+  // When push_last is 0, then this simply counts up to the DeserializationRatio - 1
+  // and then we complete the pop flit. When push_last is 1, then we can complete
+  // the pop flit early.
+  //
+  // Reinitialize the counter on the cycle that the pop flit is completed so that a new pop flit
+  // can be started on the next cycle.
+  //------
+  localparam int DrMinus1 = DeserializationRatio - 1;
+  logic               push_flit_id_incr_valid;
+  logic [IdWidth-1:0] push_flit_id;
+  logic               push;
+  logic               pop;
 
-  br_flow_demux_select_unstable #(
-      .NumFlows(NumPushFlits),
-      .Width(PushWidth),
-      .EnableCoverPushBackpressure(1),
-      .EnableAssertPushValidStability(1),
-      .EnableAssertPushDataStability(1)
-  ) br_flow_demux_select_unstable (
+  br_counter_incr #(
+      .MaxValue(DrMinus1),
+      .MaxIncrement(1)
+  ) br_counter_incr_push_flit_id (
       .clk,
       .rst,
-      .select(push_id),
-      .push_ready(push_ready),
-      .push_valid(push_valid),
-      .push_data(push_data),
-      .pop_ready(internal_ready),
-      .pop_valid(internal_valid),
-      .pop_data(internal_data)
+      .reinit(pop),
+      .initial_value(IdWidth'(0)),
+      .incr_valid(push_flit_id_incr_valid),
+      .incr(1'b1),
+      .value(push_flit_id),
+      .value_next()  // unused
   );
 
-  // TODO(mgottscho): Simplify. We know by construction that internal_ready when visiting push_id > 0.
-  // So we can omit some register logic.
-  for (genvar i = 0; i < NumPushFlitsMinus1; i++) begin : gen_reg
-    br_flow_reg_fwd #(
-        .Width(PushWidth)
-    ) br_flow_reg_fwd (
-        .clk,
-        .rst,
-        .push_ready(internal_ready[i]),
-        .push_valid(internal_valid[i]),
-        .push_data (internal_data[i]),
-        .pop_ready (internal_pop_ready[i]),
-        .pop_valid (internal_pop_valid[i]),
-        .pop_data  (internal_pop_data[i])
-    );
+  assign push = push_ready && push_valid;
+  assign pop = pop_ready && pop_valid;
+  assign push_flit_id_incr_valid = !pop && push;
+
+  //-----
+  // Use the push_flit_id to demux the incoming push_data into slices that form the pop_data.
+  //-----
+  logic [IdWidth-1:0] dr_minus_1;
+  logic [DeserializationRatio-2:0][PushWidth-1:0] slice_data;
+  logic [DeserializationRatio-2:0] slice_ld_en;
+  logic [PushWidth-1:0] last_slice_data;
+
+  assign dr_minus_1 = DrMinus1;
+
+  for (genvar i = 0; i < DrMinus1; i++) begin : gen_reg
+    `BR_REGL(slice_data[i], push_data, slice_ld_en[i])
   end
 
-  // Only need to register the first N-1 flits, since the last flit can directly handshake with the pop side.
-  assign internal_ready[NumPushFlits-1] = internal_pop_ready[NumPushFlits-1];
-  assign internal_pop_valid[NumPushFlits-1] = internal_valid[NumPushFlits-1];
-  assign internal_pop_data[NumPushFlits-1] = internal_data[NumPushFlits-1];
+  // This is only used when the pop flit is fully populated.
+  // In this case, the push and pop ready/valid signals directly handshake so
+  // we don't need to register the data.
+  assign last_slice_data = push_data;
 
+  always_comb begin
+    slice_ld_en = '0;
+    slice_ld_en[push_flit_id] |= (push && !push_last);
+  end
+
+  //-----
   // Concat & merge the pop interface; all deserialized flits must be synchronously popped.
-  assign pop_valid = &internal_pop_valid;
-  assign internal_pop_ready = {NumPushFlits{pop_ready && pop_valid}};
+  //-----
+  assign pop_valid = push_valid && ((push_flit_id == dr_minus_1) || push_last);
 
-  if (DeserializeMostSignificantFirst) begin : gen_concat_msb_first
-    for (genvar i = 0; i < NumPushFlits; i++) begin : gen_loop
-      localparam int Lsb = ((NumPushFlits - i) - 1) * PushWidth;
-      localparam int Msb = Lsb + PushWidth - 1;
-      assign pop_data[Msb:Lsb] = internal_pop_data[i];
-    end
-  end else begin : gen_concat_lsb_first
-    assign pop_data = internal_pop_data;  // concat
+  for (genvar i = 0; i < DrMinus1; i++) begin : gen_pop_data_concat
+    localparam int Lsb =
+      DeserializeMostSignificantFirst ?
+      ((DeserializationRatio - i) - 1) * PushWidth :
+      i * PushWidth;
+    localparam int Msb = Lsb + PushWidth - 1;
+    assign pop_data[Msb:Lsb] = push_last && (push_flit_id == i) ? last_slice_data : slice_data[i];
   end
+  assign pop_data[PopWidth-1:PushWidth*DrMinus1] = last_slice_data;
 
   //------------------------------------------
   // Implementation checks

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -1,0 +1,191 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow Deserializer
+//
+// This module deserializes an input packet consisting of multiple narrower flits into a single wider flit.
+// Data flows from pop-side to push-side using ready-valid handshakes on both sides.
+//
+// The push and pop bitwidths are parameterized; the PopWidth must be a positive integer
+// that is greater than PushWidth and is also divisible by PushWidth.
+// The number of deserialized flits per packet is a constant given by PopWidth / PushWidth.
+//
+// The deserialization order is configured by DeserializeMostSignificantFirst. If 1, then the first flit
+// is placed in the most significant bits of the pop data; otherwise, the last flit is placed there.
+// The order of bits within each push flit is always maintained on the pop side.
+//
+// Although the number of push flits per packet is constant, each push flit is accompanied by a
+// push_id sideband signal. This is useful for any logic that needs to directly operate on data within the
+// serialized flow. For convenience, a push_last signal is also provided in case the user only needs to know
+// when a deserialized packet is complete (equivalent to push_id == (NumPushFlits-1)).
+//
+// The push_valid and push_data must be held stable until push_ready is 1.
+//
+// The throughput of this module is 1 push flit per cycle; equivalently, a packet output interval of
+// 1 packet per (PushWidth / PopWidth) cycles.
+//
+// Examples(where the ready and valid signals are not shown and are always 1):
+//
+//     PushWidth = 8, PopWidth = 64, DeserializeMostSignificantFirst = 1
+//     Cycle | push_data | push_id | push_last | pop_data
+//     ------|-----------|---------|-----------|--------------
+//     0     | 8'hBA     | 2'd0    | 1'b0      | 64'hBAxxxxxx
+//     1     | 8'hAD     | 2'd1    | 1'b0      | 64'hBAADxxxx
+//     2     | 8'hF0     | 2'd2    | 1'b0      | 64'hBAADF0xx
+//     3     | 8'h0D     | 2'd3    | 1'b1      | 64'hBAADF00D
+//
+//     PushWidth = 8, PopWidth = 64, DeserializeMostSignificantFirst = 0
+//     Cycle | push_data | push_id | push_last | pop_data
+//     ------|-----------|---------|-----------|--------------
+//     0     | 8'h0D     | 2'd0    | 1'b0      | 64'hxxxxxx0D
+//     1     | 8'hF0     | 2'd1    | 1'b0      | 64'hxxxxF00D
+//     2     | 8'hAD     | 2'd2    | 1'b0      | 64'hxxADF00D
+//     3     | 8'hBA     | 2'd3    | 1'b1      | 64'hBAADF00D
+
+`include "br_asserts.svh"
+`include "br_asserts_internal.svh"
+
+module br_flow_deserializer #(
+    // Width of the push side flit. Must be at least 1.
+    parameter int PushWidth = 1,
+    // Width of the pop side packet. Must be greater than PushWidth
+    // and evenly divisible by PushWidth.
+    parameter int PopWidth = 2,
+    // If 1, the most significant bits of the packet are received first.
+    // If 0, the least significant bits are received first.
+    // The order of bits within each flit is always the same that they
+    // appear on the push interface.
+    parameter bit DeserializeMostSignificantFirst = 1,
+    localparam int NumPushFlits = PopWidth / PushWidth,
+    localparam int PushFlidIdWidth = $clog2(NumPushFlits)
+) (
+    // Posedge-triggered clock
+    input logic clk,
+    // Synchronous active-high reset
+    input logic rst,
+
+    // Push-side interface (narrow, serialized)
+    output logic                       push_ready,
+    input  logic                       push_valid,
+    input  logic [PushWidth-1:0]       push_data,
+    input  logic [PushFlidIdWidth-1:0] push_id,
+    input  logic                       push_last,
+
+    // Pop-side interface (wide)
+    input  logic                      pop_ready,
+    output logic                      pop_valid,
+    output logic [      PopWidth-1:0] pop_data,
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(push_width_gte_1_a, PushWidth >= 1)
+  `BR_ASSERT_STATIC(pop_width_multiple_of_push_width_a, (PopWidth % PushWidth) == 0)
+  `BR_ASSERT_STATIC(pop_width_greater_than_push_width_a, PopWidth > PushWidth)
+
+  `BR_ASSERT_INTG(push_id_in_range_a, push_valid |-> push_id < NumPushFlits)
+  // TODO(mgottscho): check that push_id always increments by 1 and wraps around as expected.
+  `BR_ASSERT_INTG(push_last_a, push_valid && push_id == NumPushFlitsMinus1 |-> push_last)
+
+  br_flow_checks_valid_data #(
+      .NumFlows(1),
+      .Width(PushWidth + PushFlidIdWidth + 1),
+      .EnableCoverBackpressure(1),
+      .EnableAssertValidStability(1),
+      .EnableAssertDataStability(1)
+  ) br_flow_checks_valid_data (
+      .clk,
+      .rst,
+      .ready(push_ready),
+      .valid(push_valid),
+      .data ({push_data, push_id, push_last})
+  );
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  localparam int NumPushFlitsMinus1 = NumPushFlits - 1;
+  logic [PushFlidIdWidth-1:0] num_push_flits_minus_1;
+
+  logic [NumPushFlits-1:0] internal_ready;
+  logic [NumPushFlits-1:0] internal_valid;
+  logic [NumPushFlits-1:0][PushWidth-1:0] internal_data;
+
+  logic [NumPushFlits-1:0] internal_pop_ready;
+  logic [NumPushFlits-1:0] internal_pop_valid;
+  logic [NumPushFlits-1:0][PushWidth-1:0] internal_pop_data;
+
+  br_flow_demux_select_unstable #(
+      .NumFlows(NumPushFlits),
+      .Width(PushWidth),
+      .EnableCoverPushBackpressure(1),
+      .EnableAssertPushValidStability(1),
+      .EnableAssertPushDataStability(1)
+  ) br_flow_demux_select_unstable (
+      .clk,
+      .rst,
+      .select(push_id),
+      .push_ready(push_ready),
+      .push_valid(push_valid),
+      .push_data(push_data),
+      .pop_ready(internal_ready),
+      .pop_valid(internal_valid),
+      .pop_data(internal_data)
+  );
+
+  // TODO(mgottscho): Simplify. We know by construction that internal_ready when visiting push_id > 0.
+  // So we can omit some register logic.
+  for (genvar i = 0; i < NumPushFlits - 1; i++) begin : gen_reg
+    br_flow_reg_fwd #(
+        .Width(PopWidth + PopFlidIdWidth + 1)
+    ) br_flow_reg_fwd (
+        .clk,
+        .rst,
+        .push_ready(internal_ready[i]),
+        .push_valid(internal_valid[i]),
+        .push_data (internal_data[i]),
+        .pop_ready (internal_pop_ready[i]),
+        .pop_valid (internal_pop_valid[i]),
+        .pop_data  (internal_pop_data[i])
+    );
+  end
+
+  // Only need to register the first N-1 flits, since the last flit can directly handshake with the pop side.
+  assign internal_ready[NumPushFlits-1] = internal_pop_ready[NumPushFlits-1];
+  assign internal_pop_valid[NumPushFlits-1] = internal_valid[NumPushFlits-1];
+  assign internal_pop_data[NumPushFlits-1] = internal_data[NumPushFlits-1];
+
+  // Concat & merge the pop interface; all deserialized flits must be synchronously popped.
+  assign pop_valid = &internal_pop_valid;
+  assign internal_pop_ready = {NumPushFlits{pop_ready && pop_valid}};
+
+  if (DeserializeMostSignificantFirst) begin : gen_concat_msb_first
+    for (genvar i = 0; i < NumPushFlits; i++) begin : gen_loop
+      localparam int Lsb = (NumPushFlits - i - 1) * PushWidth;
+      localparam int Msb = Lsb + PushWidth - 1;
+      assign pop_data[Msb:Lsb] = internal_pop_data[i];
+    end
+  end else begin : gen_concat_lsb_first
+    assign pop_data = internal_pop_data;  // concat
+  end
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  // TODO: standard ready-valid check modules
+
+  `BR_ASSERT_IMPL(pop_valid_iff_last_a, pop_valid |-> push_valid && push_last)
+
+endmodule : br_flow_deserializer

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -104,6 +104,10 @@ module br_flow_deserializer #(
   br_flow_checks_valid_data #(
       .NumFlows(1),
       .Width(PushWidth + PushFlitIdWidth + 1),
+      // Ready/valid stability is required for the serializer to work correctly.
+      // That's because it serially scans over the valid push data until the entire
+      // packet has been transmitted. If the push data is unstable during
+      // transmission, then the data integrity is compromised.
       .EnableCoverBackpressure(1),
       .EnableAssertValidStability(1),
       .EnableAssertDataStability(1)

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -107,7 +107,7 @@ module br_flow_deserializer #(
     localparam int DeserializationRatio = PopWidth / PushWidth,
     // Vector widths cannot be 0, so we need to special-case when DeserializationRatio == 1
     // even though the pop_last_dont_care_count port will be unused downstream in that case.
-    localparam int IdWidth = DeserializationRatio > 1 ? $clog2(DeserializationRatio) : 1
+    localparam int SerFlitIdWidth = DeserializationRatio > 1 ? $clog2(DeserializationRatio) : 1
 ) (
     // Posedge-triggered clock
     input logic clk,
@@ -126,21 +126,21 @@ module br_flow_deserializer #(
     input  logic [MetadataWidth-1:0] push_metadata,
 
     // Pop-side interface (wide flits).
-    input  logic                     pop_ready,
-    output logic                     pop_valid,
+    input  logic                      pop_ready,
+    output logic                      pop_valid,
     // If pop_last is 1, inspect pop_last_dont_care_count to determine
     // how much of the pop_data consists of valid data.
-    output logic [     PopWidth-1:0] pop_data,
+    output logic [      PopWidth-1:0] pop_data,
     // Indicates that this is the last pop flit of a packet.
-    output logic                     pop_last,
+    output logic                      pop_last,
     // This signal must be ignored if push_last is 0.
     // However, if push_last is 1, then this is the
     // number of don't care slices at the tail end of the pop flit.
     // It will be less than DeserializationRatio, i.e., the entire pop flit
     // will not consist of "don't care" slices. 0 means the pop flit
     // is entirely populated with valid data.
-    output logic [      IdWidth-1:0] pop_last_dont_care_count,
-    output logic [MetadataWidth-1:0] pop_metadata
+    output logic [SerFlitIdWidth-1:0] pop_last_dont_care_count,
+    output logic [ MetadataWidth-1:0] pop_metadata
 );
 
   //------------------------------------------
@@ -197,10 +197,10 @@ module br_flow_deserializer #(
     //------
     localparam int DrMinus1 = DeserializationRatio - 1;
 
-    logic               push_flit_id_incr_valid;
-    logic [IdWidth-1:0] push_flit_id;
-    logic               push;
-    logic               pop;
+    logic                      push_flit_id_incr_valid;
+    logic [SerFlitIdWidth-1:0] push_flit_id;
+    logic                      push;
+    logic                      pop;
 
     br_counter_incr #(
         .MaxValue(DrMinus1),
@@ -209,7 +209,7 @@ module br_flow_deserializer #(
         .clk,
         .rst,
         .reinit(pop),
-        .initial_value(IdWidth'(0)),
+        .initial_value(SerFlitIdWidth'(0)),
         .incr_valid(push_flit_id_incr_valid),
         .incr(1'b1),
         .value(push_flit_id),
@@ -240,7 +240,7 @@ module br_flow_deserializer #(
     //-----
     // Register the slice data for all but the last slice.
     //-----
-    logic [IdWidth-1:0] dr_minus_1;
+    logic [SerFlitIdWidth-1:0] dr_minus_1;
     logic [DeserializationRatio-2:0][PushWidth-1:0] slice_reg;
     logic [DeserializationRatio-2:0] slice_reg_ld_en;
 

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -63,7 +63,7 @@
 //
 // Examples (where the ready signals are not shown and are assumed to always be 1; X denotes an unknown value when pop_valid is 0):
 //
-//     Packet length = 32 bits (4 push flits)
+//     Packet length = 32 bits (4 push flits), not using last bit
 //     PushWidth = 8, PopWidth = 32, MetadataWidth = 3, (DeserializationRatio = 4), DeserializeMostSignificantFirst = 1
 //     Cycle | push_valid | push_data | push_last | push_metadata | pop_valid | pop_data     | pop_last | pop_last_dont_care_count | pop_metadata
 //     ------|------------|-----------|-----------|---------------|-----------|--------------|----------|--------------------------|-------------
@@ -72,7 +72,7 @@
 //     2     | 1'b1       | 8'hF0     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'dX                     | 3'dX
 //     3     | 1'b1       | 8'h0D     | 1'b0      | stable        | 1'b1      | 32'hBAADF00D | 1'b0     | 2'd0                     | 3'd6
 //
-//     Packet length = 56 bits (7 push flits)
+//     Packet length = 56 bits (7 push flits), using last bit
 //     PushWidth = 8, PopWidth = 32, MetadataWidth = 3, (DeserializationRatio = 4), DeserializeMostSignificantFirst = 0
 //     Cycle | push_valid | push_data | push_last | push_metadata | pop_valid | pop_data     | pop_last | pop_last_dont_care_count | pop_metadata
 //     ------|------------|-----------|-----------|---------------|-----------|--------------|----------|--------------------------|-------------

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -54,6 +54,8 @@
 // The latency from the first push flit valid to the pop flit being valid varies from 0 cycles (when push_last is 1 on the first flit)
 // up to (DeserializationRatio - 1) cycles (when push_last is 1 on the last flit or not set at all).
 //
+// The implementation uses a demux into staging registers rather than a shift register to reduce power.
+//
 // Examples (where the ready signals are not shown and are assumed to always be 1; X denotes an unknown value when pop_valid is 0):
 //
 //     Packet length = 32 bits (4 push flits)

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -68,7 +68,7 @@ module br_flow_deserializer #(
     // appear on the push interface.
     parameter bit DeserializeMostSignificantFirst = 1,
     localparam int NumPushFlits = PopWidth / PushWidth,
-    localparam int PushFlidIdWidth = $clog2(NumPushFlits)
+    localparam int PushFlitIdWidth = $clog2(NumPushFlits)
 ) (
     // Posedge-triggered clock
     input logic clk,
@@ -79,7 +79,7 @@ module br_flow_deserializer #(
     output logic                       push_ready,
     input  logic                       push_valid,
     input  logic [      PushWidth-1:0] push_data,
-    input  logic [PushFlidIdWidth-1:0] push_id,
+    input  logic [PushFlitIdWidth-1:0] push_id,
     input  logic                       push_last,
 
     // Pop-side interface (wide)
@@ -103,7 +103,7 @@ module br_flow_deserializer #(
 
   br_flow_checks_valid_data #(
       .NumFlows(1),
-      .Width(PushWidth + PushFlidIdWidth + 1),
+      .Width(PushWidth + PushFlitIdWidth + 1),
       .EnableCoverBackpressure(1),
       .EnableAssertValidStability(1),
       .EnableAssertDataStability(1)

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -35,7 +35,7 @@
 // The throughput of this module is 1 push flit per cycle; equivalently, a packet output interval of
 // 1 packet per (PushWidth / PopWidth) cycles.
 //
-// Examples(where the ready and valid signals are not shown and are always 1):
+// Examples(where the ready and valid signals are not shown:
 //
 //     PushWidth = 8, PopWidth = 64, DeserializeMostSignificantFirst = 1
 //     Cycle | push_data | push_id | push_last | pop_data

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -96,12 +96,13 @@ module br_flow_deserializer #(
     parameter int PopWidth = 2,
     // Width of the sideband metadata (not serialized). Must be at least 1.
     parameter int MetadataWidth = 1,
-    // If 1, the most significant bits of the packet are received first.
-    // If 0, the least significant bits are received first.
+    // If 1, the most significant bits of the packet are received first (big endian).
+    // If 0, the least significant bits are received first (little endian).
     // The order of bits within each flit is always the same that they
     // appear on the push interface.
-    parameter bit DeserializeMostSignificantFirst = 1,
-    localparam int DeserializationRatio = PopWidth / PushWidth
+    parameter bit DeserializeMostSignificantFirst,
+    localparam int DeserializationRatio = PopWidth / PushWidth,
+    localparam int IdWidth = $clog2(DeserializationRatio)
 ) (
     // Posedge-triggered clock
     input logic clk,
@@ -176,7 +177,6 @@ module br_flow_deserializer #(
   // Reinitialize the counter on the cycle that the pop flit is completed so that a new pop flit
   // can be started on the next cycle.
   //------
-  localparam int IdWidth = $clog2(DeserializationRatio);
   localparam int DrMinus1 = DeserializationRatio - 1;
 
   logic               push_flit_id_incr_valid;

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -104,10 +104,10 @@ module br_flow_deserializer #(
   br_flow_checks_valid_data #(
       .NumFlows(1),
       .Width(PushWidth + PushFlitIdWidth + 1),
-      // Ready/valid stability is required for the serializer to work correctly.
-      // That's because it serially scans over the valid push data until the entire
-      // packet has been transmitted. If the push data is unstable during
-      // transmission, then the data integrity is compromised.
+      // Push ready/valid stability is required for the deserializer to work correctly.
+      // That's because it serially receives the valid push data until the entire packet
+      // has been received. If the push data is unstable during reception, then the data
+      // integrity is compromised.
       .EnableCoverBackpressure(1),
       .EnableAssertValidStability(1),
       .EnableAssertDataStability(1)

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -48,6 +48,8 @@
 //
 // The cut-through latency of the push packet to the first pop flit is 0 cycles.
 //
+// The implementation uses a mux rather than a shift register to reduce power.
+//
 // Examples (where the ready signals are not shown and are assumed to always be 1; X denotes an unknown value):
 //
 //     Packet length = 32 bits (4 push flits), not using last bit

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -72,7 +72,7 @@
 //     1     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h45    | 1'b0     | 3'd2
 //     2     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h23    | 1'b0     | 3'd2
 //     3     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h01    | 1'b0     | 3'd2
-//     4     | 1'b1       | 32'hXXAAF00D | 1'b1      | 2'd1                      | 3'd5          | 1'b1      | 8'h0D    | 1'b0     | 3'd5
+//     4     | 1'b1       | 32'hXXADF00D | 1'b1      | 2'd1                      | 3'd5          | 1'b1      | 8'h0D    | 1'b0     | 3'd5
 //     5     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'hF0    | 1'b0     | 3'd5
 //     6     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'hAD    | 1'b1     | 3'd5
 

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -92,7 +92,7 @@ module br_flow_serializer #(
     // If 0, the least significant bits are sent first (little endian).
     // The order of bits within each flit is always the same that they
     // appear on the push interface.
-    parameter bit SerializeMostSignificantFirst,
+    parameter bit SerializeMostSignificantFirst = 1,
     localparam int SerializationRatio = PushWidth / PopWidth,
     // Vector widths cannot be 0, so we need to special-case when SerializationRatio == 1
     // even though the push_last_dont_care_count port won't be used in that case.
@@ -253,7 +253,7 @@ module br_flow_serializer #(
     //------
     // Complete the push flit when we're finished serializing it (the last pop flit is accepted).
     //------
-    assign push_ready = pop_ready && pop_last;
+    assign push_ready = pop_ready && pop_flit_id_plus_dont_care_count;
 
   end
 

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -14,46 +14,55 @@
 
 // Bedrock-RTL Flow Serializer
 //
-// This module serializes an input packet consisting of exactly one flit into multiple narrower flits.
+// This module serializes packet flits from a wide bus onto a narrow bus.
 // Data flows from push-side to pop-side using ready-valid handshakes on both sides.
 //
 // The push and pop bitwidths are parameterized; the PushWidth must be a positive integer
 // that is greater than PopWidth and is also divisible by PopWidth.
-// The number of serialized flits per packet is a constant given by PopWidth / PushWidth.
+// The flit serialization ratio is given by SerializationRatio = PushWidth / PopWidth, i.e.,
+// the ratio of bus widths is 1:SerializationRatio for some integer SerializationRatio > 1 and the
+// maximum number of pop flits per push flit is SerializationRatio.
 //
 // The serialization order is configured by SerializeMostSignificantFirst. If 1, then the most-significant
-// bits of the packet are sent first; otherwise, the least-significant are sent first.
-// The order of bits within the flit is always the same that they appear on the push interface.
+// bits of the push flit are sent first; otherwise, the least-significant are sent first.
+// The order of bits within each pop flit is always the same that they appear in a slice of the push flit.
 //
-// Although the number of pop flits per packet is constant, each pop flit is accompanied by a
-// pop_id sideband signal. This is useful for any logic that needs to directly operate on data within the
-// serialized flow. For convenience, a pop_last signal is also provided in case the user only needs to know
-// when a serialized packet is complete (equivalent to pop_id == (NumPopFlits-1)).
+// Each push flit is accompanied by a push_metadata sideband signal that does not get serialized.
+// It is replicated on the pop side as pop_metadata for each pop flit corresponding to the same push flit.
+// The module does not care about the contents of push_metadata.
 //
-// The push_valid and push_data must be held stable until push_ready is 1.
+// The push interface has a push_last signal that indicates the last flit of a packet on the push side.
+// For push flits where push_last is 0, then exactly SerializationRatio pop flits are produced.
+// When push_last is 1, then the number of pop flits produced can vary between 1 and SerializationRatio. The exact
+// number is given by (SerializationRatio - push_last_dont_care_count). The push_last_dont_care_count port indicates how much
+// of the last push_data flit contains "don't care" values that can be dropped from the serialized transmission.
+// The don't care values are always in contiguous multiples of PopWidth bits. If SerializeMostSignificantFirst
+// is 1, then the don't care values are the least-significant bits; otherwise, they are the most-significant bits,
+// i.e., the tail end of the flit.
+//
+// The push_valid, push_data, push_last, and push_last_dont_care_count must be held stable until push_ready is 1.
 //
 // The throughput of this module is 1 pop flit per cycle; equivalently, a packet initiation interval of
-// 1 packet per (PopWidth / PushWidth) cycles.
+// 1 packet per SerializationRatio cycles.
 //
 // The cut-through latency of the push packet to the first pop flit is 0 cycles.
 //
-// Examples(where the ready and valid signals are not shown:
+// Examples(where the ready and valid signals are not shown and handshake every cycle):
 //
-//     PushWidth = 64, PopWidth = 8, SerializeMostSignificantFirst = 1
-//     Cycle | push_data    | pop_data | pop_id | pop_last
-//     ------|--------------|----------|--------|---------
-//     0     | 64'hBAADF00D | 8'hBA    | 2'd0   | 1'b0
-//     1     | stable       | 8'hAD    | 2'd1   | 1'b0
-//     2     | stable       | 8'hF0    | 2'd2   | 1'b0
-//     3     | stable       | 8'h0D    | 2'd3   | 1'b1
+//     PushWidth = 32, PopWidth = 8, MetadataWidth = 3, (SerializationRatio = 4), SerializeMostSignificantFirst = 1
+//     Cycle | push_data    | push_last | push_last_dont_care_count | push_metadata | pop_data | pop_last | pop_metadata
+//     ------|--------------|-----------|---------------------------|---------------|----------|----------|------------
+//     0     | 32'hBAADF00D | 1'b0      | 2'd0                      | 3'd6          | 8'hBA    | 1'b0     | 3'd6
+//     1     | stable       | stable    | stable                    | stable        | 8'hAD    | 1'b0     | 3'd6
+//     2     | stable       | stable    | stable                    | stable        | 8'hF0    | 1'b0     | 3'd6
+//     3     | stable       | stable    | stable                    | stable        | 8'h0D    | 1'b0     | 3'd6
 //
-//     PushWidth = 64, PopWidth = 8, SerializeMostSignificantFirst = 0
-//     Cycle | push_data    | pop_data | pop_id | pop_last
-//     ------|--------------|----------|--------|---------
-//     0     | 64'hBAADF00D | 8'h0D    | 2'd0   | 1'b0
-//     1     | stable       | 8'hF0    | 2'd1   | 1'b0
-//     2     | stable       | 8'hAD    | 2'd2   | 1'b0
-//     3     | stable       | 8'hBA    | 2'd3   | 1'b1
+//     PushWidth = 32, PopWidth = 8, MetadataWidth = 3, (SerializationRatio = 4), SerializeMostSignificantFirst = 0
+//     Cycle | push_data    | push_last | push_last_dont_care_count | push_metadata | pop_data | pop_last | pop_metadata
+//     ------|--------------|-----------|---------------------------|---------------|----------|----------|------------
+//     0     | 32'hXXADF00D | 1'b1      | 2'd1                      | 3'd2          | 8'h0D    | 1'b0     | 3'd2
+//     1     | stable       | stable    | stable                    | stable        | 8'hF0    | 1'b0     | 3'd2
+//     2     | stable       | stable    | stable                    | stable        | 8'hAD    | 1'b1     | 3'd2
 
 `include "br_asserts.svh"
 `include "br_asserts_internal.svh"
@@ -64,30 +73,51 @@ module br_flow_serializer #(
     parameter int PushWidth = 2,
     // Width of the pop side flit. Must be at least 1.
     parameter int PopWidth = 1,
+    // Width of the push side metadata. Must be at least 1.
+    parameter int MetadataWidth = 1,
     // If 1, the most significant bits of the packet are sent first.
     // If 0, the least significant bits are sent first.
     // The order of bits within each flit is always the same that they
     // appear on the push interface.
     parameter bit SerializeMostSignificantFirst = 1,
-    localparam int NumPopFlits = PushWidth / PopWidth,
-    localparam int PopFlitIdWidth = $clog2(NumPopFlits)
+    localparam int SerializationRatio = PushWidth / PopWidth,
+    localparam int IdWidth = $clog2(SerializationRatio)
 ) (
     // Posedge-triggered clock
     input logic clk,
     // Synchronous active-high reset
     input logic rst,
 
-    // Push-side interface (wide).
-    output logic                 push_ready,
-    input  logic                 push_valid,
-    input  logic [PushWidth-1:0] push_data,
+    // Push-side interface (wide flits).
+    output logic                     push_ready,
+    input  logic                     push_valid,
+    input  logic [PushWidth-1:0]     push_data,
+    // Indicates that this is the last push flit of a packet.
+    // Safe to tie to 0 if you don't need to keep track of this
+    // in external logic.
+    input  logic                     push_last,
+    // This signal is ignored if push_last is 0.
+    // However, if push_last is 1, then this is the
+    // number of don't care slices at the tail end of the push flit.
+    // It must be less than SerializationRatio, i.e., the entire push flit
+    // is not allowed to consist of "don't care" slices. Tie to 0
+    // if each push flit should be fully serialized and transmitted
+    // over SerializationRatio pop flits.
+    input  logic [IdWidth-1:0]       push_last_dont_care_count,
+    // Constant metadata to carry alongside the flits.
+    // Does not get serialized (simply replicated alongside each pop flit).
+    input  logic [MetadataWidth-1:0] push_metadata,
 
-    // Pop-side interface (narrow, serialized)
+    // Pop-side interface (narrow, serialized flits).
     input  logic                      pop_ready,
     output logic                      pop_valid,
     output logic [      PopWidth-1:0] pop_data,
-    output logic [PopFlitIdWidth-1:0] pop_id,
-    output logic                      pop_last
+    // Driven to 1 on the last pop flit of the packet, i.e.,
+    // the last slice of the push flit when push_last is 1.
+    // If push_last is tied to 0 then pop_last will always be 0.
+    output logic                      pop_last,
+    // Each pop flit has replicated metadata from the push interface.
+    output logic [MetadataWidth-1:0]  pop_metadata
 );
 
   //------------------------------------------
@@ -95,7 +125,11 @@ module br_flow_serializer #(
   //------------------------------------------
   `BR_ASSERT_STATIC(pop_width_gte_1_a, PopWidth >= 1)
   `BR_ASSERT_STATIC(push_width_multiple_of_pop_width_a, (PushWidth % PopWidth) == 0)
-  `BR_ASSERT_STATIC(push_width_greater_than_pop_width_a, PushWidth > PopWidth)
+  `BR_ASSERT_STATIC(metadata_width_gte_1_a, MetadataWidth >= 1)
+  `BR_ASSERT_STATIC(serialization_ratio_gt_1_a, SerializationRatio > 1)
+
+  `BR_ASSERT_INTG(push_last_dont_care_count_in_range_a,
+    push_valid && push_last |-> push_last_dont_care_count < SerializationRatio)
 
   // Check push side validity and data stability
   br_flow_checks_valid_data #(
@@ -119,35 +153,80 @@ module br_flow_serializer #(
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  localparam int NumPopFlitsMinus1 = NumPopFlits - 1;
-  logic [PopFlitIdWidth-1:0] num_pop_flits_minus_1;
-  logic [PopFlitIdWidth-1:0] slice_id;
-  logic                      pop_id_incr;
 
-  br_counter_incr #(
-      .MaxValue(NumPopFlitsMinus1),
-      .MaxIncrement(1)
-  ) br_counter_incr_pop_id (
+  //------
+  // Remember the push handshake from the prior cycle (needed for reinitializing the FSM
+  // on a new push flit).
+  //------
+  logic push_valid_d;
+  logic push_ready_d;
+
+  br_delay_nr #(
+      .NumStages(1),
+      .Width(2)
+  ) br_delay_nr_push_handshake (
       .clk,
-      .rst,
-      .reinit(1'b0),  // unused
-      .initial_value(PopFlitIdWidth'(0)),
-      .incr_valid(pop_id_incr),
-      .incr(1'b1),
-      .value(pop_id),
-      .value_next()  // unused
+      .in({push_valid, push_ready}),
+      .out({push_valid_d, push_ready_d})
+      .out_stages()  // unused
   );
 
-  assign pop_id_incr = pop_ready && pop_valid;
+  //------
+  // FSM is just an incrementing counter that keeps track of the pop flit ID.
+  // When push_last is 0, then this simply counts up to the SerializationRatio - 1
+  // and then we complete the push flit. When push_last is 1, then we can complete
+  // the push flit early when push_last_dont_care_count is not 0.
+  //
+  // Reinitialize the counter sans bubbles when either of the following is true:
+  // (1) A new push flit appears (push_valid) after a cycle where there was no flit (!push_valid_d)
+  // (2) A new push flit appears (push_valid) after a cycle where we potentially completed the previous push flit (push_ready_d)
+  //
+  // We need both the current and next value of pop_flit_id because
+  // we don't want to incur a pop bubble cycle every time we finish serializing
+  // a push flit.
+  //------
+  localparam int SrMinus1 = SerializationRatio - 1;
+  logic               pop_flit_id_reinit;
+  logic [IdWidth-1:0] pop_flit_id;
+  logic [IdWidth-1:0] pop_flit_id_next;
+  logic [IdWidth-1:0] pop_flit_id_internal;
+  logic pop;
 
-  assign num_pop_flits_minus_1 = NumPopFlitsMinus1;
-  assign pop_last = (pop_id == num_pop_flits_minus_1);
-  assign pop_valid = push_valid;
-  assign push_ready = pop_ready && pop_last;
-  assign slice_id = SerializeMostSignificantFirst ? (num_pop_flits_minus_1 - pop_id) : pop_id;
+  br_counter_incr #(
+      .MaxValue(SrMinus1),
+      .MaxIncrement(1)
+  ) br_counter_incr_pop_flit_id (
+      .clk,
+      .rst,
+      .reinit(pop_flit_id_reinit),
+      .initial_value(IdWidth'(0)),
+      .incr_valid(pop),
+      .incr(1'b1),
+      .value(pop_flit_id),
+      .value_next(pop_flit_id_next)
+  );
 
+  assign pop = pop_ready && pop_valid;
+  assign pop_flit_id_reinit = push_valid && (!push_valid_d || push_ready_d);
+  assign pop_flit_id_internal = pop_flit_id_reinit ? pop_flit_id_next : pop_flit_id;
+
+  //------
+  // Calculate which slice of the push flit is muxed to the pop interface.
+  // It depends on both the serialization order and the state of the counter.
+  //------
+  logic [IdWidth-1:0] sr_minus_1;
+  logic [IdWidth-1:0] slice_id;
+
+  assign sr_minus_1 = SrMinus1;
+  assign slice_id = SerializeMostSignificantFirst ?
+    (sr_minus_1 - pop_flit_id_internal) :
+    pop_flit_id_internal;
+
+  //------
+  // Do the muxing.
+  //------
   br_mux_bin #(
-      .NumSymbolsIn(NumPopFlits),
+      .NumSymbolsIn(SerializationRatio),
       .SymbolWidth (PopWidth)
   ) br_mux_bin (
       .select(slice_id),
@@ -155,13 +234,27 @@ module br_flow_serializer #(
       .out(pop_data)
   );
 
+  //------
+  // Drive the rest of the pop interface outputs.
+  // Terminate the pop stream early when it's the last push flit and
+  // there are "don't care" slices at the tail of it.
+  //
+  // The metadata is replicated from the push side for each pop flit.
+  //------
+  assign pop_valid = push_valid;
+  assign pop_last = push_last && ((pop_flit_id + push_last_dont_care_count) == sr_minus_1);
+  assign pop_metadata = push_metadata;
+
+  //------
+  // Complete the push flit when we're finished serializing it (the last pop flit is accepted).
+  //------
+  assign push_ready = pop_ready && pop_last;
+
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
   // TODO: standard ready-valid check modules
   `BR_ASSERT_IMPL(cut_through_latency_0_a, push_valid |-> pop_valid)
-  `BR_ASSERT_IMPL(pop_id_in_range_a, pop_valid |-> pop_id < NumPopFlits)
-  `BR_ASSERT_IMPL(pop_last_a, pop_valid && pop_id == NumPopFlitsMinus1 |-> pop_last)
-  `BR_ASSERT_IMPL(push_ready_iff_pop_last_a, push_ready |-> pop_ready && pop_valid && pop_last)
+  // TODO: more checks
 
 endmodule : br_flow_serializer

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -101,6 +101,10 @@ module br_flow_serializer #(
   br_flow_checks_valid_data #(
       .NumFlows(1),
       .Width(PushWidth),
+      // Ready/valid stability is required for the serializer to work correctly.
+      // That's because it serially scans over the valid push data until the entire
+      // packet has been transmitted. If the push data is unstable during
+      // transmission, then the data integrity is compromised.
       .EnableCoverBackpressure(1),
       .EnableAssertValidStability(1),
       .EnableAssertDataStability(1)

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -1,0 +1,188 @@
+// Copyright 2024 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow Serializer
+//
+// This module serializes an input packet consisting of exactly one flit into multiple narrower flits.
+// Data flows from push-side to pop-side using ready-valid handshakes on both sides.
+//
+// The push and pop bitwidths are parameterized; the PushWidth must be a positive integer
+// that is greater than PopWidth and is also divisible by PopWidth.
+// The number of serialized flits per packet is a constant given by PopWidth / PushWidth.
+//
+// The serialization order is configured by SerializeMostSignificantFirst. If 1, then the most-significant
+// bits of the packet are sent first; otherwise, the least-significant are sent first.
+// The order of bits within the flit is always the same that they appear on the push interface.
+//
+// Although the number of pop flits per packet is constant, each pop flit is accompanied by a
+// pop_id sideband signal. This is useful for any logic that needs to directly operate on data within the
+// serialized flow. For convenience, a pop_last signal is also provided in case the user only needs to know
+// when a serialized packet is complete (equivalent to pop_id == (NumPopFlits-1)).
+//
+// The push_valid and push_data must be held stable until push_ready is 1.
+//
+// The throughput of this module is 1 pop flit per cycle; equivalently, a packet initiation interval of
+// 1 packet per (PopWidth / PushWidth) cycles.
+//
+// The pop interface can be optionally registered. If it is, then the cut-through latency
+// of the push packet to the first pop flit is 1 cycle; otherwise, it is 0 cycles.
+//
+// Examples(where the ready and valid signals are not shown and are always 1):
+//
+//     PushWidth = 64, PopWidth = 8, SerializeMostSignificantFirst = 1, RegisterPopOutputs = 0
+//     Cycle | push_data    | pop_data | pop_id | pop_last
+//     ------|--------------|----------|--------|---------
+//     0     | 64'hBAADF00D | 8'hBA    | 2'd0   | 1'b0
+//     1     | stable       | 8'hAD    | 2'd1   | 1'b0
+//     2     | stable       | 8'hF0    | 2'd2   | 1'b0
+//     3     | stable       | 8'h0D    | 2'd3   | 1'b1
+//
+//     PushWidth = 64, PopWidth = 8, SerializeMostSignificantFirst = 0, RegisterPopOutputs = 1
+//     Cycle | push_data    | pop_data | pop_id | pop_last
+//     ------|--------------|----------|--------|---------
+//     0     | 64'hBAADF00D |          |        |
+//     1     | stable       | 8'h0D    | 2'd0   | 1'b0
+//     2     | stable       | 8'hF0    | 2'd1   | 1'b0
+//     3     | stable       | 8'hAD    | 2'd2   | 1'b0
+//     4     | stable       | 8'hBA    | 2'd3   | 1'b1
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+
+module br_flow_serializer #(
+    // Width of the push side packet. Must be greater than PopWidth
+    // and evenly divisible by PopWidth.
+    parameter int PushWidth = 2,
+    // Width of the pop side flit. Must be at least 1.
+    parameter int PopWidth = 1,
+    // If 1, the most significant bits of the packet are sent first.
+    // If 0, the least significant bits are sent first.
+    // The order of bits within each flit is always the same that they
+    // appear on the push interface.
+    parameter bit SerializeMostSignificantFirst = 1,
+    // If 1, the pop interface outputs are registered.
+    parameter bit RegisterPopOutputs = 0,
+    localparam int NumPopFlits = PushWidth / PopWidth,
+    localparam int PopFlidIdWidth = $clog2(NumPopFlits)
+) (
+    // Posedge-triggered clock
+    input logic clk,
+    // Synchronous active-high reset
+    input logic rst,
+
+    // Push-side interface (wide).
+    output logic                 push_ready,
+    input  logic                 push_valid,
+    input  logic [PushWidth-1:0] push_data,
+
+    // Pop-side interface (narrow, serialized)
+    input  logic                      pop_ready,
+    output logic                      pop_valid,
+    output logic [      PopWidth-1:0] pop_data,
+    output logic [PopFlidIdWidth-1:0] pop_id,
+    output logic                      pop_last
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(pop_width_gte_1_a, PopWidth >= 1)
+  `BR_ASSERT_STATIC(push_width_multiple_of_pop_width_a, (PushWidth % PopWidth) == 0)
+  `BR_ASSERT_STATIC(push_width_greater_than_pop_width_a, PushWidth > PopWidth)
+
+  // Check push side validity and data stability
+  br_flow_checks_valid_data #(
+      .NumFlows(1),
+      .Width(PushWidth),
+      .EnableCoverBackpressure(1),
+      .EnableAssertValidStability(1),
+      .EnableAssertDataStability(1)
+  ) br_flow_checks_valid_data (
+      .clk,
+      .rst,
+      .ready(push_ready),
+      .valid(push_valid),
+      .data (push_data)
+  );
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  localparam int NumPopFlitsMinus1 = NumPopFlits - 1;
+  logic [PopFlidIdWidth-1:0] num_pop_flits_minus_1;
+  logic [PopFlidIdWidth-1:0] slice_id;
+  logic                      internal_pop_ready;
+  logic                      internal_pop_valid;
+  logic [      PopWidth-1:0] internal_pop_data;
+  logic [PopFlidIdWidth-1:0] internal_pop_id;
+  logic                      internal_pop_last;
+
+  br_counter_incr #(
+      .MaxValue(NumPopFlitsMinus1),
+      .MaxIncrement(1)
+  ) br_counter_incr_pop_id (
+      .clk,
+      .rst,
+      .reinit(1'b0),  // unused
+      .initial_value('0),
+      .incr_valid(internal_pop_ready && internal_pop_valid),
+      .incr(1'b1),
+      .value(internal_pop_id),
+      .value_next()  // unused
+  );
+
+  assign num_pop_flits_minus_1 = NumPopFlitsMinus1;
+  assign internal_pop_last = (internal_pop_id == num_pop_flits_minus_1);
+  assign internal_pop_valid = push_valid;
+  assign push_ready = internal_pop_ready && internal_pop_last;
+  assign slice_id = SerializeMostSignificantFirst ?
+    (num_pop_flits_minus_1 - internal_pop_id) : internal_pop_id;
+
+  br_mux_bin #(
+      .NumSymbolsIn(NumPopFlits),
+      .SymbolWidth (PopWidth)
+  ) br_mux_bin (
+      .select(slice_id),
+      .in(push_data),
+      .out(internal_pop_data)
+  );
+
+  // Optionally register the pop outputs
+  if (RegisterPopOutputs) begin : gen_register_pop_outputs
+    br_flow_reg_fwd #(
+        .Width(PopWidth + PopFlidIdWidth + 1)
+    ) br_flow_reg_fwd (
+        .clk,
+        .rst,
+        .push_ready(internal_pop_ready),
+        .push_valid(internal_pop_valid),
+        .push_data ({internal_pop_data, internal_pop_id, internal_pop_last}),
+        .pop_ready (pop_ready),
+        .pop_valid (pop_valid),
+        .pop_data  ({pop_data, pop_id, pop_last})
+    );
+  end else begin : gen_no_register_pop_outputs
+    assign internal_pop_ready = pop_ready;
+    assign pop_valid = internal_pop_valid;
+    assign pop_data = pop_data_internal;
+    assign pop_id = pop_id_internal;
+    assign pop_last = pop_last_internal;
+  end
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+
+
+endmodule : br_flow_serializer

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -70,7 +70,7 @@ module br_flow_serializer #(
     // appear on the push interface.
     parameter bit SerializeMostSignificantFirst = 1,
     localparam int NumPopFlits = PushWidth / PopWidth,
-    localparam int PopFlidIdWidth = $clog2(NumPopFlits)
+    localparam int PopFlitIdWidth = $clog2(NumPopFlits)
 ) (
     // Posedge-triggered clock
     input logic clk,
@@ -86,7 +86,7 @@ module br_flow_serializer #(
     input  logic                      pop_ready,
     output logic                      pop_valid,
     output logic [      PopWidth-1:0] pop_data,
-    output logic [PopFlidIdWidth-1:0] pop_id,
+    output logic [PopFlitIdWidth-1:0] pop_id,
     output logic                      pop_last
 );
 
@@ -116,8 +116,8 @@ module br_flow_serializer #(
   // Implementation
   //------------------------------------------
   localparam int NumPopFlitsMinus1 = NumPopFlits - 1;
-  logic [PopFlidIdWidth-1:0] num_pop_flits_minus_1;
-  logic [PopFlidIdWidth-1:0] slice_id;
+  logic [PopFlitIdWidth-1:0] num_pop_flits_minus_1;
+  logic [PopFlitIdWidth-1:0] slice_id;
   logic                      pop_id_incr;
 
   br_counter_incr #(
@@ -127,7 +127,7 @@ module br_flow_serializer #(
       .clk,
       .rst,
       .reinit(1'b0),  // unused
-      .initial_value(PopFlidIdWidth'(0)),
+      .initial_value(PopFlitIdWidth'(0)),
       .incr_valid(pop_id_incr),
       .incr(1'b1),
       .value(pop_id),

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -85,11 +85,11 @@ module br_flow_serializer #(
     parameter int PopWidth = 1,
     // Width of the sideband metadata (not serialized). Must be at least 1.
     parameter int MetadataWidth = 1,
-    // If 1, the most significant bits of the packet are sent first.
-    // If 0, the least significant bits are sent first.
+    // If 1, the most significant bits of the packet are sent first (big endian).
+    // If 0, the least significant bits are sent first (little endian).
     // The order of bits within each flit is always the same that they
     // appear on the push interface.
-    parameter bit SerializeMostSignificantFirst = 1,
+    parameter bit SerializeMostSignificantFirst,
     localparam int SerializationRatio = PushWidth / PopWidth,
     localparam int IdWidth = $clog2(SerializationRatio)
 ) (

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -64,15 +64,15 @@
 //
 //     Packet length = 56 bits (7 pop flits), using last bit
 //     PushWidth = 32, PopWidth = 8, MetadataWidth = 3, (SerializationRatio = 4), SerializeMostSignificantFirst = 0
-//     Cycle | push_valid | push_data    | push_last | push_last_dont_care_count | push_metadata | pop_data | pop_last | pop_metadata
-//     ------|------------|--------------|-----------|---------------------------|---------------|----------|----------|------------
-//     0     | 1'b1       | 32'h01234567 | 1'b0      | 2'd0                      | 3'd2          | 8'h67    | 1'b0     | 3'd2
-//     1     | stable     | stable       | stable    | stable                    | stable        | 8'h45    | 1'b0     | 3'd2
-//     2     | stable     | stable       | stable    | stable                    | stable        | 8'h23    | 1'b0     | 3'd2
-//     3     | stable     | stable       | stable    | stable                    | stable        | 8'h01    | 1'b0     | 3'd2
-//     4     | 1'b1       | 32'hXXAAF00D | 1'b1      | 2'd1                      | 3'd5          | 8'h0D    | 1'b0     | 3'd5
-//     5     | stable     | stable       | stable    | stable                    | stable        | 8'hF0    | 1'b0     | 3'd5
-//     6     | stable     | stable       | stable    | stable                    | stable        | 8'hAD    | 1'b1     | 3'd5
+//     Cycle | push_valid | push_data    | push_last | push_last_dont_care_count | push_metadata | pop_valid | pop_data | pop_last | pop_metadata
+//     ------|------------|--------------|-----------|---------------------------|---------------|-----------|----------|----------|------------
+//     0     | 1'b1       | 32'h01234567 | 1'b0      | 2'd0                      | 3'd2          | 1'b1      | 8'h67    | 1'b0     | 3'd2
+//     1     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h45    | 1'b0     | 3'd2
+//     2     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h23    | 1'b0     | 3'd2
+//     3     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h01    | 1'b0     | 3'd2
+//     4     | 1'b1       | 32'hXXAAF00D | 1'b1      | 2'd1                      | 3'd5          | 1'b1      | 8'h0D    | 1'b0     | 3'd5
+//     5     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'hF0    | 1'b0     | 3'd5
+//     6     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'hAD    | 1'b1     | 3'd5
 
 `include "br_asserts.svh"
 `include "br_asserts_internal.svh"

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -57,8 +57,8 @@
 //     3     | stable       | 8'hAD    | 2'd2   | 1'b0
 //     4     | stable       | 8'hBA    | 2'd3   | 1'b1
 
+`include "br_asserts.svh"
 `include "br_asserts_internal.svh"
-`include "br_registers.svh"
 
 module br_flow_serializer #(
     // Width of the push side packet. Must be greater than PopWidth

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -34,11 +34,12 @@
 // The push interface has a push_last signal that indicates the last flit of a packet on the push side.
 // For push flits where push_last is 0, then exactly SerializationRatio pop flits are produced.
 // When push_last is 1, then the number of pop flits produced can vary between 1 and SerializationRatio. The exact
-// number is given by (SerializationRatio - push_last_dont_care_count). The push_last_dont_care_count port indicates how much
-// of the last push_data flit contains "don't care" values that can be dropped from the serialized transmission.
-// The don't care values are always in contiguous multiples of PopWidth bits. If SerializeMostSignificantFirst
-// is 1, then the don't care values are the least-significant bits; otherwise, they are the most-significant bits,
-// i.e., the tail end of the flit.
+// number is given by (SerializationRatio - push_last_dont_care_count).
+//
+// The push_last_dont_care_count port indicates how much of the last push_data flit contains "don't care"
+// values that can be dropped from the serialized transmission. The don't care values are always in contiguous
+// multiples of PopWidth bits. If SerializeMostSignificantFirst is 1, then the don't care values are the
+// least-significant bits; otherwise, they are the most-significant bits, i.e., either way, the tail end of the flit.
 //
 // The push_valid, push_data, push_last, push_last_dont_care_count, and push_metadata must be held stable until push_ready is 1.
 //

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -111,13 +111,11 @@ module br_flow_serializer #(
     // Safe to tie to 0 if you don't need to keep track of this
     // in external logic.
     input  logic                      push_last,
-    // This signal is ignored if push_last is 0.
-    // However, if push_last is 1, then this is the
-    // number of don't care slices at the tail end of the push flit.
-    // It must be less than SerializationRatio, i.e., the entire push flit
-    // is not allowed to consist of "don't care" slices. Tie to 0
-    // if each push flit should be fully serialized and transmitted
-    // over SerializationRatio pop flits.
+    // If push_last is 1, then this is the number of don't care slices at
+    // the tail end of the push flit. It must be less than SerializationRatio,
+    // i.e., the entire push flit is not allowed to consist of "don't care" slices.
+    // Drive to 0 if each push flit should be fully serialized and transmitted
+    // over SerializationRatio pop flits. Must be 0 when push_last is 0.
     input  logic [SerFlitIdWidth-1:0] push_last_dont_care_count,
     // Constant metadata to carry alongside the flits.
     // Does not get serialized (simply replicated alongside each pop flit).
@@ -145,6 +143,8 @@ module br_flow_serializer #(
 
   `BR_ASSERT_INTG(push_last_dont_care_count_in_range_a,
                   push_valid && push_last |-> push_last_dont_care_count < SerializationRatio)
+  `BR_ASSERT_INTG(push_last_dont_care_count_zero_a,
+                  push_valid && !push_last |-> push_last_dont_care_count == 0)
 
   // Check push side validity and data stability
   br_flow_checks_valid_data #(

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -183,6 +183,15 @@ module br_flow_serializer #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
+  // TODO: standard ready-valid check modules
 
+  if (RegisterPopOutputs) begin : gen_register_pop_outputs
+    `BR_ASSERT_IMPL(cut_through_latency_1_a, push_valid |=> pop_valid)
+  end else begin : gen_no_register_pop_outputs
+    `BR_ASSERT_IMPL(cut_through_latency_0_a, push_valid |-> pop_valid)
+  end
+  `BR_ASSERT_IMPL(pop_id_in_range_a, pop_valid |-> pop_id < NumPopFlits)
+  `BR_ASSERT_IMPL(pop_last_a, pop_valid && pop_id == NumPopFlitsMinus1 |-> pop_last)
+  `BR_ASSERT_IMPL(push_ready_iff_pop_last_a, push_ready |-> pop_ready && pop_valid && pop_last)
 
 endmodule : br_flow_serializer

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -37,7 +37,7 @@
 //
 // The cut-through latency of the push packet to the first pop flit is 0 cycles.
 //
-// Examples(where the ready and valid signals are not shown and are always 1):
+// Examples(where the ready and valid signals are not shown:
 //
 //     PushWidth = 64, PopWidth = 8, SerializeMostSignificantFirst = 1
 //     Cycle | push_data    | pop_data | pop_id | pop_last

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -101,7 +101,7 @@ module br_flow_serializer #(
   br_flow_checks_valid_data #(
       .NumFlows(1),
       .Width(PushWidth),
-      // Ready/valid stability is required for the serializer to work correctly.
+      // Push ready/valid stability is required for the serializer to work correctly.
       // That's because it serially scans over the valid push data until the entire
       // packet has been transmitted. If the push data is unstable during
       // transmission, then the data integrity is compromised.

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -78,6 +78,7 @@
 
 `include "br_asserts.svh"
 `include "br_asserts_internal.svh"
+`include "br_unused.svh"
 
 module br_flow_serializer #(
     // Width of the push side packet. Must be greater than PopWidth


### PR DESCRIPTION
Implements #262 

# Behavior

Behavior is best explained with some timing diagrams.

## Serializer

```
// Examples (where the ready signals are not shown and are assumed to always be 1; X denotes an unknown value):
//
//     Packet length = 32 bits (4 push flits), not using last bit
//     PushWidth = 32, PopWidth = 8, MetadataWidth = 3, (SerializationRatio = 4), SerializeMostSignificantFirst = 1
//     Cycle | push_valid | push_data    | push_last | push_last_dont_care_count | push_metadata | pop_valid | pop_data | pop_last | pop_metadata
//     ------|------------|--------------|-----------|---------------------------|---------------|-----------|----------|----------|------------
//     0     | 1'b1       | 32'hBAADF00D | 1'b0      | 2'd0                      | 3'd6          | 1'b1      | 8'hBA    | 1'b0     | 3'd6
//     1     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'hAD    | 1'b0     | 3'd6
//     2     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'hF0    | 1'b0     | 3'd6
//     3     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h0D    | 1'b0     | 3'd6
//
//     Packet length = 56 bits (7 pop flits), using last bit
//     PushWidth = 32, PopWidth = 8, MetadataWidth = 3, (SerializationRatio = 4), SerializeMostSignificantFirst = 0
//     Cycle | push_valid | push_data    | push_last | push_last_dont_care_count | push_metadata | pop_valid | pop_data | pop_last | pop_metadata
//     ------|------------|--------------|-----------|---------------------------|---------------|-----------|----------|----------|------------
//     0     | 1'b1       | 32'h01234567 | 1'b0      | 2'd0                      | 3'd2          | 1'b1      | 8'h67    | 1'b0     | 3'd2
//     1     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h45    | 1'b0     | 3'd2
//     2     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h23    | 1'b0     | 3'd2
//     3     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'h01    | 1'b0     | 3'd2
//     4     | 1'b1       | 32'hXXAAF00D | 1'b1      | 2'd1                      | 3'd5          | 1'b1      | 8'h0D    | 1'b0     | 3'd5
//     5     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'hF0    | 1'b0     | 3'd5
//     6     | stable     | stable       | stable    | stable                    | stable        | 1'b1      | 8'hAD    | 1'b1     | 3'd5
```

## Deserializer

```
// Examples (where the ready signals are not shown and are assumed to always be 1; X denotes an unknown value when pop_valid is 0):
//
//     Packet length = 32 bits (4 push flits), not using last bit
//     PushWidth = 8, PopWidth = 32, MetadataWidth = 3, (DeserializationRatio = 4), DeserializeMostSignificantFirst = 1
//     Cycle | push_valid | push_data | push_last | push_metadata | pop_valid | pop_data     | pop_last | pop_last_dont_care_count | pop_metadata
//     ------|------------|-----------|-----------|---------------|-----------|--------------|----------|--------------------------|-------------
//     0     | 1'b1       | 8'hBA     | 1'b0      | 3'd6          | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'dX                     | 3'dX
//     1     | 1'b1       | 8'hAD     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'dX                     | 3'dX
//     2     | 1'b1       | 8'hF0     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'dX                     | 3'dX
//     3     | 1'b1       | 8'h0D     | 1'b0      | stable        | 1'b1      | 32'hBAADF00D | 1'b0     | 2'd0                     | 3'd6
//
//     Packet length = 56 bits (7 push flits), using last bit
//     PushWidth = 8, PopWidth = 32, MetadataWidth = 3, (DeserializationRatio = 4), DeserializeMostSignificantFirst = 0
//     Cycle | push_valid | push_data | push_last | push_metadata | pop_valid | pop_data     | pop_last | pop_last_dont_care_count | pop_metadata
//     ------|------------|-----------|-----------|---------------|-----------|--------------|----------|--------------------------|-------------
//     0     | 1'b1       | 8'h67     | 1'b0      | 3'd2          | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'dX                     | 3'dX
//     1     | 1'b1       | 8'h45     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'dX                     | 3'dX
//     2     | 1'b1       | 8'h23     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'dX                     | 3'dX
//     3     | 1'b1       | 8'h01     | 1'b0      | stable        | 1'b1      | 32'h01234567 | 1'b0     | 2'dX                     | 3'd2
//     4     | 1'b1       | 8'h0D     | 1'b0      | 3'd5          | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'dX                     | 3'dX
//     5     | 1'b1       | 8'hF0     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'dX                     | 3'dX
//     6     | 1'b1       | 8'hAD     | 1'b1      | stable        | 1'b1      | 32'hXXADF00D | 1'b1     | 2'd1                     | 3'd5
```