### PR TITLE
[br:cdc] Remove flop on slots/items calculation in CDC FIFOs

### DIFF
--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
@@ -41,9 +41,10 @@
 // Let PushT and PopT be the push period and pop period, respectively.
 //
 // The cut-through latency is max(RegisterResetActive + 1, RamWriteLatency + 1)
-// * PushT + (NumSyncStages + 1 + RamReadLatency + RegisterPopOutputs) * PopT.
+// * PushT + (NumSyncStages + RamReadLatency + RegisterPopOutputs) * PopT.
 //
-// The backpressure latency is (RegisterResetActive + 1) * PopT + (NumSyncStages + 1) * PushT.
+// The backpressure latency is (RegisterResetActive + 1) * PopT + (NumSyncStages
+// + RegisterPushOutputs) * PushT.
 //
 // To achieve full bandwidth, the depth of the FIFO must be at least
 // (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
@@ -101,9 +102,7 @@ module br_cdc_fifo_ctrl_1r1w #(
 
     // Push-side status flags
     output logic                  push_full,
-    output logic                  push_full_next,
     output logic [CountWidth-1:0] push_slots,
-    output logic [CountWidth-1:0] push_slots_next,
 
     // Push-side RAM write interface
     output logic                 push_ram_wr_valid,
@@ -122,9 +121,7 @@ module br_cdc_fifo_ctrl_1r1w #(
 
     // Pop-side status flags
     output logic                  pop_empty,
-    output logic                  pop_empty_next,
     output logic [CountWidth-1:0] pop_items,
-    output logic [CountWidth-1:0] pop_items_next,
 
     // Pop-side RAM read interface
     output logic                 pop_ram_rd_addr_valid,
@@ -163,9 +160,7 @@ module br_cdc_fifo_ctrl_1r1w #(
       .push_valid,
       .push_data,
       .push_full,
-      .push_full_next,
       .push_slots,
-      .push_slots_next,
       .push_ram_wr_valid,
       .push_ram_wr_addr,
       .push_ram_wr_data,
@@ -198,9 +193,7 @@ module br_cdc_fifo_ctrl_1r1w #(
       .pop_valid,
       .pop_data,
       .pop_empty,
-      .pop_empty_next,
       .pop_items,
-      .pop_items_next,
       .pop_ram_rd_addr_valid,
       .pop_ram_rd_addr,
       .pop_ram_rd_data_valid,

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
@@ -41,10 +41,10 @@
 // Let PushT and PopT be the push period and pop period, respectively.
 //
 // The cut-through latency is max(RegisterResetActive + 1, RamWriteLatency + 1)
-// * PushT + (NumSyncStages + 1 + RamReadLatency + RegisterPopOutputs) * PopT.
+// * PushT + (NumSyncStages + RamReadLatency + RegisterPopOutputs) * PopT.
 //
 // The backpressure latency is (RegisterResetActive + 1) * PopT + (NumSyncStages
-// + 1 + RegisterPushOutputs) * PushT.
+// + RegisterPushOutputs) * PushT.
 //
 // To achieve full bandwidth, the depth of the FIFO must be at least
 // (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
@@ -106,9 +106,7 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
 
     // Push-side status flags
     output logic                  push_full,
-    output logic                  push_full_next,
     output logic [CountWidth-1:0] push_slots,
-    output logic [CountWidth-1:0] push_slots_next,
 
     // Push-side credits
     input  logic [CreditWidth-1:0] credit_initial_push,
@@ -133,9 +131,7 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
 
     // Pop-side status flags
     output logic                  pop_empty,
-    output logic                  pop_empty_next,
     output logic [CountWidth-1:0] pop_items,
-    output logic [CountWidth-1:0] pop_items_next,
 
     // Pop-side RAM read interface
     output logic                 pop_ram_rd_addr_valid,
@@ -179,9 +175,7 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
       .push_valid,
       .push_data,
       .push_full,
-      .push_full_next,
       .push_slots,
-      .push_slots_next,
       .credit_initial_push,
       .credit_withhold_push,
       .credit_count_push,
@@ -221,9 +215,7 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
       .pop_valid,
       .pop_data,
       .pop_empty,
-      .pop_empty_next,
       .pop_items,
