### PR TITLE
Extra newline in generated filelist to make iverilog happy.

### DIFF
--- a/python/verilog_runner/util.py
+++ b/python/verilog_runner/util.py
@@ -159,7 +159,7 @@ def generate_random_seed() -> int:
 
 def to_filelist(srcs: List[str]) -> str:
     """Returns a filelist string representation of a list of sources."""
-    return "\n".join(srcs)
+    return "\n".join(srcs) + "\n"
 
 
 def write_and_dump_file(content: str, filename: str, logger: logging.Logger) -> None:


### PR DESCRIPTION
**Stack**:
- [verilog_runner] add way to pass in custom env setup bash commands before invoking an EDA tool #359
- [verilog_runner] add iverilog plugin #358
- Refactored verilog_runner logging utils #357
- Extra newline in generated filelist to make iverilog happy. #356 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*