### PR TITLE
Fix assertion bug in br_flow_mux_core

### DIFF
--- a/flow/rtl/internal/br_flow_mux_core.sv
+++ b/flow/rtl/internal/br_flow_mux_core.sv
@@ -109,7 +109,7 @@ module br_flow_mux_core #(
 
   for (genvar i = 0; i < NumFlows; i++) begin : gen_data_selected_assert
     `BR_ASSERT_IMPL(data_selected_when_granted_a,
-                    (pop_valid && push_ready[i]) |-> pop_data == push_data[i])
+                    (push_valid[i] && push_ready[i]) |-> pop_data == push_data[i])
   end
   // Additional implementation checks in submodules
 


### PR DESCRIPTION
The precondition for this assertion should use push_valid[i], not
pop_valid[i], since we allow push_ready[i] to be high if push_valid[i]
is not.

---

**Stack**:
- #280 ⬅
- #279


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*