-      .pop_items_next,
       .pop_ram_rd_addr_valid,
       .pop_ram_rd_addr,
       .pop_ram_rd_data_valid,

--- a/cdc/rtl/br_cdc_fifo_ctrl_pop_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_pop_1r1w.sv
@@ -79,9 +79,7 @@ module br_cdc_fifo_ctrl_pop_1r1w #(
 
     // Pop-side status flags
     output logic                  pop_empty,
-    output logic                  pop_empty_next,
     output logic [CountWidth-1:0] pop_items,
-    output logic [CountWidth-1:0] pop_items_next,
 
     // Pop-side RAM read interface
     output logic                 pop_ram_rd_addr_valid,
@@ -141,9 +139,7 @@ module br_cdc_fifo_ctrl_pop_1r1w #(
       .pop_valid,
       .pop_data,
       .empty            (pop_empty),
-      .empty_next       (pop_empty_next),
       .items            (pop_items),
-      .items_next       (pop_items_next),
       .ram_rd_addr_valid(pop_ram_rd_addr_valid),
       .ram_rd_addr      (pop_ram_rd_addr),
       .ram_rd_data_valid(pop_ram_rd_data_valid),

--- a/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w.sv
@@ -70,9 +70,7 @@ module br_cdc_fifo_ctrl_push_1r1w #(
 
     // Push-side status flags
     output logic                  push_full,
-    output logic                  push_full_next,
     output logic [CountWidth-1:0] push_slots,
-    output logic [CountWidth-1:0] push_slots_next,
 
     // Push-side RAM write interface
     output logic                 push_ram_wr_valid,
@@ -118,9 +116,7 @@ module br_cdc_fifo_ctrl_push_1r1w #(
       .push_valid,
       .push_data,
       .full             (push_full),
-      .full_next        (push_full_next),
       .slots            (push_slots),
-      .slots_next       (push_slots_next),
       .ram_wr_valid     (push_ram_wr_valid),
       .ram_wr_addr      (push_ram_wr_addr),
       .ram_wr_data      (push_ram_wr_data),

--- a/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w_push_credit.sv
@@ -76,9 +76,7 @@ module br_cdc_fifo_ctrl_push_1r1w_push_credit #(
 
     // Push-side status flags
     output logic                  push_full,
-    output logic                  push_full_next,
     output logic [CountWidth-1:0] push_slots,
-    output logic [CountWidth-1:0] push_slots_next,
 
     // Push-side credits
     input  logic [CreditWidth-1:0] credit_initial_push,
@@ -139,9 +137,7 @@ module br_cdc_fifo_ctrl_push_1r1w_push_credit #(
       .credit_count_push,
       .credit_available_push,
       .full             (push_full),
-      .full_next        (push_full_next),
       .slots            (push_slots),
-      .slots_next       (push_slots_next),
       .ram_wr_valid     (push_ram_wr_valid),
       .ram_wr_addr      (push_ram_wr_addr),
       .ram_wr_data      (push_ram_wr_data),

--- a/cdc/rtl/br_cdc_fifo_flops.sv
+++ b/cdc/rtl/br_cdc_fifo_flops.sv
@@ -34,11 +34,11 @@
 // Let PushT and PopT be the push period and pop period, respectively.
 //
 // The cut-through latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 2) * PushT +
-// (NumSyncStages + 1 + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
+// (NumSyncStages + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
 // FlopRamReadDataWidthStages + RegisterPopOutputs) * PopT.
 //
 // The backpressure latency is (RegisterResetActive + 1) * PopT +
-// (NumSyncStages + 1 + RegisterPushOutputs) * PushT.
+// (NumSyncStages + RegisterPushOutputs) * PushT.
 //
 // To achieve full bandwidth, the depth of the FIFO must be at least
 // (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
@@ -105,21 +105,16 @@ module br_cdc_fifo_flops #(
     input logic pop_rst,
 
     // Pop-side interface.
-    input  logic             pop_ready,
-    output logic             pop_valid,
-    output logic [Width-1:0] pop_data,
-
+    input  logic                  pop_ready,
+    output logic                  pop_valid,
+    output logic [     Width-1:0] pop_data,
     // Push-side status flags
