### PR TITLE
Split CDC FIFO control into push/pop side

### DIFF
--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -46,10 +46,41 @@ verilog_library(
     name = "br_cdc_fifo_ctrl_1r1w",
     srcs = ["br_cdc_fifo_ctrl_1r1w.sv"],
     deps = [
+        ":br_cdc_fifo_ctrl_pop_1r1w",
+        ":br_cdc_fifo_ctrl_push_1r1w",
+    ],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_ctrl_pop_1r1w",
+    srcs = ["br_cdc_fifo_ctrl_pop_1r1w.sv"],
+    deps = [
         ":br_cdc_bit_toggle",
         "//cdc/rtl/internal:br_cdc_fifo_gray_count_sync",
         "//cdc/rtl/internal:br_cdc_fifo_pop_ctrl",
+        "//macros:br_asserts_internal",
+        "//macros:br_gates",
+    ],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_ctrl_push_1r1w",
+    srcs = ["br_cdc_fifo_ctrl_push_1r1w.sv"],
+    deps = [
+        ":br_cdc_bit_toggle",
+        "//cdc/rtl/internal:br_cdc_fifo_gray_count_sync",
         "//cdc/rtl/internal:br_cdc_fifo_push_ctrl",
+        "//macros:br_asserts_internal",
+    ],
+)
+
+verilog_library(
+    name = "br_cdc_fifo_ctrl_push_1r1w_push_credit",
+    srcs = ["br_cdc_fifo_ctrl_push_1r1w_push_credit.sv"],
+    deps = [
+        ":br_cdc_bit_toggle",
+        "//cdc/rtl/internal:br_cdc_fifo_gray_count_sync",
+        "//cdc/rtl/internal:br_cdc_fifo_push_ctrl_credit",
     ],
 )
 
@@ -83,10 +114,8 @@ verilog_library(
     name = "br_cdc_fifo_ctrl_1r1w_push_credit",
     srcs = ["br_cdc_fifo_ctrl_1r1w_push_credit.sv"],
     deps = [
-        ":br_cdc_bit_toggle",
-        "//cdc/rtl/internal:br_cdc_fifo_gray_count_sync",
-        "//cdc/rtl/internal:br_cdc_fifo_pop_ctrl",
-        "//cdc/rtl/internal:br_cdc_fifo_push_ctrl_credit",
+        ":br_cdc_fifo_ctrl_pop_1r1w",
+        ":br_cdc_fifo_ctrl_push_1r1w_push_credit",
     ],
 )
 

--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -23,6 +23,7 @@ verilog_library(
     deps = [
         "//gate/rtl:br_gate_behav",
         "//macros:br_asserts",
+        "//macros:br_gates",
         "//macros:br_registers",
     ],
 )

--- a/cdc/rtl/br_cdc_bit_toggle.sv
+++ b/cdc/rtl/br_cdc_bit_toggle.sv
@@ -16,7 +16,7 @@
 
 `include "br_registers.svh"
 `include "br_asserts.svh"
-
+`include "br_gates.svh"
 module br_cdc_bit_toggle #(
     // Number of synchronization stages. Must be at least 1.
     // WARNING: Setting this parameter correctly is critical to
@@ -46,7 +46,7 @@ module br_cdc_bit_toggle #(
   `BR_ASSERT_STATIC(num_stages_must_be_at_least_one_a, NumStages >= 1)
 
   // Implementation
-  logic src_bit_internal;
+  logic src_bit_internal, src_bit_internal_maxdel;
 
   if (AddSourceFlop) begin : gen_src_flop
     `BR_REGNX(src_bit_internal, src_bit, src_clk)
@@ -54,13 +54,17 @@ module br_cdc_bit_toggle #(
     assign src_bit_internal = src_bit;
   end
 
+  // ri lint_check_off ONE_CONN_PER_LINE
+  `BR_GATE_CDC_MAXDEL(src_bit_internal_maxdel, src_bit_internal)
+  // ri lint_check_on ONE_CONN_PER_LINE
+
   // TODO: Add simulation delay modeling
 
   br_gate_cdc_sync #(
       .NumStages(NumStages)
   ) br_gate_cdc_sync (
       .clk(dst_clk),  // ri lint_check_waive SAME_CLOCK_NAME
-      .in(src_bit_internal),
+      .in(src_bit_internal_maxdel),
       .out(dst_bit)
   );
 

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
@@ -155,8 +155,6 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
       .RegisterPushCredit(RegisterPushCredit),
       .MaxCredit(MaxCredit),
       .NumSyncStages(NumSyncStages),
