### PR TITLE
Test //mux/sim with iverilog

### DIFF
--- a/arb/sim/chipstack/BUILD.bazel
+++ b/arb/sim/chipstack/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -32,9 +32,10 @@ verilog_elab_test(
     deps = [":br_arb_fixed_gen_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_arb_fixed_gen_tb_vcs_test_suite",
-    tool = "vcs",
+br_verilog_sim_test_tools_suite(
+    name = "br_arb_fixed_gen_tb_sim_test_tools_suite",
+    # TODO: Does not work with iverilog.
+    tools = ["vcs"],
     deps = [":br_arb_fixed_gen_tb"],
 )
 
@@ -52,9 +53,10 @@ verilog_elab_test(
     deps = [":br_arb_lru_gen_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_arb_lru_gen_tb_vcs_test_suite",
-    tool = "vcs",
+br_verilog_sim_test_tools_suite(
+    name = "br_arb_lru_gen_tb_sim_test_tools_suite",
+    # TODO: Does not work with iverilog.
+    tools = ["vcs"],
     deps = [":br_arb_lru_gen_tb"],
 )
 
@@ -72,8 +74,9 @@ verilog_elab_test(
     deps = [":br_arb_rr_gen_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_arb_rr_gen_tb_vcs_test_suite",
-    tool = "vcs",
+br_verilog_sim_test_tools_suite(
+    name = "br_arb_rr_gen_tb_sim_test_tools_suite",
+    # TODO: Does not work with iverilog.
+    tools = ["vcs"],
     deps = [":br_arb_rr_gen_tb"],
 )

--- a/counter/sim/BUILD.bazel
+++ b/counter/sim/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -29,8 +29,8 @@ verilog_elab_test(
     deps = [":br_counter_incr_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_counter_incr_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_counter_incr_sim_test_tools_suite",
     params = {
         "MaxValue": [
             "8",
@@ -49,7 +49,10 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_counter_incr_tb"],
 )
 
@@ -67,8 +70,8 @@ verilog_elab_test(
     deps = [":br_counter_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_counter_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_counter_sim_test_tools_suite",
     params = {
         "MaxValue": [
             "8",
@@ -87,7 +90,10 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_counter_tb"],
 )
 
@@ -105,8 +111,8 @@ verilog_elab_test(
     deps = [":br_counter_decr_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_counter_decr_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_counter_decr_sim_test_tools_suite",
     params = {
         "MaxValue": [
             "8",
@@ -125,6 +131,9 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_counter_decr_tb"],
 )

--- a/credit/sim/BUILD.bazel
+++ b/credit/sim/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -32,8 +32,8 @@ verilog_elab_test(
     deps = [":br_credit_receiver_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_credit_receiver_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_credit_receiver_sim_test_tools_suite",
     params = {
         "Width": ["8"],
         "MaxCredit": [
@@ -49,6 +49,9 @@ br_verilog_sim_test_suite(
             "2",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_credit_receiver_tb"],
 )

--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -54,6 +54,7 @@ module br_delay #(
   assign stages[0] = in;
 
   for (genvar i = 1; i <= NumStages; i++) begin : gen_stages
+    // ri lint_check_waive BA_NBA_REG
     `BR_REG(stages[i], stages[i-1])
   end
 

--- a/delay/rtl/br_delay_nr.sv
+++ b/delay/rtl/br_delay_nr.sv
@@ -48,9 +48,13 @@ module br_delay_nr #(
   //------------------------------------------
   logic [NumStages:0][Width-1:0] stages;
 
-  assign stages[0] = in;
+  // always_comb instead of assign here to keep iverilog happy
+  always_comb begin
+    stages[0] = in;
+  end
 
   for (genvar i = 1; i <= NumStages; i++) begin : gen_stages
+    // ri lint_check_waive BA_NBA_REG
     `BR_REGN(stages[i], stages[i-1])
   end
 

--- a/delay/rtl/br_delay_valid.sv
+++ b/delay/rtl/br_delay_valid.sv
@@ -67,11 +67,16 @@ module br_delay_valid #(
   logic [NumStages:0] stage_valid;
   logic [NumStages:0][Width-1:0] stage;
 
-  assign stage_valid[0] = in_valid;
-  assign stage[0] = in;
+  // always_comb instead of assign here to keep iverilog happy
+  always_comb begin
+    stage_valid[0] = in_valid;
+    stage[0] = in;
+  end
 
   for (genvar i = 1; i <= NumStages; i++) begin : gen_stages
+    // ri lint_check_waive BA_NBA_REG
     `BR_REG(stage_valid[i], stage_valid[i-1])
+    // ri lint_check_waive BA_NBA_REG
     `BR_REGLN(stage[i], stage[i-1], stage_valid[i-1])
   end
 

--- a/delay/rtl/br_delay_valid_next.sv
+++ b/delay/rtl/br_delay_valid_next.sv
@@ -71,13 +71,18 @@ module br_delay_valid_next #(
   logic [NumStages:0] stage_valid_next;
   logic [NumStages:0][Width-1:0] stage;
 
-  assign stage_valid_next[0] = in_valid_next;
-  assign stage[0] = in;
+  // always_comb instead of assign here to keep iverilog happy
+  always_comb begin
+    stage_valid_next[0] = in_valid_next;
+    stage[0] = in;
+  end
 
   for (genvar i = 1; i <= NumStages; i++) begin : gen_stages
+    // ri lint_check_waive BA_NBA_REG
     `BR_REG(stage_valid_next[i], stage_valid_next[i-1])
     // stage_valid_next[i] is equivalent to hypothetical stage_valid[i-1],
     // which would be aligned to stage[i-1].
+    // ri lint_check_waive BA_NBA_REG
     `BR_REGLN(stage[i], stage[i-1], stage_valid_next[i])
   end
 

--- a/delay/rtl/br_delay_valid_next_nr.sv
+++ b/delay/rtl/br_delay_valid_next_nr.sv
@@ -69,13 +69,18 @@ module br_delay_valid_next_nr #(
   logic [NumStages:0]            stage_valid_next;
   logic [NumStages:0][Width-1:0] stage;
 
-  assign stage_valid_next[0] = in_valid_next;
-  assign stage[0] = in;
+  // always_comb instead of assign here to keep iverilog happy
+  always_comb begin
+    stage_valid_next[0] = in_valid_next;
+    stage[0] = in;
+  end
 
   for (genvar i = 1; i <= NumStages; i++) begin : gen_stages
+    // ri lint_check_waive BA_NBA_REG
     `BR_REGN(stage_valid_next[i], stage_valid_next[i-1])
     // stage_valid_next[i] is equivalent to hypothetical stage_valid[i-1],
     // which would be aligned to stage[i-1].
+    // ri lint_check_waive BA_NBA_REG
     `BR_REGLN(stage[i], stage[i-1], stage_valid_next[i])
   end
 

--- a/ecc/sim/BUILD.bazel
+++ b/ecc/sim/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:private"])
@@ -35,9 +35,12 @@ verilog_elab_test(
     deps = [":br_ecc_sed_encoder_decoder_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_ecc_sed_encoder_decoder_vcs_test_suite",
-    tool = "vcs",
+br_verilog_sim_test_tools_suite(
+    name = "br_ecc_sed_encoder_decoder_sim_test_tools_suite",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_ecc_sed_encoder_decoder_tb"],
 )
 
@@ -58,8 +61,11 @@ verilog_elab_test(
     deps = [":br_ecc_secded_encoder_decoder_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_ecc_secded_encoder_decoder_vcs_test_suite",
-    tool = "vcs",
+br_verilog_sim_test_tools_suite(
+    name = "br_ecc_secded_encoder_decoder_sim_test_tools_suite",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_ecc_secded_encoder_decoder_tb"],
 )

--- a/enc/sim/BUILD.bazel
+++ b/enc/sim/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:private"])
@@ -32,6 +32,7 @@ verilog_library(
         "//enc/rtl:br_enc_gray2bin",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
+        "//pkg:br_math_pkg",
     ],
 )
 
@@ -49,14 +50,17 @@ verilog_elab_test(
     deps = [":br_enc_bin2onehot_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_enc_bin2onehot_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_enc_bin2onehot_sim_test_tools_suite",
     params = {"NumValues": [
         "2",
         "4",
         "5",
     ]},
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_enc_bin2onehot_tb"],
 )
 
@@ -65,14 +69,17 @@ verilog_elab_test(
     deps = [":br_enc_gray_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_enc_gray_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_enc_gray_sim_test_tools_suite",
     params = {"Width": [
         "2",
         "3",
         "5",
     ]},
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_enc_gray_tb"],
 )
 
@@ -81,8 +88,8 @@ verilog_elab_test(
     deps = [":br_enc_priority_encoder_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_enc_priority_encoder_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_enc_priority_encoder_sim_test_tools_suite",
     params = {
         "NumRequesters": ["7"],
         "NumResults": [
@@ -90,6 +97,7 @@ br_verilog_sim_test_suite(
             "3",
         ],
     },
-    tool = "vcs",
+    # TODO: Does not work with iverilog.
+    tools = ["vcs"],
     deps = [":br_enc_priority_encoder_tb"],
 )

--- a/enc/sim/br_enc_gray_tb.sv
+++ b/enc/sim/br_enc_gray_tb.sv
@@ -53,6 +53,7 @@ module br_enc_gray_tb;
   end
 
   integer errors = 0;
+  logic   result;
 
   // Test sequence
   initial begin
@@ -69,8 +70,9 @@ module br_enc_gray_tb;
         errors = errors + 1;
       end
 
-      if ($countones(counter_bin2gray ^ counter_bin2gray_prev) > 1) begin
-        $error("Time: %0t | Counter: %0h | Gray Output: %0h | Previous Gray Output: %0h", $time,
+      result = counter_bin2gray ^ counter_bin2gray_prev;
+      if (result != 0 && !br_math::is_power_of_2(result)) begin
+        $error("Time: %0t | Counter: %0h | Gray Output: %2b | Previous Gray Output: %2b", $time,
                counter, counter_bin2gray, counter_bin2gray_prev);
         errors = errors + 1;
       end

--- a/mux/sim/BUILD.bazel
+++ b/mux/sim/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:private"])
@@ -32,8 +32,8 @@ verilog_elab_test(
     deps = [":br_mux_bin_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_mux_bin_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_mux_bin_sim_test_tools_suite",
     params = {
         "NumSymbolsIn": [
             "2",
@@ -54,6 +54,9 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_mux_bin_tb"],
 )

--- a/mux/sim/br_mux_bin_tb.sv
+++ b/mux/sim/br_mux_bin_tb.sv
@@ -1,8 +1,8 @@
 module br_mux_bin_tb;
 
-  localparam int NumSymbolsIn = 2;
-  localparam int SymbolWidth = 8;
-  localparam bit UseStructuredGates = 0;
+  parameter int NumSymbolsIn = 2;
+  parameter int SymbolWidth = 8;
+  parameter bit UseStructuredGates = 0;
 
   logic clk;
   logic rst;

--- a/ram/sim/BUILD.bazel
+++ b/ram/sim/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -38,8 +38,8 @@ verilog_elab_test(
     deps = [":br_ram_flops_1r1w_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_ram_flops_1r1w_vcs_test_suite_basic",
+br_verilog_sim_test_tools_suite(
+    name = "br_ram_flops_1r1w_sim_test_tools_suite_basic",
     params = {
         "TileEnableBypass": [
             "0",
@@ -54,12 +54,15 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_ram_flops_1r1w_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_ram_flops_1r1w_vcs_test_suite_evenshape",
+br_verilog_sim_test_tools_suite(
+    name = "br_ram_flops_1r1w_sim_test_tools_suite_evenshape",
     params = {
         "Depth": ["16"],
         "Width": ["8"],
@@ -76,7 +79,10 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     top = "br_ram_flops_1r1w_tb",
     deps = [
         ":br_ram_flops_1r1w_tb",
@@ -84,8 +90,8 @@ br_verilog_sim_test_suite(
     ],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_ram_flops_1r1w_vcs_test_suite_oddshape",
+br_verilog_sim_test_tools_suite(
+    name = "br_ram_flops_1r1w_sim_test_tools_suite_oddshape",
     params = {
         "Depth": ["15"],
         "Width": ["9"],
@@ -102,12 +108,15 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_ram_flops_1r1w_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_ram_flops_1r1w_vcs_test_suite_latency1a",
+br_verilog_sim_test_tools_suite(
+    name = "br_ram_flops_1r1w_sim_test_tools_suite_latency1a",
     params = {
         "Depth": ["16"],
         "Width": ["4"],
@@ -117,12 +126,15 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_ram_flops_1r1w_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_ram_flops_1r1w_vcs_test_suite_latency1b",
+br_verilog_sim_test_tools_suite(
+    name = "br_ram_flops_1r1w_sim_test_tools_suite_latency1b",
     params = {
         "Depth": ["16"],
         "Width": ["4"],
@@ -132,12 +144,15 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_ram_flops_1r1w_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_ram_flops_1r1w_vcs_test_suite_latency1c",
+br_verilog_sim_test_tools_suite(
+    name = "br_ram_flops_1r1w_sim_test_tools_suite_latency1c",
     params = {
         "Depth": ["16"],
         "Width": ["4"],
@@ -147,13 +162,16 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_ram_flops_1r1w_tb"],
 )
 
 # TODO(mgottscho): enable test suite when they all pass. TB doesn't work if total read latency > 1.
-#br_verilog_sim_test_suite(
-#    name = "br_ram_flops_1r1w_vcs_test_suite_latency",
+#br_verilog_sim_test_tools_suite(
+#    name = "br_ram_flops_1r1w_sim_test_tools_suite_latency",
 #    params = {
 #        "Depth": ["16"],
 #        "Width": ["4"],
@@ -165,6 +183,6 @@ br_verilog_sim_test_suite(
 #            "1",
 #        ],
 #    },
-#    tool = "vcs",
+#    tools = ["vcs", "iverilog"],
 #    deps = [":br_ram_flops_1r1w_tb"],
 #)


### PR DESCRIPTION
**Stack**:
- Test //cdc/sim with iverilog #373
- Adjust coding style in br_delay.sv to support iverilog #372
- Test //fifo/sim with iverilog #371
- Add iverilog TODO in tracker/sim/BUILD.bazel #370
- Test //mux/sim with iverilog #369 ⬅
- Test //ram/sim with iverilog #368
- Tweak delay lib coding style to keep iverilog happy #367
- Test //ecc/sim with iverilog #366
- Test //credit/sim with iverilog #365
- Test //counter/sim with iverilog #364
- TODOs to test //arb/sim/chipstack/ using iverilog #363
- Add iverilog test targets for enc/sim #362
- Adjust enc/sim/br_enc_gray_tb.sv to be compatible with iverilog #361
- br_verilog_sim_test_tools_suite macro #360


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*