-    output logic push_full,
-    output logic push_full_next,
+    output logic                  push_full,
     output logic [CountWidth-1:0] push_slots,
-    output logic [CountWidth-1:0] push_slots_next,
 
     // Pop-side status flags
     output logic pop_empty,
-    output logic pop_empty_next,
-    output logic [CountWidth-1:0] pop_items,
-    output logic [CountWidth-1:0] pop_items_next
+    output logic [CountWidth-1:0] pop_items
 );
 
   localparam int RamReadLatency =
@@ -166,13 +161,9 @@ module br_cdc_fifo_flops #(
       .pop_valid,
       .pop_data,
       .push_full,
-      .push_full_next,
       .push_slots,
-      .push_slots_next,
       .pop_empty,
-      .pop_empty_next,
       .pop_items,
-      .pop_items_next,
       .push_ram_wr_valid,
       .push_ram_wr_addr,
       .push_ram_wr_data,

--- a/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
@@ -31,11 +31,11 @@
 // Let PushT and PopT be the push period and pop period, respectively.
 //
 // The cut-through latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 2) * PushT +
-// (NumSyncStages + 1 + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
+// (NumSyncStages + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
 // FlopRamReadDataWidthStages + RegisterPopOutputs) * PopT.
 //
 // The backpressure latency is (RegisterResetActive + 1) * PopT +
-// (NumSyncStages + 1 + RegisterPushOutputs) * PushT.
+// (NumSyncStages + RegisterPushOutputs) * PushT.
 //
 // To achieve full bandwidth, the depth of the FIFO must be at least
 // (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
@@ -112,9 +112,7 @@ module br_cdc_fifo_flops_push_credit #(
 
     // Push-side status flags
     output logic push_full,
-    output logic push_full_next,
     output logic [CountWidth-1:0] push_slots,
-    output logic [CountWidth-1:0] push_slots_next,
 
     // Push-side credits
     input  logic [CreditWidth-1:0] credit_initial_push,
@@ -124,9 +122,7 @@ module br_cdc_fifo_flops_push_credit #(
 
     // Pop-side status flags
     output logic pop_empty,
-    output logic pop_empty_next,
-    output logic [CountWidth-1:0] pop_items,
-    output logic [CountWidth-1:0] pop_items_next
+    output logic [CountWidth-1:0] pop_items
 );
 
   localparam int RamReadLatency =
@@ -177,13 +173,9 @@ module br_cdc_fifo_flops_push_credit #(
       .pop_valid,
       .pop_data,
       .push_full,
-      .push_full_next,
       .push_slots,
-      .push_slots_next,
       .pop_empty,
-      .pop_empty_next,
       .pop_items,
-      .pop_items_next,
       .credit_initial_push,
       .credit_withhold_push,
       .credit_count_push,

--- a/cdc/rtl/internal/br_cdc_fifo_pop_ctrl.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_pop_ctrl.sv
@@ -42,9 +42,7 @@ module br_cdc_fifo_pop_ctrl #(
 
     // Pop-side status flags
     output logic                  empty,
-    output logic                  empty_next,
     output logic [CountWidth-1:0] items,
-    output logic [CountWidth-1:0] items_next,
 
     // RAM interface
     output logic                 ram_rd_addr_valid,
@@ -113,9 +111,7 @@ module br_cdc_fifo_pop_ctrl #(
       .pop_beat,
       .push_count_gray,
       .pop_count_gray,
-      .items_next,
       .items,
-      .empty_next,
       .empty,
       .reset_active_push,
       .reset_active_pop
@@ -131,7 +127,6 @@ module br_cdc_fifo_pop_ctrl #(
 
   // Flags
   `BR_ASSERT_IMPL(items_in_range_a, items <= Depth)
-  `BR_ASSERT_IMPL(pop_items_a, (items_next < items) |-> pop_beat)
   `BR_ASSERT_IMPL(empty_a, empty == (items == 0))
 
 endmodule : br_cdc_fifo_pop_ctrl

--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
@@ -48,9 +48,7 @@ module br_cdc_fifo_push_ctrl #(
 
     // Push-side status flags
     output logic                  full,
-    output logic                  full_next,
     output logic [CountWidth-1:0] slots,
-    output logic [CountWidth-1:0] slots_next,
 
     // RAM interface
     output logic                 ram_wr_valid,
@@ -88,9 +86,7 @@ module br_cdc_fifo_push_ctrl #(
       .push_count_gray,
       .pop_count_gray,
       .pop_count_delta(),
-      .slots_next,
       .slots,
-      .full_next,
       .full,
       .reset_active_push,
       .reset_active_pop
@@ -134,9 +130,6 @@ module br_cdc_fifo_push_ctrl #(
 
   // Flags
   `BR_ASSERT_IMPL(slots_in_range_a, slots <= Depth)
