### PR TITLE
[verilog_runner] add way to pass in custom env setup bash commands before invoking an EDA tool

### DIFF
--- a/python/verilog_runner/cli.py
+++ b/python/verilog_runner/cli.py
@@ -115,6 +115,11 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
         "The tcl body (custom or not) is unconditionally followed by the tcl footer.",
     )
     parser.add_argument(
+        "--env_setup_commands",
+        type=sh_file,
+        help="A Bash script of custom environment setup commands that will be executed before invoking the tool.",
+    )
+    parser.add_argument(
         "--script",
         type=sh_file,
         help="Shell script file to write commands to.",
@@ -166,6 +171,7 @@ def common_args(args: argparse.Namespace):
         "filelist": args.filelist,
         "tclfile_custom_header": args.custom_tcl_header,
         "tclfile_custom_body": args.custom_tcl_body,
+        "env_setup_commands": args.env_setup_commands,
     }
 
 

--- a/python/verilog_runner/eda_tool.py
+++ b/python/verilog_runner/eda_tool.py
@@ -38,6 +38,7 @@ class EdaTool(ABC):
     filelist: str = field(default_factory=str)
     tclfile_custom_header: Optional[str] = field(default_factory=Optional[str])
     tclfile_custom_body: Optional[str] = field(default_factory=Optional[str])
+    env_setup_commands: Optional[str] = field(default_factory=Optional[str])
 
     @abstractmethod
     def tcl_preamble(self) -> str:
@@ -107,6 +108,12 @@ class EdaTool(ABC):
                 self.tcl_footer(),
             ]
         )
+
+    def read_env_setup_commands(self) -> List[str]:
+        if self.env_setup_commands:
+            with open(self.env_setup_commands, "r") as file:
+                return file.readlines()
+        return []
 
     @abstractmethod
     def cmd(self) -> str:

--- a/python/verilog_runner/logging_utils.py
+++ b/python/verilog_runner/logging_utils.py
@@ -1,0 +1,109 @@
+# Copyright 2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Logging utilities for Verilog Runner."""
+import logging
+import sys
+
+MAIN_FILE_ABBREV = "vr"
+MAIN_FILE = "verilog_runner.py"
+PASS_ART = f"""
+######   #######   ######  ######
+##  ##   ##   ##   ##      ##
+######   #######   ######  #####
+##       ##   ##       ##      ##
+##       ##   ##   ######  ######"""
+FAIL_ART = f"""
+######   #######  ######   ##
+##       ##   ##    ##     ##
+######   #######    ##     ##
+##       ##   ##    ##     ##
+##       ##   ##  ######   #######"""
+SEPARATOR = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+
+class MaxLevelFilter(logging.Filter):
+    def __init__(self, max_level):
+        super().__init__()
+        self.max_level = max_level
+
+    def filter(self, record):
+        # Allow only records with a level number below max_level
+        return record.levelno < self.max_level
+
+
+def get_class_logger(subcommand: str, tool: str) -> logging.LoggerAdapter:
+    logger = logging.getLogger(subcommand)
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+
+    # Formatters
+    general_formatter = logging.Formatter(
+        f"[{MAIN_FILE_ABBREV}][%(name)s][%(tool)s][%(filename)s:%(lineno)-4d] %(message)s"
+    )
+    warning_error_formatter = logging.Formatter(
+        f"[{MAIN_FILE_ABBREV}][%(name)s][%(tool)s][%(filename)s:%(lineno)-4d] !! %(levelname)s !! %(message)s"
+    )
+
+    # Handler for INFO and below to stdout
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.INFO)
+    stdout_handler.addFilter(
+        MaxLevelFilter(logging.WARNING)
+    )  # Exclude WARNING and above
+    stdout_handler.setFormatter(general_formatter)
+
+    # Handler for WARNING and above to stderr
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.WARNING)
+    stderr_handler.setFormatter(warning_error_formatter)
+
+    logger.addHandler(stdout_handler)
+    logger.addHandler(stderr_handler)
+
+    adapter = logging.LoggerAdapter(logger, {"tool": tool})
+    return adapter
+
+
+def init_root_logger():
+    # Configure the root logger
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    # Formatter for regular messages
+    general_formatter = logging.Formatter(
+        f"[{MAIN_FILE_ABBREV}][%(filename)s:%(lineno)-4d] %(message)s"
+    )
+
+    # Formatter for warnings/errors
+    warning_error_formatter = logging.Formatter(
+        f"[{MAIN_FILE_ABBREV}][%(filename)s:%(lineno)-4d] !! %(levelname)s !! %(message)s"
+    )
+
+    # Handler for info-level messages to stdout
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.INFO)
+    stdout_handler.addFilter(
+        MaxLevelFilter(logging.WARNING)
+    )  # Exclude WARNING and above
+    stdout_handler.setFormatter(general_formatter)
+
+    # Handler for warnings and errors to stderr
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.WARNING)  # handles WARNING and above
+    stderr_handler.setFormatter(warning_error_formatter)
+
+    # Add both handlers to the root logger
+    root_logger.addHandler(stdout_handler)
+    root_logger.addHandler(stderr_handler)

