### PR TITLE
Rename pop_data on br_flow_mux variants to pop_data_unstable

### DIFF
--- a/flow/fpv/arb/br_flow_arb_basic_fpv_monitor.sv
+++ b/flow/fpv/arb/br_flow_arb_basic_fpv_monitor.sv
@@ -27,7 +27,7 @@ module br_flow_arb_basic_fpv_monitor #(
     input logic [NumFlows-1:0] push_ready,
     input logic [NumFlows-1:0] push_valid,
     input logic                pop_ready,
-    input logic                pop_valid
+    input logic                pop_valid_unstable
 );
 
   // ----------FV assumptions----------
@@ -41,11 +41,11 @@ module br_flow_arb_basic_fpv_monitor #(
 
   // ----------Sanity Check----------
   if (EnableAssertPushValidStability) begin : gen_pop_valid
-    `BR_ASSERT(pop_valid_stable_a, pop_valid && !pop_ready |=> pop_valid)
+    `BR_ASSERT(pop_valid_stable_a, pop_valid_unstable && !pop_ready |=> pop_valid_unstable)
   end
 
   // ----------Forward Progress Check----------
-  `BR_ASSERT(must_grant_a, |push_valid == pop_valid)
+  `BR_ASSERT(must_grant_a, |push_valid == pop_valid_unstable)
 
   // ----------Critical Covers----------
   `BR_COVER(all_push_valid_c, &push_valid)

--- a/flow/fpv/arb/br_flow_arb_fixed_fpv_monitor.sv
+++ b/flow/fpv/arb/br_flow_arb_fixed_fpv_monitor.sv
@@ -28,7 +28,7 @@ module br_flow_arb_fixed_fpv_monitor #(
     input logic [NumFlows-1:0] push_ready,
     input logic [NumFlows-1:0] push_valid,
     input logic                pop_ready,
-    input logic                pop_valid,
+    input logic                pop_valid_unstable,
     // RTL internal signal
     input logic [NumFlows-1:0] grant
 );
@@ -44,7 +44,7 @@ module br_flow_arb_fixed_fpv_monitor #(
       .push_ready,
       .push_valid,
       .pop_ready,
-      .pop_valid
+      .pop_valid_unstable
   );
 
   // ----------FV Modeling Code----------

--- a/flow/fpv/arb/br_flow_arb_lru_fpv_monitor.sv
+++ b/flow/fpv/arb/br_flow_arb_lru_fpv_monitor.sv
@@ -28,7 +28,7 @@ module br_flow_arb_lru_fpv_monitor #(
     input logic [NumFlows-1:0] push_ready,
     input logic [NumFlows-1:0] push_valid,
     input logic                pop_ready,
-    input logic                pop_valid,
+    input logic                pop_valid_unstable,
     // RTL internal signal
     input logic [NumFlows-1:0] grant
 );
@@ -44,7 +44,7 @@ module br_flow_arb_lru_fpv_monitor #(
       .push_ready,
       .push_valid,
       .pop_ready,
-      .pop_valid
+      .pop_valid_unstable
   );
 
   // ----------LRU checks----------

--- a/flow/fpv/arb/br_flow_arb_rr_fpv_monitor.sv
+++ b/flow/fpv/arb/br_flow_arb_rr_fpv_monitor.sv
@@ -28,7 +28,7 @@ module br_flow_arb_rr_fpv_monitor #(
     input logic [NumFlows-1:0] push_ready,
     input logic [NumFlows-1:0] push_valid,
     input logic                pop_ready,
-    input logic                pop_valid,
+    input logic                pop_valid_unstable,
     // RTL internal signal
     input logic [NumFlows-1:0] grant
 );
@@ -44,7 +44,7 @@ module br_flow_arb_rr_fpv_monitor #(
       .push_ready,
       .push_valid,
       .pop_ready,
-      .pop_valid
+      .pop_valid_unstable
   );
 
   // ----------Round Robin checks----------

--- a/flow/rtl/br_flow_arb_fixed.sv
+++ b/flow/rtl/br_flow_arb_fixed.sv
@@ -20,6 +20,8 @@
 // and the grant (pop).
 //
 // Purely combinational (no delays).
+// Pop valid can be unstable if push valid is unstable and all active push_valid
+// are withdrawn while pop_ready is low.
 //
 // TODO(mgottscho): Write spec
 
@@ -46,7 +48,9 @@ module br_flow_arb_fixed #(
     output logic [NumFlows-1:0] push_ready,
     input logic [NumFlows-1:0] push_valid,
     input logic pop_ready,
-    output logic pop_valid
+    // Pop valid can be unstable if push valid is unstable
+    // and all active push_valid are withdrawn while pop_ready is low
+    output logic pop_valid_unstable
 );
 
   //------------------------------------------
@@ -84,7 +88,7 @@ module br_flow_arb_fixed #(
       .push_ready,
       .push_valid,
       .pop_ready,
-      .pop_valid
+      .pop_valid_unstable
   );
 
   //------------------------------------------

--- a/flow/rtl/br_flow_arb_lru.sv
+++ b/flow/rtl/br_flow_arb_lru.sv
@@ -21,6 +21,8 @@
 //
 // 0-cycle latency, but clock and reset are still needed to manage
 // the internal arbiter priority state.
+// Pop valid can be unstable if push valid is unstable and all active push_valid
+// are withdrawn while pop_ready is low.
 //
 // TODO(mgottscho): Write spec
 
@@ -44,7 +46,9 @@ module br_flow_arb_lru #(
     output logic [NumFlows-1:0] push_ready,
     input logic [NumFlows-1:0] push_valid,
     input logic pop_ready,
-    output logic pop_valid
+    // Pop valid can be unstable if push valid is unstable
+    // and all active push_valid are withdrawn while pop_ready is low
+    output logic pop_valid_unstable
 );
 
   //------------------------------------------
@@ -88,7 +92,7 @@ module br_flow_arb_lru #(
       .push_ready,
       .push_valid,
       .pop_ready,
-      .pop_valid
+      .pop_valid_unstable
   );
 
   //------------------------------------------

--- a/flow/rtl/br_flow_arb_rr.sv
+++ b/flow/rtl/br_flow_arb_rr.sv
@@ -21,6 +21,8 @@
 //
 // 0-cycle latency, but clock and reset are still needed to manage
 // the internal arbiter priority state.
+// Pop valid can be unstable if push valid is unstable and all active push_valid
+// are withdrawn while pop_ready is low.
 //
 // TODO(mgottscho): Write spec
 
@@ -44,7 +46,9 @@ module br_flow_arb_rr #(
     output logic [NumFlows-1:0] push_ready,
     input logic [NumFlows-1:0] push_valid,
     input logic pop_ready,
-    output logic pop_valid
+    // Pop valid can be unstable if push valid is unstable
+    // and all active push_valid are withdrawn while pop_ready is low
+    output logic pop_valid_unstable
 );
 
   //------------------------------------------
@@ -88,7 +92,7 @@ module br_flow_arb_rr #(
       .push_ready,
       .push_valid,
       .pop_ready,
-      .pop_valid
+      .pop_valid_unstable
   );
 
   //------------------------------------------

--- a/flow/rtl/br_flow_mux_lru.sv
+++ b/flow/rtl/br_flow_mux_lru.sv
@@ -20,6 +20,9 @@
 // and the grant (pop).
 //
 // Stateful arbiter, but 0 latency from push to pop.
+// The pop data is thus unstable as a new requester with higher priority will
+// preempt an existing requester. Pop valid can be unstable if all push valids
+// are revoked while pop_ready is low.
 
 `include "br_asserts.svh"
 
