### PR TITLE
Add prioritized round-robin arbiter

### DIFF
--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -144,13 +144,16 @@ verilog_elab_test(
 br_verilog_fpv_test_suite(
     name = "br_arb_pri_rr_jg_test_suite",
     custom_tcl_body = "br_arb_rr_fpv.tcl",
-    gui = True,
     params = {
         "NumRequesters": [
             "2",
+            "5",
+            "8",
         ],
         "NumPriorities": [
             "2",
+            "3",
+            "4",
         ],
     },
     tool = "jg",

--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -123,3 +123,37 @@ rule_verilog_sandbox(
     top = "br_arb_lru",
     deps = [":br_arb_lru_fpv_monitor"],
 )
+
+# Prioritized round-robin arbiter
+
+verilog_library(
+    name = "br_arb_pri_rr_fpv_monitor",
+    srcs = ["br_arb_pri_rr_fpv_monitor.sv"],
+    deps = [
+        "//arb/rtl:br_arb_pri_rr",
+        "//arb/rtl:br_arb_rr",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_arb_pri_rr_fpv_monitor_elab_test",
+    deps = [":br_arb_pri_rr_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_arb_pri_rr_jg_test_suite",
+    custom_tcl_body = "br_arb_rr_fpv.tcl",
+    gui = True,
+    params = {
+        "NumRequesters": [
+            "2",
+        ],
+        "NumPriorities": [
+            "2",
+        ],
+    },
+    tool = "jg",
+    top = "br_arb_pri_rr",
+    deps = [":br_arb_pri_rr_fpv_monitor"],
+)

--- a/arb/fpv/br_arb_pri_rr_fpv_monitor.sv
+++ b/arb/fpv/br_arb_pri_rr_fpv_monitor.sv
@@ -1,0 +1,72 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Prioritized Round Robin Arbiter FPV monitor
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_arb_pri_rr_fpv_monitor #(
+    // Must be at least 2
+    parameter int NumRequesters = 2,
+    // Must be at least 2
+    parameter int NumPriorities = 2
+) (
+    input logic clk,
+    input logic rst,
+    input logic enable_priority_update,
+    input logic [NumRequesters-1:0] request,
+    input logic [NumRequesters-1:0][$clog2(NumPriorities)-1:0] request_priority,
+    input logic [NumRequesters-1:0] grant
+);
+  `BR_ASSERT(must_grant_a, request != 0 |-> grant != 0)
+  `BR_ASSERT(onehot_grant_a, $countones(grant) <= 1)
+  `BR_COVER(all_request_c, request == '1)
+
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_req_0
+    `BR_ASSUME(req_priority_range_a, request[i] |-> request_priority[i] < NumPriorities)
+  end
+
+  logic [$clog2(NumPriorities)-1:0] max_priority;
+  always_comb begin
+    max_priority = '0;
+    for (int i = 0; i < NumRequesters; i++) begin
+      if (request[i] && (request_priority[i] > max_priority)) begin
+        max_priority = request_priority[i];
+      end
+    end
+  end
+
+  logic [NumRequesters-1:0] highest_priority_request;
+  always_comb begin
+    for (int i = 0; i < NumRequesters; i++) begin
+      highest_priority_request[i] = request[i] && (request_priority[i] == max_priority);
+    end
+  end
+
+  logic [NumRequesters-1:0] expected_grant;
+  br_arb_rr #(
+    .NumRequesters(NumRequesters)
+  ) br_arb_rr_inst (
+    .clk,
+    .rst,
+    .enable_priority_update,
+    .request(highest_priority_request),
+    .grant(expected_grant)
+  );
+  `BR_ASSERT(grant_match_a, grant == expected_grant)
+
+endmodule : br_arb_pri_rr_fpv_monitor
+
+bind br_arb_pri_rr br_arb_pri_rr_fpv_monitor#(.NumRequesters(NumRequesters), .NumPriorities(NumPriorities)) monitor (.*);

--- a/arb/rtl/BUILD.bazel
+++ b/arb/rtl/BUILD.bazel
@@ -53,6 +53,8 @@ verilog_library(
     deps = [
         "//arb/rtl/internal:br_rr_state_internal",
         "//macros:br_asserts_internal",
+        "//macros:br_unused",
+        "//pkg:br_math_pkg",
     ],
 )
 

--- a/arb/rtl/BUILD.bazel
+++ b/arb/rtl/BUILD.bazel
@@ -47,6 +47,15 @@ verilog_library(
     ],
 )
 
+verilog_library(
+    name = "br_arb_pri_rr",
+    srcs = ["br_arb_pri_rr.sv"],
+    deps = [
+        "//arb/rtl/internal:br_rr_state_internal",
+        "//macros:br_asserts_internal",
+    ],
+)
+
 br_verilog_elab_and_lint_test_suite(
     name = "br_arb_fixed_test_suite",
     params = {"NumRequesters": [
@@ -72,4 +81,19 @@ br_verilog_elab_and_lint_test_suite(
         "5",
     ]},
     deps = [":br_arb_rr"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_arb_rr_test_suite",
+    params = {
+        "NumRequesters": [
+            "2",
+            "5",
+        ],
+        "NumPriorities": [
+            "2",
+            "3",
+        ],
+    },
+    deps = [":br_arb_pri_rr"],
 )

--- a/arb/rtl/br_arb_pri_rr.sv
+++ b/arb/rtl/br_arb_pri_rr.sv
@@ -1,0 +1,161 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Prioritized Round-Robin Arbiter
+//
+// Grants a single request at a time, by selecting the highest priority 
+// request using the per-request priority inputs. If there are multiple 
+// requests with the highest priority, then a round-robin arbiter is used 
+// to break ties. On the cycle after any grant, the granted index becomes 
+// the lowest round-robin priority and the next higher index (modulo 
+// NumRequesters) becomes the highest priority.
+//
+// The enable_priority_update signal allows the priority state to update 
+// when a grant is made. If low, grants can still be made, but the priority 
+// will remain unchanged for the next cycle.
+//
+// There is zero latency from request to grant.
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+
+module br_arb_pri_rr #(
+    // Must be at least 2
+    parameter int NumRequesters = 2,
+    // Must be at least 2
+    parameter int NumPriorities = 2
+) (
+    input logic clk,
+    input logic rst,  // Synchronous active-high
+    input logic enable_priority_update,
+    input logic [NumRequesters-1:0] request,
+    input logic [$clog2(NumPriorities)-1:0] priority,
+    output logic [NumRequesters-1:0] grant
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+
+  `BR_COVER_INTG(request_multihot_c, !$onehot0(request))
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+
+  // Track round-robin priority state
+  logic update_priority;
+  logic [NumRequesters-1:0] priority_mask;
+
+  assign update_priority = enable_priority_update && |request;
+
+  br_rr_state_internal #(
+      .NumRequesters(NumRequesters)
+  ) rr_state_internal (
+      .clk,
+      .rst,
+      .update_priority,
+      .grant,
+      .last_grant(),
+      .priority_mask
+  );
+
+  // Adopt the approach described in Towles et al., 
+  // "Unifying on-chip and inter-node switching within the Anton 2 network"
+  // where the priority and priority_mask are unrolled into a request
+  // vector that is then fed into a fixed priority arbiter to find 
+  // the highest priority request.
+
+  // First unroll requests into NumPriorities+1 levels. The requests at
+  // priority level p are those whose
+  //   1) input priority is = p and index < RR priority, or
+  //   2) input priority is = p-1 and index >= RR priority
+  //
+  // This assigns every request a unique priority level. And the requests
+  // greater than the RR priority are effectively bumped to the next 
+  // input priority level, which allows the fixed priority arbiter
+  // to find the highest priority request using the RR priority to break
+  // ties.
+  //
+  // We simplify the find first set by theremometer encoding a
+  // request's prority level such that request_unrolled[p][i] implies
+  // request_unrolled[p-1][i] for all p > 0. Then, we simplifiy case
+  // 1 by removing the RR priority check: the request will either
+  // pass the check or already be encoded in case 2, which is a higher
+  // priority level. Finally, we make use the RR pointer encoded in the 
+  // priority_mask:
+  //   1) priority[i] => p, OR
+  //   2) priority[i] => p-1 AND !priority_mask[i]
+  //
+  // Note: for a single priority level, the correspondes to the typical
+  // approach used for a non-prioritized RR arbiter.
+
+  logic [NumPriorities:0][NumRequesters-1:0] request_unrolled;
+
+  always_comb begin
+    request_unrolled[0] = request;
+    for (int p = 1; p <= NumPriorities; p++) begin
+      for (int i = 0; i < NumRequesters; i++) begin
+        request_unrolled[p][i] = request[i] && (
+            (priority[i] >= p) ||
+            ((priority[i] >= p - 1) && !priority_mask[i]));
+      end
+    end
+  end
+
+  // Now, treat request_unrolled as a flattened vector and 
+  // create a mask to disable all lower priority requests using
+  // a Kogge-Stone parallel prefix tree. Note: we only need
+  // $clog2(NumRequesters-1) levels of prefix tree because
+  // request_unrolled[i][j] -> request_unrolled[i-1][j] for
+  // all i > 0 due the encoding used above.
+
+  logic [NumPriorities:0][NumRequesters-1:0] any_higher_pri_req;
+
+  always_comb begin
+    any_higher_pri_req = request_unrolled >> 1;
+    for (int i = 0; i < $clog2(NumRequesters-1); i++) begin
+      any_higher_pri_req |= any_higher_pri_req >> (1 << i);
+    end
+  end
+
+  // Finally, generate an unrolled grant by disabling unrolled
+  // requests for which there are higher priority requests. Then
+  // OR each unrolled grant into the final grant.
+
+  logic [NumPriorities:0][NumRequesters-1:0] grant_unrolled;
+  assign grant_unrolled = request_unrolled & ~any_higher_pri_req;
+
+  always_comb begin
+    grant = '0;
+    for (int i = 0; i <= NumPriorities; i++) begin
+      grant |= grant_unrolled[i];
+    end
+  end
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  // Rely on submodule implementation checks
+
+  `BR_ASSERT_IMPL(grant_onehot0_A, $onehot0(grant))
+  `BR_ASSERT_IMPL(always_grant_A, |request |-> |grant)
+  `BR_ASSERT_IMPL(grant_implies_request_A, (grant & request) == grant)
+  `BR_COVER_IMPL(grant_without_state_update_C, !enable_priority_update && |grant)
+
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_priority_range
+    `BR_ASSERT_IMPL(requested_priority_range_A, request[i] |-> priority[i] < NumPriorities)
+  end
+
+endmodule : br_arb_pri_rr

--- a/arb/rtl/br_arb_pri_rr.sv
+++ b/arb/rtl/br_arb_pri_rr.sv
@@ -135,8 +135,8 @@ module br_arb_pri_rr #(
   // create a mask to disable all lower priority requests using
   // a Kogge-Stone parallel prefix tree. Note: we only need
   // $clog2(NumRequesters-1) levels of prefix tree because
-  // request_unrolled[i][j] -> request_unrolled[i-1][j] for
-  // all i > 0 due the encoding used above.
+  // request_unrolled[i][j] -> request_unrolled[i+1][j] for
+  // due the encoding used above.
 
   logic [$clog2(NumRequesters-1):0][NumPriorities:0][NumRequesters-1:0] any_higher_pri_req;
 

--- a/arb/rtl/internal/BUILD.bazel
+++ b/arb/rtl/internal/BUILD.bazel
@@ -38,9 +38,18 @@ verilog_library(
     name = "br_arb_rr_internal",
     srcs = ["br_arb_rr_internal.sv"],
     deps = [
+        ":br_rr_state_internal",
+    ],
+)
+
+verilog_library(
+    name = "br_rr_state_internal",
+    srcs = ["br_rr_state_internal.sv"],
+    deps = [
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],
 )
 
 # Elab/Lint tests done on public modules
+

--- a/arb/rtl/internal/BUILD.bazel
+++ b/arb/rtl/internal/BUILD.bazel
@@ -52,4 +52,3 @@ verilog_library(
 )
 
 # Elab/Lint tests done on public modules
-

--- a/arb/rtl/internal/br_arb_rr_internal.sv
+++ b/arb/rtl/internal/br_arb_rr_internal.sv
@@ -50,7 +50,8 @@ module br_arb_rr_internal #(
   // We use two priority encoders to handle the modulo indexing.
   // * The first encoder uses a masked request vector to find the highest priority
   // request (if any exists) before wrapping around. These are the requests in the
-  // range [RR_ptr, NumRequesters).
+  // range [RR_ptr, NumRequesters), where RR_ptr is the current round-robin priority
+  // pointer.
   // * The second encoder uses the unmasked request vector to find the highest
   // priority request after the wraparound index. These are the requests in the
   // range [0, RR_ptr).
@@ -58,12 +59,8 @@ module br_arb_rr_internal #(
   // The round-robin state is tracked in the rr_state_internal module. The
   // priority_mask output contains a mask of all request indices that are less
   // than the current  round-robin priority---those in the range [0, RR_ptr) that
-  // are passed to the second (lower priority) encoder.
-  //
-  // The last_grant gets updated on the next cycle with grant, so that the
-  // priority rotates in a round-robin fashion.
-  // last_grant initializes to NumRequesters'b100....0 such that index 0 is the
-  // highest priority out of reset.
+  // are passed to the second (lower priority) encoder. The RR_ptr is initialized
+  // to 0.
 
   logic update_priority;
   logic [NumRequesters-1:0] priority_mask;

--- a/arb/rtl/internal/br_arb_rr_internal.sv
+++ b/arb/rtl/internal/br_arb_rr_internal.sv
@@ -48,21 +48,21 @@ module br_arb_rr_internal #(
   //------------------------------------------
 
   // We use two priority encoders to handle the modulo indexing.
-  // * The first encoder uses a masked request vector to find the highest priority 
-  // request (if any exists) before wrapping around. These are the requests in the 
+  // * The first encoder uses a masked request vector to find the highest priority
+  // request (if any exists) before wrapping around. These are the requests in the
   // range [RR_ptr, NumRequesters).
-  // * The second encoder uses the unmasked request vector to find the highest 
-  // priority request after the wraparound index. These are the requests in the 
+  // * The second encoder uses the unmasked request vector to find the highest
+  // priority request after the wraparound index. These are the requests in the
   // range [0, RR_ptr).
   //
-  // The round-robin state is tracked in the rr_state_internal module. The 
-  // priority_mask output contains a mask of all request indices that are less 
-  // than the current  round-robin priority---those in the range [0, RR_ptr) that 
+  // The round-robin state is tracked in the rr_state_internal module. The
+  // priority_mask output contains a mask of all request indices that are less
+  // than the current  round-robin priority---those in the range [0, RR_ptr) that
   // are passed to the second (lower priority) encoder.
   //
   // The last_grant gets updated on the next cycle with grant, so that the
   // priority rotates in a round-robin fashion.
-  // last_grant initializes to NumRequesters'b100....0 such that index 0 is the 
+  // last_grant initializes to NumRequesters'b100....0 such that index 0 is the
   // highest priority out of reset.
 
   logic update_priority;
@@ -81,6 +81,7 @@ module br_arb_rr_internal #(
       .priority_mask
   );
 
+  logic [NumRequesters-1:0] request_high;
   // request_high[0] is constant 0
   // ri lint_check_waive CONST_ASSIGN
   assign request_high = request & ~priority_mask;

--- a/arb/rtl/internal/br_rr_state_internal.sv
+++ b/arb/rtl/internal/br_rr_state_internal.sv
@@ -17,11 +17,11 @@
 
 // Bedrock-RTL Round-Robin State
 //
-// Tracks round-robin priority pointer state. When a grant is issued and 
-// update_priority is high, the last_grant register is updated to the 
+// Tracks round-robin priority pointer state. When a grant is issued and
+// update_priority is high, the last_grant register is updated to the
 // grant index.
 //
-// The priority_mask output contains a mask of all request indices that 
+// The priority_mask output contains a mask of all request indices that
 // are less than the current round-robin priority---those in the range
 // [0, RR_ptr).
 
@@ -37,9 +37,6 @@ module br_rr_state_internal #(
     output logic [NumRequesters-1:0] priority_mask
 );
 
-  logic [NumRequesters-1:0] priority_mask;
-  logic [NumRequesters-1:0] request_high;
-  logic [NumRequesters-1:0] last_grant;
   logic [NumRequesters-1:0] last_grant_init;
 
   // priority_mask selects all bits at or below the last grant.
@@ -54,7 +51,7 @@ module br_rr_state_internal #(
   end
 
   // ri lint_check_waive CONST_ASSIGN
-  assign last_grant_init[NumRequesters-1] = 1'b1;
+  assign last_grant_init[NumRequesters-1]   = 1'b1;
   // ri lint_check_waive CONST_ASSIGN
   assign last_grant_init[NumRequesters-2:0] = '0;
 

--- a/arb/rtl/internal/br_rr_state_internal.sv
+++ b/arb/rtl/internal/br_rr_state_internal.sv
@@ -58,8 +58,8 @@ module br_rr_state_internal #(
   `BR_REGLI(last_grant, grant, update_priority, last_grant_init)
 
   `BR_ASSERT_IMPL(grant_onehot_A, update_priority |-> $onehot(grant))
-  `BR_ASSERT_IMPL(last_grant_onehot0_A, $onehot0(last_grant))
+  `BR_ASSERT_IMPL(last_grant_onehot_A, $onehot(last_grant))
   // For i > 0, priority_mask[i] |-> priority_mask[i-1]
-  `BR_ASSERT_IMPL(priority_mask_therm_encoded_A, &(~(priority_mask >> 1) | priority_mask))
+  `BR_ASSERT_IMPL(priority_mask_thermometer_encoded_A, &(~(priority_mask >> 1) | priority_mask))
 
 endmodule : br_rr_state_internal

--- a/arb/rtl/internal/br_rr_state_internal.sv
+++ b/arb/rtl/internal/br_rr_state_internal.sv
@@ -1,0 +1,68 @@
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+
+// Copyright 2024,2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Round-Robin State
+//
+// Tracks round-robin priority pointer state. When a grant is issued and 
+// update_priority is high, the last_grant register is updated to the 
+// grant index.
+//
+// The priority_mask output contains a mask of all request indices that 
+// are less than the current round-robin priority---those in the range
+// [0, RR_ptr).
+
+module br_rr_state_internal #(
+    // Must be at least 2
+    parameter int NumRequesters = 2
+) (
+    input logic clk,
+    input logic rst,  // Synchronous active-high
+    input logic update_priority,
+    input logic [NumRequesters-1:0] grant,
+    output logic [NumRequesters-1:0] last_grant,
+    output logic [NumRequesters-1:0] priority_mask
+);
+
+  logic [NumRequesters-1:0] priority_mask;
+  logic [NumRequesters-1:0] request_high;
+  logic [NumRequesters-1:0] last_grant;
+  logic [NumRequesters-1:0] last_grant_init;
+
+  // priority_mask selects all bits at or below the last grant.
+  // e.g. if last grant is 001, then priority_mask is 001
+  //      if last grant is 010, then priority_mask is 011
+  //      if last grant is 100, then priority_mask is 111
+  // priority_mask[0] is thus always 1.
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_priority_mask
+    // For i = NumRequesters - 1, the full range will be selected
+    // ri lint_check_waive FULL_RANGE
+    assign priority_mask[i] = |last_grant[NumRequesters-1:i];
+  end
+
+  // ri lint_check_waive CONST_ASSIGN
+  assign last_grant_init[NumRequesters-1] = 1'b1;
+  // ri lint_check_waive CONST_ASSIGN
+  assign last_grant_init[NumRequesters-2:0] = '0;
+
+  `BR_REGLI(last_grant, grant, update_priority, last_grant_init)
+
+  `BR_ASSERT_IMPL(grant_onehot_A, update_priority |-> $onehot(grant))
+  `BR_ASSERT_IMPL(last_grant_onehot0_A, $onehot0(last_grant))
+  // For i > 0, priority_mask[i] |-> priority_mask[i-1]
+  `BR_ASSERT_IMPL(priority_mask_therm_encoded_A, &(~(priority_mask >> 1) | priority_mask))
+
+endmodule : br_rr_state_internal


### PR DESCRIPTION
The prioritized RR arbiter adds a request priority argument along with each request. For any arbitration, all but the highest priority active requests are disabled. Any remaining requests are passed to a RR arbiter to determine the grant.

Passes lint/elab/FPV checks (bazel test //arb/...)