### PR TITLE
Fix assertions in multi-xfer modules

### DIFF
--- a/multi_xfer/rtl/br_multi_xfer_distributor_rr.sv
+++ b/multi_xfer/rtl/br_multi_xfer_distributor_rr.sv
@@ -33,6 +33,9 @@ module br_multi_xfer_distributor_rr #(
     parameter int SymbolWidth = 1,
     // The number of flows to distribute to. Must be at least NumSymbols.
     parameter int NumFlows = 2,
+    // If 1, assert that push_data is stable when push_sendable > push_receivable.
+    // If 0, cover that push_data is unstable when push_sendable > push_receivable.
+    parameter bit EnableAssertPushDataStability = 1,
     // If 1, assert that push_sendable is 0 at the end of simulation.
     parameter bit EnableAssertFinalNotSendable = 1,
 
@@ -61,6 +64,7 @@ module br_multi_xfer_distributor_rr #(
       .NumSymbols(NumSymbols),
       .SymbolWidth(SymbolWidth),
       .NumFlows(NumFlows),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertFinalNotSendable(EnableAssertFinalNotSendable)
   ) br_multi_xfer_distributor_core_inst (
       .clk,

--- a/multi_xfer/rtl/br_multi_xfer_reg_fwd.sv
+++ b/multi_xfer/rtl/br_multi_xfer_reg_fwd.sv
@@ -39,6 +39,9 @@ module br_multi_xfer_reg_fwd #(
     // The width of a single symbol.
     // Must be at least 1.
     parameter int SymbolWidth = 1,
+    // If 1, assert that push_data is stable when push_sendable > push_receivable.
+    // If 0, cover that push_data is unstable when push_sendable > push_receivable.
+    parameter bit EnableAssertPushDataStability = 1,
     // If 1, assert that the buffer is empty and push_sendable is 0
     // at end of simulation.
     parameter int EnableAssertFinalNotSendable = 1,
@@ -62,8 +65,9 @@ module br_multi_xfer_reg_fwd #(
   `BR_ASSERT_STATIC(legal_symbol_width_a, SymbolWidth >= 1)
 
   br_multi_xfer_checks_sendable_data_intg #(
-      .NumSymbols (NumSymbols),
-      .SymbolWidth(SymbolWidth)
+      .NumSymbols(NumSymbols),
+      .SymbolWidth(SymbolWidth),
+      .EnableAssertDataStability(EnableAssertPushDataStability)
   ) br_multi_xfer_checks_sendable_data_intg_push (
       .clk(clk),
       .rst(rst),

--- a/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_intg.sv
+++ b/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_intg.sv
@@ -24,8 +24,9 @@
 
 // ri lint_check_off NO_OUTPUT
 module br_multi_xfer_checks_sendable_data_intg #(
-    parameter int NumSymbols  = 2,
+    parameter int NumSymbols = 2,
     parameter int SymbolWidth = 1,
+    parameter bit EnableAssertDataStability = 1,
 
     localparam int CountWidth = $clog2(NumSymbols + 1)
 ) (
@@ -43,17 +44,24 @@ module br_multi_xfer_checks_sendable_data_intg #(
   `BR_ASSERT_INTG(sendable_no_revocation_a, (sendable > receivable) |=> (sendable >= $past
                                             (sendable - receivable)))
 
-  for (genvar i = 0; i < NumSymbols; i++) begin : gen_sendable_data_qual
-    // This isn't strictly needed for functionality, but if data is unknown,
-    // the data_shifted_a assertion below will not work since unknown values
-    // cannot be compared.
-    `BR_ASSERT_INTG(data_known_a, (sendable > i) |-> !$isunknown(data[i]))
-    `BR_ASSERT_INTG(data_shifted_a,
-                    ((sendable > receivable) && ((sendable - receivable) > i))
-        |=>
-        (data[i] == $past(
-                        data[i+receivable]
-                    )))
+  for (genvar i = 0; i < NumSymbols; i++) begin : gen_data_checks
+    if (EnableAssertDataStability) begin : gen_data_stability_checks
+      // This isn't strictly needed for functionality, but if data is unknown,
+      // the data_shifted_a assertion below will not work since unknown values
+      // cannot be compared.
+      `BR_ASSERT_INTG(data_known_a, (sendable > i) |-> !$isunknown(data[i]))
+      `BR_ASSERT_INTG(data_shifted_a,
+                      ((sendable > receivable) && ((sendable - receivable) > i))
+          |=>
+          (data[i] == $past(
+                          data[i+receivable]
+                      )))
+    end else begin : gen_data_instability_cover
+      `BR_COVER_INTG(
+          data_instability_c,
+          ((sendable > receivable) && ((sendable - receivable) > i)) && (data[i] != $past(
+          data[i+receivable])))
+    end
   end
 
   `BR_UNUSED_NAMED(all_unused, {rst, receivable, sendable, data})

--- a/multi_xfer/sim/BUILD.bazel
+++ b/multi_xfer/sim/BUILD.bazel
@@ -45,6 +45,5 @@ br_verilog_sim_test_tools_suite(
         "iverilog",
         "vcs",
     ],
-    waves = True,
     deps = [":br_multi_xfer_reg_fwd_tb"],
 )


### PR DESCRIPTION
1. Allow the push data check to be disabled. Needed for freelist manager.
2. Fix the internal integration checks in
br_multi_xfer_distributor_core.

---

**Stack**:
- #470
- #469 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*