### PR TITLE
Added [BR_ASSERT/COVER]_IMM macros that can be added inside existing always_comb/initial/final blocks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -391,9 +391,12 @@ The suffices are also listed in alphabetical order, with the exception of `L` be
 These assertion macros are intended for use by the user in their own designs.
 They are guarded (enabled) by the following defines:
 
-* `BR_ASSERT_ON` -- if not defined, then all assertion macros are no-ops.
-* `BR_DISABLE_ASSERT_COMB` -- if defined, then all BR_ASSERT_COMB* macros are no-ops.
-* `BR_DISABLE_FINAL_CHECKS` -- if defined, then the BR_ASSERT_FINAL macro is a no-op.
+* `BR_ASSERT_ON` -- if not defined, then all macros other than `BR_ASSERT_STATIC*`
+      are no-ops.
+* `BR_ENABLE_FPV` -- if not defined, then all `BR_*_FPV` macros are no-ops.
+* `BR_DISABLE_ASSERT_IMM` -- if defined, then all `BR_ASSERT_IMM*`, `BR_COVER_IMM*`,
+      `BR_ASSERT_COMB*`, and `BR_ASSERT_IMM*` macros are no-ops.
+* `BR_DISABLE_FINAL_CHECKS` -- if defined, then all `BR_ASSERT_FINAL*` macros are no-ops.
 
 TIP: It is recommended that users simply define `BR_ASSERT_ON` when integrating Bedrock modules into their designs.
 The other guards will typically not be necessary.
@@ -411,7 +414,7 @@ Resets are always active-high.
 | `BR_ASSERT_STATIC_IN_PACKAGE`
 | Static (elaboration-time) assertion for use within packages
 
-| BR_ASSERT_FINAL
+| `BR_ASSERT_FINAL`
 a| Immediate assertion evaluated at the end of simulation (e.g., when `$finish` is called).
 Disable by defining `BR_DISABLE_FINAL_CHECKS`.
 
@@ -421,12 +424,15 @@ Disable by defining `BR_DISABLE_FINAL_CHECKS`.
 | `BR_ASSERT_CR`
 | Concurrent assertion with explicit clock and reset names.
 
-| `BR_ASSERT_COMB`
-a| Combinational/immediate assertion that exists outside the scope of an always_comb block.
+| `BR_ASSERT_IMM`
+a| Immediate assertion.
 Also passes if the expression is unknown.
-If an immediate assertion is needed inside an always_comb block, recommend to use built-in
-SystemVerilog assert syntax.
-Disable by defining `BR_DISABLE_ASSERT_COMB`.
+Disable by defining `BR_DISABLE_ASSERT_IMM`.
+
+| `BR_ASSERT_COMB`
+a| Immediate assertion wrapped inside of an `always_comb` block.
+Also passes if the expression is unknown.
+Disable by defining `BR_DISABLE_ASSERT_IMM`.
 
 | `BR_COVER`
 | Concurrent cover with implicit `clk` and `rst` names.
@@ -434,8 +440,13 @@ Disable by defining `BR_DISABLE_ASSERT_COMB`.
 | `BR_COVER_CR`
 | Concurrent cover with explicit clock and reset names.
 
+| `BR_COVER_IMM`
+a| Immediate cover.
+Disable by defining `BR_DISABLE_ASSERT_IMM`.
+
 | `BR_COVER_COMB`