-      .MaxCredit(MaxCredit),
-      .RegisterPushCredit(RegisterPushCredit),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_cdc_fifo_ctrl_push_1r1w_push_credit_inst (
       .push_clk,
@@ -189,7 +187,7 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
       .Width(Width),
       .RegisterPopOutputs(RegisterPopOutputs),
       .RamReadLatency(RamReadLatency),
-      .NumSyncStages(NumSyncStages)
+      .NumSyncStages(NumSyncStages),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_cdc_fifo_ctrl_pop_1r1w_inst (
       .push_clk,

--- a/cdc/rtl/br_cdc_fifo_ctrl_pop_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_pop_1r1w.sv
@@ -43,6 +43,9 @@ module br_cdc_fifo_ctrl_pop_1r1w #(
     parameter int RamReadLatency = 0,
     // The number of synchronization stages to use for the gray counts.
     parameter int NumSyncStages = 3,
+    // If 1, then assert there are no valid bits asserted and that the FIFO is
+    // empty at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -121,7 +124,8 @@ module br_cdc_fifo_ctrl_pop_1r1w #(
       .Depth(Depth),
       .Width(Width),
       .RegisterPopOutputs(RegisterPopOutputs),
-      .RamReadLatency(RamReadLatency)
+      .RamReadLatency(RamReadLatency),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_cdc_fifo_pop_ctrl (
       .clk              (pop_clk),                 // ri lint_check_waive SAME_CLOCK_NAME
       .rst              (pop_rst),

--- a/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w.sv
@@ -18,35 +18,13 @@
 // that uses the AMBA-inspired ready-valid handshake protocol for synchronizing
 // pipeline stages and stalling when encountering backpressure hazards.
 //
-// This module does not include any internal RAM. Instead, it exposes
-// write ports to an external 1R1W (pseudo-dual-port) RAM module, which
-// RAM module, which could be implemented in flops or SRAM.
+// This module is intended to connect to an instance of br_cdc_fifo_ctrl_pop_1r1w
+// as well as a 1R1W RAM module.
 //
-// Data progresses from one stage to another when both
-// the corresponding ready signal and valid signal are
-// both 1 on the same cycle. Otherwise, the stage is stalled.
-//
-// The FIFO controller can work with RAMs of arbitrary fixed read latency.
-// If the latency is non-zero, a FLOP-based staging buffer is kept in the
-// controller so that a synchronous ready/valid interface can be maintained
-// at the pop interface.
-//
-// The RegisterPopOutputs parameter can be set to 1 to add an additional br_flow_reg_fwd
-// before the pop interface of the FIFO. This may improve timing of paths dependent on
-// the pop interface at the expense of an additional pop cycle of cut-through latency.
-
-// The cut-through latency (push_valid to pop_valid latency) and backpressure
-// latency (pop_ready to push_ready) can be calculated as follows:
-//
-// Let PushT and PopT be the push period and pop period, respectively.
-//
-// The cut-through latency is max(2, RamWriteLatency + 1) * PushT +
-// (NumSyncStages + 1 + RamReadLatency + RegisterPopOutputs) * PopT.
-
-// The backpressure latency is 2 * PopT + (NumSyncStages + 1) * PushT.
-//
-// To achieve full bandwidth, the depth of the FIFO must be at least
-// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+// Ordinarily the push and pop sides of the FIFO controller can be connected
+// together directly. If necessary, they can be separated, for example to
+// implement a CDC crossing across a boundary where the sending and receiving
+// flops must be separated or logic needs to be placed in between the two sides.
 
 `include "br_asserts_internal.svh"
 
@@ -144,6 +122,7 @@ module br_cdc_fifo_ctrl_push_1r1w #(
       .CountWidth(CountWidth),
       .NumStages (NumSyncStages)
   ) br_cdc_fifo_gray_count_sync_pop2push (
+      // TODO(zhemao): Remove need for pop_clk and pop_rst here.
       .src_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
       .src_rst(pop_rst),
       .src_count_gray(pop_pop_count_gray),

--- a/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w.sv
@@ -45,6 +45,9 @@ module br_cdc_fifo_ctrl_push_1r1w #(
     // If 1, assert that push_data is stable when backpressured.
     // If 0, cover that push_data can be unstable.
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, then assert there are no valid bits asserted and that the FIFO is
+    // empty at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -98,7 +101,8 @@ module br_cdc_fifo_ctrl_push_1r1w #(
       .RamWriteLatency(RamWriteLatency),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
-      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_cdc_fifo_push_ctrl (
       .clk              (push_clk),               // ri lint_check_waive SAME_CLOCK_NAME
       .rst              (push_rst),

--- a/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w_push_credit.sv
@@ -46,6 +46,9 @@ module br_cdc_fifo_ctrl_push_1r1w_push_credit #(
     // driven directly from a flop. This comes at the expense of one additional
     // push cycle of credit loop latency.
     parameter bit RegisterPushCredit = 0,
+    // If 1, then assert there are no valid bits asserted and that the FIFO is
+    // empty at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int CreditWidth = $clog2(MaxCredit + 1)
@@ -106,7 +109,8 @@ module br_cdc_fifo_ctrl_push_1r1w_push_credit #(
       .Width(Width),
       .RamWriteLatency(RamWriteLatency),
       .RegisterPushCredit(RegisterPushCredit),
-      .MaxCredit(MaxCredit)
+      .MaxCredit(MaxCredit),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_cdc_fifo_push_ctrl_credit (
       .clk              (push_clk),               // ri lint_check_waive SAME_CLOCK_NAME
       .rst              (push_rst),

--- a/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w_push_credit.sv
@@ -19,31 +19,13 @@
 // interface for synchronizing pipeline stages and stalling when encountering
 // backpressure hazards.
 //
-// This module does not include any internal RAM. Instead, it exposes
-// write ports to an external 1R1W (pseudo-dual-port) RAM module, which
-// could be implemented in flops or SRAM.
+// This module is intended to connect to an instance of br_cdc_fifo_ctrl_pop_1r1w
+// as well as a 1R1W RAM module.
 //
-// Data progresses from one stage to another when both
-// the corresponding ready signal and valid signal are
-// both 1 on the same cycle. Otherwise, the stage is stalled.
-//
-// The FIFO controller can work with RAMs of arbitrary fixed read latency.
-// If the latency is non-zero, a FLOP-based staging buffer is kept in the
-// controller so that a synchronous ready/valid interface can be maintained
-// at the pop interface.
-//
-// The cut-through latency (push_valid to pop_valid latency) and backpressure
-// latency (pop_ready to push_ready) can be calculated as follows:
-//
-// Let PushT and PopT be the push period and pop period, respectively.
-//
-// The cut-through latency is max(2, RamWriteLatency + 1) * PushT +
-// (NumSyncStages + 1 + RamReadLatency + RegisterPopOutputs) * PopT.
-
-// The backpressure latency is 2 * PopT + (NumSyncStages + 1 + RegisterPushCredit) * PushT.
-//
-// To achieve full bandwidth, the depth of the FIFO must be at least
-// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+// Ordinarily the push and pop sides of the FIFO controller can be connected
+// together directly. If necessary, they can be separated, for example to
+// implement a CDC crossing across a boundary where the sending and receiving
+// flops must be separated or logic needs to be placed in between the two sides.
 
 `include "br_asserts_internal.svh"
 
@@ -153,6 +135,7 @@ module br_cdc_fifo_ctrl_push_1r1w_push_credit #(
       .CountWidth(CountWidth),
       .NumStages (NumSyncStages)
   ) br_cdc_fifo_gray_count_sync_pop2push (
+      // TODO(zhemao): Remove need for pop_clk and pop_rst here.
       .src_clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
       .src_rst(pop_rst),
       .src_count_gray(pop_pop_count_gray),


### PR DESCRIPTION
Split CDC FIFO control into push/pop side. This enables different constructions of CDC FIFOs, such as a source-synchronous design where the push and pop side need to be separated.