### PR TITLE
Add BR_ASSERT_RST macro

### DIFF
--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -66,10 +66,10 @@ end
 // Clock: 'clk'
 // Reset: 'rst'
 `ifdef BR_ASSERT_ON
-`define BR_ASSERT_RST(__name__, __expr__) \
+`define BR_ASSERT_IN_RST(__name__, __expr__) \
 __name__ : assert property (@(posedge clk) (__expr__));
 `else  // BR_ASSERT_ON
-`define BR_ASSERT_RST(__name__, __expr__) \
+`define BR_ASSERT_IN_RST(__name__, __expr__) \
 `BR_NOOP
 `endif  // BR_ASSERT_ON
 

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -60,6 +60,20 @@ end
 `endif  // BR_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
+// Concurrent assertion macros (evaluated on posedge of a clock and enabled during a synchronous active-high reset)
+////////////////////////////////////////////////////////////////////////////////
+
+// Clock: 'clk'
+// Reset: 'rst'
+`ifdef BR_ASSERT_ON
+`define BR_ASSERT_RST(__name__, __expr__) \
+__name__ : assert property (@(posedge clk) (__expr__));
+`else  // BR_ASSERT_ON
+`define BR_ASSERT_RST(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
+////////////////////////////////////////////////////////////////////////////////
 // Concurrent assertion macros (evaluated on posedge of a clock and disabled during a synchronous active-high reset)
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -73,6 +73,15 @@ __name__ : assert property (@(posedge clk) (__expr__));
 `BR_NOOP
 `endif  // BR_ASSERT_ON
 
+// More expressive form of BR_ASSERT_IN_RST that allows the use of custom clock and reset signal names.
+`ifdef BR_ASSERT_ON
+`define BR_ASSERT_IN_RST_C(__name__, __expr__, __clk__) \
+__name__ : assert property (@(posedge __clk__) (__expr__));
+`else  // BR_ASSERT_ON
+`define BR_ASSERT_IN_RST_C(__name__, __expr__, __clk__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
 ////////////////////////////////////////////////////////////////////////////////
 // Concurrent assertion macros (evaluated on posedge of a clock and disabled during a synchronous active-high reset)
 ////////////////////////////////////////////////////////////////////////////////

--- a/macros/br_asserts_test.sv
+++ b/macros/br_asserts_test.sv
@@ -82,7 +82,7 @@ module br_asserts_test;
   `BR_ASSERT_FINAL(valid_0_final_a, valid == 0)
 
   // Use BR_ASSERT_RST
-  `BR_ASSERT_RST(valid_0_final_a, rst |-> !valid)
+  `BR_ASSERT_RST(valid_0_during_rst_a, rst |-> valid == 0)
 
   // Use BR_ASSERT
   `BR_ASSERT(sum_range_check_a, sum <= 15)

--- a/macros/br_asserts_test.sv
+++ b/macros/br_asserts_test.sv
@@ -81,6 +81,9 @@ module br_asserts_test;
   // Use BR_ASSERT_FINAL
   `BR_ASSERT_FINAL(valid_0_final_a, valid == 0)
 
+  // Use BR_ASSERT_RST
+  `BR_ASSERT_RST(valid_0_final_a, rst |-> !valid)
+
   // Use BR_ASSERT
   `BR_ASSERT(sum_range_check_a, sum <= 15)
   `BR_ASSERT_FPV(sum_range_check_fpv_a, sum <= 15)

--- a/macros/br_asserts_test.sv
+++ b/macros/br_asserts_test.sv
@@ -83,6 +83,7 @@ module br_asserts_test;
 
   // Use BR_ASSERT_IN_RST
   `BR_ASSERT_IN_RST(valid_0_during_rst_a, rst |-> valid == 0)
+  `BR_ASSERT_IN_RST_C(valid_0_during_rst_c_a, rst |-> valid == 0, clk)
 
   // Use BR_ASSERT
   `BR_ASSERT(sum_range_check_a, sum <= 15)

--- a/macros/br_asserts_test.sv
+++ b/macros/br_asserts_test.sv
@@ -81,8 +81,8 @@ module br_asserts_test;
   // Use BR_ASSERT_FINAL
   `BR_ASSERT_FINAL(valid_0_final_a, valid == 0)
 
-  // Use BR_ASSERT_RST
-  `BR_ASSERT_RST(valid_0_during_rst_a, rst |-> valid == 0)
+  // Use BR_ASSERT_IN_RST
+  `BR_ASSERT_IN_RST(valid_0_during_rst_a, rst |-> valid == 0)
 
   // Use BR_ASSERT
   `BR_ASSERT(sum_range_check_a, sum <= 15)


### PR DESCRIPTION
to test simple properties during reset.
for example: rst |-> valid. == 0