### PR TITLE
Test //cdc/sim with iverilog

### DIFF
--- a/cdc/sim/BUILD.bazel
+++ b/cdc/sim/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
-load("//bazel:br_verilog.bzl", "br_verilog_sim_test_suite")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -34,8 +34,8 @@ verilog_elab_test(
     deps = [":br_cdc_fifo_flops_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_cdc_fifo_flops_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_cdc_fifo_flops_sim_test_tools_suite",
     params = {
         "Depth": [
             # Minimum depth needed for full bandwidth at the maximum cut-through and backpressure latencies
@@ -59,8 +59,10 @@ br_verilog_sim_test_suite(
             "3",
         ],
     },
-    tool = "vcs",
-    waves = True,
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_cdc_fifo_flops_tb"],
 )
 
@@ -81,8 +83,8 @@ verilog_elab_test(
     deps = [":br_cdc_fifo_flops_push_credit_tb"],
 )
 
-br_verilog_sim_test_suite(
-    name = "br_cdc_fifo_flops_push_credit_vcs_test_suite",
+br_verilog_sim_test_tools_suite(
+    name = "br_cdc_fifo_flops_push_credit_sim_test_tools_suite",
     params = {
         "RegisterPopOutputs": [
             "0",
@@ -105,7 +107,9 @@ br_verilog_sim_test_suite(
             "1",
         ],
     },
-    tool = "vcs",
-    waves = True,
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
     deps = [":br_cdc_fifo_flops_push_credit_tb"],
 )


### PR DESCRIPTION
**Stack**:
- Test //cdc/sim with iverilog #373 ⬅
- Adjust coding style in br_delay.sv to support iverilog #372
- Test //fifo/sim with iverilog #371
- Add iverilog TODO in tracker/sim/BUILD.bazel #370
- Test //mux/sim with iverilog #369
- Test //ram/sim with iverilog #368
- Tweak delay lib coding style to keep iverilog happy #367
- Test //ecc/sim with iverilog #366
- Test //credit/sim with iverilog #365
- Test //counter/sim with iverilog #364
- TODOs to test //arb/sim/chipstack/ using iverilog #363
- Add iverilog test targets for enc/sim #362
- Adjust enc/sim/br_enc_gray_tb.sv to be compatible with iverilog #361
- br_verilog_sim_test_tools_suite macro #360


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*