### PR TITLE
amba: update axi2axil splitting logic

### DIFF
--- a/amba/rtl/BUILD.bazel
+++ b/amba/rtl/BUILD.bazel
@@ -279,6 +279,10 @@ br_verilog_elab_and_lint_test_suite(
             "32",
             "64",
         ],
+        "ForwardLatencyCycles": [
+            "0",
+            "1",
+        ],
     },
     deps = [":br_amba_axi2axil"],
 )

--- a/amba/rtl/br_amba_axi2axil.sv
+++ b/amba/rtl/br_amba_axi2axil.sv
@@ -14,9 +14,9 @@
 
 // Bedrock-RTL AXI4 to AXI4-Lite Bridge
 //
-// Converts an AXI4 interface to an AXI4-Lite interface. This module supports FIXED and INCR bursts.
-// It does not support WRAP bursts. AXI4 burst transactions will be split into multiple AXI4-Lite
-// transactions. All write responses will be aggregated into a single AXI4 write response.
+// Converts an AXI4 interface to an AXI4-Lite interface. AXI4 burst transactions will be split into
+// multiple AXI4-Lite transactions. All write responses will be aggregated into a single AXI4 write
+// response.
 //
 
 `include "br_asserts_internal.svh"
@@ -32,6 +32,9 @@ module br_amba_axi2axil #(
     parameter int BUserWidth = 8,  // Must be at least 1
     parameter int RUserWidth = 8,  // Must be at least 1
     parameter int MaxOutstandingReqs = 16,  // Must be at least 2
+    // If 0, a rev timing slice will be added and the forward latency will be 0 cycles.
+    // If 1, a full timing slice will be added and the forward latency will be 1 cycle.
+    parameter bit ForwardLatencyCycles = 0,
     localparam int StrobeWidth = DataWidth / 8
 ) (
     input clk,
@@ -130,7 +133,8 @@ module br_amba_axi2axil #(
       .RespUserWidth(BUserWidth),
       .ReqDataUserWidth(WUserWidth),
       .IsReadNotWrite(0),
-      .MaxOutstandingReqs(MaxOutstandingReqs)
+      .MaxOutstandingReqs(MaxOutstandingReqs),
+      .ForwardLatencyCycles(ForwardLatencyCycles)
   ) br_amba_axi2axil_core_write (
       .clk,
       .rst,
@@ -189,7 +193,8 @@ module br_amba_axi2axil #(
       .RespUserWidth(RUserWidth),
       .ReqDataUserWidth(1),
       .IsReadNotWrite(1),
-      .MaxOutstandingReqs(MaxOutstandingReqs)
+      .MaxOutstandingReqs(MaxOutstandingReqs),
+      .ForwardLatencyCycles(ForwardLatencyCycles)
   ) br_amba_axi2axil_core_read (
       .clk,
       .rst,

--- a/amba/rtl/internal/BUILD.bazel
+++ b/amba/rtl/internal/BUILD.bazel
@@ -24,6 +24,7 @@ verilog_library(
         "//amba/rtl:br_amba_pkg",
         "//counter/rtl:br_counter_incr",
         "//fifo/rtl:br_fifo_flops",
+        "//flow/rtl:br_flow_reg_both",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
         "//macros:br_unused",

--- a/amba/rtl/internal/BUILD.bazel
+++ b/amba/rtl/internal/BUILD.bazel
@@ -25,6 +25,7 @@ verilog_library(
         "//counter/rtl:br_counter_incr",
         "//fifo/rtl:br_fifo_flops",
         "//flow/rtl:br_flow_reg_both",
+        "//flow/rtl:br_flow_reg_rev",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
         "//macros:br_unused",
@@ -39,6 +40,10 @@ br_verilog_elab_and_lint_test_suite(
         ],
         "DataWidth": [
             "64",
+        ],
+        "ForwardLatencyCycles": [
+            "0",
+            "1",
         ],
     },
     deps = [":br_amba_axi2axil_core"],

--- a/amba/rtl/internal/br_amba_axi2axil_core.sv
+++ b/amba/rtl/internal/br_amba_axi2axil_core.sv
@@ -196,7 +196,7 @@ module br_amba_axi2axil_core #(
       br_amba::AxiProtWidth +
       ReqUserWidth
     )
-  ) br_flow_reg_both_aw_slice (
+  ) br_flow_reg_both_req (
       .clk,
       .rst,
       .push_ready(axi_req_ready),

--- a/amba/rtl/internal/br_amba_axi2axil_core.sv
+++ b/amba/rtl/internal/br_amba_axi2axil_core.sv
@@ -36,6 +36,7 @@ module br_amba_axi2axil_core #(
     parameter int ReqDataUserWidth = 8,  // Must be at least 1
     parameter int MaxOutstandingReqs = 16,  // Must be at least 2
     parameter bit IsReadNotWrite = 0,  // Must be 0 or 1
+    parameter bit ForwardLatencyCycles = 0,  // Must be 0 or 1
     localparam int StrobeWidth = DataWidth / 8
 ) (
     input clk,
@@ -186,42 +187,82 @@ module br_amba_axi2axil_core #(
   // Flow Register to Capture the AXI4 Request
   //----------------------------------------------------------------------------
 
-  br_flow_reg_both #(
-      .Width(
-      AddrWidth +
-      IdWidth +
-      br_amba::AxiBurstLenWidth +
-      br_amba::AxiBurstSizeWidth +
-      br_amba::AxiBurstTypeWidth +
-      br_amba::AxiProtWidth +
-      ReqUserWidth
-    )
-  ) br_flow_reg_both_req (
-      .clk,
-      .rst,
-      .push_ready(axi_req_ready),
-      .push_valid(axi_req_valid),
-      .push_data({
-        axi_req_addr,
-        axi_req_id,
-        axi_req_len,
-        axi_req_size,
-        axi_req_burst,
-        axi_req_prot,
-        axi_req_user
-      }),
-      .pop_ready(flow_reg_pop_ready),
-      .pop_valid(flow_reg_pop_valid),
-      .pop_data({
-        axi_req_addr_reg,
-        axi_req_id_reg,
-        axi_req_len_reg,
-        axi_req_size_reg,
-        axi_req_burst_reg,
-        axi_req_prot_reg,
-        axi_req_user_reg
-      })
-  );
+  if (ForwardLatencyCycles) begin : gen_forward_latency
+    br_flow_reg_both #(
+        .Width(
+        AddrWidth +
+        IdWidth +
+        br_amba::AxiBurstLenWidth +
+        br_amba::AxiBurstSizeWidth +
+        br_amba::AxiBurstTypeWidth +
+        br_amba::AxiProtWidth +
+        ReqUserWidth
+      )
+    ) br_flow_reg_both_req (
+        .clk,
+        .rst,
+        .push_ready(axi_req_ready),
+        .push_valid(axi_req_valid),
+        .push_data({
+          axi_req_addr,
+          axi_req_id,
+          axi_req_len,
+          axi_req_size,
+          axi_req_burst,
+          axi_req_prot,
+          axi_req_user
+        }),
+        .pop_ready(flow_reg_pop_ready),
+        .pop_valid(flow_reg_pop_valid),
+        .pop_data({
+          axi_req_addr_reg,
+          axi_req_id_reg,
+          axi_req_len_reg,
+          axi_req_size_reg,
+          axi_req_burst_reg,
+          axi_req_prot_reg,
+          axi_req_user_reg
+        })
+    );
+  end : gen_forward_latency
+  else begin : gen_no_forward_latency
+    br_flow_reg_rev #(
+        .Width(
+        AddrWidth +
+        IdWidth +
+        br_amba::AxiBurstLenWidth +
+        br_amba::AxiBurstSizeWidth +
+        br_amba::AxiBurstTypeWidth +
+        br_amba::AxiProtWidth +
+        ReqUserWidth
+      )
+    ) br_flow_reg_rev_req (
+        .clk,
+        .rst,
+        .push_ready(axi_req_ready),
+        .push_valid(axi_req_valid),
+        .push_data({
+          axi_req_addr,
+          axi_req_id,
+          axi_req_len,
+          axi_req_size,
+          axi_req_burst,
+          axi_req_prot,
+          axi_req_user
+        }),
+        .pop_ready(flow_reg_pop_ready),
+        .pop_valid(flow_reg_pop_valid),
+        .pop_data({
+          axi_req_addr_reg,
+          axi_req_id_reg,
+          axi_req_len_reg,
+          axi_req_size_reg,
+          axi_req_burst_reg,
+          axi_req_prot_reg,
+          axi_req_user_reg
+        })
+    );
+  end : gen_no_forward_latency
 
   assign flow_reg_pop_handshake = flow_reg_pop_valid && flow_reg_pop_ready;
 

--- a/amba/rtl/internal/br_amba_axi2axil_core.sv
+++ b/amba/rtl/internal/br_amba_axi2axil_core.sv
@@ -157,7 +157,7 @@ module br_amba_axi2axil_core #(
 
   logic [br_amba::AxiBurstLenWidth-1:0] req_count;
   logic [br_amba::AxiRespWidth-1:0] resp, resp_next;
-  logic axi_req_handshake;
+  logic flow_reg_pop_handshake;
   logic axi_resp_handshake;
   logic axil_req_handshake;
   logic axil_resp_handshake;
@@ -165,7 +165,15 @@ module br_amba_axi2axil_core #(
   logic resp_fifo_push_valid;
   logic resp_fifo_push_ready, resp_fifo_pop_ready;
   logic is_last_req_beat;
-  logic req_counter_incr;
+  logic flow_reg_pop_valid;
+  logic flow_reg_pop_ready;
+  logic [AddrWidth-1:0] axi_req_addr_reg;
+  logic [IdWidth-1:0] axi_req_id_reg;
+  logic [br_amba::AxiProtWidth-1:0] axi_req_prot_reg;
+  logic [ReqUserWidth-1:0] axi_req_user_reg;
+  logic [br_amba::AxiBurstLenWidth-1:0] axi_req_len_reg;
+  logic [br_amba::AxiBurstSizeWidth-1:0] axi_req_size_reg;
+  logic [br_amba::AxiBurstTypeWidth-1:0] axi_req_burst_reg;
 
   //----------------------------------------------------------------------------
   // Registers
@@ -175,10 +183,52 @@ module br_amba_axi2axil_core #(
             br_amba::AxiRespOkay)  // ri lint_check_waive ENUM_RHS
 
   //----------------------------------------------------------------------------
+  // Flow Register to Capture the AXI4 Request
+  //----------------------------------------------------------------------------
+
+  br_flow_reg_both #(
+      .Width(
+      AddrWidth +
+      IdWidth +
+      br_amba::AxiBurstLenWidth +
+      br_amba::AxiBurstSizeWidth +
+      br_amba::AxiBurstTypeWidth +
+      br_amba::AxiProtWidth +
+      ReqUserWidth
+    )
+  ) br_flow_reg_both_aw_slice (
+      .clk,
+      .rst,
+      .push_ready(axi_req_ready),
+      .push_valid(axi_req_valid),
+      .push_data({
+        axi_req_addr,
+        axi_req_id,
+        axi_req_len,
+        axi_req_size,
+        axi_req_burst,
+        axi_req_prot,
+        axi_req_user
+      }),
+      .pop_ready(flow_reg_pop_ready),
+      .pop_valid(flow_reg_pop_valid),
+      .pop_data({
+        axi_req_addr_reg,
+        axi_req_id_reg,
+        axi_req_len_reg,
+        axi_req_size_reg,
+        axi_req_burst_reg,
+        axi_req_prot_reg,
+        axi_req_user_reg
+      })
+  );
+
+  assign flow_reg_pop_handshake = flow_reg_pop_valid && flow_reg_pop_ready;
+
+  //----------------------------------------------------------------------------
   // AXI4 and AXI4-Lite Handshakes
   //----------------------------------------------------------------------------
 
-  assign axi_req_handshake = axi_req_valid && axi_req_ready;
   assign axi_resp_handshake = axi_resp_valid && axi_resp_ready;
 
   assign axil_req_handshake = axil_req_valid && axil_req_ready;
@@ -188,11 +238,11 @@ module br_amba_axi2axil_core #(
   // Request Handshake Logic
   //----------------------------------------------------------------------------
 
-  // Perform AXI handshake when the last AXI4-Lite request is issued
-  assign axi_req_ready = axil_req_handshake && is_last_req_beat;
+  // Pop the flow reg when the last AXI4-Lite request is issued
+  assign flow_reg_pop_ready = axil_req_handshake && is_last_req_beat;
 
   // Issue AXI4-Lite requests as long as the response FIFO is ready
-  assign axil_req_valid = axi_req_valid && resp_fifo_push_ready;
+  assign axil_req_valid = flow_reg_pop_valid && resp_fifo_push_ready;
 
 
   //----------------------------------------------------------------------------
@@ -202,23 +252,21 @@ module br_amba_axi2axil_core #(
   // Request count
   br_counter_incr #(
       .MaxValue((1 << br_amba::AxiBurstLenWidth) - 1),
-      .MaxIncrement(1)
+      .MaxIncrement(1),
+      .EnableReinitAndIncr(0)
   ) br_counter_incr_req (
       .clk,
       .rst,
-      .reinit(axi_req_handshake),
+      .reinit(flow_reg_pop_handshake),
       .initial_value({br_amba::AxiBurstLenWidth{1'b0}}),
       .incr_valid(axil_req_handshake),
-      .incr(req_counter_incr),
+      .incr(1'b1),
       .value(req_count),
       .value_next()
   );
 
-  // Do not increment in the same cycle as reinit. Otherwise, increment by 1.
-  assign req_counter_incr = !axi_req_handshake;
-
   // We only need to compare the lower bits of the request count to the burst length.
-  assign is_last_req_beat = (req_count == axi_req_len);
+  assign is_last_req_beat = (req_count == axi_req_len_reg);
 
   //----------------------------------------------------------------------------
   // Request Transaction Signals
@@ -226,10 +274,10 @@ module br_amba_axi2axil_core #(
 
   // AXI4-Lite request signals
   assign axil_req_addr = next_address(
-      axi_req_addr, axi_req_size, axi_req_len, axi_req_burst, req_count
+      axi_req_addr_reg, axi_req_size_reg, axi_req_len_reg, axi_req_burst_reg, req_count
   );
-  assign axil_req_prot = axi_req_prot;
-  assign axil_req_user = axi_req_user;
+  assign axil_req_prot = axi_req_prot_reg;
+  assign axil_req_user = axi_req_user_reg;
 
   //----------------------------------------------------------------------------
   // Request Data Path Signals
@@ -282,7 +330,7 @@ module br_amba_axi2axil_core #(
       .items_next()
   );
 
-  assign resp_fifo_push_data = {axi_req_id, is_last_req_beat};
+  assign resp_fifo_push_data = {axi_req_id_reg, is_last_req_beat};
   assign resp_fifo_push_valid = axil_req_handshake;
 
   assign resp_fifo_pop_ready = axil_resp_handshake;


### PR DESCRIPTION
This PR addresses a functional bug in the AXI4 burst splitting logic for read bursts. 

In the previous implementation, we held the `arready` signal low until we had sent all of the single-beat AXI4-Lite requests. We implicitly made an assumption that we would be able to send all of the requests before read responses returned. We do not buffer AXI4-Lite read responses and pass them back through to the AXI4 initiator. 

However, if the burst is really long, or if the read response data returns quickly, then the read responses were returning to the initiator before `arready` was even asserted. This violates the AXI4 specification.

There are a few solutions:

1. Buffer the read responses until all AXI4-Lite transactions have been forwarded. This could lead to deadlock without using a large enough FIFO to buffer the maximum possible burst length.
2. Assert `arready` when the first AXI4-Lite transaction is sent, capturing the transaction attributes in a flow reg, and using the registered transaction attributes for the remaining AXI4-Lite transactions. 

In this PR, we take Approach 2 to keep the implementation simple. 