### PR TITLE
move FIFO and CDC FIFO to BR

### DIFF
--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -233,7 +233,7 @@ br_verilog_fpv_test_suite(
             "8",
         ],
     },
-    #tags = ["manual"],
+    tags = ["manual"],
     tool = "jg",
     top = "br_arb_weighted_rr",
     deps = [":br_arb_weighted_rr_fpv_monitor"],

--- a/cdc/fpv/BUILD.bazel
+++ b/cdc/fpv/BUILD.bazel
@@ -1,0 +1,485 @@
+# Copyright 2024-2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_fpv_test_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# Delays an input signal by a fixed number of clock cycles.
+verilog_library(
+    name = "fv_delay",
+    srcs = ["fv_delay.sv"],
+    deps = [
+        "//macros:br_registers",
+    ],
+)
+
+# Basic cdc FIFO checkers
+verilog_library(
+    name = "br_cdc_fifo_basic_fpv_monitor",
+    srcs = ["br_cdc_fifo_basic_fpv_monitor.sv"],
+    deps = [
+        ":fv_delay",
+    ],
+)
+
+# Bedrock-RTL CDC FIFO (Internal 1R1W Flop-RAM, Push Ready/Valid, Pop Ready/Valid Variant)
+
+verilog_library(
+    name = "br_cdc_fifo_flops_fpv_monitor",
+    srcs = ["br_cdc_fifo_flops_fpv_monitor.sv"],
+    deps = [
+        ":br_cdc_fifo_basic_fpv_monitor",
+        "//cdc/rtl:br_cdc_fifo_flops",
+        "//gate/rtl:br_gate_mock",
+        "//macros:br_gates",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_fifo_flops_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_cdc_fifo_flops_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_cdc_fifo_flops_jg_test_suite",
+    custom_tcl_body = "br_cdc_fifo_flops_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_cdc_fifo_flops_fpv_monitor",
+    deps = [":br_cdc_fifo_flops_fpv_monitor"],
+)
+
+# Bedrock-RTL CDC FIFO (Internal 1R1W Flop-RAM, Push Credit/Valid, Pop Ready/Valid Variant)
+
+verilog_library(
+    name = "br_cdc_fifo_flops_push_credit_fpv_monitor",
+    srcs = ["br_cdc_fifo_flops_push_credit_fpv_monitor.sv"],
+    deps = [
+        ":br_cdc_fifo_basic_fpv_monitor",
+        "//cdc/rtl:br_cdc_fifo_flops_push_credit",
+        "//fifo/fpv:br_credit_receiver_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+        "//macros:br_gates",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_fifo_flops_push_credit_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_cdc_fifo_flops_push_credit_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_cdc_fifo_flops_push_credit_jg_test_suite",
+    custom_tcl_body = "br_cdc_fifo_flops_push_credit_fpv.tcl",
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "MaxCredit": [
+            "2",
+            "6",
+            "8",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_cdc_fifo_flops_push_credit_fpv_monitor",
+    deps = [":br_cdc_fifo_flops_push_credit_fpv_monitor"],
+)
+
+# Bedrock-RTL CDC FIFO Controller (1R1W, Push Ready/Valid, Pop Ready/Valid Variant)
+
+verilog_library(
+    name = "br_cdc_fifo_ctrl_1r1w_fpv_monitor",
+    srcs = ["br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv"],
+    deps = [
+        ":br_cdc_fifo_basic_fpv_monitor",
+        "//cdc/rtl:br_cdc_fifo_ctrl_1r1w",
+        "//gate/rtl:br_gate_mock",
+        "//macros:br_gates",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_fifo_ctrl_1r1w_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_cdc_fifo_ctrl_1r1w_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_cdc_fifo_ctrl_1r1w_jg_test_suite",
+    custom_tcl_body = "br_cdc_fifo_ctrl_1r1w_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RamReadLatency": [
+            "0",
+            "3",
+            "5",
+        ],
+        "RamWriteLatency": [
+            "1",
+            "3",
+            "5",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_cdc_fifo_ctrl_1r1w_fpv_monitor",
+    deps = [":br_cdc_fifo_ctrl_1r1w_fpv_monitor"],
+)
+
+# Bedrock-RTL CDC FIFO Controller (1R1W, Push Ready/Valid, Pop Credit/Valid Variant)
+
+verilog_library(
+    name = "br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor",
+    srcs = ["br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv"],
+    deps = [
+        ":br_cdc_fifo_basic_fpv_monitor",
+        "//cdc/rtl:br_cdc_fifo_ctrl_1r1w_push_credit",
+        "//fifo/fpv:br_credit_receiver_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+        "//macros:br_gates",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_cdc_fifo_ctrl_1r1w_push_credit_jg_test_suite",
+    custom_tcl_body = "br_cdc_fifo_ctrl_1r1w_push_credit_fpv.tcl",
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "MaxCredit": [
+            "2",
+            "6",
+            "8",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RamReadLatency": [
+            "0",
+            "3",
+            "5",
+        ],
+        "RamWriteLatency": [
+            "1",
+            "3",
+            "5",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor",
+    deps = [":br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
+)
+
+# Combined FV env:
+# Push-side of Bedrock-RTL CDC FIFO Controller (1R1W, Ready/Valid Variant)
+# Pop-side of Bedrock-RTL CDC FIFO Controller (1R1W, Ready/Valid Variant)
+
+verilog_library(
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor",
+    srcs = ["br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor.sv"],
+    deps = [
+        ":br_cdc_fifo_basic_fpv_monitor",
+        "//cdc/rtl:br_cdc_fifo_ctrl_pop_1r1w",
+        "//cdc/rtl:br_cdc_fifo_ctrl_push_1r1w",
+        "//gate/rtl:br_gate_mock",
+        "//macros:br_gates",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_jg_test_suite",
+    custom_tcl_body = "br_cdc_fifo_ctrl_push_pop_1r1w_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RamReadLatency": [
+            "0",
+            "3",
+            "5",
+        ],
+        "RamWriteLatency": [
+            "1",
+            "3",
+            "5",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor",
+    deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor"],
+)
+
+# Combined FV env:
+# Push-side of Bedrock-RTL CDC FIFO Controller (1R1W, Push Credit/Valid)
+# Pop-side of Bedrock-RTL CDC FIFO Controller (1R1W, Ready/Valid Variant)
+
+verilog_library(
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor",
+    srcs = ["br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor.sv"],
+    deps = [
+        ":br_cdc_fifo_basic_fpv_monitor",
+        "//cdc/rtl:br_cdc_fifo_ctrl_pop_1r1w",
+        "//cdc/rtl:br_cdc_fifo_ctrl_push_1r1w_push_credit",
+        "//fifo/fpv:br_credit_receiver_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+        "//macros:br_gates",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_jg_test_suite",
+    custom_tcl_body = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.tcl",
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "MaxCredit": [
+            "2",
+            "6",
+            "8",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RamReadLatency": [
+            "0",
+            "3",
+            "5",
+        ],
+        "RamWriteLatency": [
+            "1",
+            "3",
+            "5",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor",
+    deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor"],
+)

--- a/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
@@ -1,0 +1,199 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Basic FPV checks for all CDC FIFO variations
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_cdc_fifo_basic_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    // Number of synchronization stages to use for the gray counts. Must be >=2.
+    parameter int NumSyncStages = 3,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter int RamWriteLatency = 1,
+    parameter int RamReadLatency = 1,
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    // FV system clk and rst
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface.
+    input logic             push_clk,
+    input logic             push_rst,
+    input logic             push_ready,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface.
+    input logic             pop_clk,
+    input logic             pop_rst,
+    input logic             pop_ready,
+    input logic             pop_valid,
+    input logic [Width-1:0] pop_data,
+
+    // Push-side status flags
+    input logic push_full,
+    input logic [CountWidth-1:0] push_slots,
+
+    // Pop-side status flags
+    input logic pop_empty,
+    input logic [CountWidth-1:0] pop_items
+);
+
+  localparam int ResetActiveDelay = 1;
+  // Need to make sure that on push reset, the updated push_count is not visible
+  // to the pop side before reset_active is.
+  localparam int PushCountDelay = (ResetActiveDelay + 1) >= RamWriteLatency ?
+  (ResetActiveDelay + 1) : RamWriteLatency;
+  // Need to make sure that on pop reset, the updated pop_count is not visible
+  // to the push side before reset_active is.
+  localparam int PopCountDelay = ResetActiveDelay + 1;
+
+  // ----------FV assumptions----------
+  `BR_ASSUME_CR(pop_ready_liveness_a, s_eventually (pop_ready), pop_clk, pop_rst)
+  if (EnableAssertPushValidStability) begin : gen_push_valid_stable
+    `BR_ASSUME_CR(push_valid_stable_a, push_valid && !push_ready |=> push_valid, push_clk, push_rst)
+  end
+  if (EnableAssertPushDataStability) begin : gen_push_data_stable
+    `BR_ASSUME_CR(push_data_stable_a, push_valid && !push_ready |=> $stable(push_data), push_clk,
+                  push_rst)
+  end
+
+  // ----------FV Modeling Code----------
+  logic push_vr;
+  logic pop_vr;
+  logic fv_push_full;
+  logic fv_pop_empty;
+  logic [CountWidth-1:0] fv_push_items, fv_push_slots;
+  logic [CountWidth-1:0] fv_pop_items;
+
+  // pop side info
+  localparam int CW = 32;  //FV CountWidth;
+  logic [CW-1:0] fv_pop_cnt;
+  logic [CW-1:0] fv_pop_sync;
+  logic [CW-1:0] fv_pop_sync_cnt;
+  // push side info
+  logic [CW-1:0] fv_push_cnt;
+  logic [CW-1:0] fv_push_sync;
+  logic [CW-1:0] fv_push_sync_cnt;
+
+  assign push_vr = push_valid & push_ready;
+  assign pop_vr  = pop_valid & pop_ready;
+  // count number of valid push at push side
+  `BR_REGX(fv_push_cnt, fv_push_cnt + push_vr, push_clk, push_rst)
+  // count number of valid pop at pop side
+  `BR_REGX(fv_pop_cnt, fv_pop_cnt + pop_vr, pop_clk, pop_rst)
+
+  // number of valid pop synced to push side
+  fv_delay #(
+      .Width(CW),
+      .NumStages(PopCountDelay - 1)  // -1 since fv_pop_cnt is flopped
+  ) delay_pop_vr (
+      .clk(pop_clk),
+      .rst(pop_rst),
+      .in (fv_pop_cnt),
+      .out(fv_pop_sync)
+  );
+
+  fv_delay #(
+      .Width(CW),
+      .NumStages(NumSyncStages + 1)
+  ) delay_pop_sync (
+      .clk(push_clk),
+      .rst(push_rst),
+      .in (fv_pop_sync),
+      .out(fv_pop_sync_cnt)
+  );
+
+  // number of valid push synced to pop side
+  fv_delay #(
+      .Width(CW),
+      .NumStages(PushCountDelay - 1)  // -1 since fv_push_cnt is flopped
+  ) delay_push_vr (
+      .clk(push_clk),
+      .rst(push_rst),
+      .in (fv_push_cnt),
+      .out(fv_push_sync)
+  );
+
+  fv_delay #(
+      .Width(CW),
+      .NumStages(NumSyncStages + 1)
+  ) delay_push_sync (
+      .clk(pop_clk),
+      .rst(pop_rst),
+      .in (fv_push_sync),
+      .out(fv_push_sync_cnt)
+  );
+
+  assign fv_push_items = fv_push_cnt - fv_pop_sync_cnt;
+  assign fv_push_slots = Depth - fv_push_items;
+  assign fv_pop_items  = fv_push_sync_cnt - fv_pop_cnt;
+
+  assign fv_push_full  = fv_push_items == Depth;
+  assign fv_pop_empty  = fv_pop_items == 'd0;
+
+  // ----------Sanity Check----------
+  `BR_ASSERT_CR(no_ready_when_full_a, push_full |-> !push_ready, push_clk, push_rst)
+  `BR_ASSERT_CR(no_pop_when_empty_a, pop_empty |-> !pop_valid, pop_clk, pop_rst)
+  `BR_ASSERT_CR(pop_valid_ready_a, pop_valid && !pop_ready |=> pop_valid && $stable(pop_data),
+                pop_clk, pop_rst)
+
+  // empty, full check
+  `BR_ASSERT_CR(push_full_a, fv_push_full == push_full, push_clk, push_rst)
+  `BR_ASSERT_CR(pop_empty_a, fv_pop_empty == pop_empty, pop_clk, pop_rst)
+
+  // slots, items check
+  `BR_ASSERT_CR(pop_items_a, fv_pop_items == pop_items, pop_clk, pop_rst)
+  `BR_ASSERT_CR(push_slots_a, fv_push_slots == push_slots, push_clk, push_rst)
+
+  // ----------Data integrity Check----------
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(Width),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(0),
+      .MAX_PENDING(Depth)
+  ) scoreboard (
+      .incoming_clk(push_clk),
+      .outgoing_clk(pop_clk),
+      .rstN(!rst),
+      .incoming_vld(push_vr),
+      .incoming_data(push_data),
+      .outgoing_vld(pop_vr),
+      .outgoing_data(pop_data)
+  );
+
+  // ----------Forward Progress Check----------
+  if (EnableAssertPushValidStability) begin : gen_stable
+    `BR_ASSERT(no_deadlock_pop_a, push_valid |-> s_eventually pop_valid)
+  end else begin : gen_not_stable
+    `BR_ASSERT(no_deadlock_pop_a, push_vr |-> s_eventually pop_valid)
+  end
+
+  // ----------Critical Covers----------
+  `BR_COVER_CR(fifo_full_c, push_full, push_clk, push_rst)
+
+endmodule : br_cdc_fifo_basic_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.tcl
@@ -1,0 +1,35 @@
+# clock/reset set up
+clock clk
+clock push_clk -from 1 -to 10 -both_edges
+clock pop_clk -from 1 -to 10 -both_edges
+reset rst push_rst pop_rst
+
+# push/pop side primary input signals only toggle w.r.t its clock
+clock -rate {push_rst \
+            push_valid \
+            push_data} push_clk
+clock -rate {pop_rst \
+            pop_ready \
+            pop_ram_rd_data_valid \
+            pop_ram_rd_data} pop_clk
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name no_push_valid_during_reset {@(posedge push_clk) \
+push_rst |-> push_valid == 'd0}
+
+assume -name no_pop_ram_rd_data_valid_during_reset {@(posedge pop_clk) \
+pop_rst |-> pop_ram_rd_data_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_push_ram_write_valid {@(posedge push_clk) \
+push_rst |-> push_ram_wr_valid == 'd0}
+
+assert -name fv_rst_check_pop_valid {@(posedge pop_clk) \
+pop_rst |-> pop_valid == 'd0}
+
+assert -name fv_rst_check_pop_ram_rd_addr_valid {@(posedge pop_clk) \
+pop_rst |-> pop_ram_rd_addr_valid == 'd0}
+
+prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
@@ -1,0 +1,168 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL CDC FIFO Controller (1R1W, Push Ready/Valid, Pop Ready/Valid Variant)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter bit RegisterPopOutputs = 0,
+    // The number of push cycles after ram_wr_valid is asserted at which
+    // it is safe to read the newly written data.
+    parameter int RamWriteLatency = 1,
+    // The number of pop cycles between when ram_rd_addr_valid is asserted and
+    // ram_rd_data_valid is asserted.
+    parameter int RamReadLatency = 0,
+    // The number of synchronization stages to use for the gray counts.
+    parameter int NumSyncStages = 3,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, then assert there are no valid bits asserted and that the FIFO is
+    // empty at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    // FV system clk and rst
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic             push_clk,
+    input logic             push_rst,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface
+    input logic pop_clk,
+    input logic pop_rst,
+    input logic pop_ready,
+
+    // Pop-side RAM read interface
+    input logic             pop_ram_rd_data_valid,
+    input logic [Width-1:0] pop_ram_rd_data
+);
+  // Push-side output signals
+  logic                             push_ready;
+  // Push-side status flags
+  logic                             push_full;
+  logic [CountWidth-1:0]            push_slots;
+  // Push-side RAM write interface
+  logic                             push_ram_wr_valid;
+  logic [ AddrWidth-1:0]            push_ram_wr_addr;
+  logic [     Width-1:0]            push_ram_wr_data;
+
+  // Pop-side output signals
+  logic                             pop_valid;
+  logic [     Width-1:0]            pop_data;
+  // Pop-side status flags
+  logic                             pop_empty;
+  logic [CountWidth-1:0]            pop_items;
+  // Pop-side RAM read interface
+  logic                             pop_ram_rd_addr_valid;
+  logic [ AddrWidth-1:0]            pop_ram_rd_addr;
+
+  // ----------FV Modeling Code----------
+  logic [     Depth-1:0][Width-1:0] fv_ram_data;
+
+  `BR_REGLNX(fv_ram_data[push_ram_wr_addr], push_ram_wr_data, push_ram_wr_valid, push_clk)
+
+  // ----------FV assumptions----------
+  if (RamReadLatency == 0) begin : gen_latency0
+    `BR_ASSUME_CR(ram_rd_data_a, pop_ram_rd_data == fv_ram_data[pop_ram_rd_addr], pop_clk, pop_rst)
+    `BR_ASSUME_CR(ram_rd_data_addr_latency_a, pop_ram_rd_data_valid == pop_ram_rd_addr_valid,
+                  pop_clk, pop_rst)
+  end else begin : gen_latency_non0
+    `BR_ASSUME_CR(ram_rd_data_a, pop_ram_rd_data == fv_ram_data[$past(
+                  pop_ram_rd_addr, RamReadLatency)], pop_clk, pop_rst)
+    `BR_ASSUME_CR(ram_rd_data_addr_latency_a, pop_ram_rd_data_valid == $past(
+                  pop_ram_rd_addr_valid, RamReadLatency), pop_clk, pop_rst)
+  end
+
+  // ----------Instantiate DUT----------
+  br_cdc_fifo_ctrl_1r1w #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency),
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) dut (
+      .push_clk,
+      .push_rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .push_full,
+      .push_slots,
+      .push_ram_wr_valid,
+      .push_ram_wr_addr,
+      .push_ram_wr_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .pop_empty,
+      .pop_items,
+      .pop_ram_rd_addr_valid,
+      .pop_ram_rd_addr,
+      .pop_ram_rd_data_valid,
+      .pop_ram_rd_data
+  );
+
+  // ----------Instantiate CDC FIFO FV basic checks----------
+  br_cdc_fifo_basic_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_clk,
+      .push_rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_slots,
+      .pop_empty,
+      .pop_items
+  );
+
+endmodule : br_cdc_fifo_ctrl_1r1w_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.tcl
@@ -1,0 +1,56 @@
+# clock/reset set up
+clock clk
+clock push_clk -from 1 -to 10 -both_edges
+clock pop_clk -from 1 -to 10 -both_edges
+
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+assume -env {rst == push_rst}
+assume -env {rst == pop_rst}
+
+# push/pop side primary input signals only toggle w.r.t its clock
+clock -rate {push_rst \
+            push_sender_in_reset \
+            push_credit_stall \
+            push_valid \
+            push_data \
+            credit_initial_push \
+            credit_withhold_push} push_clk
+clock -rate {pop_rst \
+            pop_ready \
+            pop_ram_rd_data_valid \
+            pop_ram_rd_data} pop_clk
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name initial_value_during_reset {@(posedge push_clk) \
+push_rst | push_sender_in_reset |-> \
+(credit_initial_push <= Depth) && $stable(credit_initial_push)}
+
+assume -name no_push_valid_during_reset {@(posedge push_clk) \
+push_rst | push_sender_in_reset |-> push_valid == 'd0}
+
+assume -name no_pop_ram_rd_data_valid_during_reset {@(posedge pop_clk) \
+pop_rst |-> pop_ram_rd_data_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_push_credit {@(posedge push_clk) \
+push_rst | push_sender_in_reset |-> push_credit == 'd0}
+
+assert -name fv_rst_check_push_ram_write_valid {@(posedge push_clk) \
+push_rst | push_sender_in_reset  |-> push_ram_wr_valid == 'd0}
+
+assert -name fv_rst_check_pop_valid {@(posedge pop_clk) \
+pop_rst |-> pop_valid == 'd0}
+
+assert -name fv_rst_check_pop_ram_rd_addr_valid {@(posedge pop_clk) \
+pop_rst |-> pop_ram_rd_addr_valid == 'd0}
+
+# disable cdc_fifo_basic_fpv_monitor assertions don't apply to DUT
+# no push_ready signal in push credit interface
+assert -disable *fv_checker.no_ready_when_full_a*
+
+prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
@@ -1,0 +1,192 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL CDC FIFO Controller (1R1W, Push Ready/Valid, Pop Credit/Valid Variant)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter bit RegisterPopOutputs = 0,
+    // The number of push cycles after ram_wr_valid is asserted at which
+    // it is safe to read the newly written data.
+    parameter int RamWriteLatency = 1,
+    // The number of pop cycles between when ram_rd_addr_valid is asserted and
+    // ram_rd_data_valid is asserted.
+    parameter int RamReadLatency = 0,
+    // The number of synchronization stages to use for the gray counts.
+    parameter int NumSyncStages = 3,
+    parameter int MaxCredit = Depth,
+    parameter bit RegisterPushOutputs = 0,
+    parameter bit EnableAssertFinalNotValid = 1,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1),
+    localparam int CreditWidth = $clog2(MaxCredit + 1)
+) (
+    // FV system clk and rst
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic                   push_clk,
+    input logic                   push_rst,
+    input logic                   push_sender_in_reset,
+    input logic                   push_credit_stall,
+    input logic                   push_valid,
+    input logic [      Width-1:0] push_data,
+    // Push-side credits
+    input logic [CreditWidth-1:0] credit_initial_push,
+    input logic [CreditWidth-1:0] credit_withhold_push,
+
+    // Pop-side interface
+    input logic             pop_clk,
+    input logic             pop_rst,
+    input logic             pop_ready,
+    // Pop-side RAM read interface
+    input logic             pop_ram_rd_data_valid,
+    input logic [Width-1:0] pop_ram_rd_data
+);
+
+  // Push-side output signals
+  logic                              push_receiver_in_reset;
+  logic                              push_credit;
+  // Push-side status flags
+  logic                              push_full;
+  logic [ CountWidth-1:0]            push_slots;
+  // Push-side credits
+  logic [CreditWidth-1:0]            credit_count_push;
+  logic [CreditWidth-1:0]            credit_available_push;
+  // Push-side RAM write interface
+  logic                              push_ram_wr_valid;
+  logic [  AddrWidth-1:0]            push_ram_wr_addr;
+  logic [      Width-1:0]            push_ram_wr_data;
+
+  // Pop-side output signals
+  logic                              pop_valid;
+  logic [      Width-1:0]            pop_data;
+  // Pop-side status flags
+  logic                              pop_empty;
+  logic [ CountWidth-1:0]            pop_items;
+  // Pop-side RAM read interface
+  logic                              pop_ram_rd_addr_valid;
+  logic [  AddrWidth-1:0]            pop_ram_rd_addr;
+
+  // ----------FV Modeling Code----------
+  logic [      Depth-1:0][Width-1:0] fv_ram_data;
+
+  `BR_REGLNX(fv_ram_data[push_ram_wr_addr], push_ram_wr_data, push_ram_wr_valid, push_clk)
+
+  // ----------FV assumptions----------
+  if (RamReadLatency == 0) begin : gen_latency0
+    `BR_ASSUME_CR(ram_rd_data_a, pop_ram_rd_data == fv_ram_data[pop_ram_rd_addr], pop_clk, pop_rst)
+    `BR_ASSUME_CR(ram_rd_data_addr_latency_a, pop_ram_rd_data_valid == pop_ram_rd_addr_valid,
+                  pop_clk, pop_rst)
+  end else begin : gen_latency_non0
+    `BR_ASSUME_CR(ram_rd_data_a, pop_ram_rd_data == fv_ram_data[$past(
+                  pop_ram_rd_addr, RamReadLatency)], pop_clk, pop_rst)
+    `BR_ASSUME_CR(ram_rd_data_addr_latency_a, pop_ram_rd_data_valid == $past(
+                  pop_ram_rd_addr_valid, RamReadLatency), pop_clk, pop_rst)
+  end
+
+  // ----------Instantiate DUT----------
+  br_cdc_fifo_ctrl_1r1w_push_credit #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency),
+      .NumSyncStages(NumSyncStages),
+      .MaxCredit(MaxCredit),
+      .RegisterPushOutputs(RegisterPushOutputs),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) dut (
+      .push_clk,
+      .push_rst,
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .push_data,
+      .push_full,
+      .push_slots,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push,
+      .push_ram_wr_valid,
+      .push_ram_wr_addr,
+      .push_ram_wr_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .pop_empty,
+      .pop_items,
+      .pop_ram_rd_addr_valid,
+      .pop_ram_rd_addr,
+      .pop_ram_rd_data_valid,
+      .pop_ram_rd_data
+  );
+
+  // ----------Instantiate credit FV checker----------
+  br_credit_receiver_fpv_monitor #(
+      .MaxCredit(MaxCredit)
+  ) fv_credit_receiver (
+      .clk(push_clk),
+      .rst(push_rst),
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push
+  );
+
+  // ----------Instantiate CDC FIFO FV basic checks----------
+  br_cdc_fifo_basic_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(0),
+      .EnableAssertPushValidStability(0),
+      .EnableAssertPushDataStability(0),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_clk,
+      .push_rst,
+      .push_ready(1'd1),
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_slots,
+      .pop_empty,
+      .pop_items
+  );
+
+endmodule : br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv.tcl
@@ -1,0 +1,42 @@
+# clock/reset set up
+clock clk
+clock push_clk -from 1 -to 10 -both_edges
+clock pop_clk -from 1 -to 10 -both_edges
+
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+assume -env {rst == push_rst}
+assume -env {rst == pop_rst}
+
+# push/pop side primary input signals only toggle w.r.t its clock
+clock -rate {push_rst \
+            push_valid \
+            push_data} push_clk
+clock -rate {pop_rst \
+            pop_ready \
+            pop_ram_rd_data_valid \
+            pop_ram_rd_data} pop_clk
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name no_push_valid_during_reset {@(posedge push_clk) \
+push_rst |-> push_valid == 'd0}
+
+assume -name no_pop_ram_rd_data_valid_during_reset {@(posedge pop_clk) \
+pop_rst |-> pop_ram_rd_data_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_push_ram_write_valid {@(posedge push_clk) \
+push_rst |-> push_ram_wr_valid == 'd0}
+
+assert -name fv_rst_check_pop_valid {@(posedge pop_clk) \
+pop_rst |-> pop_valid == 'd0}
+
+assert -name fv_rst_check_pop_ram_rd_addr_valid {@(posedge pop_clk) \
+pop_rst |-> pop_ram_rd_addr_valid == 'd0}
+
+# prove command
+prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor.sv
@@ -1,0 +1,199 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Combined FV env of br_cdc_fifo_ctrl_push_1r1w and br_cdc_fifo_ctrl_pop_1r1w
+
+// br_cdc_fifo_ctrl_push_1r1w
+// Push-side of Bedrock-RTL CDC FIFO Controller (1R1W, Ready/Valid Variant)
+// This module is intended to connect to an instance of br_cdc_fifo_ctrl_pop_1r1w
+// as well as a 1R1W RAM module.
+
+// br_cdc_fifo_ctrl_pop_1r1w
+// Pop-side of Bedrock-RTL CDC FIFO Controller (1R1W, Ready/Valid Variant)
+// This module is intended to connect to an instance of br_cdc_fifo_ctrl_push_1r1w
+// or br_cdc_fifo_ctrl_push_1r1w_push_credit, as well as a 1R1W RAM module.
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter int RamWriteLatency = 1,
+    parameter int RamReadLatency = 0,
+    parameter int NumSyncStages = 3,
+    parameter bit RegisterPopOutputs = 0,
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertFinalNotValid = 1,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    // FV system clk and rst
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic             push_clk,
+    input logic             push_rst,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface
+    input logic pop_clk,
+    input logic pop_rst,
+    input logic pop_ready,
+
+    // Pop-side RAM read interface
+    input logic             pop_ram_rd_data_valid,
+    input logic [Width-1:0] pop_ram_rd_data
+);
+
+  // ----------Push-side interface----------
+  logic                             push_ready;
+  // Push-side status flags
+  logic                             push_full;
+  logic [CountWidth-1:0]            push_slots;
+  // Push-side RAM write interface
+  logic                             push_ram_wr_valid;
+  logic [ AddrWidth-1:0]            push_ram_wr_addr;
+  logic [     Width-1:0]            push_ram_wr_data;
+
+  // ----------Pop-side interface----------
+  logic                             pop_valid;
+  logic [     Width-1:0]            pop_data;
+  // Pop-side status flags
+  logic                             pop_empty;
+  logic [CountWidth-1:0]            pop_items;
+  // Pop-side RAM read interface
+  logic                             pop_ram_rd_addr_valid;
+  logic [ AddrWidth-1:0]            pop_ram_rd_addr;
+
+  // ----------Push/Pop interface----------
+  // Signals that connect to the pop side.
+  logic                             pop_reset_active_pop;
+  logic [CountWidth-1:0]            pop_pop_count_gray;
+  logic [CountWidth-1:0]            push_push_count_gray;
+  logic                             push_reset_active_push;
+
+  // ----------FV 1R1W RAM model----------
+  logic [     Depth-1:0][Width-1:0] fv_ram_data;
+
+  `BR_REGLNX(fv_ram_data[push_ram_wr_addr], push_ram_wr_data, push_ram_wr_valid, push_clk)
+
+  if (RamReadLatency == 0) begin : gen_latency0
+    `BR_ASSUME_CR(ram_rd_data_a, pop_ram_rd_data == fv_ram_data[pop_ram_rd_addr], pop_clk, pop_rst)
+    `BR_ASSUME_CR(ram_rd_data_addr_latency_a, pop_ram_rd_data_valid == pop_ram_rd_addr_valid,
+                  pop_clk, pop_rst)
+  end else begin : gen_latency_non0
+    `BR_ASSUME_CR(ram_rd_data_a, pop_ram_rd_data == fv_ram_data[$past(
+                  pop_ram_rd_addr, RamReadLatency)], pop_clk, pop_rst)
+    `BR_ASSUME_CR(ram_rd_data_addr_latency_a, pop_ram_rd_data_valid == $past(
+                  pop_ram_rd_addr_valid, RamReadLatency), pop_clk, pop_rst)
+  end
+
+  // ----------Instantiate DUT----------
+  br_cdc_fifo_ctrl_push_1r1w #(
+      .Depth(Depth),
+      .Width(Width),
+      .RamWriteLatency(RamWriteLatency),
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) push_dut (
+      .push_clk,
+      .push_rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .push_full,
+      .push_slots,
+      .push_ram_wr_valid,
+      .push_ram_wr_addr,
+      .push_ram_wr_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_reset_active_pop,
+      .pop_pop_count_gray,
+      .push_push_count_gray,
+      .push_reset_active_push
+  );
+
+  br_cdc_fifo_ctrl_pop_1r1w #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RamReadLatency(RamReadLatency),
+      .NumSyncStages(NumSyncStages),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) pop_dut (
+      .push_clk,
+      .push_rst,
+      .pop_reset_active_pop,
+      .pop_pop_count_gray,
+      .push_push_count_gray,
+      .push_reset_active_push,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .pop_empty,
+      .pop_items,
+      .pop_ram_rd_addr_valid,
+      .pop_ram_rd_addr,
+      .pop_ram_rd_data_valid,
+      .pop_ram_rd_data
+  );
+
+  // ----------Instantiate CDC FIFO FV basic checks----------
+  br_cdc_fifo_basic_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_clk,
+      .push_rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_slots,
+      .pop_empty,
+      .pop_items
+  );
+
+  `BR_ASSERT_CR(push_count_gray_a, $changed(push_push_count_gray) |-> $countones
+                                   (push_push_count_gray ^ $past(push_push_count_gray)) == 'd1,
+                push_clk, push_rst)
+  `BR_ASSERT_CR(pop_count_gray_a, $changed(pop_pop_count_gray) |-> $countones
+                                  (pop_pop_count_gray ^ $past(pop_pop_count_gray)) == 'd1, pop_clk,
+                pop_rst)
+
+endmodule : br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.tcl
@@ -1,0 +1,56 @@
+# clock/reset set up
+clock clk
+clock push_clk -from 1 -to 10 -both_edges
+clock pop_clk -from 1 -to 10 -both_edges
+
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+assume -env {rst == push_rst}
+assume -env {rst == pop_rst}
+
+# push/pop side primary input signals only toggle w.r.t its clock
+clock -rate {push_rst \
+            push_sender_in_reset \
+            push_credit_stall \
+            push_valid \
+            push_data \
+            credit_initial_push \
+            credit_withhold_push} push_clk
+clock -rate {pop_rst \
+            pop_ready \
+            pop_ram_rd_data_valid \
+            pop_ram_rd_data} pop_clk
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name initial_value_during_reset {@(posedge push_clk) \
+push_rst | push_sender_in_reset |-> \
+(credit_initial_push <= Depth) && $stable(credit_initial_push)}
+
+assume -name no_push_valid_during_reset {@(posedge push_clk) \
+push_rst | push_sender_in_reset |-> push_valid == 'd0}
+
+assume -name no_pop_ram_rd_data_valid_during_reset {@(posedge pop_clk) \
+pop_rst |-> pop_ram_rd_data_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_push_credit {@(posedge push_clk) \
+push_rst | push_sender_in_reset |-> push_credit == 'd0}
+
+assert -name fv_rst_check_push_ram_write_valid {@(posedge push_clk) \
+push_rst | push_sender_in_reset  |-> push_ram_wr_valid == 'd0}
+
+assert -name fv_rst_check_pop_valid {@(posedge pop_clk) \
+pop_rst |-> pop_valid == 'd0}
+
+assert -name fv_rst_check_pop_ram_rd_addr_valid {@(posedge pop_clk) \
+pop_rst |-> pop_ram_rd_addr_valid == 'd0}
+
+# disable cdc_fifo_basic_fpv_monitor assertions don't apply to DUT
+# no push_ready signal in push credit interface
+assert -disable *fv_checker.no_ready_when_full_a*
+
+prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor.sv
@@ -1,0 +1,231 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Combined FV env of br_cdc_fifo_ctrl_push_1r1w_push_credit and br_cdc_fifo_ctrl_pop_1r1w
+
+// br_cdc_fifo_ctrl_push_1r1w_push_credit
+// Push-side of Bedrock-RTL CDC FIFO Controller (1R1W, Push Credit/Valid)
+// This module is intended to connect to an instance of br_cdc_fifo_ctrl_pop_1r1w
+// as well as a 1R1W RAM module.
+
+// br_cdc_fifo_ctrl_pop_1r1w
+// Pop-side of Bedrock-RTL CDC FIFO Controller (1R1W, Ready/Valid Variant)
+// This module is intended to connect to an instance of br_cdc_fifo_ctrl_push_1r1w
+// or br_cdc_fifo_ctrl_push_1r1w_push_credit, as well as a 1R1W RAM module.
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter int RamWriteLatency = 1,
+    parameter int RamReadLatency = 0,
+    parameter int NumSyncStages = 3,
+    parameter int MaxCredit = Depth,
+    parameter bit RegisterPushOutputs = 0,
+    parameter bit RegisterPopOutputs = 0,
+    parameter bit EnableAssertFinalNotValid = 1,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1),
+    localparam int CreditWidth = $clog2(MaxCredit + 1)
+) (
+    // FV system clk and rst
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic                   push_clk,
+    input logic                   push_rst,
+    input logic                   push_sender_in_reset,
+    input logic                   push_credit_stall,
+    input logic                   push_valid,
+    input logic [      Width-1:0] push_data,
+    // Push-side credits
+    input logic [CreditWidth-1:0] credit_initial_push,
+    input logic [CreditWidth-1:0] credit_withhold_push,
+
+    // Pop-side interface
+    input logic pop_clk,
+    input logic pop_rst,
+    input logic pop_ready,
+
+    // Pop-side RAM read interface
+    input logic             pop_ram_rd_data_valid,
+    input logic [Width-1:0] pop_ram_rd_data
+);
+
+  // ----------Push-side interface----------
+  logic                              push_receiver_in_reset;
+  logic                              push_credit;
+  // Push-side credits
+  logic [CreditWidth-1:0]            credit_count_push;
+  logic [CreditWidth-1:0]            credit_available_push;
+  // Push-side status flags
+  logic                              push_full;
+  logic [ CountWidth-1:0]            push_slots;
+  // Push-side RAM write interface
+  logic                              push_ram_wr_valid;
+  logic [  AddrWidth-1:0]            push_ram_wr_addr;
+  logic [      Width-1:0]            push_ram_wr_data;
+
+  // ----------Pop-side interface----------
+  logic                              pop_valid;
+  logic [      Width-1:0]            pop_data;
+  // Pop-side status flags
+  logic                              pop_empty;
+  logic [ CountWidth-1:0]            pop_items;
+  // Pop-side RAM read interface
+  logic                              pop_ram_rd_addr_valid;
+  logic [  AddrWidth-1:0]            pop_ram_rd_addr;
+
+  // ----------Push/Pop interface----------
+  // Signals that connect to the pop side.
+  logic                              pop_reset_active_pop;
+  logic [ CountWidth-1:0]            pop_pop_count_gray;
+  logic [ CountWidth-1:0]            push_push_count_gray;
+  logic                              push_reset_active_push;
+
+  // ----------FV 1R1W RAM model----------
+  logic [      Depth-1:0][Width-1:0] fv_ram_data;
+
+  `BR_REGLNX(fv_ram_data[push_ram_wr_addr], push_ram_wr_data, push_ram_wr_valid, push_clk)
+
+  if (RamReadLatency == 0) begin : gen_latency0
+    `BR_ASSUME_CR(ram_rd_data_a, pop_ram_rd_data == fv_ram_data[pop_ram_rd_addr], pop_clk, pop_rst)
+    `BR_ASSUME_CR(ram_rd_data_addr_latency_a, pop_ram_rd_data_valid == pop_ram_rd_addr_valid,
+                  pop_clk, pop_rst)
+  end else begin : gen_latency_non0
+    `BR_ASSUME_CR(ram_rd_data_a, pop_ram_rd_data == fv_ram_data[$past(
+                  pop_ram_rd_addr, RamReadLatency)], pop_clk, pop_rst)
+    `BR_ASSUME_CR(ram_rd_data_addr_latency_a, pop_ram_rd_data_valid == $past(
+                  pop_ram_rd_addr_valid, RamReadLatency), pop_clk, pop_rst)
+  end
+
+  // ----------Instantiate DUT----------
+  br_cdc_fifo_ctrl_push_1r1w_push_credit #(
+      .Depth(Depth),
+      .Width(Width),
+      .RamWriteLatency(RamWriteLatency),
+      .NumSyncStages(NumSyncStages),
+      .MaxCredit(MaxCredit),
+      .RegisterPushOutputs(RegisterPushOutputs),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) push_dut (
+      .push_clk,
+      .push_rst,
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .push_data,
+      .push_full,
+      .push_slots,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push,
+      .push_ram_wr_valid,
+      .push_ram_wr_addr,
+      .push_ram_wr_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_reset_active_pop,
+      .pop_pop_count_gray,
+      .push_push_count_gray,
+      .push_reset_active_push
+  );
+
+  br_cdc_fifo_ctrl_pop_1r1w #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RamReadLatency(RamReadLatency),
+      .NumSyncStages(NumSyncStages),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) pop_dut (
+      .push_clk,
+      .push_rst,
+      .pop_reset_active_pop,
+      .pop_pop_count_gray,
+      .push_push_count_gray,
+      .push_reset_active_push,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .pop_empty,
+      .pop_items,
+      .pop_ram_rd_addr_valid,
+      .pop_ram_rd_addr,
+      .pop_ram_rd_data_valid,
+      .pop_ram_rd_data
+  );
+
+  // ----------Instantiate credit FV checker----------
+  br_credit_receiver_fpv_monitor #(
+      .MaxCredit(MaxCredit)
+  ) fv_credit_receiver (
+      .clk(push_clk),
+      .rst(push_rst),
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push
+  );
+
+  // ----------Instantiate CDC FIFO FV basic checks----------
+  br_cdc_fifo_basic_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(0),
+      .EnableAssertPushValidStability(0),
+      .EnableAssertPushDataStability(0),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_clk,
+      .push_rst,
+      .push_ready(1'd1),
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_slots,
+      .pop_empty,
+      .pop_items
+  );
+
+  `BR_ASSERT_CR(push_count_gray_a, $changed(push_push_count_gray) |-> $countones
+                                   (push_push_count_gray ^ $past(push_push_count_gray)) == 'd1,
+                push_clk, push_rst)
+  `BR_ASSERT_CR(pop_count_gray_a, $changed(pop_pop_count_gray) |-> $countones
+                                  (pop_pop_count_gray ^ $past(pop_pop_count_gray)) == 'd1, pop_clk,
+                pop_rst)
+
+endmodule : br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_flops_fpv.tcl
+++ b/cdc/fpv/br_cdc_fifo_flops_fpv.tcl
@@ -1,0 +1,21 @@
+# clock/reset set up
+clock clk
+clock push_clk -from 1 -to 10 -both_edges
+clock pop_clk -from 1 -to 10 -both_edges
+reset rst push_rst pop_rst
+
+# push/pop side primary input signals only toggle w.r.t its clock
+clock -rate {push_valid push_data} push_clk
+clock -rate {pop_ready} pop_clk
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name no_push_valid_during_reset {@(posedge push_clk) \
+push_rst |-> push_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_pop_valid {@(posedge pop_clk) \
+pop_rst |-> pop_valid == 'd0}
+
+prove -all

--- a/cdc/fpv/br_cdc_fifo_flops_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_flops_fpv_monitor.sv
@@ -1,0 +1,152 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL CDC FIFO (Internal 1R1W Flop-RAM, Push Ready/Valid, Pop Ready/Valid Variant)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_cdc_fifo_flops_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    // If 1, then ensure pop_valid/pop_data always come directly from a register
+    // at the cost of an additional pop cycle of cut-through latency.
+    // If 0, pop_valid/pop_data comes directly from push_valid (if bypass is enabled)
+    // and/or ram_wr_data.
+    parameter bit RegisterPopOutputs = 0,
+    // Number of synchronization stages to use for the gray counts. Must be >=2.
+    parameter int NumSyncStages = 3,
+    // Number of tiles in the depth (address) dimension. Must be at least 1 and evenly divide Depth.
+    parameter int FlopRamDepthTiles = 1,
+    // Number of tiles along the width (data) dimension. Must be at least 1 and evenly divide Width.
+    parameter int FlopRamWidthTiles = 1,
+    // Number of pipeline register stages inserted along the write address and read address paths
+    // in the depth dimension. Must be at least 0.
+    parameter int FlopRamAddressDepthStages = 0,
+    // Number of pipeline register stages inserted along the read data path in the depth dimension.
+    // Must be at least 0.
+    parameter int FlopRamReadDataDepthStages = 0,
+    // Number of pipeline register stages inserted along the read data path in the width dimension.
+    // Must be at least 0.
+    parameter int FlopRamReadDataWidthStages = 0,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, assert that there is never backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    // If 0, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable when backpressured.
+    // If 0, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, then assert there are no valid bits asserted and that the FIFO is
+    // empty at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
+
+    // Internal computed parameters
+    localparam int AddrWidth  = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    // FV system clk and rst
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface.
+    input logic             push_clk,
+    input logic             push_rst,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface.
+    input logic pop_clk,
+    input logic pop_rst,
+    input logic pop_ready
+);
+
+  localparam int RamReadLatency =
+      FlopRamAddressDepthStages + FlopRamReadDataDepthStages + FlopRamReadDataWidthStages;
+  localparam int RamWriteLatency = FlopRamAddressDepthStages + 1;
+
+  // DUT primary outputs
+  logic                  push_ready;
+  logic                  pop_valid;
+  logic [     Width-1:0] pop_data;
+  // Push-side status flags
+  logic                  push_full;
+  logic [CountWidth-1:0] push_slots;
+  // Pop-side status flags
+  logic                  pop_empty;
+  logic [CountWidth-1:0] pop_items;
+
+  // ----------Instantiate DUT----------
+  br_cdc_fifo_flops #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .NumSyncStages(NumSyncStages),
+      .FlopRamDepthTiles(FlopRamDepthTiles),
+      .FlopRamWidthTiles(FlopRamWidthTiles),
+      .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
+      .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages),
+      .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) dut (
+      .push_clk,
+      .push_rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_slots,
+      .pop_empty,
+      .pop_items
+  );
+
+  // ----------Instantiate CDC FIFO FV basic checks----------
+  br_cdc_fifo_basic_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_clk,
+      .push_rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_slots,
+      .pop_empty,
+      .pop_items
+  );
+
+endmodule : br_cdc_fifo_flops_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv.tcl
+++ b/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv.tcl
@@ -1,0 +1,44 @@
+# clock/reset set up
+clock clk
+clock push_clk -from 1 -to 10 -both_edges
+clock pop_clk -from 1 -to 10 -both_edges
+
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+assume -env {rst == push_rst}
+assume -env {rst == pop_rst}
+
+# push/pop side primary input signals only toggle w.r.t its clock
+clock -rate {push_rst \
+            push_sender_in_reset \
+            push_credit_stall \
+            push_valid \
+            push_data \
+            credit_initial_push \
+            credit_withhold_push} push_clk
+clock -rate {pop_rst pop_ready} pop_clk
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name initial_value_during_reset {@(posedge push_clk) \
+push_rst | push_sender_in_reset |-> \
+(credit_initial_push <= Depth) && $stable(credit_initial_push)}
+
+assume -name no_push_valid_during_reset {@(posedge push_clk) \
+push_rst | push_sender_in_reset |-> push_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_push_credit {@(posedge push_clk) \
+push_rst | push_sender_in_reset |-> push_credit == 'd0}
+
+assert -name fv_rst_check_pop_valid {@(posedge pop_clk) \
+pop_rst |-> pop_valid == 'd0}
+
+# disable cdc_fifo_basic_fpv_monitor assertions don't apply to DUT
+# no push_ready signal in push credit interface
+assert -disable *fv_checker.no_ready_when_full_a*
+
+prove -all

--- a/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv_monitor.sv
@@ -1,0 +1,176 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL CDC FIFO (Internal 1R1W Flop-RAM, Push Credit/Valid, Pop Ready/Valid Variant)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_cdc_fifo_flops_push_credit_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter int MaxCredit = Depth,
+    parameter bit RegisterPushOutputs = 0,
+    parameter bit RegisterPopOutputs = 1,
+    // Number of synchronization stages to use for the gray counts. Must be >=2.
+    parameter int NumSyncStages = 3,
+    // Number of tiles in the depth (address) dimension. Must be at least 1 and evenly divide Depth.
+    parameter int FlopRamDepthTiles = 1,
+    // Number of tiles along the width (data) dimension. Must be at least 1 and evenly divide Width.
+    parameter int FlopRamWidthTiles = 1,
+    // Number of pipeline register stages inserted along the write address and read address paths
+    // in the depth dimension. Must be at least 0.
+    parameter int FlopRamAddressDepthStages = 0,
+    // Number of pipeline register stages inserted along the read data path in the depth dimension.
+    // Must be at least 0.
+    parameter int FlopRamReadDataDepthStages = 0,
+    // Number of pipeline register stages inserted along the read data path in the width dimension.
+    // Must be at least 0.
+    parameter int FlopRamReadDataWidthStages = 0,
+    // If 1, then assert there are no valid bits asserted and that the FIFO is
+    // empty at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
+    // Internal computed parameters
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1),
+    localparam int CreditWidth = $clog2(MaxCredit + 1)
+) (
+    // FV system clk and rst
+    input logic clk,
+    input logic rst,
+
+    // DUT clk & rst
+    input logic push_clk,
+    input logic push_rst,
+    input logic pop_clk,
+    input logic pop_rst,
+
+    // Push-side interface
+    input logic             push_sender_in_reset,
+    input logic             push_credit_stall,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface.
+    input logic pop_ready,
+
+    // Push-side credits
+    input logic [CreditWidth-1:0] credit_initial_push,
+    input logic [CreditWidth-1:0] credit_withhold_push
+);
+
+  localparam int RamReadLatency =
+      FlopRamAddressDepthStages + FlopRamReadDataDepthStages + FlopRamReadDataWidthStages;
+  localparam int RamWriteLatency = FlopRamAddressDepthStages + 1;
+
+  // DUT primary outputs
+  logic                   push_receiver_in_reset;
+  logic                   push_credit;
+  logic                   pop_valid;
+  logic [      Width-1:0] pop_data;
+  // Push-side credits
+  logic [CreditWidth-1:0] credit_count_push;
+  logic [CreditWidth-1:0] credit_available_push;
+  // Push-side status flags
+  logic                   push_full;
+  logic [ CountWidth-1:0] push_slots;
+  // Pop-side status flags
+  logic                   pop_empty;
+  logic [ CountWidth-1:0] pop_items;
+
+  // ----------Instantiate DUT----------
+  br_cdc_fifo_flops_push_credit #(
+      .Depth(Depth),
+      .Width(Width),
+      .MaxCredit(MaxCredit),
+      .RegisterPushOutputs(RegisterPushOutputs),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .NumSyncStages(NumSyncStages),
+      .FlopRamDepthTiles(FlopRamDepthTiles),
+      .FlopRamWidthTiles(FlopRamWidthTiles),
+      .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
+      .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages),
+      .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) dut (
+      .push_clk,
+      .push_rst,
+      .pop_clk,
+      .pop_rst,
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_slots,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push,
+      .pop_empty,
+      .pop_items
+  );
+
+  // ----------Instantiate credit FV checker----------
+  br_credit_receiver_fpv_monitor #(
+      .MaxCredit(MaxCredit)
+  ) fv_credit_receiver (
+      .clk(push_clk),
+      .rst(push_rst),
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push
+  );
+
+  // ----------Instantiate CDC FIFO FV basic checks----------
+  br_cdc_fifo_basic_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(0),
+      .EnableAssertPushValidStability(0),
+      .EnableAssertPushDataStability(0),
+      .RamWriteLatency(RamWriteLatency),
+      .RamReadLatency(RamReadLatency)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_clk,
+      .push_rst,
+      .push_ready(1'd1),
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .push_full,
+      .push_slots,
+      .pop_empty,
+      .pop_items
+  );
+
+endmodule : br_cdc_fifo_flops_push_credit_fpv_monitor

--- a/cdc/fpv/fv_delay.sv
+++ b/cdc/fpv/fv_delay.sv
@@ -1,0 +1,37 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+`include "br_registers.svh"
+
+module fv_delay #(
+    parameter int Width = 1,
+    parameter int NumStages = 0
+) (
+    input  logic             clk,
+    input  logic             rst,
+    input  logic [Width-1:0] in,
+    output logic [Width-1:0] out
+);
+
+  logic [NumStages:0][Width-1:0] stages;
+
+  assign stages[0] = in;
+
+  for (genvar i = 1; i <= NumStages; i++) begin : gen_stages
+    `BR_REG(stages[i], stages[i-1])
+  end
+
+  assign out = stages[NumStages];
+
+endmodule : fv_delay

--- a/fifo/fpv/BUILD.bazel
+++ b/fifo/fpv/BUILD.bazel
@@ -1,0 +1,240 @@
+# Copyright 2024-2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_fpv_test_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# Basic FIFO checkers
+verilog_library(
+    name = "br_fifo_basic_fpv_monitor",
+    srcs = ["br_fifo_basic_fpv_monitor.sv"],
+)
+
+# credit_receiver checkers
+verilog_library(
+    name = "br_credit_receiver_fpv_monitor",
+    srcs = ["br_credit_receiver_fpv_monitor.sv"],
+)
+
+# FIFO Controller (1R1W, Push Ready/Valid, Pop Ready/Valid Variant)
+
+verilog_library(
+    name = "br_fifo_ctrl_1r1w_fpv_monitor",
+    srcs = ["br_fifo_ctrl_1r1w_fpv_monitor.sv"],
+    deps = [
+        ":br_fifo_basic_fpv_monitor",
+        "//fifo/rtl:br_fifo_ctrl_1r1w",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_ctrl_1r1w_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_fifo_ctrl_1r1w_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_fifo_ctrl_1r1w_jg_test_suite",
+    custom_tcl_body = "br_fifo_ctrl_1r1w_fpv.tcl",
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "EnableBypass": [
+            "1",
+            "0",
+        ],
+        "RamReadLatency": [
+            "2",
+            "1",
+            "0",
+        ],
+        "RegisterPopOutputs": [
+            "1",
+            "0",
+        ],
+        "Width": [
+            "1",
+            "5",
+            "6",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_fifo_ctrl_1r1w",
+    deps = [":br_fifo_ctrl_1r1w_fpv_monitor"],
+)
+
+# FIFO (Internal 1R1W Flop-RAM, Push Ready/Valid, Pop Ready/Valid Variant)
+verilog_library(
+    name = "br_fifo_flops_fpv_monitor",
+    srcs = ["br_fifo_flops_fpv_monitor.sv"],
+    deps = [
+        ":br_fifo_basic_fpv_monitor",
+        "//fifo/rtl:br_fifo_flops",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_flops_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_fifo_flops_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_fifo_flops_jg_test_suite",
+    custom_tcl_body = "br_fifo_flops_fpv.tcl",
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "EnableBypass": [
+            "1",
+            "0",
+        ],
+        "RegisterPopOutputs": [
+            "1",
+            "0",
+        ],
+        "Width": [
+            "1",
+            "5",
+            "6",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_fifo_flops",
+    deps = [":br_fifo_flops_fpv_monitor"],
+)
+
+# FIFO Controller (1R1W, Push Credit/Valid, Pop Ready/Valid Variant)
+verilog_library(
+    name = "br_fifo_ctrl_1r1w_push_credit_fpv_monitor",
+    srcs = ["br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv"],
+    deps = [
+        ":br_credit_receiver_fpv_monitor",
+        ":br_fifo_ctrl_1r1w_fpv_monitor",
+        "//fifo/rtl:br_fifo_ctrl_1r1w_push_credit",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_ctrl_1r1w_push_credit_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_fifo_ctrl_1r1w_push_credit_jg_test_suite",
+    custom_tcl_body = "br_fifo_ctrl_1r1w_push_credit_fpv.tcl",
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "EnableBypass": [
+            "1",
+            "0",
+        ],
+        "RamReadLatency": [
+            "2",
+            "1",
+            "0",
+        ],
+        "RegisterPopOutputs": [
+            "1",
+            "0",
+        ],
+        "RegisterPushOutputs": [
+            "1",
+            "0",
+        ],
+        "Width": [
+            "1",
+            "5",
+            "6",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_fifo_ctrl_1r1w_push_credit",
+    deps = [":br_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
+)
+
+# Bedrock-RTL FIFO (Internal 1R1W Flop-RAM, Push Credit/Valid, Pop Ready/Valid Variant)
+verilog_library(
+    name = "br_fifo_flops_push_credit_fpv_monitor",
+    srcs = ["br_fifo_flops_push_credit_fpv_monitor.sv"],
+    deps = [
+        ":br_credit_receiver_fpv_monitor",
+        ":br_fifo_flops_fpv_monitor",
+        "//fifo/rtl:br_fifo_flops_push_credit",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_flops_push_credit_fpv_monitor_elab_test",
+    # TODO: need to demote warning
+    tags = ["manual"],
+    deps = [":br_fifo_flops_push_credit_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_fifo_flops_push_credit_jg_test_suite",
+    custom_tcl_body = "br_fifo_flops_push_credit_fpv.tcl",
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "EnableBypass": [
+            "1",
+            "0",
+        ],
+        "RegisterPopOutputs": [
+            "1",
+            "0",
+        ],
+        "RegisterPushOutputs": [
+            "1",
+            "0",
+        ],
+        "Width": [
+            "1",
+            "5",
+            "6",
+        ],
+    },
+    tags = ["manual"],
+    tool = "jg",
+    top = "br_fifo_flops_push_credit",
+    deps = [":br_fifo_flops_push_credit_fpv_monitor"],
+)

--- a/fifo/fpv/br_credit_receiver_fpv_monitor.sv
+++ b/fifo/fpv/br_credit_receiver_fpv_monitor.sv
@@ -1,0 +1,60 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// FIFO br_credit_receiver FPV checks
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_credit_receiver_fpv_monitor #(
+    parameter  int MaxCredit   = 1,
+    localparam int CreditWidth = $clog2(MaxCredit + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic push_sender_in_reset,
+    input logic push_receiver_in_reset,
+    input logic push_credit_stall,
+    input logic push_credit,
+    input logic push_valid,
+
+    // Push-side credits
+    input logic [CreditWidth-1:0] credit_initial_push,
+    input logic [CreditWidth-1:0] credit_withhold_push,
+    input logic [CreditWidth-1:0] credit_count_push,
+    input logic [CreditWidth-1:0] credit_available_push
+);
+
+  // ----------FV modeling code----------
+  logic fv_rst;
+  logic [CreditWidth-1:0] fv_credit_cnt;
+  logic [CreditWidth-1:0] fv_max_credit;
+
+  assign fv_rst = rst | push_sender_in_reset;
+  `BR_REG(fv_credit_cnt, fv_credit_cnt + push_credit - push_valid)
+  `BR_REGIX(fv_max_credit, fv_max_credit, credit_initial_push, clk, fv_rst)
+
+  // ----------FV assumptions----------
+  `BR_ASSUME(push_sender_in_reset_a, !push_sender_in_reset |=> !push_sender_in_reset)
+  `BR_ASSUME(credit_withhold_push_a, credit_withhold_push <= MaxCredit)
+  `BR_ASSUME(credit_withhold_liveness_a, s_eventually (credit_withhold_push < fv_max_credit))
+  `BR_ASSUME(no_spurious_push_valid_a, fv_credit_cnt == 'd0 |-> !push_valid)
+
+  // ----------FV assertions----------
+  `BR_ASSERT(fv_credit_sanity_a, fv_credit_cnt <= fv_max_credit)
+  `BR_ASSERT(push_credit_deadlock_a, push_valid |-> s_eventually (fv_credit_cnt != 'd0))
+
+endmodule : br_credit_receiver_fpv_monitor

--- a/fifo/fpv/br_fifo_basic_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_basic_fpv_monitor.sv
@@ -1,0 +1,106 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Basic FPV checks for all FIFO variations
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+`include "br_fv.svh"
+
+module br_fifo_basic_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter bit EnableBypass = 1,
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic             push_ready,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface
+    input logic             pop_ready,
+    input logic             pop_valid,
+    input logic [Width-1:0] pop_data,
+
+    // Push-side status flags
+    input logic                  full,
+    input logic                  full_next,
+    input logic [CountWidth-1:0] slots,
+    input logic [CountWidth-1:0] slots_next,
+
+    // Pop-side status flags
+    input logic                  empty,
+    input logic                  empty_next,
+    input logic [CountWidth-1:0] items,
+    input logic [CountWidth-1:0] items_next
+);
+
+  // ----------FV assumptions----------
+  `BR_ASSUME(pop_ready_liveness_a, s_eventually (pop_ready))
+
+  // ----------FV Modeling Code----------
+  logic [CountWidth-1:0] fv_items;
+  logic [CountWidth-1:0] fv_slots;
+
+  `BR_REG(fv_items, fv_items + (push_valid & push_ready) - (pop_valid & pop_ready))
+  assign fv_slots = Depth - fv_items;
+
+  // ----------Sanity Check----------
+  if (EnableBypass) begin : gen_bypass
+    `BR_ASSERT(no_pop_when_empty_a, empty && !push_valid |-> !pop_valid)
+  end else begin : gen_non_bypass
+    `BR_ASSERT(no_pop_when_empty_a, empty |-> !pop_valid)
+  end
+
+  // empty, full check
+  `BR_ASSERT(full_a, (fv_items == Depth) == full)
+  `BR_ASSERT(empty_a, (fv_items == 'd0) == empty)
+
+  // primary output and its next check
+  `BR_ASSERT(full_next_a, $fell(rst) |=> full == $past(full_next))
+  `BR_ASSERT(slots_next_a, $fell(rst) |=> slots == $past(slots_next))
+  `BR_ASSERT(empty_next_a, $fell(rst) |=> empty == $past(empty_next))
+  `BR_ASSERT(items_next_a, $fell(rst) |=> items == $past(items_next))
+
+  // slots, items check
+  `BR_ASSERT(items_a, fv_items == items)
+  `BR_ASSERT(slots_a, fv_slots == slots)
+
+  // ----------Data integrity Check----------
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(Width),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(Depth)
+  ) scoreboard (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(push_valid & push_ready),
+      .incoming_data(push_data),
+      .outgoing_vld(pop_valid & pop_ready),
+      .outgoing_data(pop_data)
+  );
+
+  // ----------Forward Progress Check----------
+  `BR_ASSERT(no_deadlock_pop_a, push_valid |-> s_eventually pop_valid)
+
+  // ----------Critical Covers----------
+  `BR_COVER(fifo_full_c, full)
+
+endmodule : br_fifo_basic_fpv_monitor

--- a/fifo/fpv/br_fifo_ctrl_1r1w_fpv.tcl
+++ b/fifo/fpv/br_fifo_ctrl_1r1w_fpv.tcl
@@ -1,0 +1,20 @@
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name no_push_valid_during_reset {rst |-> push_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_pop_valid {rst |-> pop_valid == 'd0}
+assert -name fv_rst_check_ram_wr_valid {rst |-> ram_wr_valid == 'd0}
+assert -name fv_rst_check_ram_rd_addr_valid {rst |-> ram_rd_addr_valid == 'd0}
+
+# disable primary input side RTL integration assertion
+# it's best practice to have valid/data stability when backpressured,
+# but the FIFO itself doesn't care and will work fine even if it's unstable
+assert -disable *br_fifo_push_ctrl.*valid_data_stable_when_backpressured_a
+
+# prove command
+prove -all

--- a/fifo/fpv/br_fifo_ctrl_1r1w_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_ctrl_1r1w_fpv_monitor.sv
@@ -1,0 +1,112 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// FIFO Controller (1R1W, Push Ready/Valid, Pop Ready/Valid Variant)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+`include "br_fv.svh"
+
+module br_fifo_ctrl_1r1w_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter bit EnableBypass = 1,
+    parameter bit RegisterPopOutputs = 0,
+    parameter int RamReadLatency = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic             push_ready,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface
+    input logic             pop_ready,
+    input logic             pop_valid,
+    input logic [Width-1:0] pop_data,
+
+    // Push-side status flags
+    input logic                  full,
+    input logic                  full_next,
+    input logic [CountWidth-1:0] slots,
+    input logic [CountWidth-1:0] slots_next,
+
+    // Pop-side status flags
+    input logic                  empty,
+    input logic                  empty_next,
+    input logic [CountWidth-1:0] items,
+    input logic [CountWidth-1:0] items_next,
+
+    // 1R1W RAM interface
+    input logic                 ram_wr_valid,
+    input logic [AddrWidth-1:0] ram_wr_addr,
+    input logic [    Width-1:0] ram_wr_data,
+    input logic                 ram_rd_addr_valid,
+    input logic [AddrWidth-1:0] ram_rd_addr,
+    input logic                 ram_rd_data_valid,
+    input logic [    Width-1:0] ram_rd_data
+);
+
+  // ----------FV Modeling Code----------
+  logic [Depth-1:0][Width-1:0] fv_ram_data;
+
+  `BR_REGLN(fv_ram_data[ram_wr_addr], ram_wr_data, ram_wr_valid)
+
+  // ----------FV assumptions----------
+  if (RamReadLatency == 0) begin : gen_latency0
+    `BR_ASSUME(ram_rd_data_a, ram_rd_data == fv_ram_data[ram_rd_addr])
+    `BR_ASSUME(ram_rd_data_addr_latency_a, ram_rd_data_valid == ram_rd_addr_valid)
+  end else begin : gen_latency_non0
+    `BR_ASSUME(ram_rd_data_a, ram_rd_data == fv_ram_data[$past(ram_rd_addr, RamReadLatency)])
+    `BR_ASSUME(ram_rd_data_addr_latency_a, ram_rd_data_valid == $past(
+               ram_rd_addr_valid, RamReadLatency))
+  end
+
+  // ----------FIFO basic checks----------
+  br_fifo_basic_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .EnableBypass(EnableBypass)
+  ) br_fifo_basic_fpv_monitor (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .full,
+      .full_next,
+      .slots,
+      .slots_next,
+      .empty,
+      .empty_next,
+      .items,
+      .items_next
+  );
+
+endmodule : br_fifo_ctrl_1r1w_fpv_monitor
+
+bind br_fifo_ctrl_1r1w br_fifo_ctrl_1r1w_fpv_monitor #(
+    .Depth(Depth),
+    .Width(Width),
+    .EnableBypass(EnableBypass),
+    .RegisterPopOutputs(RegisterPopOutputs),
+    .RamReadLatency(RamReadLatency)
+) monitor (.*);

--- a/fifo/fpv/br_fifo_ctrl_1r1w_push_credit_fpv.tcl
+++ b/fifo/fpv/br_fifo_ctrl_1r1w_push_credit_fpv.tcl
@@ -1,0 +1,23 @@
+# clock/reset set up
+clock clk
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name initial_value_during_reset {rst | push_sender_in_reset |-> \
+(credit_initial_push <= MaxCredit) && $stable(credit_initial_push)}
+assume -name no_ram_rd_data_valid_during_reset {rst | push_sender_in_reset |-> ram_rd_data_valid == 'd0}
+assume -name no_push_valid_during_reset {rst | push_sender_in_reset |-> push_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_push_credit {rst | push_sender_in_reset |-> push_credit == 'd0}
+assert -name fv_rst_check_pop_valid {rst | push_sender_in_reset |-> pop_valid == 'd0}
+assert -name fv_rst_check_ram_wr_valid {rst | push_sender_in_reset |-> ram_wr_valid == 'd0}
+assert -name fv_rst_check_ram_rd_addr_valid {rst | push_sender_in_reset |-> ram_rd_addr_valid == 'd0}
+
+# prove command
+prove -all

--- a/fifo/fpv/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
@@ -1,0 +1,137 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// FIFO Controller (1R1W, Push Credit/Valid, Pop Ready/Valid Variant)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+`include "br_fv.svh"
+
+module br_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter bit EnableBypass = 1,
+    parameter int MaxCredit = Depth,
+    parameter bit RegisterPushOutputs = 0,
+    parameter bit RegisterPopOutputs = 0,
+    parameter int RamReadLatency = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1),
+    localparam int CreditWidth = $clog2(MaxCredit + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic             push_sender_in_reset,
+    input logic             push_receiver_in_reset,
+    input logic             push_credit_stall,
+    input logic             push_credit,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface
+    input logic             pop_ready,
+    input logic             pop_valid,
+    input logic [Width-1:0] pop_data,
+
+    // Push-side status flags
+    input logic                  full,
+    input logic                  full_next,
+    input logic [CountWidth-1:0] slots,
+    input logic [CountWidth-1:0] slots_next,
+
+    // Pop-side status flags
+    input logic                  empty,
+    input logic                  empty_next,
+    input logic [CountWidth-1:0] items,
+    input logic [CountWidth-1:0] items_next,
+
+    // Push-side credits
+    input logic [CreditWidth-1:0] credit_initial_push,
+    input logic [CreditWidth-1:0] credit_withhold_push,
+    input logic [CreditWidth-1:0] credit_count_push,
+    input logic [CreditWidth-1:0] credit_available_push,
+
+    // 1R1W RAM interface
+    input logic                 ram_wr_valid,
+    input logic [AddrWidth-1:0] ram_wr_addr,
+    input logic [    Width-1:0] ram_wr_data,
+    input logic                 ram_rd_addr_valid,
+    input logic [AddrWidth-1:0] ram_rd_addr,
+    input logic                 ram_rd_data_valid,
+    input logic [    Width-1:0] ram_rd_data
+);
+
+  // ----------Instantiate credit FV checker----------
+  br_credit_receiver_fpv_monitor #(
+      .MaxCredit(MaxCredit)
+  ) br_credit_receiver_fpv_monitor (
+      .clk,
+      .rst,
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push
+  );
+
+  // ----------Instantiate non-credit version FV checker----------
+  br_fifo_ctrl_1r1w_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .EnableBypass(EnableBypass),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RamReadLatency(RamReadLatency)
+  ) br_fifo_ctrl_1r1w_fpv_monitor (
+      .clk,
+      .rst,
+      .push_ready(1'd1),
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .full,
+      .full_next,
+      .slots,
+      .slots_next,
+      .empty,
+      .empty_next,
+      .items,
+      .items_next,
+      .ram_wr_valid,
+      .ram_wr_addr,
+      .ram_wr_data,
+      .ram_rd_addr_valid,
+      .ram_rd_addr,
+      .ram_rd_data_valid,
+      .ram_rd_data
+  );
+
+endmodule : br_fifo_ctrl_1r1w_push_credit_fpv_monitor
+
+bind br_fifo_ctrl_1r1w_push_credit br_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
+    .Depth(Depth),
+    .Width(Width),
+    .EnableBypass(EnableBypass),
+    .MaxCredit(MaxCredit),
+    .RegisterPushOutputs(RegisterPushOutputs),
+    .RegisterPopOutputs(RegisterPopOutputs),
+    .RamReadLatency(RamReadLatency)
+) monitor (.*);

--- a/fifo/fpv/br_fifo_flops_fpv.tcl
+++ b/fifo/fpv/br_fifo_flops_fpv.tcl
@@ -1,0 +1,18 @@
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name no_push_valid_during_reset {rst |-> push_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_pop_valid {rst |-> pop_valid == 'd0}
+
+# disable primary input side RTL integration assertion
+# it's best practice to have valid/data stability when backpressured,
+# but the FIFO itself doesn't care and will work fine even if it's unstable
+assert -disable *br_fifo_push_ctrl.*valid_data_stable_when_backpressured_a
+
+# prove command
+prove -all

--- a/fifo/fpv/br_fifo_flops_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_flops_fpv_monitor.sv
@@ -1,0 +1,95 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// FIFO (Internal 1R1W Flop-RAM, Push Ready/Valid, Pop Ready/Valid Variant)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+`include "br_fv.svh"
+
+module br_fifo_flops_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter bit EnableBypass = 1,
+    parameter bit RegisterPopOutputs = 0,
+    parameter int FlopRamDepthTiles = 1,
+    parameter int FlopRamWidthTiles = 1,
+    parameter int FlopRamAddressDepthStages = 0,
+    parameter int FlopRamReadDataDepthStages = 0,
+    parameter int FlopRamReadDataWidthStages = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic             push_ready,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface
+    input logic             pop_ready,
+    input logic             pop_valid,
+    input logic [Width-1:0] pop_data,
+
+    // Push-side status flags
+    input logic                  full,
+    input logic                  full_next,
+    input logic [CountWidth-1:0] slots,
+    input logic [CountWidth-1:0] slots_next,
+
+    // Pop-side status flags
+    input logic                  empty,
+    input logic                  empty_next,
+    input logic [CountWidth-1:0] items,
+    input logic [CountWidth-1:0] items_next
+);
+
+  br_fifo_basic_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .EnableBypass(EnableBypass)
+  ) br_fifo_basic_fpv_monitor (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .full,
+      .full_next,
+      .slots,
+      .slots_next,
+      .empty,
+      .empty_next,
+      .items,
+      .items_next
+  );
+
+endmodule : br_fifo_flops_fpv_monitor
+
+bind br_fifo_flops br_fifo_flops_fpv_monitor #(
+    .Depth(Depth),
+    .Width(Width),
+    .EnableBypass(EnableBypass),
+    .RegisterPopOutputs(RegisterPopOutputs),
+    .FlopRamDepthTiles(FlopRamDepthTiles),
+    .FlopRamWidthTiles(FlopRamWidthTiles),
+    .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
+    .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages),
+    .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages)
+) monitor (.*);

--- a/fifo/fpv/br_fifo_flops_push_credit_fpv.tcl
+++ b/fifo/fpv/br_fifo_flops_push_credit_fpv.tcl
@@ -1,0 +1,21 @@
+# clock/reset set up
+clock clk
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name initial_value_during_reset {rst | push_sender_in_reset |-> \
+(credit_initial_push <= MaxCredit) && $stable(credit_initial_push)}
+assume -name no_ram_rd_data_valid_during_reset {rst | push_sender_in_reset |-> ram_rd_data_valid == 'd0}
+assume -name no_push_valid_during_reset {rst | push_sender_in_reset |-> push_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_push_credit {rst | push_sender_in_reset |-> push_credit == 'd0}
+assert -name fv_rst_check_pop_valid {rst | push_sender_in_reset |-> pop_valid == 'd0}
+
+# prove command
+prove -all

--- a/fifo/fpv/br_fifo_flops_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_flops_push_credit_fpv_monitor.sv
@@ -1,0 +1,133 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL FIFO (Internal 1R1W Flop-RAM, Push Credit/Valid, Pop Ready/Valid Variant)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+`include "br_fv.svh"
+
+module br_fifo_flops_push_credit_fpv_monitor #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    parameter bit EnableBypass = 1,
+    parameter int MaxCredit = Depth,
+    parameter bit RegisterPushOutputs = 0,
+    parameter bit RegisterPopOutputs = 1,
+    parameter int FlopRamDepthTiles = 1,
+    parameter int FlopRamWidthTiles = 1,
+    parameter int FlopRamAddressDepthStages = 0,
+    parameter int FlopRamReadDataDepthStages = 0,
+    parameter int FlopRamReadDataWidthStages = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1),
+    localparam int CreditWidth = $clog2(MaxCredit + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic             push_sender_in_reset,
+    input logic             push_receiver_in_reset,
+    input logic             push_credit_stall,
+    input logic             push_credit,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface
+    input logic             pop_ready,
+    input logic             pop_valid,
+    input logic [Width-1:0] pop_data,
+
+    // Push-side status flags
+    input logic                  full,
+    input logic                  full_next,
+    input logic [CountWidth-1:0] slots,
+    input logic [CountWidth-1:0] slots_next,
+
+    // Push-side credits
+    input logic [CreditWidth-1:0] credit_initial_push,
+    input logic [CreditWidth-1:0] credit_withhold_push,
+    input logic [CreditWidth-1:0] credit_count_push,
+    input logic [CreditWidth-1:0] credit_available_push,
+
+    // Pop-side status flags
+    input logic                  empty,
+    input logic                  empty_next,
+    input logic [CountWidth-1:0] items,
+    input logic [CountWidth-1:0] items_next
+);
+
+  // ----------Instantiate credit FV checker----------
+  br_credit_receiver_fpv_monitor #(
+      .MaxCredit(MaxCredit)
+  ) br_credit_receiver_fpv_monitor (
+      .clk,
+      .rst,
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push
+  );
+
+  // ----------Instantiate non-credit version FV checker----------
+  br_fifo_flops_fpv_monitor #(
+      .Depth(Depth),
+      .Width(Width),
+      .EnableBypass(EnableBypass),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .FlopRamDepthTiles(FlopRamDepthTiles),
+      .FlopRamWidthTiles(FlopRamWidthTiles),
+      .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
+      .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages),
+      .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages)
+  ) br_fifo_flops_fpv_monitor (
+      .clk,
+      .rst,
+      .push_ready(1'd1),
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .full,
+      .full_next,
+      .slots,
+      .slots_next,
+      .empty,
+      .empty_next,
+      .items,
+      .items_next
+  );
+
+endmodule : br_fifo_flops_push_credit_fpv_monitor
+
+bind br_fifo_flops_push_credit br_fifo_flops_push_credit_fpv_monitor #(
+    .Depth(Depth),
+    .Width(Width),
+    .EnableBypass(EnableBypass),
+    .MaxCredit(MaxCredit),
+    .RegisterPushOutputs(RegisterPushOutputs),
+    .RegisterPopOutputs(RegisterPopOutputs),
+    .FlopRamDepthTiles(FlopRamDepthTiles),
+    .FlopRamWidthTiles(FlopRamWidthTiles),
+    .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
+    .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages),
+    .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages)
+) monitor (.*);


### PR DESCRIPTION
1. elab_test is manual for now, need to demote verific warning to message in verilog.bzl.
2. CDC fifo is failing now due to RTL change, will fix soon.