--- a/python/verilog_runner/plugins.py
+++ b/python/verilog_runner/plugins.py
@@ -30,7 +30,7 @@ from typing import Dict, List, Tuple, Type
 #
 # Major version changes are definitely breaking.
 # Minor version changes are intended to be non-breaking but we don't guarantee it.
-PLUGIN_API_VERSION = "1.0"
+PLUGIN_API_VERSION = "1.1"
 
 
 def check_plugin_api_version(module: object) -> bool:
@@ -92,7 +92,7 @@ def import_plugin_modules(plugin_files: List[str]) -> List[object]:
             else:
                 logging.warning(f"Skipping import of plugin module {module_name}.")
         except Exception as e:
-            logging.error(f"Failed to load plugin module {module_name}: {e}")
+            logging.warning(f"Failed to load plugin module {module_name}: {e}")
         finally:
             sys.path.pop(0)  # Remove directory from sys.path
     return modules

--- a/python/verilog_runner/plugins/iverilog.py
+++ b/python/verilog_runner/plugins/iverilog.py
@@ -1,0 +1,107 @@
+"""iverilog plugin for Verilog Runner."""
+
+import argparse
+from dataclasses import dataclass, field
+import textwrap
+from typing import Dict, Type
+
+from cli import Sim, Subcommand, common_args
+from eda_tool import EdaTool
+from util import (
+    check_simulation_success,
+    gen_file_header,
+    include_dirs,
+    run_shell_script,
+    dump_file,
+    write_and_dump_file,
+    print_summary,
+)
+from logging_utils import get_class_logger
+
+PLUGIN_API_VERSION = "1.1"
+
+
+@dataclass
+class Iverilog(EdaTool):
+    subcommand: Type[Subcommand] = Sim
+    tool_name: str = "iverilog"
+    help: str = "Simulate a Verilog/SystemVerilog design using iverilog"
+
+    def __post_init__(self):
+        self.logger = get_class_logger("sim", "iverilog")
+
+    @classmethod
+    def add_args(cls, parser: argparse.ArgumentParser) -> None:
+        pass
+
+    @classmethod
+    def from_args(cls, args):
+        sim_args = {}
+        return cls(**common_args(args), **sim_args)
+
+    def tcl_preamble(self) -> str:
+        return gen_file_header(self.tclfile, "iverilog")
+
+    def default_tcl_header(self) -> str:
+        return ""
+
+    def tcl_analysis_elaborate(self) -> str:
+        return ""
+
+    def default_tcl_body(self) -> str:
+        tcl_body = ""
+        return tcl_body
+
+    def tcl_footer(self) -> str:
+        return ""
+
+    def cmd(self) -> str:
+        """Returns a default shell script to run iverilog."""
+        self.logger.info("Generating shell script.")
+        cmd = ["#!/bin/bash"]
+        cmd += [gen_file_header(self.scriptfile, "iverilog")]
+        cmd += ["set -e"]
+        cmd += self.read_env_setup_commands()
+        cmd += ["echo ' '"]
+        cmd += [
+            "echo '--------------------------- iverilog ---------------------------'"
+        ]
+        iverilog_cmd = [
+            "iverilog",
+            "-o compiled.vvp",
+            "-g2012",
+            f"-f{self.filelist}",
+            f"-s {self.top}",
+        ]
+        iverilog_cmd += [f"-I {dir}" for dir in include_dirs(self.hdrs)]
+        iverilog_cmd += [f"-D{define}" for define in self.defines]
+        iverilog_cmd += [
+            f"-P{self.top}.{key}={value}" for key, value in self.params.items()
+        ]
+        iverilog_cmd += self.opts
+        iverilog_cmd = " ".join(iverilog_cmd)
+        vvp_cmd = "vvp compiled.vvp"
+        cmd += [" && ".join([iverilog_cmd, vvp_cmd])]
+        cmd += [""]
+        return "\n".join(cmd)
+
+    def run_cmd(self) -> Dict[str, bool]:
+        """Runs a shell script and returns a dict of success criteria."""
+        self.logger.info("Running shell script.")
+        self.prepare_files()
+        returncode, shell_output = run_shell_script(self.scriptfile, self.logger)
+        write_and_dump_file(shell_output, self.logfile, logger=self.logger)
+        return check_simulation_success(returncode, False, shell_output)
+
+    def run_test(self) -> bool:
+        """Runs the test and returns True if successful."""
+        self.logger.info("Running test.")
+        step_success = self.run_cmd()
+        success = all(step_success.values())
+        print_summary(
+            success=success,
+            step_success=step_success,
+            report_table="",
+            logger=self.logger,
+        )
+        return success

