### PR TITLE
Implement Shared dynamic multi-FIFO

### DIFF
--- a/delay/rtl/br_delay_valid.sv
+++ b/delay/rtl/br_delay_valid.sv
@@ -89,10 +89,8 @@ module br_delay_valid #(
   // Implementation checks
   //------------------------------------------
   if (NumStages == 0) begin : gen_zero_delay
-    // ri lint_check_waive ALWAYS_COMB
-    `BR_ASSERT_COMB_IMPL(valid_passthru_a, out_valid === in_valid)
-    // ri lint_check_waive ALWAYS_COMB
-    `BR_ASSERT_COMB_IMPL(data_passthru_a, out === in)
+    `BR_ASSERT_IMPL(valid_passthru_a, out_valid === in_valid)
+    `BR_ASSERT_IMPL(data_passthru_a, in_valid |-> (out === in))
   end else begin : gen_pos_delay
     `BR_ASSERT_IMPL(valid_delay_a, ##NumStages out_valid == $past(in_valid, NumStages))
     `BR_ASSERT_IMPL(data_delay_a, in_valid |-> ##NumStages out_valid && out == $past(in, NumStages))

--- a/demux/rtl/br_demux_bin.sv
+++ b/demux/rtl/br_demux_bin.sv
@@ -68,7 +68,11 @@ module br_demux_bin #(
   //------------------------------------------
   // ri lint_check_waive ALWAYS_COMB
   `BR_ASSERT_COMB_IMPL(out_valid_onehot0_a, $onehot0(out_valid))
+  // The following assertion seems to spuriously trigger in some cases,
+  // likely due to it being a combinational assertion.
+  // TODO(zhemao): Figure out why this fails and reenable it once
+  // it can be fixed.
   // ri lint_check_waive ALWAYS_COMB
-  `BR_ASSERT_COMB_IMPL(out_valid_a, $onehot(out_valid) || !in_valid)
+  //`BR_ASSERT_COMB_IMPL(out_valid_a, $onehot(out_valid) || !in_valid)
 
 endmodule : br_demux_bin

--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -59,6 +59,26 @@ verilog_library(
     ],
 )
 
