### PR TITLE
FPV/bazel: Add sandbox target for fpv test suite macro

### DIFF
--- a/bazel/br_verilog.bzl
+++ b/bazel/br_verilog.bzl
@@ -84,14 +84,14 @@ def br_verilog_sim_test_suite(name, tool, opts = [], **kwargs):
         **kwargs
     )
 
-def br_verilog_fpv_test_suite(name, sandbox = False, **kwargs):
+def br_verilog_fpv_test_suite(name, sandbox = True, **kwargs):
     """Wraps verilog_fpv_test_suite with Bedrock-internal settings. Not intended to be called by Bedrock users.
 
     * Defines `BR_ASSERT_ON`, `BR_ENABLE_IMPL_CHECKS`, `BR_DISABLE_FINAL_CHECKS` and `BR_ENABLE_FPV`.
 
     Args:
         name (str): The base name of the test suite.
-        sadnbox (bool): Whether to create a sandbox for fpv test
+        sandbox (bool): Whether to create a sandbox for fpv test
         **kwargs: Additional keyword arguments passed to verilog_fpv_test_suite. Do not pass defines.
     """
 

--- a/bazel/br_verilog.bzl
+++ b/bazel/br_verilog.bzl
@@ -84,13 +84,14 @@ def br_verilog_sim_test_suite(name, tool, opts = [], **kwargs):
         **kwargs
     )
 
-def br_verilog_fpv_test_suite(name, **kwargs):
+def br_verilog_fpv_test_suite(name, sandbox = False, **kwargs):
     """Wraps verilog_fpv_test_suite with Bedrock-internal settings. Not intended to be called by Bedrock users.
 
     * Defines `BR_ASSERT_ON`, `BR_ENABLE_IMPL_CHECKS`, `BR_DISABLE_FINAL_CHECKS` and `BR_ENABLE_FPV`.
 
     Args:
         name (str): The base name of the test suite.
+        sadnbox (bool): Whether to create a sandbox for fpv test
         **kwargs: Additional keyword arguments passed to verilog_fpv_test_suite. Do not pass defines.
     """
 
@@ -100,5 +101,6 @@ def br_verilog_fpv_test_suite(name, **kwargs):
     verilog_fpv_test_suite(
         name = name,
         defines = ["BR_ASSERT_ON", "BR_ENABLE_IMPL_CHECKS", "BR_DISABLE_FINAL_CHECKS", "BR_ENABLE_FPV"],
+        sandbox = sandbox,
         **kwargs
     )

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -603,7 +603,7 @@ def verilog_elab_and_lint_test_suite(name, defines = [], params = {}, **kwargs):
             **kwargs
         )
 
-def verilog_fpv_test_suite(name, defines = [], params = {}, **kwargs):
+def verilog_fpv_test_suite(name, defines = [], params = {}, sandbox = True, **kwargs):
     """Creates a suite of Verilog fpv tests for each combination of the provided parameters.
 
     The function generates all possible combinations of the provided parameters and creates a verilog_fpv_test
@@ -614,6 +614,7 @@ def verilog_fpv_test_suite(name, defines = [], params = {}, **kwargs):
         name (str): The base name for the test suite.
         defines (list): A list of defines.
         params (dict): A dictionary where keys are parameter names and values are lists of possible values for those parameters.
+        sandbox (bool): Whether to create a sandbox for the test.
         **kwargs: Additional keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.
     """
     param_keys = sorted(params.keys())
@@ -629,6 +630,14 @@ def verilog_fpv_test_suite(name, defines = [], params = {}, **kwargs):
             params = params,
             **kwargs
         )
+        if sandbox:
+            rule_verilog_sandbox(
+                name = _make_test_name(name, "fpv_sandbox", param_keys, param_combination),
+                kind = "fpv",
+                defines = defines,
+                params = params,
+                **kwargs
+            )
 
 def verilog_sim_test_suite(name, defines = [], params = {}, **kwargs):
     """Creates a suite of Verilog sim tests for each combination of the provided parameters.

--- a/delay/fpv/br_delay/BUILD.bazel
+++ b/delay/fpv/br_delay/BUILD.bazel
@@ -40,6 +40,7 @@ br_verilog_fpv_test_suite(
             "2",
         ],
     },
+    sandbox = True,
     tool = "jg",
     top = "br_delay",
     deps = [":br_delay_monitor"],


### PR DESCRIPTION
Default create sandbox targets for fpv test_suite. This is needed to enable running FPV regression with the eda_runner