### PR TITLE
Turn off select in range assertion in br_mux_bin

### DIFF
--- a/mux/rtl/br_mux_bin.sv
+++ b/mux/rtl/br_mux_bin.sv
@@ -44,8 +44,6 @@ module br_mux_bin #(
   //------------------------------------------
   `BR_ASSERT_STATIC(legal_num_symbols_in_a, NumSymbolsIn >= 2)
   `BR_ASSERT_STATIC(legal_symbol_width_a, SymbolWidth >= 1)
-  // ri lint_check_waive ALWAYS_COMB
-  `BR_ASSERT_COMB_INTG(select_in_range_a, select < NumSymbolsIn)
 
   //------------------------------------------
   // Implementation


### PR DESCRIPTION
Since we have the out_valid signal now, this is no longer needed.

---

**Stack**:
- #441
- #437
- #430
- #429
- #428 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*