-| Combinational/immediate cover.
+a| Immediate cover wrapped inside of an `always_comb` block.
+Disable by defining `BR_DISABLE_ASSERT_IMM`.
 
 | `BR_ASSUME`
 | Concurrent assumption with implicit `clk` and `rst` names.

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -109,12 +109,6 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_asserts_elab_test",
-    defines = ["BR_ASSERT_ON"],
-    deps = [":br_asserts_test"],
-)
-
-verilog_elab_test(
-    name = "br_asserts_fpv_elab_test",
     defines = [
         "BR_ASSERT_ON",
         "BR_ENABLE_FPV",
@@ -138,6 +132,7 @@ verilog_elab_test(
     name = "br_asserts_elab_internal_test",
     defines = [
         "BR_ASSERT_ON",
+        "BR_ENABLE_FPV",
         "BR_ENABLE_IMPL_CHECKS",
     ],
     deps = [":br_asserts_internal_test"],

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -186,11 +186,8 @@ __name__ : assert property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || 
 ////////////////////////////////////////////////////////////////////////////////
 
 // BR_ASSERT_COMB and BR_ASSERT_COMB_EXPR are guarded with BR_DISABLE_ASSERT_COMB because some tools don't
-// like immediate assertions, and/or $isunknown in combinational blocks, even when it's used inside of an
-// assert statement. Implemented using an always_comb block, so this cannot be embedded inside another
-// always_comb block. If an immediate assertion is needed inside an existing always_comb block,
-// recommend the user leverage built-in
-// SystemVerilog assert syntax.
+// like immediate assertions, and/or $isunknown in combinational blocks, even when they're used inside of an
+// assert statement. 
 
 `ifdef BR_ASSERT_ON
 `ifndef BR_DISABLE_ASSERT_COMB

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -195,9 +195,7 @@ __name__ : assert property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || 
 `ifdef BR_ASSERT_ON
 `ifndef BR_DISABLE_ASSERT_COMB
 `define BR_ASSERT_COMB_EXPR(__name__, __expr__) \
-begin : gen_``__name__ \
-assert ($isunknown(__expr__) || (__expr__)); \
-end
+assert ($isunknown(__expr__) || (__expr__));
 `else  // BR_DISABLE_ASSERT_COMB
 `define BR_ASSERT_COMB_EXPR(__name__, __expr__) \
 `BR_NOOP

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -185,11 +185,28 @@ __name__ : assert property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || 
 // Also pass if the expression is unknown.
 ////////////////////////////////////////////////////////////////////////////////
 
-// BR_ASSERT_COMB is guarded with BR_DISABLE_ASSERT_COMB because some tools don't like immediate assertions,
-// and/or $isunknown in combinational blocks, even when it's used inside of an assert statement.
-// Implemented using an always_comb block, so this cannot be embedded inside another always_comb block.
-// If an immediate assertion is needed inside an existing always_comb block, recommend the user leverage built-in
+// BR_ASSERT_COMB and BR_ASSERT_COMB_EXPR are guarded with BR_DISABLE_ASSERT_COMB because some tools don't
+// like immediate assertions, and/or $isunknown in combinational blocks, even when it's used inside of an
+// assert statement. Implemented using an always_comb block, so this cannot be embedded inside another
+// always_comb block. If an immediate assertion is needed inside an existing always_comb block,
+// recommend the user leverage built-in
 // SystemVerilog assert syntax.
+
+`ifdef BR_ASSERT_ON
+`ifndef BR_DISABLE_ASSERT_COMB
+`define BR_ASSERT_COMB_EXPR(__name__, __expr__) \
+begin : gen_``__name__ \
+assert ($isunknown(__expr__) || (__expr__)); \
+end
+`else  // BR_DISABLE_ASSERT_COMB
+`define BR_ASSERT_COMB_EXPR(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_DISABLE_ASSERT_COMB
+`else  // BR_ASSERT_ON
+`define BR_ASSERT_COMB_EXPR(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
 `ifdef BR_ASSERT_ON
 `ifndef BR_DISABLE_ASSERT_COMB
 `define BR_ASSERT_COMB(__name__, __expr__) \

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -27,9 +27,11 @@
 // Therefore we namespace all macros with the BR_ prefix (stands for Bedrock).
 //
 // The macros in this file are guarded with the following defines.
-// * BR_ASSERT_ON -- if not defined, then all assertion macros are no-ops.
+// * BR_ASSERT_ON -- if not defined, then all macros other than BR_ASSERT_STATIC*
+//       are no-ops.
 // * BR_ENABLE_FPV -- if not defined, then all BR_*_FPV macros are no-ops.
-// * BR_DISABLE_ASSERT_COMB -- if defined, then all BR_ASSERT_COMB* macros are no-ops.
+// * BR_DISABLE_ASSERT_IMM -- if defined, then all BR_ASSERT_IMM*, BR_COVER_IMM*,
+//       BR_ASSERT_COMB*, and BR_ASSERT_IMM* macros are no-ops.
 // * BR_DISABLE_FINAL_CHECKS -- if defined, then all BR_ASSERT_FINAL macros are no-ops.
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -181,37 +183,33 @@ __name__ : assert property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || 
 `endif  // BR_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
-// Combinational assertion macros (evaluated continuously based on the expression sensitivity).
+// Combinational/immediate assertion macros (evaluated continuously based on the expression sensitivity).
 // Also pass if the expression is unknown.
 ////////////////////////////////////////////////////////////////////////////////
 
-// BR_ASSERT_COMB and BR_ASSERT_COMB_EXPR are guarded with BR_DISABLE_ASSERT_COMB because some tools don't
-// like immediate assertions, and/or $isunknown in combinational blocks, even when they're used inside of an
-// assert statement. 
-
 `ifdef BR_ASSERT_ON
-`ifndef BR_DISABLE_ASSERT_COMB
-`define BR_ASSERT_COMB_EXPR(__name__, __expr__) \
+`ifndef BR_DISABLE_ASSERT_IMM
+`define BR_ASSERT_IMM(__name__, __expr__) \
 assert ($isunknown(__expr__) || (__expr__));
-`else  // BR_DISABLE_ASSERT_COMB
-`define BR_ASSERT_COMB_EXPR(__name__, __expr__) \
+`else  // BR_DISABLE_ASSERT_IMM
+`define BR_ASSERT_IMM(__name__, __expr__) \
 `BR_NOOP
-`endif  // BR_DISABLE_ASSERT_COMB
+`endif  // BR_DISABLE_ASSERT_IMM
 `else  // BR_ASSERT_ON
-`define BR_ASSERT_COMB_EXPR(__name__, __expr__) \
+`define BR_ASSERT_IMM(__name__, __expr__) \
 `BR_NOOP
 `endif  // BR_ASSERT_ON
 
 `ifdef BR_ASSERT_ON
-`ifndef BR_DISABLE_ASSERT_COMB
+`ifndef BR_DISABLE_ASSERT_IMM
 `define BR_ASSERT_COMB(__name__, __expr__) \
 always_comb begin  : gen_``__name__ \
-assert ($isunknown(__expr__) || (__expr__)); \
+`BR_ASSERT_IMM(__name__, __expr__); \
 end
-`else  // BR_DISABLE_ASSERT_COMB
+`else  // BR_DISABLE_ASSERT_IMM
 `define BR_ASSERT_COMB(__name__, __expr__) \
 `BR_NOOP
-`endif  // BR_DISABLE_ASSERT_COMB
+`endif  // BR_DISABLE_ASSERT_IMM
 `else  // BR_ASSERT_ON
 `define BR_ASSERT_COMB(__name__, __expr__) \
 `BR_NOOP
@@ -219,7 +217,6 @@ end
 
 // FPV version macros
 `ifdef BR_ASSERT_ON
-`ifndef BR_DISABLE_ASSERT_COMB
 `ifdef BR_ENABLE_FPV
 `define BR_ASSERT_COMB_FPV(__name__, __expr__) \
 `BR_ASSERT_COMB(__name__, __expr__);
@@ -227,10 +224,6 @@ end
 `define BR_ASSERT_COMB_FPV(__name__, __expr__) \
 `BR_NOOP
 `endif  // BR_ENABLE_FPV
-`else  // BR_DISABLE_ASSERT_COMB
-`define BR_ASSERT_COMB_FPV(__name__, __expr__) \
-`BR_NOOP
-`endif  // BR_DISABLE_ASSERT_COMB
 `else  // BR_ASSERT_ON
 `define BR_ASSERT_COMB_FPV(__name__, __expr__) \
 `BR_NOOP
@@ -287,13 +280,32 @@ __name__ : cover property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || _
 `endif  // BR_ASSERT_ON
 
 ////////////////////////////////////////////////////////////////////////////////
-// Combinational cover macros (evaluated continuously based on the expression sensitivity)
+// Combinational/immediate cover macros (evaluated continuously based on the expression sensitivity)
 ////////////////////////////////////////////////////////////////////////////////
+
 `ifdef BR_ASSERT_ON
+`ifndef BR_DISABLE_ASSERT_IMM
+`define BR_COVER_IMM(__name__, __expr__) \
+cover (__expr__);
+`else  // BR_DISABLE_ASSERT_IMM
+`define BR_COVER_IMM(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_DISABLE_ASSERT_IMM
+`else  // BR_ASSERT_ON
+`define BR_COVER_IMM(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
+`ifdef BR_ASSERT_ON
+`ifndef BR_DISABLE_ASSERT_IMM
 `define BR_COVER_COMB(__name__, __expr__) \
 always_comb begin  : gen_``__name__ \
-cover (__expr__); \
+`BR_COVER_IMM(__name__, __expr__); \
 end
+`else  // BR_DISABLE_ASSERT_IMM
+`define BR_COVER_COMB(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_DISABLE_ASSERT_IMM
 `else  // BR_ASSERT_ON
 `define BR_COVER_COMB(__name__, __expr__) \
 `BR_NOOP

--- a/macros/br_asserts_internal.svh
+++ b/macros/br_asserts_internal.svh
@@ -185,8 +185,24 @@
 `endif  // BR_ENABLE_IMPL_CHECKS
 
 ////////////////////////////////////////////////////////////////////////////////
-// Combinational assertion macros (evaluated continuously based on the expression sensitivity)
+// Combinational/immediate assertion macros (evaluated continuously based on the expression sensitivity)
 ////////////////////////////////////////////////////////////////////////////////
+`ifndef BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_IMM_INTG(__name__, __expr__) \
+`BR_ASSERT_IMM(__name__, __expr__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_ASSERT_IMM_INTG(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_DISABLE_INTG_CHECKS
+
+`ifdef BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_IMM_IMPL(__name__, __expr__) \
+`BR_ASSERT_IMM(__name__, __expr__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_ASSERT_IMM_IMPL(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ENABLE_IMPL_CHECKS
+
 `ifndef BR_DISABLE_INTG_CHECKS
 `define BR_ASSERT_COMB_INTG(__name__, __expr__) \
 `BR_ASSERT_COMB(__name__, __expr__)
@@ -248,6 +264,22 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Combinational cover macros (evaluated continuously based on the expression sensitivity)
 ////////////////////////////////////////////////////////////////////////////////
+`ifndef BR_DISABLE_INTG_CHECKS
+`define BR_COVER_IMM_INTG(__name__, __expr__) \
+`BR_COVER_IMM(__name__, __expr__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_COVER_IMM_INTG(__name__, __expr__) \
+`BR_NOOP
+`endif // BR_DISABLE_INTG_CHECKS
+
+`ifdef BR_ENABLE_IMPL_CHECKS
+`define BR_COVER_IMM_IMPL(__name__, __expr__) \
+`BR_COVER_IMM(__name__, __expr__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_COVER_IMM_IMPL(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ENABLE_IMPL_CHECKS
+
 `ifndef BR_DISABLE_INTG_CHECKS
 `define BR_COVER_COMB_INTG(__name__, __expr__) \
 `BR_COVER_COMB(__name__, __expr__)

--- a/macros/br_asserts_internal_test.sv
+++ b/macros/br_asserts_internal_test.sv
@@ -130,6 +130,27 @@ module br_asserts_internal_test;
   // Use BR_ASSERT_COMB_IMPL
   `BR_ASSERT_COMB_IMPL(sum_in_range_impl, sum <= 15)
 
+  always_comb begin
+    `BR_ASSERT_IMM_INTG(comb_sanity_imm_intg_a, 0 === 0)
+    `BR_ASSERT_IMM_IMPL(comb_sanity_imm_impl_a, 0 === 0)
+    `BR_COVER_IMM_INTG(comb_sanity_imm_intg_c, 0 === 0)
+    `BR_COVER_IMM_IMPL(comb_sanity_imm_impl_c, 0 === 0)
+  end
+
+  initial begin
+    `BR_ASSERT_IMM_INTG(initial_sanity_imm_intg_a, 0 === 0)
+    `BR_ASSERT_IMM_IMPL(initial_sanity_imm_impl_a, 0 === 0)
+    `BR_COVER_IMM_INTG(initial_sanity_imm_intg_c, 0 === 0)
+    `BR_COVER_IMM_IMPL(initial_sanity_imm_impl_c, 0 === 0)
+  end
+
+  final begin
+    `BR_ASSERT_IMM_INTG(final_sanity_imm_intg_a, 0 === 0)
+    `BR_ASSERT_IMM_IMPL(final_sanity_imm_impl_a, 0 === 0)
+    `BR_COVER_IMM_INTG(final_sanity_imm_intg_c, 0 === 0)
+    `BR_COVER_IMM_IMPL(final_sanity_imm_impl_c, 0 === 0)
+  end
+
   // Use BR_COVER_INTG
   `BR_COVER_INTG(sum_overflow_intg, sum > 15)
 

--- a/macros/br_asserts_test.sv
+++ b/macros/br_asserts_test.sv
@@ -117,6 +117,12 @@ module br_asserts_test;
   `BR_ASSUME_CR(valid_data_check_m, (valid == 1) |-> (sum == a + b), custom_clk, custom_rst)
   `BR_ASSUME_CR_FPV(valid_data_check_fpv_m, (valid == 1) |-> (sum == a + b), custom_clk, custom_rst)
 
+  // Use BR_ASSERT_COMB_EXPR
+  always_comb begin
+    `BR_ASSERT_COMB_EXPR(inputs_nonzero_a, (a != 0) || (b != 0))
+    `BR_ASSERT_COMB_FPV(inputs_nonzero_fpv_a, (a != 0) || (b != 0))
+  end
+
   // Use BR_ASSERT_COMB
   `BR_ASSERT_COMB(inputs_nonzero_a, (a != 0) || (b != 0))
   `BR_ASSERT_COMB_FPV(inputs_nonzero_fpv_a, (a != 0) || (b != 0))

--- a/macros/br_asserts_test.sv
+++ b/macros/br_asserts_test.sv
@@ -117,10 +117,18 @@ module br_asserts_test;
   `BR_ASSUME_CR(valid_data_check_m, (valid == 1) |-> (sum == a + b), custom_clk, custom_rst)
   `BR_ASSUME_CR_FPV(valid_data_check_fpv_m, (valid == 1) |-> (sum == a + b), custom_clk, custom_rst)
 
-  // Use BR_ASSERT_COMB_EXPR
   always_comb begin
-    `BR_ASSERT_COMB_EXPR(inputs_nonzero_a, (a != 0) || (b != 0))
-    `BR_ASSERT_COMB_FPV(inputs_nonzero_fpv_a, (a != 0) || (b != 0))
+    `BR_ASSERT_IMM(inputs_nonzero_in_comb_a, (a != 0) || (b != 0))
+  end
+
+  initial begin
+    `BR_ASSERT_IMM(imm_assert_initial_a, 1 === 1)
+    `BR_COVER_IMM(imm_cover_initial_c, 0 === 0)
+  end
+
+  final begin
+    `BR_ASSERT_IMM(imm_assert_final_a, 1 === 1)
+    `BR_COVER_IMM(imm_cover_final_c, 0 === 0)
   end
 
   // Use BR_ASSERT_COMB


### PR DESCRIPTION
[mgottscho] Also did a drive-by cleanup of comb/imm macros since there was some tech debt