### PR TITLE
Add BBOX lint waiver for tieoff/unused.

### DIFF
--- a/macros/br_tieoff.svh
+++ b/macros/br_tieoff.svh
@@ -23,6 +23,7 @@
 `define BR_TIEOFF_ZERO_NAMED(__name__, __x__) \
 br_misc_tieoff_zero #( \
     .Width($bits(__x__)) \
+// ri lint_check_waive BLACKBOX \
 ) br_misc_tieoff_zero_``__name__ ( \
     .out(__x__) \
 );
@@ -31,6 +32,7 @@ br_misc_tieoff_zero #( \
 `define BR_TIEOFF_ONE_NAMED(__name__, __x__) \
 br_misc_tieoff_one #( \
     .Width($bits(__x__)) \
+// ri lint_check_waive BLACKBOX \
 ) br_misc_tieoff_one_``__name__ ( \
     .out(__x__) \
 );

--- a/macros/br_unused.svh
+++ b/macros/br_unused.svh
@@ -20,6 +20,7 @@
 `define BR_UNUSED_NAMED(__name__, __x__) \
 br_misc_unused #( \
     .Width($bits(__x__))) \
+// ri lint_check_waive BLACKBOX \
 br_misc_unused_``__name__ ( \
     .in(__x__) \
 );


### PR DESCRIPTION
The intent is to set these modules as blackbox for ascentlint, such that their input/output being unused aren't visible to instantiating modules.