### PR TITLE
Rename `br_gate_mock.sv` and drop it from all `verilog_library` dependencies

### DIFF
--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -21,7 +21,9 @@ verilog_library(
     name = "br_cdc_bit_toggle",
     srcs = ["br_cdc_bit_toggle.sv"],
     deps = [
-        "//gate/rtl:br_gate_behav",
+        # Omitting //gate/rtl:br_gate_behav so that downstream targets (which may exist in another repo)
+        # can decide whether to use these behavioral models or swap them out for some other vendor models.
+        # Downstream targets should decide whether to add the //gate/rtl:br_gate_behav dependency themselves.
         "//macros:br_asserts",
         "//macros:br_gates",
         "//macros:br_registers",
@@ -40,7 +42,11 @@ br_verilog_elab_and_lint_test_suite(
             "1",
         ],
     },
-    deps = [":br_cdc_bit_toggle"],
+    top = "br_cdc_bit_toggle",
+    deps = [
+        ":br_cdc_bit_toggle",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 verilog_library(
@@ -108,7 +114,10 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     top = "br_cdc_fifo_ctrl_1r1w",
-    deps = [":br_cdc_fifo_ctrl_1r1w"],
+    deps = [
+        ":br_cdc_fifo_ctrl_1r1w",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 verilog_library(
@@ -143,7 +152,10 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     top = "br_cdc_fifo_ctrl_1r1w_push_credit",
-    deps = [":br_cdc_fifo_ctrl_1r1w_push_credit"],
+    deps = [
+        ":br_cdc_fifo_ctrl_1r1w_push_credit",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 verilog_library(
@@ -178,7 +190,10 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     top = "br_cdc_fifo_flops",
-    deps = [":br_cdc_fifo_flops"],
+    deps = [
+        ":br_cdc_fifo_flops",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 verilog_library(
@@ -213,14 +228,19 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     top = "br_cdc_fifo_flops_push_credit",
-    deps = [":br_cdc_fifo_flops_push_credit"],
+    deps = [
+        ":br_cdc_fifo_flops_push_credit",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 verilog_library(
     name = "br_cdc_rst_sync",
     srcs = ["br_cdc_rst_sync.sv"],
     deps = [
-        "//gate/rtl:br_gate_behav",
+        # Omitting //gate/rtl:br_gate_behav so that downstream targets (which may exist in another repo)
+        # can decide whether to use these behavioral models or swap them out for some other vendor models.
+        # Downstream targets should decide whether to add the //gate/rtl:br_gate_behav dependency themselves.
         "//macros:br_asserts",
         "//macros:br_gates",
     ],
@@ -235,5 +255,8 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     top = "br_cdc_rst_sync",
-    deps = [":br_cdc_rst_sync"],
+    deps = [
+        ":br_cdc_rst_sync",
+        "//gate/rtl:br_gate_behav",
+    ],
 )

--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -21,9 +21,9 @@ verilog_library(
     name = "br_cdc_bit_toggle",
     srcs = ["br_cdc_bit_toggle.sv"],
     deps = [
-        # Omitting //gate/rtl:br_gate_behav so that downstream targets (which may exist in another repo)
+        # Omitting //gate/rtl:br_gate_mock so that downstream targets (which may exist in another repo)
         # can decide whether to use these behavioral models or swap them out for some other vendor models.
-        # Downstream targets should decide whether to add the //gate/rtl:br_gate_behav dependency themselves.
+        # Downstream targets should decide whether to add the //gate/rtl:br_gate_mock dependency themselves.
         "//macros:br_asserts",
         "//macros:br_gates",
         "//macros:br_registers",
@@ -45,7 +45,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_cdc_bit_toggle",
     deps = [
         ":br_cdc_bit_toggle",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -116,7 +116,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_cdc_fifo_ctrl_1r1w",
     deps = [
         ":br_cdc_fifo_ctrl_1r1w",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -154,7 +154,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_cdc_fifo_ctrl_1r1w_push_credit",
     deps = [
         ":br_cdc_fifo_ctrl_1r1w_push_credit",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -192,7 +192,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_cdc_fifo_flops",
     deps = [
         ":br_cdc_fifo_flops",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -230,7 +230,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_cdc_fifo_flops_push_credit",
     deps = [
         ":br_cdc_fifo_flops_push_credit",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -238,9 +238,9 @@ verilog_library(
     name = "br_cdc_rst_sync",
     srcs = ["br_cdc_rst_sync.sv"],
     deps = [
-        # Omitting //gate/rtl:br_gate_behav so that downstream targets (which may exist in another repo)
+        # Omitting //gate/rtl:br_gate_mock so that downstream targets (which may exist in another repo)
         # can decide whether to use these behavioral models or swap them out for some other vendor models.
-        # Downstream targets should decide whether to add the //gate/rtl:br_gate_behav dependency themselves.
+        # Downstream targets should decide whether to add the //gate/rtl:br_gate_mock dependency themselves.
         "//macros:br_asserts",
         "//macros:br_gates",
     ],
@@ -257,6 +257,6 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_cdc_rst_sync",
     deps = [
         ":br_cdc_rst_sync",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )

--- a/cdc/rtl/internal/BUILD.bazel
+++ b/cdc/rtl/internal/BUILD.bazel
@@ -166,5 +166,9 @@ br_verilog_elab_and_lint_test_suite(
             "3",
         ],
     },
-    deps = [":br_cdc_fifo_gray_count_sync"],
+    top = "br_cdc_fifo_gray_count_sync",
+    deps = [
+        ":br_cdc_fifo_gray_count_sync",
+        "//gate/rtl:br_gate_behav",
+    ],
 )

--- a/cdc/rtl/internal/BUILD.bazel
+++ b/cdc/rtl/internal/BUILD.bazel
@@ -168,7 +168,7 @@ br_verilog_elab_and_lint_test_suite(
     },
     top = "br_cdc_fifo_gray_count_sync",
     deps = [
-        ":br_cdc_fifo_gray_count_sync",
+        ":br_cdc_fifbr_gate_mocksync",
         "//gate/rtl:br_gate_behav",
     ],
 )

--- a/cdc/rtl/internal/BUILD.bazel
+++ b/cdc/rtl/internal/BUILD.bazel
@@ -168,7 +168,7 @@ br_verilog_elab_and_lint_test_suite(
     },
     top = "br_cdc_fifo_gray_count_sync",
     deps = [
-        ":br_cdc_fifbr_gate_mocksync",
-        "//gate/rtl:br_gate_behav",
+        ":br_cdc_fifo_gray_count_sync",
+        "//gate/rtl:br_gate_mock",
     ],
 )

--- a/cdc/sim/BUILD.bazel
+++ b/cdc/sim/BUILD.bazel
@@ -31,7 +31,11 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_flops_tb_elab_test",
-    deps = [":br_cdc_fifo_flops_tb"],
+    top = "br_cdc_fifo_flops_tb",
+    deps = [
+        ":br_cdc_fifo_flops_tb",
+        "//gate/rtl:br_gate_mock",
+    ],
 )
 
 br_verilog_sim_test_tools_suite(
@@ -63,7 +67,11 @@ br_verilog_sim_test_tools_suite(
         "iverilog",
         "vcs",
     ],
-    deps = [":br_cdc_fifo_flops_tb"],
+    top = "br_cdc_fifo_flops_tb",
+    deps = [
+        ":br_cdc_fifo_flops_tb",
+        "//gate/rtl:br_gate_mock",
+    ],
 )
 
 verilog_library(
@@ -80,7 +88,11 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_flops_push_credit_tb_elab_test",
-    deps = [":br_cdc_fifo_flops_push_credit_tb"],
+    top = "br_cdc_fifo_flops_push_credit_tb",
+    deps = [
+        ":br_cdc_fifo_flops_push_credit_tb",
+        "//gate/rtl:br_gate_mock",
+    ],
 )
 
 br_verilog_sim_test_tools_suite(
@@ -111,5 +123,9 @@ br_verilog_sim_test_tools_suite(
         "iverilog",
         "vcs",
     ],
-    deps = [":br_cdc_fifo_flops_push_credit_tb"],
+    top = "br_cdc_fifo_flops_push_credit_tb",
+    deps = [
+        ":br_cdc_fifo_flops_push_credit_tb",
+        "//gate/rtl:br_gate_mock",
+    ],
 )

--- a/gate/rtl/BUILD.bazel
+++ b/gate/rtl/BUILD.bazel
@@ -18,8 +18,8 @@ load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
 package(default_visibility = ["//visibility:public"])
 
 verilog_library(
-    name = "br_gate_behav",
-    srcs = ["br_gate_behav.sv"],
+    name = "br_gate_mock",
+    srcs = ["br_gate_mock.sv"],
     deps = [
         "//macros:br_asserts",
         "//macros:br_registers",
@@ -30,7 +30,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_buf_test_suite",
     top = "br_gate_buf",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -38,7 +38,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_clk_buf_test_suite",
     top = "br_gate_clk_buf",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -46,7 +46,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_inv_test_suite",
     top = "br_gate_inv",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -54,7 +54,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_and2_test_suite",
     top = "br_gate_and2",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -62,7 +62,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_or2_test_suite_basic",
     top = "br_gate_or2",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -70,7 +70,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_xor2_test_suite_basic",
     top = "br_gate_xor2",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -78,7 +78,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_mux2_test_suite",
     top = "br_gate_mux2",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -86,7 +86,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_clk_mux2_test_suite",
     top = "br_gate_clk_mux2",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -94,7 +94,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_icg_test_suite",
     top = "br_gate_icg",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -102,7 +102,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_icg_rst_test_suite",
     top = "br_gate_icg_rst",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -116,7 +116,7 @@ br_verilog_elab_and_lint_test_suite(
     },
     top = "br_gate_cdc_sync",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -130,7 +130,7 @@ br_verilog_elab_and_lint_test_suite(
     },
     top = "br_gate_cdc_sync_arst",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -138,7 +138,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_cdc_pseudostatic_test_suite",
     top = "br_gate_cdc_pseudostatic",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )
 
@@ -146,6 +146,6 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_gate_cdc_maxdel_test_suite",
     top = "br_gate_cdc_maxdel",
     deps = [
-        ":br_gate_behav",
+        ":br_gate_mock",
     ],
 )

--- a/gate/rtl/br_gate_mock.sv
+++ b/gate/rtl/br_gate_mock.sv
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Bedrock-RTL Gate Library Behavioral Models
+// Bedrock-RTL Gate Library Mock Behavioral Models
 //
-// This file contains behavioral models for the Bedrock-RTL gate library. This
+// This file contains mock behavioral models for the Bedrock-RTL gate library. This
 // file is expected to be branched for each vendor technology and behavioral
 // models should be replaced with vendor-specific standard cells. Only one
 // version of the gatelib should be included in the design filelist.
 
-// TODO: add a mechanism to make sure these modules are never synthesized
+`ifdef SYNTHESIS
+`BR_ASSERT_STATIC(do_not_synthesize_br_gate_mock_modules_a, 0)
+`endif
 
 // verilog_lint: waive-start module-filename
 // ri lint_check_off ONE_PER_FILE FILE_NAME

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -169,7 +169,7 @@ verilog_library(
     deps = [
         ":br_asserts",
         ":br_gates",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 

--- a/mux/rtl/BUILD.bazel
+++ b/mux/rtl/BUILD.bazel
@@ -46,7 +46,9 @@ verilog_library(
     name = "br_mux_bin",
     srcs = ["br_mux_bin.sv"],
     deps = [
-        "//gate/rtl:br_gate_behav",
+        # Omitting //gate/rtl:br_gate_behav so that downstream targets (which may exist in another repo)
+        # can decide whether to use these behavioral models or swap them out for some other vendor models.
+        # Downstream targets should decide whether to add the //gate/rtl:br_gate_behav dependency themselves.
         "//macros:br_asserts_internal",
         "//macros:br_unused",
         "//pkg:br_math_pkg",
@@ -70,7 +72,11 @@ br_verilog_elab_and_lint_test_suite(
             "0",
         ],
     },
-    deps = [":br_mux_bin"],
+    top = "br_mux_bin",
+    deps = [
+        ":br_mux_bin",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 br_verilog_elab_and_lint_test_suite(
@@ -94,7 +100,11 @@ br_verilog_elab_and_lint_test_suite(
             "1",
         ],
     },
-    deps = [":br_mux_bin"],
+    top = "br_mux_bin",
+    deps = [
+        ":br_mux_bin",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 verilog_library(
@@ -129,5 +139,9 @@ br_verilog_elab_and_lint_test_suite(
             "1",
         ],
     },
-    deps = [":br_mux_bin_array"],
+    top = "br_mux_bin_array",
+    deps = [
+        ":br_mux_bin_array",
+        "//gate/rtl:br_gate_behav",
+    ],
 )

--- a/mux/rtl/BUILD.bazel
+++ b/mux/rtl/BUILD.bazel
@@ -46,9 +46,9 @@ verilog_library(
     name = "br_mux_bin",
     srcs = ["br_mux_bin.sv"],
     deps = [
-        # Omitting //gate/rtl:br_gate_behav so that downstream targets (which may exist in another repo)
+        # Omitting //gate/rtl:br_gate_mock so that downstream targets (which may exist in another repo)
         # can decide whether to use these behavioral models or swap them out for some other vendor models.
-        # Downstream targets should decide whether to add the //gate/rtl:br_gate_behav dependency themselves.
+        # Downstream targets should decide whether to add the //gate/rtl:br_gate_mock dependency themselves.
         "//macros:br_asserts_internal",
         "//macros:br_unused",
         "//pkg:br_math_pkg",
@@ -75,7 +75,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_mux_bin",
     deps = [
         ":br_mux_bin",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -103,7 +103,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_mux_bin",
     deps = [
         ":br_mux_bin",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -142,6 +142,6 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_mux_bin_array",
     deps = [
         ":br_mux_bin_array",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )

--- a/mux/sim/BUILD.bazel
+++ b/mux/sim/BUILD.bazel
@@ -29,7 +29,11 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_mux_bin_tb_elab_test",
-    deps = [":br_mux_bin_tb"],
+    top = "br_mux_bin_tb",
+    deps = [
+        ":br_mux_bin_tb",
+        "//gate/rtl:br_gate_mock",
+    ],
 )
 
 br_verilog_sim_test_tools_suite(
@@ -58,5 +62,9 @@ br_verilog_sim_test_tools_suite(
         "iverilog",
         "vcs",
     ],
-    deps = [":br_mux_bin_tb"],
+    top = "br_mux_bin_tb",
+    deps = [
+        ":br_mux_bin_tb",
+        "//gate/rtl:br_gate_mock",
+    ],
 )

--- a/ram/rtl/BUILD.bazel
+++ b/ram/rtl/BUILD.bazel
@@ -97,7 +97,11 @@ br_verilog_elab_and_lint_test_suite(
         ],
         "EnablePartialWrite": ["0"],
     },
-    deps = [":br_ram_flops_1r1w_tile"],
+    top = "br_ram_flops_1r1w_tile",
+    deps = [
+        ":br_ram_flops_1r1w_tile",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 br_verilog_elab_and_lint_test_suite(
@@ -116,7 +120,11 @@ br_verilog_elab_and_lint_test_suite(
             "1",
         ],
     },
-    deps = [":br_ram_flops_1r1w_tile"],
+    top = "br_ram_flops_1r1w_tile",
+    deps = [
+        ":br_ram_flops_1r1w_tile",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 br_verilog_elab_and_lint_test_suite(
@@ -127,7 +135,11 @@ br_verilog_elab_and_lint_test_suite(
         "EnableBypass": ["0"],
         "UseStructuredGates": ["1"],
     },
-    deps = [":br_ram_flops_1r1w_tile"],
+    top = "br_ram_flops_1r1w_tile",
+    deps = [
+        ":br_ram_flops_1r1w_tile",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 br_verilog_elab_and_lint_test_suite(
@@ -389,7 +401,11 @@ br_verilog_elab_and_lint_test_suite(
         "TileEnableBypass": ["0"],
         "UseStructuredGates": ["1"],
     },
-    deps = [":br_ram_flops_1r1w"],
+    top = "br_ram_flops_1r1w",
+    deps = [
+        ":br_ram_flops_1r1w",
+        "//gate/rtl:br_gate_behav",
+    ],
 )
 
 br_verilog_elab_and_lint_test_suite(

--- a/ram/rtl/BUILD.bazel
+++ b/ram/rtl/BUILD.bazel
@@ -100,7 +100,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_ram_flops_1r1w_tile",
     deps = [
         ":br_ram_flops_1r1w_tile",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -123,7 +123,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_ram_flops_1r1w_tile",
     deps = [
         ":br_ram_flops_1r1w_tile",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -138,7 +138,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_ram_flops_1r1w_tile",
     deps = [
         ":br_ram_flops_1r1w_tile",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 
@@ -404,7 +404,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_ram_flops_1r1w",
     deps = [
         ":br_ram_flops_1r1w",
-        "//gate/rtl:br_gate_behav",
+        "//gate/rtl:br_gate_mock",
     ],
 )
 


### PR DESCRIPTION
In order to support downstream builds from swapping out mock behavioral libraries for technology-specific vendor implementations, we need to pull the mock gates out of the `verilog_library` dependency graph.

Do so.

To keep tests passing, add back the mock gates into the deps of the tests.

Rename `br_gate_behav.sv` to `br_gate_mock.sv` to avoid confusion with vendor behavioral models.