### PR TITLE
Disallow zero weights in weighted RR arbiter

### DIFF
--- a/arb/rtl/br_arb_pri_rr.sv
+++ b/arb/rtl/br_arb_pri_rr.sv
@@ -52,7 +52,13 @@ module br_arb_pri_rr #(
   // Integration checks
   //------------------------------------------
 
+  `BR_ASSERT_STATIC(num_requesters_gte_2_a, NumRequesters >= 2)
+  `BR_ASSERT_STATIC(num_priorities_gte_2_a, NumPriorities >= 2)
+
   `BR_COVER_INTG(request_multihot_c, !$onehot0(request))
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_intg_checks
+    `BR_ASSERT_INTG(request_priority_range_a, request[i] |-> request_priority[i] < NumPriorities)
+  end
 
   //------------------------------------------
   // Implementation
@@ -178,9 +184,5 @@ module br_arb_pri_rr #(
   `BR_ASSERT_IMPL(always_grant_A, |request |-> |grant)
   `BR_ASSERT_IMPL(grant_implies_request_A, (grant & request) == grant)
   `BR_COVER_IMPL(grant_without_state_update_C, !enable_priority_update && |grant)
-
-  for (genvar i = 0; i < NumRequesters; i++) begin : gen_priority_range
-    `BR_ASSERT_IMPL(requested_priority_range_A, request[i] |-> request_priority[i] < NumPriorities)
-  end
 
 endmodule : br_arb_pri_rr

--- a/arb/rtl/br_arb_weighted_rr.sv
+++ b/arb/rtl/br_arb_weighted_rr.sv
@@ -125,5 +125,7 @@ module br_arb_weighted_rr #(
     );
 
     assign request_priority[i] = |accumulated_weight[i];
+
+    `BR_ASSERT_IMPL(non_zero_weight_a, incr_accumulated_weight |-> request_weight[i] != 0)
   end
 endmodule

--- a/arb/rtl/br_arb_weighted_rr.sv
+++ b/arb/rtl/br_arb_weighted_rr.sv
@@ -1,5 +1,3 @@
-`include "br_asserts_internal.svh"
-
 // Copyright 2025 The Bedrock-RTL Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +52,9 @@
 // NumRequesters-1 grants before it is guaranteed to be selected.
 // So, a requestor may need to wait up to a total of
 // (MaxAccumulatedWeight+1)*(NumRequesters-1) grants before being granted itself.
+
+`include "br_asserts_internal.svh"
+
 module br_arb_weighted_rr #(
     // Must be at least 2
     parameter int NumRequesters = 2,
@@ -71,15 +72,26 @@ module br_arb_weighted_rr #(
     input logic [NumRequesters-1:0][WeightWidth-1:0] request_weight,
     output logic [NumRequesters-1:0] grant
 );
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
   `BR_ASSERT_STATIC(min_num_requestors_a, NumRequesters >= 2)
   `BR_ASSERT_STATIC(min_max_weight_a, MaxWeight >= 1)
   `BR_ASSERT_STATIC(max_accum_gte_max_weight_a, MaxAccumulatedWeight >= MaxWeight)
 
+  // We only care about request weight being non-zero when it's actually sampled
+  // to update the accumulated weight. But this check is both stronger and simpler.
+  for (genvar i = 0; i < NumRequesters; i++) begin : gen_intg_checks
+    `BR_ASSERT_INTG(request_weight_ne_0_a, request_weight[i] != 0)
+  end
+
   //------------------------------------------
-  // Arbitrate, prioritizing requests with
-  // non-zero accumulated weight
+  // Implementation
   //------------------------------------------
 
+  // Arbitrate, prioritizing requests with
+  // non-zero accumulated weight
   logic [NumRequesters-1:0] request_priority;
 
   br_arb_pri_rr #(
@@ -94,10 +106,7 @@ module br_arb_weighted_rr #(
       .grant
   );
 
-  //------------------------------------------
   // Track per-request accumulated weight
-  //------------------------------------------
-
   logic any_high_priority_request;
   logic incr_accumulated_weight;
   assign any_high_priority_request = |(request & request_priority);
@@ -125,7 +134,10 @@ module br_arb_weighted_rr #(
     );
 
     assign request_priority[i] = |accumulated_weight[i];
-
-    `BR_ASSERT_IMPL(non_zero_weight_a, incr_accumulated_weight |-> request_weight[i] != 0)
   end
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+
 endmodule


### PR DESCRIPTION
While zero weights don't put the arbiter in an undefined state, a requestor with zero weight has no forward progress guarantees and almost certainly indicates a usage error. Add an assertion to explicitly prevent this.