### PR TITLE
Add illegal_param_combinations to fpv_test_suite

### DIFF
--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -81,8 +81,7 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
     args = (["--hdr=" + hdr for hdr in hdr_files] +
             ["--define=" + define for define in ctx.attr.defines] +
             ["--top=" + top] +
-            ["--param=" + key + "=" + value for key, value in ctx.attr.params.items()] +
-            ["--illegal_param=" + key + "=" + value for key, value in ctx.attr.illegal_params.items()])
+            ["--param=" + key + "=" + value for key, value in ctx.attr.params.items()])
     filelist = ctx.label.name + ".f"
     tcl = ctx.label.name + ".tcl"
     script = ctx.label.name + ".sh"
@@ -511,9 +510,6 @@ rule_verilog_fpv_test = rule(
         "params": attr.string_dict(
             doc = "Verilog module parameters to set in the instantiation of the top-level module.",
         ),
-        "illegal_params": attr.string_dict(
-            doc = "Illegal Verilog module parameter combinations to exclude in the instantiation of the top-level module.",
-        ),
         "top": attr.string(
             doc = "The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.",
         ),
@@ -597,9 +593,6 @@ rule_verilog_fpv_sandbox = rule(
         ),
         "params": attr.string_dict(
             doc = "Verilog module parameters to set in the instantiation of the top-level module.",
-        ),
-        "illegal_params": attr.string_dict(
-            doc = "Illegal Verilog module parameter combinations to exclude in the instantiation of the top-level module.",
         ),
         "top": attr.string(
             doc = "The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.",
@@ -708,6 +701,7 @@ def verilog_fpv_test_suite(name, defines = [], params = {}, illegal_params = {},
         name (str): The base name for the test suite.
         defines (list): A list of defines.
         params (dict): A dictionary where keys are parameter names and values are lists of possible values for those parameters.
+        illegal_params (dict): A dictionary where keys are parameter tuples and values are lists of illegal values for those parameters.
         sandbox (bool): Whether to create a sandbox for the test.
         **kwargs: Additional keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.
     """

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -690,7 +690,7 @@ def verilog_elab_and_lint_test_suite(name, defines = [], params = {}, **kwargs):
             **kwargs
         )
 
-def verilog_fpv_test_suite(name, defines = [], params = {}, illegal_params = {}, sandbox = True, **kwargs):
+def verilog_fpv_test_suite(name, defines = [], params = {}, illegal_param_combinations = {}, sandbox = True, **kwargs):
     """Creates a suite of Verilog fpv tests for each combination of the provided parameters.
 
     The function generates all possible combinations of the provided parameters and creates a verilog_fpv_test
@@ -701,7 +701,7 @@ def verilog_fpv_test_suite(name, defines = [], params = {}, illegal_params = {},
         name (str): The base name for the test suite.
         defines (list): A list of defines.
         params (dict): A dictionary where keys are parameter names and values are lists of possible values for those parameters.
-        illegal_params (dict): A dictionary where keys are parameter tuples and values are lists of illegal values for those parameters.
+        illegal_param_combinations (dict): A dictionary where keys are parameter tuples and values are lists of illegal values for those parameters.
         sandbox (bool): Whether to create a sandbox for the test.
         **kwargs: Additional keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.
     """
@@ -715,7 +715,7 @@ def verilog_fpv_test_suite(name, defines = [], params = {}, illegal_params = {},
 
         # Check if this combination is illegal
         skip = False
-        for keys_tuple, disallowed_values in illegal_params.items():
+        for keys_tuple, disallowed_values in illegal_param_combinations.items():
             values_tuple = tuple([params[k] for k in keys_tuple])
             if values_tuple in disallowed_values:
                 skip = True


### PR DESCRIPTION
For FPV BUILD.bazel, if some parameter combinations are illegal, after adding illegal_params in br_verilog_fpv_test_suite. Those parameter sweep will be skipped.

br_verilog_fpv_test_suite(
    params = {
        "EnableAssertPushDataStability": [
            "0",
            "1",
        ],
        "EnableAssertPushValidStability": [
            "0",
            "1",
        ],
        "EnableCoverPushBackpressure": [
            "0",
            "1",
        ],
        "NumFlows": [
            "2",
            "4",
            "5",
        ],
        "Width": [
            "1",
            "3",
            "4",
        ],
    },
    illegal_params = {
    ("EnableCoverPushBackpressure", 
     "EnableAssertPushValidStability", 
     "EnableAssertPushDataStability"): [
        ("0","0","1"),
        ("0","1","0"),
        ("0","1","1"),
        ("1","0","1"),
    ]
    },