### PR TITLE
Add ASSERT_KNOWN family of macros

### DIFF
--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -144,6 +144,21 @@ verilog_elab_test(
 )
 
 verilog_elab_test(
+    name = "br_asserts_elab_internal_no_impl_test",
+    defines = ["BR_ASSERT_ON"],
+    deps = [":br_asserts_internal_test"],
+)
+
+verilog_elab_test(
+    name = "br_asserts_elab_internal_no_intg_test",
+    defines = [
+        "BR_ASSERT_ON",
+        "BR_DISABLE_INTG_CHECKS",
+    ],
+    deps = [":br_asserts_internal_test"],
+)
+
+verilog_elab_test(
     name = "br_asserts_internal_elab_noassert_test",
     deps = [":br_asserts_internal_test"],
 )

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -114,6 +114,15 @@ verilog_elab_test(
 )
 
 verilog_elab_test(
+    name = "br_asserts_fpv_elab_test",
+    defines = [
+        "BR_ASSERT_ON",
+        "BR_ENABLE_FPV",
+    ],
+    deps = [":br_asserts_test"],
+)
+
+verilog_elab_test(
     name = "br_asserts_elab_noassert_test",
     deps = [":br_asserts_test"],
 )

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -27,6 +27,7 @@
 // Therefore we namespace all macros with the BR_ prefix (stands for Bedrock).
 //
 // Assertion macros are only enabled when BR_ASSERT_ON is defined.
+// A subset of assertion macros are enabled when both BR_ASSERT_ON and BR_ENABLE_FPV are defined.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Static (elaboration-time) assertion macros
@@ -67,6 +68,46 @@ __name__ : assert property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || 
 `define BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__) \
 `BR_NOOP
 `endif  // BR_ASSERT_ON
+
+// Assert an expression is always known.
+`ifdef BR_ASSERT_ON
+`define BR_ASSERT_KNOWN(__name__, __expr__) \
+__name__ : assert property (@(posedge clk) disable iff (rst === 1'b1 || rst === 1'bx) (!$isunknown(__expr__)));
+`else  // BR_ASSERT_ON
+`define BR_ASSERT_KNOWN(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
+// Assert an expression is known whenever a corresponding valid signal is 1.
+`ifdef BR_ASSERT_ON
+`define BR_ASSERT_KNOWN_VALID(__name__, __valid__, __expr__) \
+__name__ : assert property (@(posedge clk) disable iff (rst === 1'b1 || rst === 1'bx) (__valid__ |-> !$isunknown(__expr__)));
+`else  // BR_ASSERT_ON
+`define BR_ASSERT_KNOWN_VALID(__name__, __valid__, __expr__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
+// More expressive form of BR_ASSERT_KNOWN that allows the use of custom clock and reset signal names.
+`ifdef BR_ASSERT_ON
+`define BR_ASSERT_KNOWN_CR(__name__, __expr__, __clk__, __rst__) \
+__name__ : assert property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || __rst__ === 1'bx) (!$isunknown(__expr__)));
+`else  // BR_ASSERT_ON
+`define BR_ASSERT_KNOWN_CR(__name__, __expr__, __clk__, __rst__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
+// More expressive form of BR_ASSERT_KNOWN_VALID that allows the use of custom clock and reset signal names.
+`ifdef BR_ASSERT_ON
+`define BR_ASSERT_KNOWN_VALID_CR(__name__, __valid__, __expr__, __clk__, __rst__) \
+__name__ : assert property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || __rst__ === 1'bx) (__valid__ |-> !$isunknown(__expr__)));
+`else  // BR_ASSERT_ON
+`define BR_ASSERT_KNOWN_VALID_CR(__name__, __valid__, __expr__, __clk__, __rst__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
+////////////////////////////////////////////////////////////////////////////////
+// FPV-only concurrent assertion macros (evaluated on posedge of a clock and disabled during a synchronous active-high reset)
+////////////////////////////////////////////////////////////////////////////////
 
 // FPV version macros
 `ifdef BR_ASSERT_ON

