### PR TITLE
[br:fifo] Allow FIFOs to have RAM depth smaller than depth if bypass is enabled

### DIFF
--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -119,7 +119,7 @@ br_verilog_elab_and_lint_test_suite(
 )
 
 br_verilog_elab_and_lint_test_suite(
-    name = "br_fifo_flops_test_suite",
+    name = "br_fifo_flops_test_suite_zero_read_latency",
     params = {
         "Depth": [
             "2",
@@ -142,7 +142,28 @@ br_verilog_elab_and_lint_test_suite(
 )
 
 br_verilog_elab_and_lint_test_suite(
-    name = "br_fifo_flops_push_credit_test_suite",
+    name = "br_fifo_flops_test_suite_nonzero_read_latency",
+    params = {
+        "Depth": ["4"],
+        "Width": ["8"],
+        "EnableBypass": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "FlopRamAddressDepthStages": [
+            "1",
+            "2",
+        ],
+    },
+    deps = [":br_fifo_flops"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_flops_push_credit_test_suite_zero_read_latency",
     params = {
         "Depth": [
             "2",
@@ -167,6 +188,35 @@ br_verilog_elab_and_lint_test_suite(
         "RegisterPopOutputs": [
             "0",
             "1",
+        ],
+    },
+    deps = [":br_fifo_flops_push_credit"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_flops_push_credit_test_suite_nonzero_read_latency",
+    params = {
+        "Depth": ["4"],
+        "Width": ["8"],
+        "EnableBypass": [
+            "0",
+            "1",
+        ],
+        "MaxCredit": [
+            "4",
+            "16",
+        ],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "FlopRamAddressDepthStages": [
+            "1",
+            "2",
         ],
     },
     deps = [":br_fifo_flops_push_credit"],

--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -26,7 +26,9 @@ verilog_library(
     deps = [
         "//counter/rtl:br_counter_incr",
         "//flow/rtl/internal:br_flow_checks_valid_data_intg",
+        "//macros:br_asserts",
         "//macros:br_unused",
+        "//pkg:br_math_pkg",
     ],
 )
 
@@ -103,7 +105,9 @@ verilog_library(
     deps = [
         ":br_fifo_staging_buffer",
         "//counter/rtl:br_counter_incr",
+        "//macros:br_asserts",
         "//macros:br_unused",
+        "//pkg:br_math_pkg",
     ],
 )
 
@@ -161,6 +165,21 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
+    },
+    deps = [":br_fifo_pop_ctrl"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_pop_ctrl_test_suite_ram_depth_ne_depth",
+    params = {
+        "Depth": ["4"],
+        "RamDepth": [
+            "2",
+            "3",
+            "5",
+        ],
+        "RamReadLatency": ["1"],
+        "EnableBypass": ["1"],
     },
     deps = [":br_fifo_pop_ctrl"],
 )

--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -24,10 +24,11 @@ module br_fifo_pop_ctrl #(
     parameter bit EnableBypass = 1,
     parameter int RamReadLatency = 0,
     parameter bit RegisterPopOutputs = 0,
+    parameter int RamDepth = Depth,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
-    localparam int AddrWidth = $clog2(Depth),
+    localparam int AddrWidth = br_math::clamped_clog2(RamDepth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
     // Posedge-triggered clock.
@@ -68,7 +69,7 @@ module br_fifo_pop_ctrl #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
+  `BR_ASSERT_STATIC(depth_must_be_at_least_two_a, Depth >= 2)
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
 
   `BR_ASSERT_INTG(ram_rd_latency_matches_a,
@@ -97,6 +98,7 @@ module br_fifo_pop_ctrl #(
       .EnableBypass(EnableBypass),
       .RamReadLatency(RamReadLatency),
       .RegisterPopOutputs(RegisterPopOutputs),
+      .RamDepth(RamDepth),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_fifo_pop_ctrl_core (
       .clk,

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -22,6 +22,7 @@ module br_fifo_push_ctrl #(
     parameter int Depth = 2,
     parameter int Width = 1,
     parameter bit EnableBypass = 1,
+    parameter int RamDepth = Depth,
     // If 1, cover that the push side experiences backpressure.
     // If 0, assert that there is never backpressure.
     parameter bit EnableCoverPushBackpressure = 1,
@@ -34,7 +35,7 @@ module br_fifo_push_ctrl #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
-    localparam int AddrWidth = $clog2(Depth),
+    localparam int AddrWidth = br_math::clamped_clog2(RamDepth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
     // Posedge-triggered clock.
@@ -85,7 +86,7 @@ module br_fifo_push_ctrl #(
 
   // Core flow-control logic
   br_fifo_push_ctrl_core #(
-      .Depth(Depth),
+      .Depth(RamDepth),
       .Width(Width),
       .EnableBypass(EnableBypass),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -24,10 +24,11 @@ module br_fifo_push_ctrl_credit #(
     parameter bit EnableBypass = 0,
     parameter int MaxCredit = Depth,
     parameter bit RegisterPushOutputs = 0,
+    parameter int RamDepth = Depth,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
-    localparam int AddrWidth = $clog2(Depth),
+    localparam int AddrWidth = br_math::clamped_clog2(RamDepth),
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int CreditWidth = $clog2(MaxCredit + 1)
 ) (
@@ -119,7 +120,7 @@ module br_fifo_push_ctrl_credit #(
 
   // Core flow-control logic
   br_fifo_push_ctrl_core #(
-      .Depth(Depth),
+      .Depth(RamDepth),
       .Width(Width),
       .EnableBypass(EnableBypass),
       // The core push control should never be backpressured.

--- a/pkg/br_math_pkg.sv
+++ b/pkg/br_math_pkg.sv
@@ -58,6 +58,13 @@ package br_math;
     end
   endfunction
 
+  // If value > 1, returns $clog2(value). Otherwise, returns 1.
+  // This function is useful for ensuring that address widths are at least 1.
+  // ri lint_check_waive TWO_STATE_TYPE
+  function automatic int clamped_clog2(input int value);
+    return (value <= 1) ? 1 : $clog2(value);
+  endfunction
+
   // Returns the minimum of two integers.
   // ri lint_check_waive TWO_STATE_TYPE
   function automatic int min2(input int a, input int b);

--- a/pkg/br_math_pkg_tb.sv
+++ b/pkg/br_math_pkg_tb.sv
@@ -53,6 +53,12 @@ module br_math_pkg_tb;
   `BR_ASSERT_STATIC(clogb_4_7_a, br_math::clogb(4, 7) == 2)
   `BR_ASSERT_STATIC(clogb_4_8_a, br_math::clogb(4, 8) == 2)
 
+  // Test cases for clamped_clog2 function
+  `BR_ASSERT_STATIC(clamped_clog2_1_a, br_math::clamped_clog2(1) == 1)
+  `BR_ASSERT_STATIC(clamped_clog2_2_a, br_math::clamped_clog2(2) == 1)
+  `BR_ASSERT_STATIC(clamped_clog2_3_a, br_math::clamped_clog2(3) == 2)
+  `BR_ASSERT_STATIC(clamped_clog2_4_a, br_math::clamped_clog2(4) == 2)
+
   // Test cases for is_power_of_2 function
   `BR_ASSERT_STATIC(ispowerof2_0_a, br_math::is_power_of_2(0) == 1)
 

--- a/ram/rtl/BUILD.bazel
+++ b/ram/rtl/BUILD.bazel
@@ -119,10 +119,6 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
-        "EnableBypass": [
-            "0",
-            "1",
-        ],
     },
     top = "br_ram_flops_1r1w_tile",
     deps = [
@@ -144,6 +140,29 @@ br_verilog_elab_and_lint_test_suite(
         ":br_ram_flops_1r1w_tile",
         "//gate/rtl:br_gate_mock",
     ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_ram_flops_1r1w_tile_test_suite_single_entry",
+    params = {
+        "EnableBypass": [
+            "0",
+            "1",
+        ],
+        "EnablePartialWrite": [
+            "0",
+            "1",
+        ],
+        "EnableReset": [
+            "0",
+            "1",
+        ],
+        "Depth": ["1"],
+        "Width": ["8"],
+        "WordWidth": ["2"],
+    },
+    top = "br_ram_flops_1r1w_tile",
+    deps = [":br_ram_flops_1r1w_tile"],
 )
 
 br_verilog_elab_and_lint_test_suite(
@@ -183,6 +202,7 @@ br_verilog_elab_and_lint_test_suite(
             "2",
             "4",
             "8",
+            "32",
         ],
         "Stages": [
             "0",
@@ -206,6 +226,7 @@ br_verilog_elab_and_lint_test_suite(
             "3",
             "5",
             "6",
+            "30",
         ],
         "Stages": [
             "0",
@@ -404,6 +425,60 @@ br_verilog_elab_and_lint_test_suite(
         "Width": ["8"],
         "TileEnableBypass": ["0"],
         "UseStructuredGates": ["1"],
+    },
+    top = "br_ram_flops_1r1w",
+    deps = [
+        ":br_ram_flops_1r1w",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_ram_flops_1r1w_test_suite_single_tile_single_entry",
+    params = {
+        "TileEnableBypass": [
+            "0",
+            "1",
+        ],
+        "EnablePartialWrite": [
+            "0",
+            "1",
+        ],
+        "EnableMemReset": [
+            "0",
+            "1",
+        ],
+        "Depth": ["1"],
+        "Width": ["8"],
+        "WordWidth": ["2"],
+    },
+    top = "br_ram_flops_1r1w",
+    deps = [
+        ":br_ram_flops_1r1w",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_ram_flops_1r1w_test_suite_multi_tile_single_entry",
+    params = {
+        "TileEnableBypass": [
+            "0",
+            "1",
+        ],
+        "EnablePartialWrite": [
+            "0",
+            "1",
+        ],
+        "EnableMemReset": [
+            "0",
+            "1",
+        ],
+        "Depth": ["2"],
+        "DepthTiles": ["2"],
+        "WidthTiles": ["2"],
+        "Width": ["8"],
+        "WordWidth": ["2"],
     },
     top = "br_ram_flops_1r1w",
     deps = [

--- a/ram/rtl/br_ram_flops_1r1w.sv
+++ b/ram/rtl/br_ram_flops_1r1w.sv
@@ -23,7 +23,7 @@
 `include "br_unused.svh"
 
 module br_ram_flops_1r1w #(
-    parameter int Depth = 2,  // Number of entries in the RAM. Must be at least 2.
+    parameter int Depth = 1,  // Number of entries in the RAM. Must be at least 1.
     parameter int Width = 1,  // Width of each entry in the RAM. Must be at least 1.
     // Number of tiles along the depth (address) dimension. Must be at least 1 and evenly divide Depth.
     parameter int DepthTiles = 1,
@@ -63,7 +63,7 @@ module br_ram_flops_1r1w #(
     parameter bit UseStructuredGates = 0,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
-    localparam int AddressWidth = $clog2(Depth),
+    localparam int AddressWidth = br_math::clamped_clog2(Depth),
     localparam int NumWords = Width / WordWidth,
     // Write latency in units of wr_clk cycles
     // ri lint_check_waive PARAM_NOT_USED
@@ -105,7 +105,7 @@ module br_ram_flops_1r1w #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(depth_gte_2_a, Depth >= 2)
+  `BR_ASSERT_STATIC(depth_gte_1_a, Depth >= 1)
   `BR_ASSERT_STATIC(width_gte_1_a, Width >= 1)
 
   // DepthTiles checks
@@ -138,7 +138,7 @@ module br_ram_flops_1r1w #(
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  localparam int TileAddressWidth = $clog2(TileDepth);
+  localparam int TileAddressWidth = br_math::clamped_clog2(TileDepth);
 
   logic [DepthTiles-1:0] tile_wr_valid;
   logic [DepthTiles-1:0][TileAddressWidth-1:0] tile_wr_addr;


### PR DESCRIPTION
If we can bypass directly to the staging buffer, we don't need RAM depth
to be the same as the FIFO depth. We can subtract the staging buffer
entries. This allows flop-based FIFOs to be more area-efficient.

---

**Stack**:
- #386 ⬅
- #385


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*