--- a/python/verilog_runner/util.py
+++ b/python/verilog_runner/util.py
@@ -159,7 +159,7 @@ def generate_random_seed() -> int:
 
 def to_filelist(srcs: List[str]) -> str:
     """Returns a filelist string representation of a list of sources."""
-    return "\n".join(srcs)
+    return "\n".join(srcs) + "\n"
 
 
 def write_and_dump_file(content: str, filename: str, logger: logging.Logger) -> None:

--- a/python/verilog_runner/util.py
+++ b/python/verilog_runner/util.py
@@ -23,43 +23,7 @@ import subprocess
 import sys
 import textwrap
 from typing import Dict, Tuple, List
-
-MAIN_FILE = "verilog_runner.py"
-MAIN_FILE_ABBREV = "vr"
-PASS_ART = f"""
-######   #######   ######  ######
-##  ##   ##   ##   ##      ##
-######   #######   ######  #####
-##       ##   ##       ##      ##
-##       ##   ##   ######  ######"""
-FAIL_ART = f"""
-######   #######  ######   ##
-##       ##   ##    ##     ##
-######   #######    ##     ##
-##       ##   ##    ##     ##
-##       ##   ##  ######   #######"""
-SEPARATOR = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-
-
-def get_class_logger(subcommand: str, tool: str) -> logging.LoggerAdapter:
-    """Returns a LoggerAdapter with a subcommand and tool name."""
-    # Create a logger with subcommand
-    logger = logging.getLogger(subcommand)
-    logger.propagate = False  # Prevent propagation to the root logger
-    logger.setLevel(logging.INFO)
-    # Create a handler that outputs to stdout
-    handler = logging.StreamHandler(sys.stdout)
-    # Define the formatter including both names
-    formatter = logging.Formatter(
-        "["
-        + MAIN_FILE_ABBREV
-        + "][%(name)s][%(tool)s][%(filename)s:%(lineno)-4d] %(message)s"
-    )
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    # Create a LoggerAdapter with extra context
-    adapter = logging.LoggerAdapter(logger, {"tool": tool})
-    return adapter
+from logging_utils import MAIN_FILE_ABBREV, MAIN_FILE, SEPARATOR, PASS_ART, FAIL_ART
 
 
 def wrap_text(text, width=60):

--- a/python/verilog_runner/verilog_runner.py
+++ b/python/verilog_runner/verilog_runner.py
@@ -21,23 +21,13 @@ import sys
 
 from cli import Elab, Lint, Sim, Fpv, add_common_args, parse_params
 from plugins import discover_plugins
-from util import MAIN_FILE_ABBREV, print_greeting
-
-# Configure the root logger
-root_logger = logging.getLogger()
-root_logger.setLevel(logging.INFO)
-
-# Create handler for the root logger
-root_handler = logging.StreamHandler(sys.stdout)
-root_formatter = logging.Formatter(
-    "[" + MAIN_FILE_ABBREV + "][%(filename)s:%(lineno)-4d] %(message)s"
-)
-root_handler.setFormatter(root_formatter)
-root_logger.addHandler(root_handler)
+from util import print_greeting
+from logging_utils import init_root_logger
 
 
 def main():
     print_greeting()
+    init_root_logger()
     logging.info("Working directory: " + os.getcwd())
     logging.info("Python binary: " + sys.executable)
     logging.info("Python version: " + sys.version)


### PR DESCRIPTION
**Stack**:
- [verilog_runner] add way to pass in custom env setup bash commands before invoking an EDA tool #359 ⬅
- [verilog_runner] add iverilog plugin #358
- Refactored verilog_runner logging utils #357
- Extra newline in generated filelist to make iverilog happy. #356


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*