--- a/macros/br_asserts_internal.svh
+++ b/macros/br_asserts_internal.svh
@@ -60,6 +60,42 @@
 `BR_NOOP
 `endif  // BR_DISABLE_INTG_CHECKS
 
+// Assert an expression is always known.
+`ifndef BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_KNOWN_INTG(__name__, __expr__) \
+`BR_ASSERT_KNOWN(__name__, __expr__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_KNOWN_INTG(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_DISABLE_INTG_CHECKS
+
+// Assert an expression is known whenever a corresponding valid signal is 1.
+`ifndef BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_KNOWN_VALID_INTG(__name__, __valid__, __expr__) \
+`BR_ASSERT_KNOWN_VALID(__name__, __valid__, __expr__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_KNOWN_VALID_INTG(__name__, __valid__, __expr__) \
+`BR_NOOP
+`endif  // BR_DISABLE_INTG_CHECKS
+
+// More expressive form of BR_ASSERT_KNOWN_INTG that allows the use of custom clock and reset signal names.
+`ifndef BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_KNOWN_CR_INTG(__name__, __expr__, __clk__, __rst__) \
+`BR_ASSERT_KNOWN_CR(__name__, __expr__, __clk__, __rst__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_KNOWN_CR_INTG(__name__, __expr__, __clk__, __rst__) \
+`BR_NOOP
+`endif  // BR_DISABLE_INTG_CHECKS
+
+// More expressive form of BR_ASSERT_KNOWN_VALID_INTG that allows the use of custom clock and reset signal names.
+`ifndef BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_KNOWN_VALID_CR_INTG(__name__, __valid__, __expr__, __clk__, __rst__) \
+`BR_ASSERT_KNOWN_VALID_CR(__name__, __valid__, __expr__, __clk__, __rst__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_KNOWN_VALID_CR_INTG(__name__, __valid__, __expr__, __clk__, __rst__) \
+`BR_NOOP
+`endif  // BR_DISABLE_INTG_CHECKS
+
 // Clock: 'clk'
 // Reset: 'rst'
 `ifdef BR_ENABLE_IMPL_CHECKS
@@ -76,6 +112,42 @@
 `BR_ASSERT_CR(__name__, __expr__, __clk__, __rst__)
 `else  // BR_ENABLE_IMPL_CHECKS
 `define BR_ASSERT_CR_IMPL(__name__, __expr__, __clk__, __rst__) \
+`BR_NOOP
+`endif  // BR_ENABLE_IMPL_CHECKS
+
+// Assert an expression is always known.
+`ifndef BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_KNOWN_IMPL(__name__, __expr__) \
+`BR_ASSERT_KNOWN(__name__, __expr__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_KNOWN_IMPL(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ENABLE_IMPL_CHECKS
+
+// Assert an expression is known whenever a corresponding valid signal is 1.
+`ifndef BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_KNOWN_VALID_IMPL(__name__, __valid__, __expr__) \
+`BR_ASSERT_KNOWN_VALID(__name__, __valid__, __expr__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_KNOWN_VALID_IMPL(__name__, __valid__, __expr__) \
+`BR_NOOP
+`endif  // BR_ENABLE_IMPL_CHECKS
+
+// More expressive form of BR_ASSERT_KNOWN_IMPL that allows the use of custom clock and reset signal names.
+`ifndef BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_KNOWN_CR_IMPL(__name__, __expr__, __clk__, __rst__) \
+`BR_ASSERT_KNOWN_CR(__name__, __expr__, __clk__, __rst__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_KNOWN_CR_IMPL(__name__, __expr__, __clk__, __rst__) \
+`BR_NOOP
+`endif  // BR_ENABLE_IMPL_CHECKS
+
+// More expressive form of BR_ASSERT_KNOWN_VALID_IMPL that allows the use of custom clock and reset signal names.
+`ifndef BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_KNOWN_VALID_CR_IMPL(__name__, __valid__, __expr__, __clk__, __rst__) \
+`BR_ASSERT_KNOWN_VALID_CR(__name__, __valid__, __expr__, __clk__, __rst__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_KNOWN_VALID_CR_IMPL(__name__, __valid__, __expr__, __clk__, __rst__) \
 `BR_NOOP
 `endif  // BR_ENABLE_IMPL_CHECKS
 

--- a/macros/br_asserts_internal_test.sv
+++ b/macros/br_asserts_internal_test.sv
@@ -71,8 +71,32 @@ module br_asserts_internal_test;
   // Use BR_ASSERT_INTG
   `BR_ASSERT_INTG(sum_range_check_intg, sum <= 15)
 
+  // Use BR_ASSERT_KNOWN_INTG
+  `BR_ASSERT_KNOWN_INTG(valid_known_intg, valid)
+
+  // Use BR_ASSERT_KNOWN_VALID_INTG
+  `BR_ASSERT_KNOWN_VALID_INTG(sum_known_when_valid_intg, valid, sum)
+
+  // Use BR_ASSERT_KNOWN_CR_INTG
+  `BR_ASSERT_KNOWN_CR_INTG(valid_known_cr_intg, valid, clk, rst)
+
+  // Use BR_ASSERT_KNOWN_VALID_CR_INTG
+  `BR_ASSERT_KNOWN_VALID_CR_INTG(sum_known_when_valid_cr_intg, valid, sum, clk, rst)
+
   // Use BR_ASSERT_IMPL
   `BR_ASSERT_IMPL(sum_correct_impl, (valid == 1) |-> (sum == a + b))
+
+  // Use BR_ASSERT_KNOWN_IMPL
+  `BR_ASSERT_KNOWN_IMPL(valid_known_impl, valid)
+
+  // Use BR_ASSERT_KNOWN_VALID_IMPL
+  `BR_ASSERT_KNOWN_VALID_IMPL(sum_known_when_valid_impl, valid, sum)
+
+  // Use BR_ASSERT_KNOWN_CR_IMPL
+  `BR_ASSERT_KNOWN_CR_IMPL(valid_known_cr_impl, valid, clk, rst)
+
+  // Use BR_ASSERT_KNOWN_VALID_CR_IMPL
+  `BR_ASSERT_KNOWN_VALID_CR_IMPL(sum_known_when_valid_cr_impl, valid, sum, clk, rst)
 
   // Use BR_ASSERT_CR_INTG
   logic custom_clk;

--- a/macros/br_asserts_test.sv
+++ b/macros/br_asserts_test.sv
@@ -82,6 +82,12 @@ module br_asserts_test;
   `BR_ASSERT(sum_range_check_a, sum <= 15)
   `BR_ASSERT_FPV(sum_range_check_fpv_a, sum <= 15)
 
+  // Use BR_ASSERT_KNOWN variants
+  `BR_ASSERT_KNOWN(valid_known_a, valid)
+  `BR_ASSERT_KNOWN_VALID(sum_known_when_valid_a, valid, sum)
+  `BR_ASSERT_KNOWN_CR(valid_known_cr_a, valid, clk, rst)
+  `BR_ASSERT_KNOWN_VALID_CR(sum_known_when_valid_cr_a, valid, sum, clk, rst)
+
   // Use BR_ASSUME
   // Not really useful (redundant with assert above) but it
   // should work like an assert when not being used in formal


### PR DESCRIPTION
Implements #105.

Public macros:
* BR_ASSERT_KNOWN
* BR_ASSERT_KNOWN_VALID
* BR_ASSERT_KNOWN_CR
* BR_ASSERT_KNOWN_VALID_CR

Internal macros:
* BR_ASSERT_KNOWN_INTG
* BR_ASSERT_KNOWN_VALID_INTG
* BR_ASSERT_KNOWN_CR_INTG
* BR_ASSERT_KNOWN_VALID_CR_INTG
* BR_ASSERT_KNOWN_IMPL
* BR_ASSERT_KNOWN_VALID_IMPL
* BR_ASSERT_KNOWN_CR_IMPL
* BR_ASSERT_KNOWN_VALID_CR_IMPL