### PR TITLE
mux: create br_mux_array

### DIFF
--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -278,7 +278,8 @@ module br_flow_deserializer #(
         ) br_mux_bin (
             .select(passthru_this_slice),
             .in({slice_data[i], slice_reg[i]}),
-            .out(pop_data[Msb:Lsb])
+            .out(pop_data[Msb:Lsb]),
+            .out_valid()
         );
 
         // Last slice does not have a register to mux from.

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -237,7 +237,8 @@ module br_flow_serializer #(
     ) br_mux_bin (
         .select(slice_id),
         .in(push_data),
-        .out(pop_data)
+        .out(pop_data),
+        .out_valid()
     );
 
     //------

--- a/mux/rtl/BUILD.bazel
+++ b/mux/rtl/BUILD.bazel
@@ -98,8 +98,8 @@ br_verilog_elab_and_lint_test_suite(
 )
 
 verilog_library(
-    name = "br_mux_array",
-    srcs = ["br_mux_array.sv"],
+    name = "br_mux_bin_array",
+    srcs = ["br_mux_bin_array.sv"],
     deps = [
         ":br_mux_bin",
         "//macros:br_asserts_internal",
@@ -107,7 +107,7 @@ verilog_library(
 )
 
 br_verilog_elab_and_lint_test_suite(
-    name = "br_mux_array_test_suite",
+    name = "br_mux_bin_array_test_suite",
     params = {
         "NumSymbolsIn": [
             "2",
@@ -125,5 +125,5 @@ br_verilog_elab_and_lint_test_suite(
             "3",
         ],
     },
-    deps = [":br_mux_array"],
+    deps = [":br_mux_bin_array"],
 )

--- a/mux/rtl/BUILD.bazel
+++ b/mux/rtl/BUILD.bazel
@@ -96,3 +96,34 @@ br_verilog_elab_and_lint_test_suite(
     },
     deps = [":br_mux_bin"],
 )
+
+verilog_library(
+    name = "br_mux_array",
+    srcs = ["br_mux_array.sv"],
+    deps = [
+        ":br_mux_bin",
+        "//macros:br_asserts_internal",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_mux_array_test_suite",
+    params = {
+        "NumSymbolsIn": [
+            "2",
+            "3",
+            "4",
+        ],
+        "SymbolWidth": [
+            "1",
+            "5",
+            "8",
+        ],
+        "NumSymbolsOut": [
+            "1",
+            "2",
+            "3",
+        ],
+    },
+    deps = [":br_mux_array"],
+)

--- a/mux/rtl/br_mux_array.sv
+++ b/mux/rtl/br_mux_array.sv
@@ -1,0 +1,66 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Bedrock-RTL Multiplexer Array
+//
+// An array of N-to-1 multiplexers with a select.
+//
+// The out[j] signal is set to in[i] for which select == i.
+// Select must be in range of NumSymbolsIn.
+
+`include "br_asserts_internal.svh"
+`include "br_unused.svh"
+
+module br_mux_array #(
+    // Number of inputs to select among. Must be >= 2.
+    parameter  int NumSymbolsIn  = 2,
+    // Number of outputs to select among. Must be >= 1.
+    parameter  int NumSymbolsOut = 1,
+    // The width of each symbol in bits. Must be >= 1.
+    parameter  int SymbolWidth   = 1,
+    localparam int SelectWidth   = $clog2(NumSymbolsIn)
+) (
+    input  logic [NumSymbolsOut-1:0][SelectWidth-1:0] select,
+    input  logic [ NumSymbolsIn-1:0][SymbolWidth-1:0] in,
+    output logic [NumSymbolsOut-1:0][SymbolWidth-1:0] out
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(legal_num_symbols_in_a, NumSymbolsIn >= 2)
+  `BR_ASSERT_STATIC(legal_num_symbols_out_a, NumSymbolsOut >= 1)
+  `BR_ASSERT_STATIC(legal_symbol_width_a, SymbolWidth >= 1)
+
+  // ri lint_check_waive ALWAYS_COMB
+  `BR_ASSERT_COMB_INTG(select_in_range_a, $isunknown(select) || select < NumSymbolsIn)
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  generate
+    for (genvar i = 0; i < NumSymbolsOut; i++) begin : gen_mux
+      br_mux_bin #(
+          .NumSymbolsIn(NumSymbolsIn),
+          .SymbolWidth (SymbolWidth)
+      ) br_mux_bin (
+          .select(select[i]),
+          .in(in),
+          .out(out[i])
+      );
+    end
+  endgenerate
+
+
+endmodule : br_mux_array

--- a/mux/rtl/br_mux_bin.sv
+++ b/mux/rtl/br_mux_bin.sv
@@ -35,7 +35,8 @@ module br_mux_bin #(
 ) (
     input  logic [ SelectWidth-1:0]                  select,
     input  logic [NumSymbolsIn-1:0][SymbolWidth-1:0] in,
-    output logic [ SymbolWidth-1:0]                  out
+    output logic [ SymbolWidth-1:0]                  out,
+    output logic                                     out_valid
 );
 
   //------------------------------------------
@@ -114,6 +115,8 @@ module br_mux_bin #(
       end
     end
   end
+
+  assign out_valid = select < NumSymbolsIn;  // ri lint_check_waive INVALID_COMPARE
 
   //------------------------------------------
   // Implementation checks

--- a/mux/rtl/br_mux_bin_array.sv
+++ b/mux/rtl/br_mux_bin_array.sv
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Bedrock-RTL Multiplexer Array
+// Bedrock-RTL Binary-Select Multiplexer Array
 //
-// An array of N-to-1 multiplexers with a select.
+// An array of N-to-1 multiplexers with a binary select.
 //
-// The out[j] signal is set to in[i] for which select == i.
-// Select must be in range of NumSymbolsIn.
+// The out[j] signal is set to in[i] for which select[j] == i.
+// Each select must be in range of NumSymbolsIn.
 
 `include "br_asserts_internal.svh"
 `include "br_unused.svh"
 
-module br_mux_array #(
+module br_mux_bin_array #(
     // Number of inputs to select among. Must be >= 2.
     parameter  int NumSymbolsIn  = 2,
     // Number of outputs to select among. Must be >= 1.
@@ -31,9 +31,10 @@ module br_mux_array #(
     parameter  int SymbolWidth   = 1,
     localparam int SelectWidth   = $clog2(NumSymbolsIn)
 ) (
-    input  logic [NumSymbolsOut-1:0][SelectWidth-1:0] select,
-    input  logic [ NumSymbolsIn-1:0][SymbolWidth-1:0] in,
-    output logic [NumSymbolsOut-1:0][SymbolWidth-1:0] out
+    input logic [NumSymbolsOut-1:0][SelectWidth-1:0] select,
+    input logic [NumSymbolsIn-1:0][SymbolWidth-1:0] in,
+    output logic [NumSymbolsOut-1:0][SymbolWidth-1:0] out,
+    output logic [NumSymbolsOut-1:0] out_valid
 );
 
   //------------------------------------------
@@ -43,24 +44,19 @@ module br_mux_array #(
   `BR_ASSERT_STATIC(legal_num_symbols_out_a, NumSymbolsOut >= 1)
   `BR_ASSERT_STATIC(legal_symbol_width_a, SymbolWidth >= 1)
 
-  // ri lint_check_waive ALWAYS_COMB
-  `BR_ASSERT_COMB_INTG(select_in_range_a, $isunknown(select) || select < NumSymbolsIn)
-
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  generate
-    for (genvar i = 0; i < NumSymbolsOut; i++) begin : gen_mux
-      br_mux_bin #(
-          .NumSymbolsIn(NumSymbolsIn),
-          .SymbolWidth (SymbolWidth)
-      ) br_mux_bin (
-          .select(select[i]),
-          .in(in),
-          .out(out[i])
-      );
-    end
-  endgenerate
+  for (genvar i = 0; i < NumSymbolsOut; i++) begin : gen_mux
+    br_mux_bin #(
+        .NumSymbolsIn(NumSymbolsIn),
+        .SymbolWidth (SymbolWidth)
+    ) br_mux_bin (
+        .select(select[i]),
+        .in(in),
+        .out(out[i]),
+        .out_valid(out_valid[i])
+    );
+  end
 
-
-endmodule : br_mux_array
+endmodule : br_mux_bin_array

--- a/mux/sim/br_mux_bin_tb.sv
+++ b/mux/sim/br_mux_bin_tb.sv
@@ -18,7 +18,8 @@ module br_mux_bin_tb;
   ) dut (
       .select,
       .in,
-      .out
+      .out,
+      .out_valid()
   );
 
   br_test_driver td (

--- a/ram/rtl/br_ram_flops_1r1w_tile.sv
+++ b/ram/rtl/br_ram_flops_1r1w_tile.sv
@@ -182,7 +182,8 @@ module br_ram_flops_1r1w_tile #(
     ) br_mux_bin_inst (
         .select(rd_addr),
         .in(mem_packed),
-        .out(rd_data)
+        .out(rd_data),
+        .out_valid()
     );
   end else begin : gen_behavioral_read
     if (EnableBypass) begin : gen_bypass


### PR DESCRIPTION
An array of multiplexors on the same input data. Could be used to programmatically select the outputs from a common input bus.