### PR TITLE
Some fixes to br_ecc_secded_encoder

### DIFF
--- a/ecc/rtl/br_ecc_secded_encoder.sv
+++ b/ecc/rtl/br_ecc_secded_encoder.sv
@@ -84,7 +84,7 @@ module br_ecc_secded_encoder #(
 );
 
   // ri lint_check_waive PARAM_NOT_USED
-  localparam int Latency = RegisterOutputs ? 1 : 0;
+  localparam int Latency = RegisterInputs + RegisterOutputs;
 
   //------------------------------------------
   // Integration checks

--- a/python/eccgen/br_ecc_secded_encoder.sv.jinja2
+++ b/python/eccgen/br_ecc_secded_encoder.sv.jinja2
@@ -84,7 +84,7 @@ module br_ecc_secded_encoder #(
 );
 
   // ri lint_check_waive PARAM_NOT_USED
-  localparam int Latency = RegisterOutputs ? 1 : 0;
+  localparam int Latency = RegisterInputs + RegisterOutputs;
 
   //------------------------------------------
   // Integration checks
@@ -138,7 +138,7 @@ module br_ecc_secded_encoder #(
 
   // ri lint_check_off EXPR_ID_LIMIT
 
-  if ((CodewordWidth == 4) && (MessageWidth == 4)) begin : gen_8_4
+  if ((CodewordWidth == 8) && (MessageWidth == 4)) begin : gen_8_4
     `BR_ASSERT_STATIC(parity_width_matches_a, ParityWidth == 4)
 {{ secded_enc_8_4 }}
   end else if ((CodewordWidth == 13) && (MessageWidth == 8)) begin : gen_13_8


### PR DESCRIPTION
1. Fix the latency assertion to include RegisterInputs
2. Fix the template for codeword width 8, message width 4 to match
the checked in generated SV. (Not sure why diff test didn't
catch this before)

---

**Stack**:
- #280
- #279 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*