### PR TITLE
br_flow_mux FPV

### DIFF
--- a/flow/fpv/mux/BUILD.bazel
+++ b/flow/fpv/mux/BUILD.bazel
@@ -1,0 +1,529 @@
+# Copyright 2024-2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_fpv_test_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# Basic mux FV checker
+verilog_library(
+    name = "br_flow_mux_basic_fpv_monitor",
+    srcs = ["br_flow_mux_basic_fpv_monitor.sv"],
+)
+
+# Bedrock-RTL Flow-Controlled Multiplexer (Fixed-Priority)(Unstable)
+
+verilog_library(
+    name = "br_flow_mux_fixed_fpv_monitor",
+    srcs = ["br_flow_mux_fixed_fpv_monitor.sv"],
+    deps = [
+        ":br_flow_mux_basic_fpv_monitor",
+        "//flow/rtl:br_flow_mux_fixed",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_mux_fixed_fpv_monitor_elab_test",
+    deps = [":br_flow_mux_fixed_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_flow_mux_fixed_jg_test_suite",
+    custom_tcl_body = "br_flow_mux_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "2",
+            "4",
+            "5",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tool = "jg",
+    top = "br_flow_mux_fixed",
+    deps = [":br_flow_mux_fixed_fpv_monitor"],
+)
+
+# Bedrock-RTL Flow-Controlled Multiplexer (Least-Recently-Used)(Unstable)
+
+verilog_library(
+    name = "br_flow_mux_lru_fpv_monitor",
+    srcs = ["br_flow_mux_lru_fpv_monitor.sv"],
+    deps = [
+        ":br_flow_mux_basic_fpv_monitor",
+        "//arb/fpv:lru_basic_fpv_monitor",
+        "//flow/rtl:br_flow_mux_lru",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_mux_lru_fpv_monitor_elab_test",
+    deps = [":br_flow_mux_lru_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_flow_mux_lru_jg_test_suite",
+    custom_tcl_body = "br_flow_mux_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "2",
+            "4",
+            "5",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tool = "jg",
+    top = "br_flow_mux_lru",
+    deps = [":br_flow_mux_lru_fpv_monitor"],
+)
+
+# Bedrock-RTL Flow-Controlled Multiplexer (Round-Robin)(Unstable)
+
+verilog_library(
+    name = "br_flow_mux_rr_fpv_monitor",
+    srcs = ["br_flow_mux_rr_fpv_monitor.sv"],
+    deps = [
+        ":br_flow_mux_basic_fpv_monitor",
+        "//arb/fpv:rr_basic_fpv_monitor",
+        "//flow/rtl:br_flow_mux_rr",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_mux_rr_fpv_monitor_elab_test",
+    deps = [":br_flow_mux_rr_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_flow_mux_rr_jg_test_suite",
+    custom_tcl_body = "br_flow_mux_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "2",
+            "4",
+            "5",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tool = "jg",
+    top = "br_flow_mux_rr",
+    deps = [":br_flow_mux_rr_fpv_monitor"],
+)
+
+# Bedrock-RTL Flow Mux with Select (Unstable)
+
+verilog_library(
+    name = "br_flow_mux_select_unstable_fpv_monitor",
+    srcs = ["br_flow_mux_select_unstable_fpv_monitor.sv"],
+    deps = [
+        ":br_flow_mux_basic_fpv_monitor",
+        "//flow/rtl:br_flow_mux_select_unstable",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_mux_select_unstable_fpv_monitor_elab_test",
+    deps = [":br_flow_mux_select_unstable_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_flow_mux_select_unstable_jg_test_suite",
+    custom_tcl_body = "br_flow_mux_select_unstable_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "2",
+            "4",
+            "5",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tool = "jg",
+    top = "br_flow_mux_select_unstable",
+    deps = [":br_flow_mux_select_unstable_fpv_monitor"],
+)
+
+# Bedrock-RTL Flow Mux with Select
+
+verilog_library(
+    name = "br_flow_mux_select_fpv_monitor",
+    srcs = ["br_flow_mux_select_fpv_monitor.sv"],
+    deps = [
+        ":br_flow_mux_basic_fpv_monitor",
+        "//flow/rtl:br_flow_mux_select",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_mux_select_fpv_monitor_elab_test",
+    deps = [":br_flow_mux_select_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_flow_mux_select_jg_test_suite",
+    custom_tcl_body = "br_flow_mux_select_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "2",
+            "4",
+            "5",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tool = "jg",
+    top = "br_flow_mux_select",
+    deps = [":br_flow_mux_select_fpv_monitor"],
+)
+
+# Bedrock-RTL Flow-Controlled Stable Multiplexer (Fixed-Priority)
+
+verilog_library(
+    name = "br_flow_mux_fixed_stable_fpv_monitor",
+    srcs = ["br_flow_mux_fixed_stable_fpv_monitor.sv"],
+    deps = [
+        ":br_flow_mux_basic_fpv_monitor",
+        "//flow/rtl:br_flow_mux_fixed_stable",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_mux_fixed_stable_fpv_monitor_elab_test",
+    deps = [":br_flow_mux_fixed_stable_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_flow_mux_fixed_stable_jg_test_suite",
+    custom_tcl_body = "br_flow_mux_stable_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "2",
+            "4",
+            "5",
+        ],
+        "RegisterPopReady": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tool = "jg",
+    top = "br_flow_mux_fixed_stable",
+    deps = [":br_flow_mux_fixed_stable_fpv_monitor"],
+)
+
+# Bedrock-RTL Flow-Controlled Stable Multiplexer (Least-Recently-Used)
+
+verilog_library(
+    name = "br_flow_mux_lru_stable_fpv_monitor",
+    srcs = ["br_flow_mux_lru_stable_fpv_monitor.sv"],
+    deps = [
+        ":br_flow_mux_basic_fpv_monitor",
+        "//arb/fpv:lru_basic_fpv_monitor",
+        "//flow/rtl:br_flow_mux_lru_stable",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_mux_lru_stable_fpv_monitor_elab_test",
+    deps = [":br_flow_mux_lru_stable_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_flow_mux_lru_stable_jg_test_suite",
+    custom_tcl_body = "br_flow_mux_stable_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "2",
+            "4",
+            "5",
+        ],
+        "RegisterPopReady": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tool = "jg",
+    top = "br_flow_mux_lru_stable",
+    deps = [":br_flow_mux_lru_stable_fpv_monitor"],
+)
+
+# Bedrock-RTL Flow-Controlled Stable Multiplexer (Round-Robin)
+
+verilog_library(
+    name = "br_flow_mux_rr_stable_fpv_monitor",
+    srcs = ["br_flow_mux_rr_stable_fpv_monitor.sv"],
+    deps = [
+        ":br_flow_mux_basic_fpv_monitor",
+        "//arb/fpv:rr_basic_fpv_monitor",
+        "//flow/rtl:br_flow_mux_rr_stable",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_mux_rr_stable_fpv_monitor_elab_test",
+    deps = [":br_flow_mux_rr_stable_fpv_monitor"],
+)
+
+br_verilog_fpv_test_suite(
+    name = "br_flow_mux_rr_stable_jg_test_suite",
+    custom_tcl_body = "br_flow_mux_stable_fpv.tcl",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "2",
+            "4",
+            "5",
+        ],
+        "RegisterPopReady": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "3",
+            "4",
+        ],
+    },
+    tool = "jg",
+    top = "br_flow_mux_rr_stable",
+    deps = [":br_flow_mux_rr_stable_fpv_monitor"],
+)

--- a/flow/fpv/mux/br_flow_mux_basic_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_basic_fpv_monitor.sv
@@ -1,0 +1,63 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Basic checker of br_flow_mux
+
+`include "br_asserts.svh"
+`include "br_fv.svh"
+
+module br_flow_mux_basic_fpv_monitor #(
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1,  // Must be at least 1
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability
+) (
+    input logic                           clk,
+    input logic                           rst,
+    input logic [NumFlows-1:0]            push_ready,
+    input logic [NumFlows-1:0]            push_valid,
+    input logic [NumFlows-1:0][Width-1:0] push_data,
+    input logic                           pop_ready,
+    input logic                           pop_valid,
+    input logic [   Width-1:0]            pop_data
+);
+
+  // ----------FV assumptions----------
+  `BR_ASSUME(pop_ready_liveness_a, s_eventually (pop_ready))
+
+  for (genvar n = 0; n < NumFlows; n++) begin : gen_asm
+    if (EnableAssertPushValidStability) begin : gen_push_valid
+      `BR_ASSUME(push_valid_stable_a, push_valid[n] && !push_ready[n] |=> push_valid[n])
+    end
+    if (EnableAssertPushDataStability) begin : gen_push_data
+      `BR_ASSUME(push_data_stable_a, push_valid[n] && !push_ready[n] |=> $stable(push_data[n]))
+    end
+  end
+
+  // ----------Sanity Check----------
+  if (EnableAssertPushValidStability) begin : gen_pop_valid
+    `BR_ASSERT(pop_valid_stable_a, pop_valid && !pop_ready |=> pop_valid)
+  end
+  if (EnableAssertPushDataStability) begin : gen_pop_data
+    `BR_ASSERT(pop_data_stable_a, pop_valid && !pop_ready |=> $stable(pop_data))
+  end
+
+  // ----------Forward Progress Check----------
+  `BR_ASSERT(must_grant_a, |push_valid == pop_valid)
+
+  // ----------Critical Covers----------
+  `BR_COVER(all_push_valid_c, &push_valid)
+
+endmodule : br_flow_mux_basic_fpv_monitor

--- a/flow/fpv/mux/br_flow_mux_fixed_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_fixed_fpv_monitor.sv
@@ -1,0 +1,75 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Fixed-Priority Arbiter FPV monitor
+
+`include "br_asserts.svh"
+`include "br_fv.svh"
+
+module br_flow_mux_fixed_fpv_monitor #(
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1,  // Must be at least 1
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertFinalNotValid = 1
+) (
+    input logic                           clk,
+    input logic                           rst,
+    input logic [NumFlows-1:0]            push_ready,
+    input logic [NumFlows-1:0]            push_valid,
+    input logic [NumFlows-1:0][Width-1:0] push_data,
+    input logic                           pop_ready,
+    input logic                           pop_valid_unstable,
+    input logic [   Width-1:0]            pop_data_unstable
+);
+
+  // ----------Instantiate basic checks----------
+  br_flow_mux_basic_fpv_monitor #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid(pop_valid_unstable),
+      .pop_data(pop_data_unstable)
+  );
+
+  // ----------FV Modeling Code----------
+  logic [$clog2(NumFlows)-1:0] i, j;
+  `BR_FV_2RAND_IDX(i, j, NumFlows)
+
+  // ----------Fairness Check----------
+  // verilog_lint: waive-start line-length
+  `BR_ASSERT(
+      strict_priority_a,
+      (i < j) && push_valid[i] && push_valid[j] |-> (pop_data_unstable == push_data[i]) || !push_ready[i])
+  // verilog_lint: waive-stop line-length
+endmodule : br_flow_mux_fixed_fpv_monitor
+
+bind br_flow_mux_fixed br_flow_mux_fixed_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .Width(Width),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertPushDataStability(EnableAssertPushDataStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);

--- a/flow/fpv/mux/br_flow_mux_fixed_stable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_fixed_stable_fpv_monitor.sv
@@ -1,0 +1,78 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow-Controlled Stable Multiplexer (Fixed-Priority) FPV monitor
+
+`include "br_asserts.svh"
+`include "br_fv.svh"
+
+module br_flow_mux_fixed_stable_fpv_monitor #(
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1,  // Must be at least 1
+    parameter bit RegisterPopReady = 0,
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertFinalNotValid = 1
+) (
+    input logic                           clk,
+    input logic                           rst,
+    input logic [NumFlows-1:0]            push_ready,
+    input logic [NumFlows-1:0]            push_valid,
+    input logic [NumFlows-1:0][Width-1:0] push_data,
+    input logic                           pop_ready,
+    input logic                           pop_valid,
+    input logic [   Width-1:0]            pop_data
+);
+
+  // ----------Instantiate basic checks----------
+  br_flow_mux_basic_fpv_monitor #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
+
+  // ----------FV Modeling Code----------
+  logic [$clog2(NumFlows)-1:0] i, j;
+  `BR_FV_2RAND_IDX(i, j, NumFlows)
+
+  // ----------Fairness Check----------
+  `BR_ASSERT(strict_priority_a, (i < j) && push_valid[i] && push_valid[j] |=> (pop_data == $past
+                                (push_data[i])) || !$past(pop_ready) || !$past(push_ready[i]))
+
+  // ----------Forward Progress Check----------
+  `BR_ASSERT(must_grant_next_cyc_a, |push_valid |=> pop_valid)
+
+endmodule : br_flow_mux_fixed_stable_fpv_monitor
+
+bind br_flow_mux_fixed_stable br_flow_mux_fixed_stable_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .Width(Width),
+    .RegisterPopReady(RegisterPopReady),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertPushDataStability(EnableAssertPushDataStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);

--- a/flow/fpv/mux/br_flow_mux_fpv.tcl
+++ b/flow/fpv/mux/br_flow_mux_fpv.tcl
@@ -1,0 +1,10 @@
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# pop_data_unstable is unstable regardless of whether push_data is stable
+assert -disable {*pop_data_stable_a}
+
+# prove command
+prove -all

--- a/flow/fpv/mux/br_flow_mux_lru_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_lru_fpv_monitor.sv
@@ -1,0 +1,82 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow-Controlled Multiplexer (Least-Recently-Used)
+
+`include "br_asserts.svh"
+`include "br_fv.svh"
+
+module br_flow_mux_lru_fpv_monitor #(
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1,  // Must be at least 1
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertFinalNotValid = 1
+) (
+    input logic                           clk,
+    input logic                           rst,
+    input logic [NumFlows-1:0]            push_ready,
+    input logic [NumFlows-1:0]            push_valid,
+    input logic [NumFlows-1:0][Width-1:0] push_data,
+    input logic                           pop_ready,
+    input logic                           pop_valid_unstable,
+    input logic [   Width-1:0]            pop_data_unstable,
+    // RTL internal signal
+    input logic [NumFlows-1:0]            grant
+);
+
+  // ----------Instantiate basic checks----------
+  br_flow_mux_basic_fpv_monitor #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid(pop_valid_unstable),
+      .pop_data(pop_data_unstable)
+  );
+
+  // ----------LRU checks----------
+  lru_basic_fpv_monitor #(
+      .NumRequesters(NumFlows)
+  ) lru_check (
+      .clk,
+      .rst,
+      .enable_priority_update(pop_ready),
+      .request(push_valid),
+      .grant
+  );
+
+  logic [$clog2(NumFlows)-1:0] index;
+  `BR_FV_IDX(index, grant, NumFlows)
+  `BR_ASSERT(grant_data_integrity_a, pop_valid_unstable |-> pop_data_unstable == push_data[index])
+
+endmodule : br_flow_mux_lru_fpv_monitor
+
+bind br_flow_mux_lru br_flow_mux_lru_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .Width(Width),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertPushDataStability(EnableAssertPushDataStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);

--- a/flow/fpv/mux/br_flow_mux_lru_stable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_lru_stable_fpv_monitor.sv
@@ -1,0 +1,104 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow-Controlled Multiplexer (Least-Recently-Used)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+`include "br_fv.svh"
+
+module br_flow_mux_lru_stable_fpv_monitor #(
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1,  // Must be at least 1
+    parameter bit RegisterPopReady = 0,
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertFinalNotValid = 1
+) (
+    input logic                           clk,
+    input logic                           rst,
+    input logic [NumFlows-1:0]            push_ready,
+    input logic [NumFlows-1:0]            push_valid,
+    input logic [NumFlows-1:0][Width-1:0] push_data,
+    input logic                           pop_ready,
+    input logic                           pop_valid,
+    input logic [   Width-1:0]            pop_data,
+    // RTL internal signal
+    input logic [NumFlows-1:0]            grant,
+    input logic                           enable_priority_update
+);
+
+  // ----------Instantiate basic checks----------
+  br_flow_mux_basic_fpv_monitor #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
+
+  // ----------LRU checks----------
+  lru_basic_fpv_monitor #(
+      .NumRequesters(NumFlows)
+  ) lru_check (
+      .clk,
+      .rst,
+      .enable_priority_update,
+      .request(push_valid),
+      .grant
+  );
+
+  // ----------Data integrity Check----------
+  logic [$clog2(NumFlows)-1:0] index;
+  `BR_FV_IDX(index, grant, NumFlows)
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(Width),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(NumFlows)
+  ) scoreboard (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(push_valid[index] & push_ready[index]),
+      .incoming_data(push_data[index]),
+      .outgoing_vld(pop_valid & pop_ready),
+      .outgoing_data(pop_data)
+  );
+
+  // ----------Forward Progress Check----------
+  `BR_ASSERT(must_grant_next_cyc_a, |push_valid |=> pop_valid)
+
+endmodule : br_flow_mux_lru_stable_fpv_monitor
+
+bind br_flow_mux_lru_stable br_flow_mux_lru_stable_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .Width(Width),
+    .RegisterPopReady(RegisterPopReady),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertPushDataStability(EnableAssertPushDataStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);

--- a/flow/fpv/mux/br_flow_mux_rr_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_rr_fpv_monitor.sv
@@ -1,0 +1,83 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow-Controlled Multiplexer (Round-Robin)
+
+`include "br_asserts.svh"
+`include "br_fv.svh"
+
+module br_flow_mux_rr_fpv_monitor #(
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1,  // Must be at least 1
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertFinalNotValid = 1
+) (
+    input logic                           clk,
+    input logic                           rst,
+    input logic [NumFlows-1:0]            push_ready,
+    input logic [NumFlows-1:0]            push_valid,
+    input logic [NumFlows-1:0][Width-1:0] push_data,
+    input logic                           pop_ready,
+    input logic                           pop_valid_unstable,
+    input logic [   Width-1:0]            pop_data_unstable,
+    // RTL internal signal
+    input logic [NumFlows-1:0]            grant
+);
+
+  // ----------Instantiate basic checks----------
+  br_flow_mux_basic_fpv_monitor #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid(pop_valid_unstable),
+      .pop_data(pop_data_unstable)
+  );
+
+  // ----------Round Robin checks----------
+  rr_basic_fpv_monitor #(
+      .NumRequesters(NumFlows),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability)
+  ) rr_check (
+      .clk,
+      .rst,
+      .enable_priority_update(pop_ready),
+      .request(push_valid),
+      .grant
+  );
+
+  logic [$clog2(NumFlows)-1:0] index;
+  `BR_FV_IDX(index, grant, NumFlows)
+  `BR_ASSERT(grant_data_integrity_a, pop_valid_unstable |-> pop_data_unstable == push_data[index])
+
+endmodule : br_flow_mux_rr_fpv_monitor
+
+bind br_flow_mux_rr br_flow_mux_rr_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .Width(Width),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertPushDataStability(EnableAssertPushDataStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);

--- a/flow/fpv/mux/br_flow_mux_rr_stable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_rr_stable_fpv_monitor.sv
@@ -1,0 +1,104 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow-Controlled Multiplexer (Round-Robin)
+
+`include "br_asserts.svh"
+`include "br_fv.svh"
+
+module br_flow_mux_rr_stable_fpv_monitor #(
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1,  // Must be at least 1
+    parameter bit RegisterPopReady = 0,
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertFinalNotValid = 1
+) (
+    input logic                           clk,
+    input logic                           rst,
+    input logic [NumFlows-1:0]            push_ready,
+    input logic [NumFlows-1:0]            push_valid,
+    input logic [NumFlows-1:0][Width-1:0] push_data,
+    input logic                           pop_ready,
+    input logic                           pop_valid,
+    input logic [   Width-1:0]            pop_data,
+    // RTL internal signal
+    input logic [NumFlows-1:0]            grant,
+    input logic                           enable_priority_update
+);
+
+  // ----------Instantiate basic checks----------
+  br_flow_mux_basic_fpv_monitor #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
+
+  // ----------Round Robin checks----------
+  rr_basic_fpv_monitor #(
+      .NumRequesters(NumFlows),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability)
+  ) rr_check (
+      .clk,
+      .rst,
+      .enable_priority_update,
+      .request(push_valid),
+      .grant
+  );
+
+  // ----------Data integrity Check----------
+  logic [$clog2(NumFlows)-1:0] index;
+  `BR_FV_IDX(index, grant, NumFlows)
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(Width),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(NumFlows)
+  ) scoreboard (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(push_valid[index] & push_ready[index]),
+      .incoming_data(push_data[index]),
+      .outgoing_vld(pop_valid & pop_ready),
+      .outgoing_data(pop_data)
+  );
+
+  // ----------Forward Progress Check----------
+  `BR_ASSERT(must_grant_next_cyc_a, |push_valid |=> pop_valid)
+
+endmodule : br_flow_mux_rr_stable_fpv_monitor
+
+bind br_flow_mux_rr_stable br_flow_mux_rr_stable_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .Width(Width),
+    .RegisterPopReady(RegisterPopReady),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertPushDataStability(EnableAssertPushDataStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);

--- a/flow/fpv/mux/br_flow_mux_select_fpv.tcl
+++ b/flow/fpv/mux/br_flow_mux_select_fpv.tcl
@@ -1,0 +1,10 @@
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# select can pick invalid index
+assert -disable {*must_grant_a*}
+
+# prove command
+prove -all

--- a/flow/fpv/mux/br_flow_mux_select_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_select_fpv_monitor.sv
@@ -1,0 +1,78 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow-Controlled Multiplexer (Round-Robin)
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+`include "br_fv.svh"
+
+module br_flow_mux_select_fpv_monitor #(
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1,  // Must be at least 1
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertFinalNotValid = 1
+) (
+    input logic                                   clk,
+    input logic                                   rst,
+    input logic [$clog2(NumFlows)-1:0]            select,
+    input logic [        NumFlows-1:0]            push_ready,
+    input logic [        NumFlows-1:0]            push_valid,
+    input logic [        NumFlows-1:0][Width-1:0] push_data,
+    input logic                                   pop_ready,
+    input logic                                   pop_valid,
+    input logic [           Width-1:0]            pop_data
+);
+
+  // ----------Instantiate basic checks----------
+  br_flow_mux_basic_fpv_monitor #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
+
+  // ----------FV assumptions----------
+  `BR_ASSUME(select_range_a, select < NumFlows)
+
+  // ----------select check----------
+  logic [Width-1:0] fv_data;
+  `BR_REGLN(fv_data, push_data[select], push_valid[select] & push_ready[select])
+
+  `BR_ASSERT(select_data_check_a, pop_valid |-> pop_data == fv_data)
+  // select can pick invalid index
+  `BR_ASSERT(forward_progress_a, push_valid[select] |=> pop_valid)
+
+endmodule : br_flow_mux_select_fpv_monitor
+
+bind br_flow_mux_select br_flow_mux_select_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .Width(Width),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertPushDataStability(EnableAssertPushDataStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);

--- a/flow/fpv/mux/br_flow_mux_select_unstable_fpv.tcl
+++ b/flow/fpv/mux/br_flow_mux_select_unstable_fpv.tcl
@@ -1,0 +1,14 @@
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# EnableAssertPushValidStability and EnableAssertPushDataStability
+# doesn't apply to DUT pop_valid and pop_data
+assert -disable {*pop_valid_stable_a}
+assert -disable {*pop_data_stable_a}
+# select can pick invalid index
+assert -disable {*must_grant_a*}
+
+# prove command
+prove -all

--- a/flow/fpv/mux/br_flow_mux_select_unstable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_select_unstable_fpv_monitor.sv
@@ -1,0 +1,73 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Flow-Controlled Multiplexer (Round-Robin)
+
+`include "br_asserts.svh"
+`include "br_fv.svh"
+
+module br_flow_mux_select_unstable_fpv_monitor #(
+    parameter int NumFlows = 2,  // Must be at least 2
+    parameter int Width = 1,  // Must be at least 1
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertFinalNotValid = 1
+) (
+    input logic                                   clk,
+    input logic                                   rst,
+    input logic [$clog2(NumFlows)-1:0]            select,
+    input logic [        NumFlows-1:0]            push_ready,
+    input logic [        NumFlows-1:0]            push_valid,
+    input logic [        NumFlows-1:0][Width-1:0] push_data,
+    input logic                                   pop_ready,
+    input logic                                   pop_valid_unstable,
+    input logic [           Width-1:0]            pop_data_unstable
+);
+
+  // ----------Instantiate basic checks----------
+  br_flow_mux_basic_fpv_monitor #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_ready,
+      .pop_valid(pop_valid_unstable),
+      .pop_data (pop_data_unstable)
+  );
+
+  // ----------FV assumptions----------
+  `BR_ASSUME(select_range_a, select < NumFlows)
+
+  // ----------select check----------
+  `BR_ASSERT(select_data_check_a, pop_valid_unstable |-> pop_data_unstable == push_data[select])
+  `BR_ASSERT(forward_progress_a, push_valid[select] |-> pop_valid_unstable)
+
+endmodule : br_flow_mux_select_unstable_fpv_monitor
+
+bind br_flow_mux_select_unstable br_flow_mux_select_unstable_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .Width(Width),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertPushDataStability(EnableAssertPushDataStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);

--- a/flow/fpv/mux/br_flow_mux_stable_fpv.tcl
+++ b/flow/fpv/mux/br_flow_mux_stable_fpv.tcl
@@ -1,0 +1,13 @@
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# pop_valid is flopped
+assert -disable {*must_grant_a}
+# this is stable version DUT: disable unreachable covers due to RTL instantiation
+cover -disable {*data_unstable_c}
+cover -disable {*valid_unstable_c}
+
+# prove command
+prove -all


### PR DESCRIPTION
1. Move br_flow_mux to BR
2. Add FPV for flow_mux stable version after #434 and #435 
3. for version without name "stable", pop_data is NOT guaranteed to be stable even if EnableAssertPushDataStability=1. So RTL renamed pop_data to pop_data_unstable.
4. for version with name "stable". pop_data is checked that without pop_ready, it should be stable if EnableAssertPushDataStability=1.
5. all parameter sweep on all br_flow variations got full proof.