-  `BR_ASSERT_IMPL(slots_next_a, ##1 slots == $past(slots_next))
-  // Slots should only decrease on a push
-  `BR_ASSERT_IMPL(push_slots_a, (slots_next < slots) |-> push_beat)
   `BR_ASSERT_IMPL(full_a, full == (slots == 0))
 
 endmodule : br_cdc_fifo_push_ctrl

--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
@@ -43,9 +43,7 @@ module br_cdc_fifo_push_ctrl_credit #(
 
     // Push-side status flags
     output logic                  full,
-    output logic                  full_next,
     output logic [CountWidth-1:0] slots,
-    output logic [CountWidth-1:0] slots_next,
 
     // Push-side credits
     input  logic [CreditWidth-1:0] credit_initial_push,
@@ -126,9 +124,7 @@ module br_cdc_fifo_push_ctrl_credit #(
       .push_count_gray,
       .pop_count_gray,
       .pop_count_delta,
-      .slots_next,
       .slots,
-      .full_next,
       .full,
       .reset_active_push,
       .reset_active_pop
@@ -172,9 +168,6 @@ module br_cdc_fifo_push_ctrl_credit #(
 
   // Flags
   `BR_ASSERT_CR_IMPL(slots_in_range_a, slots <= Depth, clk, either_rst)
-  `BR_ASSERT_CR_IMPL(slots_next_a, ##1 slots == $past(slots_next), clk, either_rst)
-  // Slots should only decrease on a push
-  `BR_ASSERT_CR_IMPL(push_slots_a, (slots_next < slots) |-> push_beat, clk, either_rst)
   `BR_ASSERT_CR_IMPL(full_a, full == (slots == 0), clk, either_rst)
 
 endmodule : br_cdc_fifo_push_ctrl_credit

--- a/cdc/sim/br_cdc_fifo_flops_push_credit_tb.sv
+++ b/cdc/sim/br_cdc_fifo_flops_push_credit_tb.sv
@@ -88,9 +88,7 @@ module br_cdc_fifo_flops_push_credit_tb ();
       .push_valid(cv_push_valid_d),
       .push_data(cv_push_data_d),
       .push_full(full),
-      .push_full_next(),
       .push_slots(slots),
-      .push_slots_next(),
       .credit_initial_push,
       .credit_withhold_push('0),
       .credit_count_push(),
@@ -101,9 +99,7 @@ module br_cdc_fifo_flops_push_credit_tb ();
       .pop_valid,
       .pop_data,
       .pop_empty(empty),
-      .pop_empty_next(),
-      .pop_items(items),
-      .pop_items_next()
+      .pop_items(items)
   );
 
   br_credit_sender #(

--- a/cdc/sim/br_cdc_fifo_flops_tb.sv
+++ b/cdc/sim/br_cdc_fifo_flops_tb.sv
@@ -68,18 +68,14 @@ module br_cdc_fifo_flops_tb;
       .push_valid,
       .push_data,
       .push_slots(slots),
-      .push_slots_next(),
       .push_full(full),
-      .push_full_next(),
       .pop_clk(clk),  // ri lint_check_waive SAME_CLOCK_NAME
       .pop_rst(rst),
       .pop_ready,
       .pop_valid,
       .pop_data,
       .pop_empty(empty),
-      .pop_empty_next(),
-      .pop_items(items),
-      .pop_items_next()
+      .pop_items(items)
   );
 
   localparam int ResetActiveDelay = 1;


### PR DESCRIPTION
This removes one pop cycle from cut-through latency and one
push cycle from backpressure latency.