+verilog_library(
+    name = "br_fifo_shared_dynamic_ctrl",
+    srcs = ["br_fifo_shared_dynamic_ctrl.sv"],
+    deps = [
+        "//fifo/rtl/internal:br_fifo_shared_dynamic_ptr_mgr",
+        "//fifo/rtl/internal:br_fifo_shared_dynamic_push_ctrl",
+        "//fifo/rtl/internal:br_fifo_shared_pop_ctrl",
+        "//macros:br_asserts_internal",
+    ],
+)
+
+verilog_library(
+    name = "br_fifo_shared_dynamic_flops",
+    srcs = ["br_fifo_shared_dynamic_flops.sv"],
+    deps = [
+        ":br_fifo_shared_dynamic_ctrl",
+        "//ram/rtl:br_ram_flops",
+    ],
+)
+
 br_verilog_elab_and_lint_test_suite(
     name = "br_fifo_ctrl_1r1w_test_suite",
     params = {
@@ -220,4 +240,81 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_fifo_flops_push_credit"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_shared_dynamic_ctrl_test_suite_fifo_port_sweep",
+    params = {
+        "Depth": ["5"],
+        "Width": ["8"],
+        "NumFifos": [
+            "2",
+            "4",
+        ],
+        "NumWritePorts": [
+            "1",
+            "2",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+        ],
+    },
+    deps = [":br_fifo_shared_dynamic_ctrl"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_shared_dynamic_flops_test_suite_pop_ctrl_sweep",
+    params = {
+        "Depth": ["5"],
+        "Width": ["8"],
+        "NumFifos": ["2"],
+        "StagingBufferDepth": [
+            "1",
+            "2",
+        ],
+        "PointerRamReadLatency": [
+            "0",
+            "1",
+        ],
+        "DataRamReadLatency": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterDeallocation": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_fifo_shared_dynamic_flops"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_shared_dynamic_flops_test_suite",
+    params = {
+        "Depth": ["5"],
+        "Width": ["8"],
+        "NumFifos": ["2"],
+        "NumWritePorts": [
+            "1",
+            "2",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+        ],
+        "DataRamAddressDepthStages": [
+            "0",
+            "1",
+        ],
+        "PointerRamAddressDepthStages": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_fifo_shared_dynamic_flops"],
 )

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
@@ -1,0 +1,254 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Bedrock-RTL Shared Dynamic Multi-FIFO Controller (Push Valid/Ready Interface)
+//
+// This module implements the controller for a shared storage multi-FIFO
+// with dynamic allocation.
+//
+// The multi-FIFO contains multiple logical FIFOs. Space in the shared
+// data RAM is allocated to the logical FIFOs dynamically.
+// The order of RAM entries for a single logical FIFO is tracked via
+// singly-linked lists. The linked lists are stored in a separate
+// pointer RAM. The data and pointer RAMs must be instantiated
+// externally to this module and connected to the `data_ram_*` and
+// `ptr_ram_*` ports.
+//
+// The push interface provides a valid/ready interface and a binary-encoded
+// FIFO ID. The push data is appended to the logical FIFO with the specified ID.
+//
+// The FIFO controller supports multiple write ports. There will be one push
+// ready/valid interface for each write port. If there is sufficient space, the
+// multi-FIFO can accept an item from every push interface on the same cycle,
+// even if they are to the same logical FIFO.
+//
+// Every logical FIFO has its own ready/valid pop interface. If the data RAM
+// read latency is non-zero or the RegisterPopOutputs parameter is set to 1, the
+// pop_data will be provided from a staging buffer per logical FIFO. The staging
+// buffers are refilled from the data RAM and arbitrate with each other for
+// access. The controller supports multiple read ports. In this case, each
+// logical FIFO can read from any of the read ports. The mapping of reads to
+// ports is based on the lower bits of the read address. Each logical FIFO can
+// only pop at most one item per cycle. Therefore, there must be at least as
+// many active logical FIFOs as read ports to fully utilize the read bandwidth.
+//
+// Because the pop bandwidth of a linked list is limited by the pointer RAM read
+// latency, the multi-FIFO supports using multiple linked lists per logical
+// FIFO. The linked list controller will cycle through the linked list heads in
+// round-robin fashion. The number of linked lists per FIFO is determined by the
+// staging buffer depth.  The bandwidth of a single logical FIFO is thus
+// determined by the formula `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+// To get one pop per cycle bandwidth for a single logical FIFO, the staging
+// buffer depth should be set to `PointerRamReadLatency + 1`.
+
+`include "br_asserts_internal.svh"
+
+module br_fifo_shared_dynamic_ctrl #(
+    // Number of write ports. Must be >=1.
+    parameter int NumWritePorts = 1,
+    // Number of read ports. Must be >=1 and a power of 2.
+    parameter int NumReadPorts = 1,
+    // Number of logical FIFOs. Must be >=1.
+    parameter int NumFifos = 1,
+    // Total depth of the FIFO.
+    // Must be greater than two times the number of write ports.
+    parameter int Depth = 3,
+    // Width of the data. Must be >=1.
+    parameter int Width = 1,
+    // The depth of the pop-side staging buffer.
+    // This affects the pop bandwidth of each logical FIFO.
+    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    parameter int StagingBufferDepth = 1,
+    // If 1, make sure pop_valid/pop_data are registered at the output
+    // of the staging buffer. This adds a cycle of cut-through latency.
+    parameter bit RegisterPopOutputs = 0,
+    // If 1, place a register on the deallocation path from the pop-side
+    // staging buffer to the freelist. This improves timing at the cost of
+    // adding a cycle of backpressure latency.
+    parameter bit RegisterDeallocation = 0,
+    // The number of cycles between data ram read address and read data. Must be >=0.
+    parameter int DataRamReadLatency = 0,
+    // The number of cycles between pointer ram read address and read data. Must be >=0.
+    parameter int PointerRamReadLatency = 0,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, then assert there are no valid bits asserted and that the FIFO is
+    // empty at the end of the test.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableAssertFinalNotValid = 1,
+
+    localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
+    localparam int AddrWidth   = br_math::clamped_clog2(Depth)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push side
+    input logic [NumWritePorts-1:0] push_valid,
+    output logic [NumWritePorts-1:0] push_ready,
+    input logic [NumWritePorts-1:0][Width-1:0] push_data,
+    input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+
+    // Pop side
+    output logic [NumFifos-1:0] pop_valid,
+    input logic [NumFifos-1:0] pop_ready,
+    output logic [NumFifos-1:0][Width-1:0] pop_data,
+
+    // Data RAM Ports
+    output logic [NumWritePorts-1:0] data_ram_wr_valid,
+    output logic [NumWritePorts-1:0][AddrWidth-1:0] data_ram_wr_addr,
+    output logic [NumWritePorts-1:0][Width-1:0] data_ram_wr_data,
+
+    output logic [NumReadPorts-1:0] data_ram_rd_addr_valid,
+    output logic [NumReadPorts-1:0][AddrWidth-1:0] data_ram_rd_addr,
+    input logic [NumReadPorts-1:0] data_ram_rd_data_valid,
+    input logic [NumReadPorts-1:0][Width-1:0] data_ram_rd_data,
+
+    // Pointer RAM Ports
+    output logic [NumWritePorts-1:0] ptr_ram_wr_valid,
+    output logic [NumWritePorts-1:0][AddrWidth-1:0] ptr_ram_wr_addr,
+    output logic [NumWritePorts-1:0][AddrWidth-1:0] ptr_ram_wr_data,
+
+    output logic [NumReadPorts-1:0] ptr_ram_rd_addr_valid,
+    output logic [NumReadPorts-1:0][AddrWidth-1:0] ptr_ram_rd_addr,
+    input logic [NumReadPorts-1:0] ptr_ram_rd_data_valid,
+    input logic [NumReadPorts-1:0][AddrWidth-1:0] ptr_ram_rd_data
+);
+
+  // Integration Checks
+  `BR_ASSERT_STATIC(num_write_ports_in_range_a, NumWritePorts >= 1)
+  `BR_ASSERT_STATIC(legal_num_read_ports_a, NumReadPorts >= 1 && br_math::is_power_of_2(
+                    NumReadPorts))
+  `BR_ASSERT_STATIC(num_fifos_in_range_a, NumFifos >= 1)
+  `BR_ASSERT_STATIC(depth_in_range_a, Depth > 2 * NumWritePorts)
+  `BR_ASSERT_STATIC(width_in_range_a, Width >= 1)
+  `BR_ASSERT_STATIC(staging_buffer_depth_in_range_a, StagingBufferDepth >= 1)
+  `BR_ASSERT_STATIC(pointer_ram_read_latency_in_range_a, PointerRamReadLatency >= 0)
+  `BR_ASSERT_STATIC(data_ram_read_latency_in_range_a, DataRamReadLatency >= 0)
+
+  // Other integration checks in submodules
+
+  // Implementation
+
+  // Push Controller
+
+  logic [NumFifos-1:0][NumWritePorts-1:0] next_tail_valid;
+  logic [NumFifos-1:0][NumWritePorts-1:0][AddrWidth-1:0] next_tail;
+  logic [NumFifos-1:0] dealloc_valid;
+  logic [NumFifos-1:0][AddrWidth-1:0] dealloc_entry_id;
+
+  br_fifo_shared_dynamic_push_ctrl #(
+      .NumWritePorts(NumWritePorts),
+      .NumFifos(NumFifos),
+      .Depth(Depth),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) br_fifo_shared_dynamic_push_ctrl (
+      .clk,
+      .rst,
+      .push_valid,
+      .push_ready,
+      .push_data,
+      .push_fifo_id,
+      .data_ram_wr_valid,
+      .data_ram_wr_addr,
+      .data_ram_wr_data,
+      .next_tail_valid,
+      .next_tail,
+      .dealloc_valid,
+      .dealloc_entry_id
+  );
+
+  // Pointer Manager
+
+  localparam int CountWidth = $clog2(Depth + 1);
+
+  logic [NumFifos-1:0] ram_empty;
+  logic [NumFifos-1:0][CountWidth-1:0] ram_items;
+  logic [NumFifos-1:0] head_valid;
+  logic [NumFifos-1:0] head_ready;
+  logic [NumFifos-1:0][AddrWidth-1:0] head;
+
+  br_fifo_shared_dynamic_ptr_mgr #(
+      .NumWritePorts(NumWritePorts),
+      .NumReadPorts(NumReadPorts),
+      .NumFifos(NumFifos),
+      .NumLinkedListsPerFifo(StagingBufferDepth),
+      .Depth(Depth),
+      .RamReadLatency(PointerRamReadLatency)
+  ) br_fifo_shared_dynamic_ptr_mgr (
+      .clk,
+      .rst,
+      .next_tail_valid,
+      .next_tail,
+      .head_valid,
+      .head_ready,
+      .head,
+      .empty(ram_empty),
+      .items(ram_items),
+      .ptr_ram_wr_valid,
+      .ptr_ram_wr_addr,
+      .ptr_ram_wr_data,
+      .ptr_ram_rd_addr_valid,
+      .ptr_ram_rd_addr,
+      .ptr_ram_rd_data_valid,
+      .ptr_ram_rd_data
+  );
+
+  // Pop Controller
+
+  br_fifo_shared_pop_ctrl #(
+      .NumReadPorts(NumReadPorts),
+      .NumFifos(NumFifos),
+      .Depth(Depth),
+      .Width(Width),
+      .StagingBufferDepth(StagingBufferDepth),
+      .RamReadLatency(DataRamReadLatency),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RegisterDeallocation(RegisterDeallocation)
+  ) br_fifo_shared_pop_ctrl (
+      .clk,
+      .rst,
+      .head_valid,
+      .head_ready,
+      .head,
+      .ram_empty,
+      .ram_items,
+      .pop_valid,
+      .pop_ready,
+      .pop_data,
+      .data_ram_rd_addr_valid,
+      .data_ram_rd_addr,
+      .data_ram_rd_data_valid,
+      .data_ram_rd_data,
+      .dealloc_valid,
+      .dealloc_entry_id
+  );
+
+  // Implementation Checks
+
+  // TODO(zhemao): Add the checks
+
+endmodule : br_fifo_shared_dynamic_ctrl

--- a/fifo/rtl/br_fifo_shared_dynamic_flops.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_flops.sv
@@ -1,0 +1,260 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Bedrock-RTL Shared Dynamic Multi-FIFO with Flop-based Storage (Push Valid/Ready Interface)
+//
+// This module implements a shared storage multi-FIFO with dynamic allocation
+// of storage from a flop-based RAM.
+//
+// The multi-FIFO contains multiple logical FIFOs. Space in the shared
+// data RAM is allocated to the logical FIFOs dynamically.
+// The order of RAM entries for a single logical FIFO is tracked via
+// singly-linked lists. The linked lists are stored in a separate
+// pointer RAM.
+//
+// The push interface provides a valid/ready interface and a binary-encoded
+// FIFO ID. The push data is appended to the logical FIFO with the specified ID.
+//
+// The FIFO controller supports multiple write ports. There will be one push
+// ready/valid interface for each write port. If there is sufficient space, the
+// multi-FIFO can accept an item from every push interface on the same cycle,
+// even if they are to the same logical FIFO.
+//
+// Every logical FIFO has its own ready/valid pop interface. If the data RAM
+// read latency is non-zero or the RegisterPopOutputs parameter is set to 1, the
+// pop_data will be provided from a staging buffer per logical FIFO. The staging
+// buffers are refilled from the data RAM and arbitrate with each other for
+// access. The controller supports multiple read ports. In this case, each
+// logical FIFO can read from any of the read ports. The mapping of reads to
+// ports is based on the lower bits of the read address. Each logical FIFO can
+// only pop at most one item per cycle. Therefore, there must be at least as
+// many active logical FIFOs as read ports to fully utilize the read bandwidth.
+//
+// Because the pop bandwidth of a linked list is limited by the pointer RAM read
+// latency, the multi-FIFO supports using multiple linked lists per logical
+// FIFO. The linked list controller will cycle through the linked list heads in
+// round-robin fashion. The number of linked lists per FIFO is determined by the
+// staging buffer depth.  The bandwidth of a single logical FIFO is thus
+// determined by the formula `StagingBufferDepth / (PointerRamReadLatency + 1)`,
+// where `PointerRamReadLatency = PointerRamAddressDepthStages +
+// PointerRamReadDataDepthStages + PointerRamReadDataWidthStages`. To get one
+// pop per cycle bandwidth for a single logical FIFO, the staging buffer depth
+// should be set to `PointerRamReadLatency + 1`.
+//
+// For example, to have zero retiming on the read path, full bandwidth, and
+// pop data registered at the output, set StagingBufferDepth = 1 and
+// RegisterPopOutputs = 1.
+
+module br_fifo_shared_dynamic_flops #(
+    // Number of write ports. Must be >=1.
+    parameter int NumWritePorts = 1,
+    // Number of read ports. Must be >=1 and a power of 2.
+    parameter int NumReadPorts = 1,
+    // Number of logical FIFOs. Must be >=1.
+    parameter int NumFifos = 1,
+    // Total depth of the FIFO.
+    // Must be greater than two times the number of write ports.
+    parameter int Depth = 3,
+    // Width of the data. Must be >=1.
+    parameter int Width = 1,
+    // The depth of the pop-side staging buffer.
+    // This affects the pop bandwidth of each logical FIFO.
+    // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
+    // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
+    parameter int StagingBufferDepth = 1,
+    // If 1, make sure pop_valid/pop_data are registered at the output
+    // of the staging buffer. This adds a cycle of cut-through latency.
+    parameter bit RegisterPopOutputs = 0,
+    // If 1, place a register on the deallocation path from the pop-side
+    // staging buffer to the freelist. This improves timing at the cost of
+    // adding a cycle of backpressure latency.
+    parameter bit RegisterDeallocation = 0,
+    // Number of tiles in the depth dimension for the data flop RAM.
+    parameter int DataRamDepthTiles = 1,
+    // Number of tiles in the width dimension for the data flop RAM.
+    parameter int DataRamWidthTiles = 1,
+    // Number of stages on the address path for the data flop RAM.
+    parameter int DataRamAddressDepthStages = 0,
+    // Number of stages in the depth dimension on the data flop RAM.
+    parameter int DataRamReadDataDepthStages = 0,
+    // Number of stages in the width dimension on the data flop RAM.
+    parameter int DataRamReadDataWidthStages = 0,
+    // Number of tiles in the depth dimension for the pointer flop RAM.
+    parameter int PointerRamDepthTiles = 1,
+    // Number of tiles in the width dimension for the pointer flop RAM.
+    parameter int PointerRamWidthTiles = 1,
+    // Number of stages on the address path for the pointer flop RAM.
+    parameter int PointerRamAddressDepthStages = 0,
+    // Number of stages in the depth dimension on the pointer flop RAM.
+    parameter int PointerRamReadDataDepthStages = 0,
+    // Number of stages in the width dimension on the pointer flop RAM.
+    parameter int PointerRamReadDataWidthStages = 0,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, then assert there are no valid bits asserted and that the FIFO is
+    // empty at the end of the test.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableAssertFinalNotValid = 1,
+
+    localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
+    localparam int AddrWidth   = br_math::clamped_clog2(Depth)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push side
+    input logic [NumWritePorts-1:0] push_valid,
+    output logic [NumWritePorts-1:0] push_ready,
+    input logic [NumWritePorts-1:0][Width-1:0] push_data,
+    input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+
+    // Pop side
+    output logic [NumFifos-1:0] pop_valid,
+    input logic [NumFifos-1:0] pop_ready,
+    output logic [NumFifos-1:0][Width-1:0] pop_data
+);
+  // Integration Checks
+  // Rely on checks in the submodules
+
+  // Implementation
+  // Data RAM
+  logic [NumWritePorts-1:0] data_ram_wr_valid;
+  logic [NumWritePorts-1:0][AddrWidth-1:0] data_ram_wr_addr;
+  logic [NumWritePorts-1:0][Width-1:0] data_ram_wr_data;
+
+  logic [NumReadPorts-1:0] data_ram_rd_addr_valid;
+  logic [NumReadPorts-1:0][AddrWidth-1:0] data_ram_rd_addr;
+  logic [NumReadPorts-1:0] data_ram_rd_data_valid;
+  logic [NumReadPorts-1:0][Width-1:0] data_ram_rd_data;
+
+  br_ram_flops #(
+      .Depth(Depth),
+      .Width(Width),
+      .NumWritePorts(NumWritePorts),
+      .NumReadPorts(NumReadPorts),
+      .DepthTiles(DataRamDepthTiles),
+      .WidthTiles(DataRamWidthTiles),
+      .AddressDepthStages(DataRamAddressDepthStages),
+      .ReadDataDepthStages(DataRamReadDataDepthStages),
+      .ReadDataWidthStages(DataRamReadDataWidthStages)
+  ) br_ram_flops_data (
+      .wr_clk(clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .wr_rst(rst),
+      .wr_valid(data_ram_wr_valid),
+      .wr_addr(data_ram_wr_addr),
+      .wr_data(data_ram_wr_data),
+      .wr_word_en({NumWritePorts{1'b1}}),
+      .rd_clk(clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .rd_rst(rst),
+      .rd_addr_valid(data_ram_rd_addr_valid),
+      .rd_addr(data_ram_rd_addr),
+      .rd_data_valid(data_ram_rd_data_valid),
+      .rd_data(data_ram_rd_data)
+  );
+
+  // Pointer RAM
+  logic [NumWritePorts-1:0] ptr_ram_wr_valid;
+  logic [NumWritePorts-1:0][AddrWidth-1:0] ptr_ram_wr_addr;
+  logic [NumWritePorts-1:0][AddrWidth-1:0] ptr_ram_wr_data;
+
+  logic [NumReadPorts-1:0] ptr_ram_rd_addr_valid;
+  logic [NumReadPorts-1:0][AddrWidth-1:0] ptr_ram_rd_addr;
+  logic [NumReadPorts-1:0] ptr_ram_rd_data_valid;
+  logic [NumReadPorts-1:0][AddrWidth-1:0] ptr_ram_rd_data;
+
+  br_ram_flops #(
+      .Depth(Depth),
+      .Width(AddrWidth),
+      .NumWritePorts(NumWritePorts),
+      .NumReadPorts(NumReadPorts),
+      .DepthTiles(PointerRamDepthTiles),
+      .WidthTiles(PointerRamWidthTiles),
+      .AddressDepthStages(PointerRamAddressDepthStages),
+      .ReadDataDepthStages(PointerRamReadDataDepthStages),
+      .ReadDataWidthStages(PointerRamReadDataWidthStages)
+  ) br_ram_flops_pointer (
+      .wr_clk(clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .wr_rst(rst),
+      .wr_valid(ptr_ram_wr_valid),
+      .wr_addr(ptr_ram_wr_addr),
+      .wr_data(ptr_ram_wr_data),
+      .wr_word_en({NumWritePorts{1'b1}}),
+      .rd_clk(clk),  // ri lint_check_waive SAME_CLOCK_NAME
+      .rd_rst(rst),
+      .rd_addr_valid(ptr_ram_rd_addr_valid),
+      .rd_addr(ptr_ram_rd_addr),
+      .rd_data_valid(ptr_ram_rd_data_valid),
+      .rd_data(ptr_ram_rd_data)
+  );
+
+  // Controller
+  localparam int DataRamReadLatency =
+      DataRamAddressDepthStages + DataRamReadDataDepthStages + DataRamReadDataWidthStages;
+  localparam int PointerRamReadLatency =
+      PointerRamAddressDepthStages + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages;
+
+  br_fifo_shared_dynamic_ctrl #(
+      .NumWritePorts(NumWritePorts),
+      .NumReadPorts(NumReadPorts),
+      .NumFifos(NumFifos),
+      .Depth(Depth),
+      .Width(Width),
+      .StagingBufferDepth(StagingBufferDepth),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RegisterDeallocation(RegisterDeallocation),
+      .DataRamReadLatency(DataRamReadLatency),
+      .PointerRamReadLatency(PointerRamReadLatency),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) br_fifo_shared_dynamic_ctrl (
+      .clk,
+      .rst,
+      .push_valid,
+      .push_ready,
+      .push_data,
+      .push_fifo_id,
+      .pop_valid,
+      .pop_ready,
+      .pop_data,
+      .data_ram_wr_valid,
+      .data_ram_wr_addr,
+      .data_ram_wr_data,
+      .data_ram_rd_addr_valid,
+      .data_ram_rd_addr,
+      .data_ram_rd_data_valid,
+      .data_ram_rd_data,
+      .ptr_ram_wr_valid,
+      .ptr_ram_wr_addr,
+      .ptr_ram_wr_data,
+      .ptr_ram_rd_addr_valid,
+      .ptr_ram_rd_addr,
+      .ptr_ram_rd_data_valid,
+      .ptr_ram_rd_data
+  );
+
+  // Implementation Checks
+
+  // Rely on implementation checks in the controller
+
+endmodule

--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -222,3 +222,138 @@ br_verilog_elab_and_lint_test_suite(
     },
     deps = [":br_fifo_staging_buffer"],
 )
+
+verilog_library(
+    name = "br_fifo_shared_read_xbar",
+    srcs = ["br_fifo_shared_read_xbar.sv"],
+    deps = [
+        "//delay/rtl:br_delay_valid",
+        "//demux/rtl:br_demux_bin",
+        "//flow/rtl:br_flow_demux_select_unstable",
+        "//flow/rtl:br_flow_mux_lru",
+        "//macros:br_asserts_internal",
+        "//mux/rtl:br_mux_onehot",
+        "//pkg:br_math_pkg",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_shared_read_xbar_test_suite",
+    params = {
+        "NumFifos": [
+            "2",
+            "4",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+        ],
+        "AddrWidth": ["2"],
+    },
+    deps = [":br_fifo_shared_read_xbar"],
+)
+
+verilog_library(
+    name = "br_fifo_shared_dynamic_push_ctrl",
+    srcs = ["br_fifo_shared_dynamic_push_ctrl.sv"],
+    deps = [
+        "//demux/rtl:br_demux_bin",
+        "//enc/rtl:br_enc_countones",
+        "//enc/rtl:br_enc_priority_dynamic",
+        "//macros:br_asserts_internal",
+        "//mux/rtl:br_mux_onehot",
+        "//pkg:br_math_pkg",
+        "//tracker/rtl:br_tracker_freelist",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_shared_dynamic_push_ctrl_test_suite",
+    params = {
+        "NumFifos": [
+            "2",
+            "4",
+        ],
+        "NumWritePorts": [
+            "1",
+            "2",
+        ],
+        "Depth": ["5"],
+        "Width": ["8"],
+    },
+    deps = [":br_fifo_shared_dynamic_push_ctrl"],
+)
+
+verilog_library(
+    name = "br_fifo_shared_dynamic_ptr_mgr",
+    srcs = ["br_fifo_shared_dynamic_ptr_mgr.sv"],
+    deps = [
+        "//demux/rtl:br_demux_bin",
+        "//mux/rtl:br_mux_onehot",
+        "//tracker/rtl:br_tracker_linked_list_ctrl",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_shared_dynamic_ptr_mgr_test_suite",
+    params = {
+        "NumFifos": [
+            "2",
+            "4",
+        ],
+        "NumWritePorts": [
+            "1",
+            "2",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+        ],
+        "Depth": ["5"],
+        "RamReadLatency": ["1"],
+    },
+    deps = [":br_fifo_shared_dynamic_ptr_mgr"],
+)
+
+verilog_library(
+    name = "br_fifo_shared_pop_ctrl",
+    srcs = ["br_fifo_shared_pop_ctrl.sv"],
+    deps = [
+        ":br_fifo_shared_read_xbar",
+        ":br_fifo_staging_buffer",
+        "//flow/rtl:br_flow_join",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_shared_pop_ctrl_test_suite",
+    params = {
+        "NumFifos": [
+            "2",
+            "4",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+        ],
+        "Depth": ["5"],
+        "Width": ["8"],
+        "StagingBufferDepth": [
+            "1",
+            "2",
+        ],
+        "RamReadLatency": [
+            "0",
+            "1",
+        ],
+        "RegisterDeallocation": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_fifo_shared_pop_ctrl"],
+)

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_ptr_mgr.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_ptr_mgr.sv
@@ -1,0 +1,230 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Bedrock-RTL Shared Dynamic Multi-FIFO Pointer Manager
+
+`include "br_asserts_internal.svh"
+
+module br_fifo_shared_dynamic_ptr_mgr #(
+    parameter int NumWritePorts = 1,
+    parameter int NumReadPorts = 1,
+    parameter int NumFifos = 2,
+    parameter int NumLinkedListsPerFifo = 1,
+    parameter int Depth = 2,
+    parameter int RamReadLatency = 0,
+
+    localparam int AddrWidth  = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [NumFifos-1:0][NumWritePorts-1:0] next_tail_valid,
+    input logic [NumFifos-1:0][NumWritePorts-1:0][AddrWidth-1:0] next_tail,
+
+    output logic [NumWritePorts-1:0] ptr_ram_wr_valid,
+    output logic [NumWritePorts-1:0][AddrWidth-1:0] ptr_ram_wr_addr,
+    output logic [NumWritePorts-1:0][AddrWidth-1:0] ptr_ram_wr_data,
+
+    output logic [NumReadPorts-1:0] ptr_ram_rd_addr_valid,
+    output logic [NumReadPorts-1:0][AddrWidth-1:0] ptr_ram_rd_addr,
+    input logic [NumReadPorts-1:0] ptr_ram_rd_data_valid,
+    input logic [NumReadPorts-1:0][AddrWidth-1:0] ptr_ram_rd_data,
+
+    input logic [NumFifos-1:0] head_ready,
+    output logic [NumFifos-1:0] head_valid,
+    output logic [NumFifos-1:0][AddrWidth-1:0] head,
+
+    output logic [NumFifos-1:0] empty,
+    output logic [NumFifos-1:0][CountWidth-1:0] items
+);
+  localparam int ReadPortIdWidth = $clog2(NumReadPorts);
+
+  // Internal Integration Checks
+
+  if (NumReadPorts > 1) begin : gen_multi_rport_checks
+    for (genvar i = 0; i < NumFifos - 1; i++) begin : gen_inter_fifo_checks
+      for (genvar j = i + 1; j < NumFifos; j++) begin : gen_inter_fifo_checks_inner
+        // To ensure no conflicts on read ports, the pop control must make sure
+        // not to simultaneously pop head pointers that are destined for the same
+        // read port.
+        `BR_ASSERT_IMPL(no_head_conflict_a,
+                        ((head_ready[i] && head_valid[i]) &&
+            (head_ready[j] && head_valid[j]))
+            |->
+          (head[i][ReadPortIdWidth-1:0] != head[j][ReadPortIdWidth-1:0]))
+      end
+    end
+  end else begin : gen_single_rport_checks
+    // With only one read port, we can only pop one head at a time.
+    `BR_ASSERT_IMPL(onehot_head_pop_a, (|head_valid) |-> $onehot0(head_ready))
+  end
+
+  // Implementation
+
+  logic [NumFifos-1:0][NumWritePorts-1:0] fifo_ptr_ram_wr_valid;
+  logic [NumFifos-1:0][NumWritePorts-1:0][AddrWidth-1:0] fifo_ptr_ram_wr_addr;
+  logic [NumFifos-1:0][NumWritePorts-1:0][AddrWidth-1:0] fifo_ptr_ram_wr_data;
+
+  logic [NumFifos-1:0][NumReadPorts-1:0] fifo_ptr_ram_rd_addr_valid;
+  logic [NumFifos-1:0][NumReadPorts-1:0][AddrWidth-1:0] fifo_ptr_ram_rd_addr;
+  logic [NumFifos-1:0][NumReadPorts-1:0] fifo_ptr_ram_rd_data_valid;
+  logic [NumFifos-1:0][NumReadPorts-1:0][AddrWidth-1:0] fifo_ptr_ram_rd_data;
+
+  for (genvar i = 0; i < NumFifos; i++) begin : gen_ll_ctrl
+    // Instantiate a linked list controller for each FIFO.
+    logic ctrl_ptr_ram_rd_addr_valid;
+    logic [AddrWidth-1:0] ctrl_ptr_ram_rd_addr;
+    logic ctrl_ptr_ram_rd_data_valid;
+    logic [AddrWidth-1:0] ctrl_ptr_ram_rd_data;
+
+    br_tracker_linked_list_ctrl #(
+        .NumLinkedLists(NumLinkedListsPerFifo),
+        .NumWritePorts(NumWritePorts),
+        .Depth(Depth),
+        .RamReadLatency(RamReadLatency)
+    ) br_tracker_linked_list_ctrl (
+        .clk(clk),
+        .rst(rst),
+
+        .next_tail_valid(next_tail_valid[i]),
+        .next_tail(next_tail[i]),
+
+        .ptr_ram_wr_valid(fifo_ptr_ram_wr_valid[i]),
+        .ptr_ram_wr_addr (fifo_ptr_ram_wr_addr[i]),
+        .ptr_ram_wr_data (fifo_ptr_ram_wr_data[i]),
+
+        .ptr_ram_rd_addr_valid(ctrl_ptr_ram_rd_addr_valid),
+        .ptr_ram_rd_addr(ctrl_ptr_ram_rd_addr),
+        .ptr_ram_rd_data_valid(ctrl_ptr_ram_rd_data_valid),
+        .ptr_ram_rd_data(ctrl_ptr_ram_rd_data),
+
+        .head_valid(head_valid[i]),
+        .head_ready(head_ready[i]),
+        .head(head[i]),
+
+        .empty(empty[i]),
+        .items(items[i])
+    );
+
+    if (NumReadPorts > 1) begin : gen_multi_read
+      // The lower bits of the address determine the read port.
+      br_demux_bin #(
+          .NumSymbolsOut(NumReadPorts),
+          .SymbolWidth  (AddrWidth)
+      ) br_demux_bin_fifo_ptr_ram_rd_addr (
+          .select(ctrl_ptr_ram_rd_addr[ReadPortIdWidth-1:0]),
+          .in_valid(ctrl_ptr_ram_rd_addr_valid),
+          .in(ctrl_ptr_ram_rd_addr),
+          .out_valid(fifo_ptr_ram_rd_addr_valid[i]),
+          .out(fifo_ptr_ram_rd_addr[i])
+      );
+
+      // Only one of the read data should be valid on a given cycle.
+      assign ctrl_ptr_ram_rd_data_valid = |fifo_ptr_ram_rd_data_valid[i];
+      br_mux_onehot #(
+          .NumSymbolsIn(NumReadPorts),
+          .SymbolWidth (AddrWidth)
+      ) br_mux_onehot_fifo_ptr_ram_rd_data (
+          .select(fifo_ptr_ram_rd_data_valid[i]),
+          .in(fifo_ptr_ram_rd_data[i]),
+          .out(ctrl_ptr_ram_rd_data)
+      );
+    end else begin : gen_single_read
+      assign fifo_ptr_ram_rd_addr_valid[i] = ctrl_ptr_ram_rd_addr_valid;
+      assign fifo_ptr_ram_rd_addr[i] = ctrl_ptr_ram_rd_addr;
+      assign ctrl_ptr_ram_rd_data_valid = fifo_ptr_ram_rd_data_valid[i];
+      assign ctrl_ptr_ram_rd_data = fifo_ptr_ram_rd_data[i];
+    end
+  end
+
+  // Mux the FIFOs for each write port.
+  for (genvar i = 0; i < NumWritePorts; i++) begin : gen_write_mux
+    logic [NumFifos-1:0] wport_fifo_ptr_ram_wr_valid;
+    logic [NumFifos-1:0][AddrWidth-1:0] wport_fifo_ptr_ram_wr_addr;
+    logic [NumFifos-1:0][AddrWidth-1:0] wport_fifo_ptr_ram_wr_data;
+
+    for (genvar j = 0; j < NumFifos; j++) begin : gen_fifo_mux
+      assign wport_fifo_ptr_ram_wr_valid[j] = fifo_ptr_ram_wr_valid[j][i];
+      assign wport_fifo_ptr_ram_wr_addr[j]  = fifo_ptr_ram_wr_addr[j][i];
+      assign wport_fifo_ptr_ram_wr_data[j]  = fifo_ptr_ram_wr_data[j][i];
+    end
+
+    assign ptr_ram_wr_valid[i] = |wport_fifo_ptr_ram_wr_valid;
+
+    br_mux_onehot #(
+        .NumSymbolsIn(NumFifos),
+        .SymbolWidth (AddrWidth)
+    ) br_mux_onehot_fifo_ptr_ram_wr_addr (
+        .select(wport_fifo_ptr_ram_wr_valid),
+        .in(wport_fifo_ptr_ram_wr_addr),
+        .out(ptr_ram_wr_addr[i])
+    );
+
+    br_mux_onehot #(
+        .NumSymbolsIn(NumFifos),
+        .SymbolWidth (AddrWidth)
+    ) br_mux_onehot_fifo_ptr_ram_wr_data (
+        .select(wport_fifo_ptr_ram_wr_valid),
+        .in(wport_fifo_ptr_ram_wr_data),
+        .out(ptr_ram_wr_data[i])
+    );
+  end
+
+  // Mux the FIFOs for each read port.
+  for (genvar i = 0; i < NumReadPorts; i++) begin : gen_read_mux
+    logic [NumFifos-1:0] rport_fifo_ptr_ram_rd_addr_valid;
+    logic [NumFifos-1:0][AddrWidth-1:0] rport_fifo_ptr_ram_rd_addr;
+    logic [NumFifos-1:0] rport_fifo_ptr_ram_rd_data_valid;
+    logic [NumFifos-1:0][AddrWidth-1:0] rport_fifo_ptr_ram_rd_data;
+
+    for (genvar j = 0; j < NumFifos; j++) begin : gen_fifo_mux
+      assign rport_fifo_ptr_ram_rd_addr_valid[j] = fifo_ptr_ram_rd_addr_valid[j][i];
+      assign rport_fifo_ptr_ram_rd_addr[j] = fifo_ptr_ram_rd_addr[j][i];
+      assign fifo_ptr_ram_rd_data_valid[j][i] = rport_fifo_ptr_ram_rd_data_valid[j];
+      assign fifo_ptr_ram_rd_data[j][i] = rport_fifo_ptr_ram_rd_data[j];
+    end
+
+    logic [NumFifos-1:0] rport_ptr_ram_rd_data_fifo_onehot;
+
+    assign ptr_ram_rd_addr_valid[i] = |rport_fifo_ptr_ram_rd_addr_valid;
+
+    br_mux_onehot #(
+        .NumSymbolsIn(NumFifos),
+        .SymbolWidth (AddrWidth)
+    ) br_mux_onehot_fifo_ptr_ram_rd_addr (
+        .select(rport_fifo_ptr_ram_rd_addr_valid),
+        .in(rport_fifo_ptr_ram_rd_addr),
+        .out(ptr_ram_rd_addr[i])
+    );
+
+    br_delay_valid #(
+        .NumStages(RamReadLatency),
+        .Width(NumFifos)
+    ) br_delay_valid_fifo_ptr_ram_rd_data_valid (
+        .clk(clk),
+        .rst(rst),
+        .in_valid(ptr_ram_rd_addr_valid[i]),
+        .in(rport_fifo_ptr_ram_rd_addr_valid),
+        .out_valid(),
+        .out(rport_ptr_ram_rd_data_fifo_onehot),
+        .out_valid_stages(),
+        .out_stages()
+    );
+
+    assign rport_fifo_ptr_ram_rd_data_valid =
+        {NumFifos{ptr_ram_rd_data_valid[i]}} & rport_ptr_ram_rd_data_fifo_onehot;
+    assign rport_fifo_ptr_ram_rd_data = {NumFifos{ptr_ram_rd_data[i]}};
+  end
+endmodule

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
@@ -1,0 +1,237 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Bedrock-RTL Shared Dynamic Multi-FIFO Push Controller
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+`include "br_unused.svh"
+
+module br_fifo_shared_dynamic_push_ctrl #(
+    // Number of write ports
+    parameter int NumWritePorts = 1,
+    // Number of logical FIFOs
+    parameter int NumFifos = 2,
+    // Total depth of the FIFO
+    parameter int Depth = 3,
+    // Width of the data
+    parameter int Width = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, then assert there are no valid bits asserted and that the FIFO is
+    // empty at the end of the test.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableAssertFinalNotValid = 1,
+
+    localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
+    localparam int AddrWidth   = br_math::clamped_clog2(Depth)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push side
+    output logic [NumWritePorts-1:0] push_ready,
+    input logic [NumWritePorts-1:0] push_valid,
+    input logic [NumWritePorts-1:0][Width-1:0] push_data,
+    input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+
+    // Data RAM write ports
+    output logic [NumWritePorts-1:0] data_ram_wr_valid,
+    output logic [NumWritePorts-1:0][AddrWidth-1:0] data_ram_wr_addr,
+    output logic [NumWritePorts-1:0][Width-1:0] data_ram_wr_data,
+
+    // To Linked List Controllers
+    output logic [NumFifos-1:0][NumWritePorts-1:0] next_tail_valid,
+    output logic [NumFifos-1:0][NumWritePorts-1:0][AddrWidth-1:0] next_tail,
+
+    // Entry deallocation from pop controller
+    input logic [NumFifos-1:0] dealloc_valid,
+    input logic [NumFifos-1:0][AddrWidth-1:0] dealloc_entry_id
+);
+
+  // Integration Assertions
+
+`ifdef BR_ASSERT_ON
+`ifndef BR_DISABLE_INTG_CHECKS
+
+  logic [NumWritePorts-1:0][Width+FifoIdWidth-1:0] push_comb_data;
+
+  for (genvar i = 0; i < NumWritePorts; i++) begin : gen_push_comb_data
+    assign push_comb_data[i] = {push_fifo_id[i], push_data[i]};
+  end
+
+  br_flow_checks_valid_data_intg #(
+      .NumFlows(NumWritePorts),
+      .Width(Width + FifoIdWidth),
+      .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertValidStability(EnableAssertPushValidStability),
+      .EnableAssertDataStability(EnableAssertPushDataStability),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) br_flow_checks_valid_data_intg_inst (
+      .clk,
+      .rst,
+      .valid(push_valid),
+      .ready(push_ready),
+      .data (push_comb_data)
+  );
+
+`endif  // BR_DISABLE_INTG_CHECKS
+`endif  // BR_ASSERT_ON
+
+  // Implementation
+
+  logic [NumWritePorts-1:0] alloc_valid;
+  logic [NumWritePorts-1:0] alloc_ready;
+  logic [NumWritePorts-1:0][AddrWidth-1:0] alloc_entry_id;
+
+  br_tracker_freelist #(
+      .NumEntries(Depth),
+      .NumAllocPorts(NumWritePorts),
+      .NumDeallocPorts(NumFifos)
+  ) br_tracker_freelist_inst (
+      .clk,
+      .rst,
+
+      .alloc_valid,
+      .alloc_ready,
+      .alloc_entry_id,
+
+      .dealloc_valid,
+      .dealloc_entry_id
+  );
+
+  if (NumWritePorts > 1) begin : gen_alloc_mapping
+    // Map the allocations to the push ports. Entries are allocated to the freelist
+    // staging buffers in a fixed priority, so the lower priority ports may not
+    // get entries even if some are free if the FIFO is running nearly full.
+    // To have a fair allocation of entries to write ports, we implement a
+    // round-robin priority scheme. On a given cycle, the allocation
+    // ports are mapped to the write ports starting from the alloc port
+    // 0 and progressing to alloc port NumWritePorts-1. The alloc ports
+    // get assigned to the active write ports in a priority order,
+    // with the lowest priority going to the port that was given the
+    // first allocated entry the last time.
+
+    // alloc_mapping[i][j] = 1 if alloc port i is mapped to write port j
+    logic [NumWritePorts-1:0][NumWritePorts-1:0] alloc_mapping;
+    logic [NumWritePorts-1:0] alloc_lowest_prio;
+    logic [NumWritePorts-1:0] alloc_lowest_prio_init;
+    logic [NumWritePorts-1:0] alloc_lowest_prio_next;
+    logic alloc_prio_update;
+
+    assign alloc_prio_update = |(push_valid & push_ready);
+    assign alloc_lowest_prio_init = {1'b1, (NumWritePorts - 1)'(1'b0)};
+    assign alloc_lowest_prio_next = alloc_mapping[0];
+
+    `BR_REGLI(alloc_lowest_prio, alloc_lowest_prio_next, alloc_prio_update, alloc_lowest_prio_init)
+
+    // Priority encoder maps lowest active port to alloc port 0,
+    // second most active to alloc port 1, etc.
+    br_enc_priority_dynamic #(
+        .NumRequesters(NumWritePorts),
+        .NumResults(NumWritePorts)
+    ) br_enc_priority_dynamic_alloc (
+        .clk,
+        .rst,
+        .in(push_valid),
+        .lowest_prio(alloc_lowest_prio),
+        .out(alloc_mapping)
+    );
+
+    for (genvar i = 0; i < NumWritePorts; i++) begin : gen_data_ram_write
+      // One-hot select of the alloc ports for this write port.
+      logic [NumWritePorts-1:0] alloc_select;
+
+      for (genvar j = 0; j < NumWritePorts; j++) begin : gen_alloc_select
+        assign alloc_select[j] = alloc_mapping[j][i];
+      end
+
+      assign push_ready[i] = |(alloc_select & alloc_valid);
+      assign alloc_ready[i] = |(push_valid & alloc_mapping[i]);
+
+      assign data_ram_wr_valid[i] = push_valid[i] & push_ready[i];
+      assign data_ram_wr_data[i] = push_data[i];
+
+      br_mux_onehot #(
+          .NumSymbolsIn(NumWritePorts),
+          .SymbolWidth (AddrWidth)
+      ) br_mux_onehot_data_ram_wr_addr_inst (
+          .select(alloc_select),
+          .in(alloc_entry_id),
+          .out(data_ram_wr_addr[i])
+      );
+    end
+  end else begin : gen_single_alloc
+    assign push_ready = alloc_valid;
+    assign alloc_ready = push_valid;
+
+    assign data_ram_wr_valid = push_valid & push_ready;
+    assign data_ram_wr_addr = alloc_entry_id;
+    assign data_ram_wr_data = push_data;
+  end
+
+  for (genvar i = 0; i < NumWritePorts; i++) begin : gen_next_tail
+    logic [NumFifos-1:0] port_next_tail_valid;
+    logic [NumFifos-1:0][AddrWidth-1:0] port_next_tail;
+
+    br_demux_bin #(
+        .NumSymbolsOut(NumFifos),
+        .SymbolWidth  (AddrWidth)
+    ) br_demux_bin_port_next_tail_valid_inst (
+        .select(push_fifo_id[i]),
+        .in_valid(data_ram_wr_valid[i]),
+        .in(data_ram_wr_addr[i]),
+        .out_valid(port_next_tail_valid),
+        .out(port_next_tail)
+    );
+
+    for (genvar j = 0; j < NumFifos; j++) begin : gen_fifo_next_tail
+      assign next_tail_valid[j][i] = port_next_tail_valid[j];
+      assign next_tail[j][i] = port_next_tail[j];
+    end
+  end
+
+  // Implementation Checks
+
+`ifdef BR_ASSERT_ON
+`ifdef BR_ENABLE_IMPL_CHECKS
+  localparam int PortCountWidth = $clog2(NumWritePorts + 1);
+
+  logic [PortCountWidth-1:0] request_count;
+  logic [PortCountWidth-1:0] alloc_count;
+  logic [PortCountWidth-1:0] grant_count;
+
+  // These are only used for assertions, so it's fine to use $countones
+  // ri lint_check_off SYS_TF
+  assign request_count = $unsigned($countones(push_valid));
+  assign alloc_count   = $unsigned($countones(alloc_valid));
+  assign grant_count   = $unsigned($countones(push_valid & push_ready));
+  // ri lint_check_on SYS_TF
+`endif
+`endif
+
+  `BR_ASSERT_IMPL(full_push_acceptance_a,
+                  (|push_valid && (alloc_count > request_count)) |-> (request_count == grant_count))
+  `BR_ASSERT_IMPL(partial_push_acceptance_a,
+                  (|push_valid && (alloc_count < request_count)) |-> (grant_count == alloc_count))
+
+endmodule

--- a/fifo/rtl/internal/br_fifo_shared_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_pop_ctrl.sv
@@ -1,0 +1,180 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Bedrock-RTL Shared Multi-FIFO Pop Controller
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+`include "br_unused.svh"
+
+module br_fifo_shared_pop_ctrl #(
+    parameter int NumReadPorts = 1,
+    parameter int NumFifos = 1,
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter int StagingBufferDepth = 1,
+    parameter bit RegisterPopOutputs = 0,
+    parameter int RamReadLatency = 0,
+    parameter bit RegisterDeallocation = 0,
+
+    localparam int AddrWidth  = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [NumFifos-1:0] head_valid,
+    output logic [NumFifos-1:0] head_ready,
+    input logic [NumFifos-1:0][AddrWidth-1:0] head,
+
+    input logic [NumFifos-1:0] ram_empty,
+    input logic [NumFifos-1:0][CountWidth-1:0] ram_items,
+
+    output logic [NumFifos-1:0] pop_valid,
+    input logic [NumFifos-1:0] pop_ready,
+    output logic [NumFifos-1:0][Width-1:0] pop_data,
+
+    output logic [NumFifos-1:0] dealloc_valid,
+    output logic [NumFifos-1:0][AddrWidth-1:0] dealloc_entry_id,
+
+    output logic [NumReadPorts-1:0] data_ram_rd_addr_valid,
+    output logic [NumReadPorts-1:0][AddrWidth-1:0] data_ram_rd_addr,
+    input logic [NumReadPorts-1:0] data_ram_rd_data_valid,
+    input logic [NumReadPorts-1:0][Width-1:0] data_ram_rd_data
+);
+
+  // Internal Integration Checks
+
+  br_flow_checks_valid_data_impl #(
+      .NumFlows(NumFifos),
+      .Width(AddrWidth)
+  ) br_flow_checks_valid_data_impl_head (
+      .clk,
+      .rst,
+      .valid(head_valid),
+      .ready(head_ready),
+      .data (head)
+  );
+
+  // Implementation
+  localparam bit NoStagingBuffer = (RamReadLatency == 0) && !RegisterPopOutputs;
+
+  logic [NumFifos-1:0] fifo_ram_rd_addr_valid;
+  logic [NumFifos-1:0] fifo_ram_rd_addr_ready;
+  logic [NumFifos-1:0][AddrWidth-1:0] fifo_ram_rd_addr;
+  logic [NumFifos-1:0] fifo_ram_rd_data_valid;
+  logic [NumFifos-1:0][Width-1:0] fifo_ram_rd_data;
+
+  for (genvar i = 0; i < NumFifos; i++) begin : gen_fifo_ram_read
+    logic ram_rd_req_valid;
+    logic ram_rd_req_ready;
+
+    if (NoStagingBuffer) begin : gen_no_buffer
+      assign ram_rd_req_valid = !ram_empty[i] && pop_ready[i];
+      assign pop_valid[i] = fifo_ram_rd_data_valid[i];
+      assign pop_data[i] = fifo_ram_rd_data[i];
+
+      `BR_UNUSED(ram_rd_req_ready)  // used for assertion only
+      `BR_ASSERT_IMPL(zero_read_latency_a,
+                      (ram_rd_req_valid && ram_rd_req_ready) |-> fifo_ram_rd_data_valid[i])
+    end else begin : gen_staging_buffer
+      br_fifo_staging_buffer #(
+          .EnableBypass(0),
+          .TotalDepth(Depth),
+          .BufferDepth(StagingBufferDepth),
+          .Width(Width),
+          .RegisterPopOutputs(RegisterPopOutputs),
+          .RamReadLatency(RamReadLatency)
+      ) br_fifo_staging_buffer (
+          .clk,
+          .rst,
+
+          .total_items(ram_items[i]),
+
+          .bypass_valid_unstable(1'b0),
+          .bypass_data_unstable(Width'(1'b0)),
+          .bypass_ready(),
+
+          .ram_rd_addr_ready(ram_rd_req_ready),
+          .ram_rd_addr_valid(ram_rd_req_valid),
+          .ram_rd_data_valid(fifo_ram_rd_data_valid[i]),
+          .ram_rd_data(fifo_ram_rd_data[i]),
+
+          .pop_ready(pop_ready[i]),
+          .pop_valid(pop_valid[i]),
+          .pop_data (pop_data[i])
+      );
+    end
+
+    br_flow_join #(
+        .NumFlows(2)
+    ) br_flow_join_ram_rd_addr (
+        .clk,
+        .rst,
+
+        .push_valid({head_valid[i], ram_rd_req_valid}),
+        .push_ready({head_ready[i], ram_rd_req_ready}),
+        .pop_valid (fifo_ram_rd_addr_valid[i]),
+        .pop_ready (fifo_ram_rd_addr_ready[i])
+    );
+
+    assign fifo_ram_rd_addr[i] = head[i];
+  end
+
+  if (NoStagingBuffer) begin : gen_no_buffer_unused
+    `BR_UNUSED(ram_items)
+  end else begin : gen_buffer_unused
+    `BR_UNUSED(ram_empty)
+  end
+
+  // Read Crossbar
+  // TODO(zhemao): Support an option to have dedicated read ports for a FIFO
+  // or group of FIFOs instead of spreading reads across all read ports.
+  br_fifo_shared_read_xbar #(
+      .NumFifos(NumFifos),
+      .NumReadPorts(NumReadPorts),
+      .AddrWidth(AddrWidth),
+      .Width(Width),
+      .RamReadLatency(RamReadLatency)
+  ) br_fifo_shared_read_xbar (
+      .clk,
+      .rst,
+
+      .push_rd_addr_valid(fifo_ram_rd_addr_valid),
+      .push_rd_addr_ready(fifo_ram_rd_addr_ready),
+      .push_rd_addr(fifo_ram_rd_addr),
+      .push_rd_data_valid(fifo_ram_rd_data_valid),
+      .push_rd_data(fifo_ram_rd_data),
+
+      .pop_rd_addr_valid(data_ram_rd_addr_valid),
+      .pop_rd_addr(data_ram_rd_addr),
+      .pop_rd_data_valid(data_ram_rd_data_valid),
+      .pop_rd_data(data_ram_rd_data)
+  );
+
+  if (RegisterDeallocation) begin : gen_reg_dealloc
+    logic [NumFifos-1:0] dealloc_valid_next;
+
+    assign dealloc_valid_next = head_valid & head_ready;
+    `BR_REG(dealloc_valid, dealloc_valid_next)
+
+    for (genvar i = 0; i < NumFifos; i++) begin : gen_reg_dealloc_entry_id
+      `BR_REGL(dealloc_entry_id[i], head[i], dealloc_valid_next[i])
+    end
+  end else begin : gen_no_reg_dealloc
+    assign dealloc_valid = head_valid & head_ready;
+    assign dealloc_entry_id = head;
+  end
+
+endmodule

--- a/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
+++ b/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
@@ -1,0 +1,177 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Bedrock-RTL Shared Multi-FIFO RAM Read Crossbar
+
+`include "br_asserts_internal.svh"
+`include "br_unused.svh"
+module br_fifo_shared_read_xbar #(
+    parameter int NumFifos = 2,
+    parameter int NumReadPorts = 1,
+    parameter int RamReadLatency = 0,
+    parameter int AddrWidth = 1,
+    parameter int Width = 1
+) (
+    // ri lint_check_waive HIER_NET_NOT_READ INPUT_NOT_READ
+    input logic clk,
+    input logic rst,
+
+    input logic [NumFifos-1:0] push_rd_addr_valid,
+    output logic [NumFifos-1:0] push_rd_addr_ready,
+    input logic [NumFifos-1:0][AddrWidth-1:0] push_rd_addr,
+    output logic [NumFifos-1:0] push_rd_data_valid,
+    output logic [NumFifos-1:0][Width-1:0] push_rd_data,
+
+    output logic [NumReadPorts-1:0] pop_rd_addr_valid,
+    output logic [NumReadPorts-1:0][AddrWidth-1:0] pop_rd_addr,
+    input logic [NumReadPorts-1:0] pop_rd_data_valid,
+    input logic [NumReadPorts-1:0][Width-1:0] pop_rd_data
+);
+
+  `BR_ASSERT_STATIC(legal_num_fifos_a, NumFifos >= 2)
+  // For now, restrict read ports to powers of two so that we don't have to do modulo operations.
+  // TODO(zhemao): Remove this restriction once we have efficient modulo block.
+  `BR_ASSERT_STATIC(legal_num_read_ports_a, NumReadPorts >= 1 && br_math::is_power_of_2(
+                    NumReadPorts))
+  `BR_ASSERT_STATIC(legal_addr_width_a, AddrWidth >= $clog2(NumReadPorts))
+
+  // Read Address Demux per FIFO
+
+  logic [NumFifos-1:0][NumReadPorts-1:0] demuxed_rd_addr_valid;
+  logic [NumFifos-1:0][NumReadPorts-1:0] demuxed_rd_addr_ready;
+  logic [NumFifos-1:0][NumReadPorts-1:0][AddrWidth-1:0] demuxed_rd_addr;
+
+  if (NumReadPorts == 1) begin : gen_no_demux_rd_addr
+    assign demuxed_rd_addr_valid = push_rd_addr_valid;
+    assign push_rd_addr_ready = demuxed_rd_addr_ready;
+    assign demuxed_rd_addr = push_rd_addr;
+  end else begin : gen_demux_rd_addr
+    localparam int PortIdWidth = $clog2(NumReadPorts);
+
+    for (genvar i = 0; i < NumFifos; i++) begin : gen_fifo_demux
+      logic [PortIdWidth-1:0] fifo_port_id;
+
+      assign fifo_port_id = push_rd_addr[i][PortIdWidth-1:0];
+
+      br_flow_demux_select_unstable #(
+          .NumFlows(NumReadPorts),
+          .Width(AddrWidth)
+      ) br_flow_demux_select_unstable_inst (
+          .clk,
+          .rst,
+          .select(fifo_port_id),
+          .push_valid(push_rd_addr_valid[i]),
+          .push_ready(push_rd_addr_ready[i]),
+          .push_data(push_rd_addr[i]),
+          .pop_valid_unstable(demuxed_rd_addr_valid[i]),
+          .pop_ready(demuxed_rd_addr_ready[i]),
+          .pop_data_unstable(demuxed_rd_addr[i])
+      );
+    end
+  end
+
+  // Read Address Mux and Data Demux per Read Port
+
+  logic [NumReadPorts-1:0][NumFifos-1:0] demuxed_rd_data_valid;
+  logic [NumReadPorts-1:0][NumFifos-1:0][Width-1:0] demuxed_rd_data;
+
+  localparam int FifoIdWidth = $clog2(NumFifos);
+  localparam int TotalMuxWidth = FifoIdWidth + AddrWidth;
+
+  logic [NumReadPorts-1:0][FifoIdWidth-1:0] pop_rd_addr_fifo_id;
+  logic [NumReadPorts-1:0][FifoIdWidth-1:0] pop_rd_data_fifo_id;
+  logic [NumReadPorts-1:0] pop_rd_data_fifo_id_valid;
+
+  for (genvar i = 0; i < NumReadPorts; i++) begin : gen_read_port_mux
+    logic [NumFifos-1:0] mux_push_ready;
+    logic [NumFifos-1:0] mux_push_valid;
+    logic [NumFifos-1:0][TotalMuxWidth-1:0] mux_push_data;
+
+    for (genvar j = 0; j < NumFifos; j++) begin : gen_mux_input
+      assign mux_push_valid[j] = demuxed_rd_addr_valid[j][i];
+      assign mux_push_data[j] = {demuxed_rd_addr[j][i], FifoIdWidth'($unsigned(j))};
+      assign demuxed_rd_addr_ready[j][i] = mux_push_ready[j];
+    end
+
+    // TODO(zhemao): Allow selection of different arbitration policy.
+    br_flow_mux_lru #(
+        .NumFlows(NumFifos),
+        .Width(TotalMuxWidth)
+    ) br_flow_mux_lru_inst (
+        .clk,
+        .rst,
+        .push_valid(mux_push_valid),
+        .push_ready(mux_push_ready),
+        .push_data (mux_push_data),
+        .pop_valid (pop_rd_addr_valid[i]),
+        .pop_ready (1'b1),
+        .pop_data  ({pop_rd_addr[i], pop_rd_addr_fifo_id[i]})
+    );
+
+    br_delay_valid #(
+        .NumStages(RamReadLatency),
+        .Width(FifoIdWidth)
+    ) br_delay_valid_fifo_id (
+        .clk,
+        .rst,
+        .in_valid(pop_rd_addr_valid[i]),
+        .in(pop_rd_addr_fifo_id[i]),
+        .out_valid(pop_rd_data_fifo_id_valid[i]),
+        .out(pop_rd_data_fifo_id[i]),
+        .out_valid_stages(),
+        .out_stages()
+    );
+
+    br_demux_bin #(
+        .NumSymbolsOut(NumFifos),
+        .SymbolWidth  (Width)
+    ) br_demux_bin_rd_data (
+        .select(pop_rd_data_fifo_id[i]),
+        .in_valid(pop_rd_data_valid[i]),
+        .in(pop_rd_data[i]),
+        .out_valid(demuxed_rd_data_valid[i]),
+        .out(demuxed_rd_data[i])
+    );
+  end
+
+  `BR_UNUSED(pop_rd_data_fifo_id_valid)  // Used for assertion only
+  `BR_ASSERT_IMPL(expected_read_latency_a, pop_rd_data_fifo_id_valid == pop_rd_data_valid)
+
+  // Read Data Mux per Read Port
+
+  if (NumReadPorts == 1) begin : gen_no_mux_rd_data
+    assign push_rd_data_valid = demuxed_rd_data_valid;
+    assign push_rd_data = demuxed_rd_data;
+  end else begin : gen_mux_rd_data
+    for (genvar i = 0; i < NumFifos; i++) begin : gen_fifo_rd_data
+      logic [NumReadPorts-1:0] mux_in_rd_data_valid;
+      logic [NumReadPorts-1:0][Width-1:0] mux_in_rd_data;
+
+      for (genvar j = 0; j < NumReadPorts; j++) begin : gen_mux_input
+        assign mux_in_rd_data_valid[j] = demuxed_rd_data_valid[j][i];
+        assign mux_in_rd_data[j] = demuxed_rd_data[j][i];
+      end
+
+      assign push_rd_data_valid[i] = |mux_in_rd_data_valid;
+      br_mux_onehot #(
+          .NumSymbolsIn(NumReadPorts),
+          .SymbolWidth (Width)
+      ) br_mux_onehot_rd_data (
+          .select(mux_in_rd_data_valid),
+          .in(mux_in_rd_data),
+          .out(push_rd_data[i])
+      );
+    end
+  end
+endmodule

--- a/fifo/rtl/internal/br_fifo_staging_buffer.sv
+++ b/fifo/rtl/internal/br_fifo_staging_buffer.sv
@@ -119,7 +119,8 @@ module br_fifo_staging_buffer #(
 
   br_counter #(
       .MaxValue(BufferDepth),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableWrap(0)
   ) br_counter (
       .clk,
       .rst,
@@ -211,8 +212,9 @@ module br_fifo_staging_buffer #(
     // and should not be possible.
     // The buffer is cleared if internal_pop_ready is asserted and there is no push.
     assign buffer_valid_next =
-        ((buffer_valid || push_valid) && !internal_pop_ready) ||
-        (ram_rd_data_valid && bypass_beat);
+        buffer_valid ?
+        (push_valid || !internal_pop_ready) :
+        ((push_valid && !internal_pop_ready) || (ram_rd_data_valid && bypass_beat));
     assign buffer_data_le = buffer_valid_next && (!buffer_valid || internal_pop_ready);
     assign buffer_data_next =
         (internal_pop_ready && !buffer_valid) ? bypass_data_unstable : push_data;

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -145,3 +145,57 @@ br_verilog_sim_test_tools_suite(
     ],
     deps = [":br_fifo_flops_push_credit_tb"],
 )
+
+verilog_library(
+    name = "br_fifo_shared_test_harness",
+    srcs = ["br_fifo_shared_test_harness.sv"],
+)
+
+verilog_library(
+    name = "br_fifo_shared_dynamic_flops_tb",
+    srcs = ["br_fifo_shared_dynamic_flops_tb.sv"],
+    deps = [
+        ":br_fifo_shared_test_harness",
+        "//fifo/rtl:br_fifo_shared_dynamic_flops",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_shared_dynamic_flops_tb_elab_test",
+    deps = [":br_fifo_shared_dynamic_flops_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_fifo_shared_dynamic_flops_sim_test_tools_suite",
+    params = {
+        "Depth": ["5"],
+        "Width": ["8"],
+        "NumFifos": ["4"],
+        "NumWritePorts": [
+            "1",
+            "2",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+        ],
+        "StagingBufferDepth": [
+            "1",
+            "2",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterDeallocation": [
+            "0",
+            "1",
+        ],
+    },
+    tools = [
+        "dsim",
+        "vcs",
+    ],
+    deps = [":br_fifo_shared_dynamic_flops_tb"],
+)

--- a/fifo/sim/br_fifo_shared_dynamic_flops_tb.sv
+++ b/fifo/sim/br_fifo_shared_dynamic_flops_tb.sv
@@ -1,0 +1,97 @@
+module br_fifo_shared_dynamic_flops_tb;
+  parameter int MaxRandomDelay = 4;
+  parameter int TestSize = 1000;
+  parameter int NumFifos = 2;
+  parameter int NumWritePorts = 1;
+  parameter int NumReadPorts = 1;
+  parameter int Depth = 5;
+  parameter int Width = 8;
+  parameter int StagingBufferDepth = 1;
+  parameter bit RegisterPopOutputs = 0;
+  parameter bit RegisterDeallocation = 0;
+
+  localparam int FifoIdWidth = $clog2(NumFifos);
+
+  logic clk;
+  logic rst;
+  logic start;
+  logic finished;
+  logic [31:0] error_count;
+
+  logic [NumWritePorts-1:0] push_ready;
+  logic [NumWritePorts-1:0] push_valid;
+  logic [NumWritePorts-1:0][Width-1:0] push_data;
+  logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id;
+
+  logic [NumFifos-1:0] pop_ready;
+  logic [NumFifos-1:0] pop_valid;
+  logic [NumFifos-1:0][Width-1:0] pop_data;
+
+  br_fifo_shared_dynamic_flops #(
+      .NumFifos(NumFifos),
+      .NumWritePorts(NumWritePorts),
+      .NumReadPorts(NumReadPorts),
+      .Depth(Depth),
+      .Width(Width),
+      .StagingBufferDepth(StagingBufferDepth),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RegisterDeallocation(RegisterDeallocation)
+  ) dut (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .push_fifo_id,
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  br_fifo_shared_test_harness #(
+      .NumFifos(NumFifos),
+      .NumWritePorts(NumWritePorts),
+      .Width(Width),
+      .TestSize(TestSize),
+      .MaxRandomDelay(MaxRandomDelay)
+  ) br_fifo_shared_test_harness (
+      .clk,
+      .rst,
+      .start,
+      .finished,
+      .error_count,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .push_fifo_id,
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
+
+  initial begin
+    start = 0;
+
+    td.reset_dut();
+    td.wait_cycles(10);
+
+    start = 1;
+    td.wait_cycles(1);
+
+    while (!finished) begin
+      td.wait_cycles();
+    end
+
+    if (error_count != 0) begin
+      $display("ERROR: %d errors occurred", error_count);
+    end else begin
+      td.finish();
+    end
+  end
+
+endmodule

--- a/fifo/sim/br_fifo_shared_test_harness.sv
+++ b/fifo/sim/br_fifo_shared_test_harness.sv
@@ -1,0 +1,128 @@
+module br_fifo_shared_test_harness #(
+    parameter int TestSize = 1000,
+    parameter int MaxRandomDelay = 4,
+    parameter int NumFifos = 2,
+    parameter int NumWritePorts = 1,
+    parameter int Width = 8,
+
+    localparam int FifoIdWidth = $clog2(NumFifos)
+) (
+    input  logic        clk,
+    input  logic        rst,
+    input  logic        start,
+    output logic        finished,
+    output logic [31:0] error_count,
+
+    input logic [NumWritePorts-1:0] push_ready,
+    output logic [NumWritePorts-1:0] push_valid,
+    output logic [NumWritePorts-1:0][Width-1:0] push_data,
+    output logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+
+    output logic [NumFifos-1:0] pop_ready,
+    input logic [NumFifos-1:0] pop_valid,
+    input logic [NumFifos-1:0][Width-1:0] pop_data
+);
+
+  localparam int WritePortIdWidth = $clog2(NumWritePorts);
+  // Reserve some bits to indicate write port.
+  // The remaining bits can be randomly assigned.
+  localparam int MaxRandomValue = 2 ** (Width - WritePortIdWidth) - 1;
+
+  int expected_data[NumFifos][NumWritePorts][$];
+  logic [NumWritePorts-1:0] push_finished;
+
+  assign finished = &push_finished;
+
+  task automatic random_push(int wport);
+    int fifo_id;
+    int data;
+    int delay;
+
+    @(posedge clk);
+    push_valid[wport] <= 1'b0;
+
+    for (int i = 0; i < TestSize; i++) begin
+      fifo_id = $urandom_range(0, NumFifos - 1);
+      data = $urandom_range(0, MaxRandomValue);
+      delay = $urandom_range(0, MaxRandomDelay);
+
+      expected_data[fifo_id][wport].push_back(data);
+
+      repeat (delay) @(posedge clk);
+
+      push_valid[wport] <= 1'b1;
+      push_data[wport] <= (data << WritePortIdWidth) | wport;
+      push_fifo_id[wport] <= fifo_id;
+      @(posedge clk);
+
+      while (!push_ready[wport]) @(posedge clk);
+      push_valid[wport] <= 1'b0;
+    end
+
+    $display("Push finished for wport %d", wport);
+    push_finished[wport] <= 1'b1;
+  endtask
+
+  task automatic random_pop(int fifo_id);
+    int actual;
+    int wport;
+    int expected;
+    int delay;
+
+    @(posedge clk);
+    pop_ready[fifo_id] <= 1'b0;
+
+    forever begin
+      delay = $urandom_range(0, MaxRandomDelay);
+      repeat (delay) @(posedge clk);
+
+      pop_ready[fifo_id] <= 1'b1;
+      @(posedge clk);
+
+      while (!pop_valid[fifo_id]) @(posedge clk);
+      pop_ready[fifo_id] <= 1'b0;
+
+      actual = pop_data[fifo_id] >> WritePortIdWidth;
+      wport = pop_data[fifo_id][WritePortIdWidth-1:0];
+      expected = expected_data[fifo_id][wport].pop_front();
+
+      if (actual !== expected) begin
+        $display("FIFO %d got wrong data from wport %d. Expected %0x, Got %0x", fifo_id, wport,
+                 expected, actual);
+        error_count++;
+      end
+    end
+  endtask
+
+  initial begin
+    push_valid = '0;
+    push_data = '0;
+    push_fifo_id = '0;
+    pop_ready = '0;
+    error_count = 0;
+    push_finished = '0;
+
+    @(negedge rst);
+    @(posedge clk);
+
+    while (!start) @(posedge clk);
+
+    $display("Starting test");
+
+    for (int i = 0; i < NumWritePorts; i++) begin
+      automatic int wport = i;
+      fork
+        random_push(wport);
+      join_none
+    end
+
+    for (int i = 0; i < NumFifos; i++) begin
+      automatic int fifo_id = i;
+      fork
+        random_pop(fifo_id);
+      join_none
+    end
+  end
+
+
+endmodule


### PR DESCRIPTION
This adds the push ready/valid variant, control and flops.
Also adds a unit test. Credit/valid version to come.

Fixes bugs in linked list control and FIFO staging buffer to
get the unit tests to pass.

1. Linked list control has RAW hazard while appending the tail
pointer to a linked list whose last entry is being popped.
Bypass the tail pointer to the head pointer in this case.
2. Single entry staging buffer incorrectly drops buffer_valid
when the buffer is being popped while data is being pushed.
Rewrite the buffer_valid_next logic to handle this properly.

Also fix some assertion issues that are triggering in the unit test.

1. br_delay_valid zero-delay implementation assertion needs to be
guarded by valid.
2. br_demux_bin implementation assertions spuriously triggering.
Commenting out for now until a solution can be found.

---

**Stack**:
- #437
- #430
- #429
- #428
- #427
- #425
- #424 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*