@@ -44,8 +47,12 @@ module br_flow_mux_lru #(
     input  logic [NumFlows-1:0]            push_valid,
     input  logic [NumFlows-1:0][Width-1:0] push_data,
     input  logic                           pop_ready,
-    output logic                           pop_valid,
-    output logic [   Width-1:0]            pop_data
+    // Pop valid can be unstable if push valid is unstable
+    // and all active push_valid are withdrawn while pop_ready is low
+    output logic                           pop_valid_unstable,
+    // Pop data will be unstable if a higher priority requester
+    // asserts on push_valid while pop_ready is low
+    output logic [   Width-1:0]            pop_data_unstable
 );
 
   //------------------------------------------
@@ -93,8 +100,8 @@ module br_flow_mux_lru #(
       .push_valid,
       .push_data,
       .pop_ready,
-      .pop_valid,
-      .pop_data
+      .pop_valid_unstable,
+      .pop_data_unstable
   );
 
   //------------------------------------------

--- a/flow/rtl/br_flow_mux_rr.sv
+++ b/flow/rtl/br_flow_mux_rr.sv
@@ -20,6 +20,9 @@
 // and the grant (pop).
 //
 // Stateful arbiter, but 0 latency from push to pop.
+// The pop data is thus unstable as a new requester with higher priority will
+// preempt an existing requester. Pop valid can be unstable if all push valids
+// are revoked while pop_ready is low.
 
 `include "br_asserts.svh"
 
@@ -44,8 +47,12 @@ module br_flow_mux_rr #(
     input  logic [NumFlows-1:0]            push_valid,
     input  logic [NumFlows-1:0][Width-1:0] push_data,
     input  logic                           pop_ready,
-    output logic                           pop_valid,
-    output logic [   Width-1:0]            pop_data
+    // Pop valid can be unstable if push valid is unstable
+    // and all active push_valid are withdrawn while pop_ready is low
+    output logic                           pop_valid_unstable,
+    // Pop data will be unstable if a higher priority requester
+    // asserts on push_valid while pop_ready is low
+    output logic [   Width-1:0]            pop_data_unstable
 );
 
   //------------------------------------------
@@ -93,8 +100,8 @@ module br_flow_mux_rr #(
       .push_valid,
       .push_data,
       .pop_ready,
-      .pop_valid,
-      .pop_data
+      .pop_valid_unstable,
+      .pop_data_unstable
   );
 
   //------------------------------------------


### PR DESCRIPTION
The pop data is unstable because a new requester with higher priority
than existing requesters will cause the pop data to change.

---

**Stack**:
- #435
- #434 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*