### PR TITLE
Test //counter/sim with iverilog

### DIFF
--- a/arb/sim/chipstack/BUILD.bazel
+++ b/arb/sim/chipstack/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -32,9 +32,10 @@ verilog_elab_test(
     deps = [":br_arb_fixed_gen_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_arb_fixed_gen_tb_vcs_test_suite",
-    tool = "vcs",
+br_verilog_sim_test_tools_suite(
+    name = "br_arb_fixed_gen_tb_sim_test_tools_suite",
+    # TODO: Does not work with iverilog.
+    tools = ["vcs"],
     deps = [":br_arb_fixed_gen_tb"],
 )
 
@@ -52,9 +53,10 @@ verilog_elab_test(
     deps = [":br_arb_lru_gen_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_arb_lru_gen_tb_vcs_test_suite",
-    tool = "vcs",
+br_verilog_sim_test_tools_suite(
+    name = "br_arb_lru_gen_tb_sim_test_tools_suite",
+    # TODO: Does not work with iverilog.
+    tools = ["vcs"],
     deps = [":br_arb_lru_gen_tb"],
 )
 
@@ -72,8 +74,9 @@ verilog_elab_test(
     deps = [":br_arb_rr_gen_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_arb_rr_gen_tb_vcs_test_suite",
-    tool = "vcs",
+br_verilog_sim_test_tools_suite(
+    name = "br_arb_rr_gen_tb_sim_test_tools_suite",
+    # TODO: Does not work with iverilog.
+    tools = ["vcs"],
     deps = [":br_arb_rr_gen_tb"],
 )

--- a/counter/sim/BUILD.bazel
+++ b/counter/sim/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -29,8 +29,8 @@ verilog_elab_test(
     deps = [":br_counter_incr_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_counter_incr_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_counter_incr_sim_test_tools_suite",
     params = {
         "MaxValue": [
             "8",
@@ -49,7 +49,10 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_counter_incr_tb"],
 )
 
@@ -67,8 +70,8 @@ verilog_elab_test(
     deps = [":br_counter_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_counter_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_counter_sim_test_tools_suite",
     params = {
         "MaxValue": [
             "8",
@@ -87,7 +90,10 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_counter_tb"],
 )
 
@@ -105,8 +111,8 @@ verilog_elab_test(
     deps = [":br_counter_decr_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_counter_decr_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_counter_decr_sim_test_tools_suite",
     params = {
         "MaxValue": [
             "8",
@@ -125,6 +131,9 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_counter_decr_tb"],
 )

--- a/enc/sim/BUILD.bazel
+++ b/enc/sim/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:private"])
@@ -32,6 +32,7 @@ verilog_library(
         "//enc/rtl:br_enc_gray2bin",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
+        "//pkg:br_math_pkg",
     ],
 )
 
@@ -49,14 +50,17 @@ verilog_elab_test(
     deps = [":br_enc_bin2onehot_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_enc_bin2onehot_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_enc_bin2onehot_sim_test_tools_suite",
     params = {"NumValues": [
         "2",
         "4",
         "5",
     ]},
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_enc_bin2onehot_tb"],
 )
 
@@ -65,14 +69,17 @@ verilog_elab_test(
     deps = [":br_enc_gray_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_enc_gray_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_enc_gray_sim_test_tools_suite",
     params = {"Width": [
         "2",
         "3",
         "5",
     ]},
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_enc_gray_tb"],
 )
 
@@ -81,8 +88,8 @@ verilog_elab_test(
     deps = [":br_enc_priority_encoder_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_enc_priority_encoder_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_enc_priority_encoder_sim_test_tools_suite",
     params = {
         "NumRequesters": ["7"],
         "NumResults": [
@@ -90,6 +97,7 @@ br_verilog_sim_test_suite(
             "3",
         ],
     },
-    tool = "vcs",
+    # TODO: Does not work with iverilog.
+    tools = ["vcs"],
     deps = [":br_enc_priority_encoder_tb"],
 )

--- a/enc/sim/br_enc_gray_tb.sv
+++ b/enc/sim/br_enc_gray_tb.sv
@@ -53,6 +53,7 @@ module br_enc_gray_tb;
   end
 
   integer errors = 0;
+  logic   result;
 
   // Test sequence
   initial begin
@@ -69,8 +70,9 @@ module br_enc_gray_tb;
         errors = errors + 1;
       end
 
-      if ($countones(counter_bin2gray ^ counter_bin2gray_prev) > 1) begin
-        $error("Time: %0t | Counter: %0h | Gray Output: %0h | Previous Gray Output: %0h", $time,
+      result = counter_bin2gray ^ counter_bin2gray_prev;
+      if (result != 0 && !br_math::is_power_of_2(result)) begin
+        $error("Time: %0t | Counter: %0h | Gray Output: %2b | Previous Gray Output: %2b", $time,
                counter, counter_bin2gray, counter_bin2gray_prev);
         errors = errors + 1;
       end


### PR DESCRIPTION
**Stack**:
- Test //cdc/sim with iverilog #373
- Adjust coding style in br_delay.sv to support iverilog #372
- Test //fifo/sim with iverilog #371
- Add iverilog TODO in tracker/sim/BUILD.bazel #370
- Test //mux/sim with iverilog #369
- Test //ram/sim with iverilog #368
- Tweak delay lib coding style to keep iverilog happy #367
- Test //ecc/sim with iverilog #366
- Test //credit/sim with iverilog #365
- Test //counter/sim with iverilog #364 ⬅
- TODOs to test //arb/sim/chipstack/ using iverilog #363
- Add iverilog test targets for enc/sim #362
- Adjust enc/sim/br_enc_gray_tb.sv to be compatible with iverilog #361
- br_verilog_sim_test_tools_suite macro #360


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*