### PR TITLE
Correct calculation of atbytes based on AMBA spec for atb funnel

### DIFF
--- a/amba/rtl/br_amba_atb_funnel.sv
+++ b/amba/rtl/br_amba_atb_funnel.sv
@@ -23,7 +23,8 @@ module br_amba_atb_funnel #(
     parameter int NumSources = 2,  // Must be at least 2
     parameter int DataWidth = 32,  // Must be at least 1
     parameter int UserWidth = 1,  // Must be at least 1
-    localparam int ByteCountWidth = $clog2(DataWidth) - 4  // Per ATB spec
+    // Per AMBA ATB spec 3.2.1, atbytes is defined this way
+    localparam int ByteCountWidth = $clog2(DataWidth) - 4
 ) (
     input logic clk,
     input logic rst,

--- a/amba/rtl/br_amba_atb_funnel.sv
+++ b/amba/rtl/br_amba_atb_funnel.sv
@@ -23,7 +23,7 @@ module br_amba_atb_funnel #(
     parameter int NumSources = 2,  // Must be at least 2
     parameter int DataWidth = 32,  // Must be at least 1
     parameter int UserWidth = 1,  // Must be at least 1
-    localparam int ByteCountWidth = $clog2(DataWidth / 8)
+    localparam int ByteCountWidth = $clog2(DataWidth) - 4  // Per ATB spec
 ) (
     input logic clk,
     input logic rst,

--- a/amba/rtl/br_amba_axil2apb.sv
+++ b/amba/rtl/br_amba_axil2apb.sv
@@ -143,7 +143,7 @@ module br_amba_axil2apb #(
         end
       end
       default: begin
-        apb_state_next = 'x;
+        apb_state_next = Idle;
       end
     endcase
   end

--- a/amba/rtl/br_amba_axil2apb.sv
+++ b/amba/rtl/br_amba_axil2apb.sv
@@ -143,7 +143,7 @@ module br_amba_axil2apb #(
         end
       end
       default: begin
-        apb_state_next = Idle;
+        apb_state_next = apb_state_t'(4'hx);  // ri lint_check_waive FSM_DEFAULT_REQ MISSING_STATE
       end
     endcase
   end


### PR DESCRIPTION
Per AMBA ATB spec, update calculation of atbytes

The following equation defines the relationship between the widths of ATBYTES and ATDATA, defined by the
values of m and n in ATBYTES[m:0] and ATDATA[n:0]:
m = log2(n+1) - 4

Also fix a lint/elab issue in br_amba_axil2apb