### PR TITLE
Make datapath optional in `br_ram_addr_decoder` and support clock gating it when enabled

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1102,7 +1102,7 @@ a| FIFO with internal flop RAM
 | Module | Description | Verified
 
 | `br_ram_addr_decoder`
-| Address decoder for a tiled RAM
+| Address decoder and optional write data steering for a tiled RAM
 |
 
 | `br_ram_data_rd_pipe`

--- a/demux/rtl/br_demux_bin.sv
+++ b/demux/rtl/br_demux_bin.sv
@@ -50,7 +50,7 @@ module br_demux_bin #(
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_in_valid_a, !in_valid)
-    `BR_ASSERT_FINAL(foutal_not_out_valid_a, !out_valid)
+    `BR_ASSERT_FINAL(final_not_out_valid_a, !out_valid)
   end
 
   //------------------------------------------

--- a/ram/rtl/BUILD.bazel
+++ b/ram/rtl/BUILD.bazel
@@ -241,6 +241,7 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
+        "EnableDatapath": ["1"],
     },
     deps = [":br_ram_addr_decoder"],
 )
@@ -264,6 +265,7 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "3",
         ],
+        "EnableDatapath": ["1"],
     },
     deps = [":br_ram_addr_decoder"],
 )
@@ -287,6 +289,7 @@ br_verilog_elab_and_lint_test_suite(
         "Stages": [
             "0",
         ],
+        "EnableDatapath": ["0"],
     },
     deps = [":br_ram_addr_decoder"],
 )

--- a/ram/rtl/BUILD.bazel
+++ b/ram/rtl/BUILD.bazel
@@ -60,6 +60,7 @@ verilog_library(
         "//delay/rtl:br_delay_valid",
         "//demux/rtl:br_demux_bin",
         "//macros:br_asserts_internal",
+        "//macros:br_tieoff",
         "//macros:br_unused",
         "//pkg:br_math_pkg",
     ],

--- a/ram/rtl/br_ram_addr_decoder.sv
+++ b/ram/rtl/br_ram_addr_decoder.sv
@@ -25,6 +25,7 @@
 // pipeline the logic inside the decoding tree, they just retime the decoded outputs.
 
 `include "br_asserts_internal.svh"
+`include "br_tieoff.svh"
 `include "br_unused.svh"
 
 module br_ram_addr_decoder #(
@@ -256,13 +257,13 @@ module br_ram_addr_decoder #(
                          tile_addr_offset[InputAddressWidth-1:OutputAddressWidth])
 
         if (EnableDatapath) begin : gen_datapath
-            assign internal_out_data_valid[i] = in_data_valid;
-            assign internal_out_data[i] = in_data;
+          assign internal_out_data_valid[i] = in_data_valid;
+          assign internal_out_data[i] = in_data;
         end else begin : gen_no_datapath
-            `BR_UNUSED(in_data_valid)
-            `BR_UNUSED(in_data)
-            `BR_TIEOFF_ZERO(internal_out_data_valid[i])
-            `BR_TIEOFF_ZERO(internal_out_data[i])
+          `BR_UNUSED(in_data_valid)
+          `BR_UNUSED(in_data)
+          `BR_TIEOFF_ZERO_NAMED(internal_out_data_valid_i, internal_out_data_valid[i])
+          `BR_TIEOFF_ZERO_NAMED(internal_out_data_i, internal_out_data[i])
         end
       end
     end
@@ -270,7 +271,7 @@ module br_ram_addr_decoder #(
     // Replicate to reduce register fanout when Stages >= 1
     for (genvar i = 0; i < Tiles; i++) begin : gen_out
       br_delay_valid #(
-          .Width(OutputAddressWidth)
+          .Width(OutputAddressWidth),
           .NumStages(Stages),
           .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
       ) br_delay_valid_addr (
@@ -300,10 +301,10 @@ module br_ram_addr_decoder #(
             .out_stages()  // unused
         );
       end else begin : gen_no_datapath
-        `BR_UNUSED(internal_out_data_valid[i])
-        `BR_UNUSED(internal_out_data[i])
-        `BR_TIEOFF_ZERO(out_data_valid[i])
-        `BR_TIEOFF_ZERO(out_data[i])
+        `BR_UNUSED_NAMED(internal_out_data_valid_i, internal_out_data_valid[i])
+        `BR_UNUSED_NAMED(internal_out_data_i, internal_out_data[i])
+        `BR_TIEOFF_ZERO_NAMED(out_data_valid_i, out_data_valid[i])
+        `BR_TIEOFF_ZERO_NAMED(out_data_i, out_data[i])
       end
     end
   end

--- a/ram/rtl/br_ram_flops.sv
+++ b/ram/rtl/br_ram_flops.sv
@@ -17,6 +17,7 @@
 // A multi-read/multi-write flop-based RAM
 // that is constructed out of pipelined tiles.
 // Heavily parameterized for tiling and pipeline configurations.
+// Read and write ports are separated.
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
@@ -166,7 +167,6 @@ module br_ram_flops #(
       localparam int DecoderDataWidth = Width + NumWords;
       logic [DecoderDataWidth-1:0] decoder_in_data;
       logic [DepthTiles-1:0][DecoderDataWidth-1:0] decoder_out_data;
-
       assign decoder_in_data = {wr_data[wport], wr_word_en[wport]};
 
       br_ram_addr_decoder #(
@@ -174,15 +174,18 @@ module br_ram_flops #(
           .DataWidth(DecoderDataWidth),
           .Tiles(DepthTiles),
           .Stages(AddressDepthStages),
+          .EnableDatapath(1),
           .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
       ) br_ram_addr_decoder_wr (
           .clk(wr_clk),  // ri lint_check_waive SAME_CLOCK_NAME
           .rst(wr_rst),
           .in_valid(wr_valid[wport]),
           .in_addr(wr_addr[wport]),
+          .in_data_valid(wr_valid[wport]),
           .in_data(decoder_in_data),
           .out_valid(decoded_wr_valid),
           .out_addr(decoded_wr_addr),
+          .out_data_valid(),  // unused
           .out_data(decoder_out_data)
       );
 
@@ -195,15 +198,18 @@ module br_ram_flops #(
           .DataWidth(Width),
           .Tiles(DepthTiles),
           .Stages(AddressDepthStages),
+          .EnableDatapath(1),
           .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
       ) br_ram_addr_decoder_wr (
           .clk(wr_clk),  // ri lint_check_waive SAME_CLOCK_NAME
           .rst(wr_rst),
           .in_valid(wr_valid[wport]),
           .in_addr(wr_addr[wport]),
+          .in_data_valid(wr_valid[wport]),
           .in_data(wr_data[wport]),
           .out_valid(decoded_wr_valid),
           .out_addr(decoded_wr_addr),
+          .out_data_valid(),  // unused
           .out_data(decoded_wr_data)
       );
 
@@ -236,9 +242,11 @@ module br_ram_flops #(
         .rst(rd_rst),
         .in_valid(rd_addr_valid[rport]),
         .in_addr(rd_addr[rport]),
+        .in_data_valid(1'b0),  // unused
         .in_data(1'b0),  // unused
         .out_valid(decoded_rd_addr_valid),
         .out_addr(decoded_rd_addr),
+        .out_data_valid(),  // unused
         .out_data()  // unused
     );
 


### PR DESCRIPTION
Fixes #352 