### PR TITLE
Elaboration fix in fifo/sim/br_fifo_shared_test_harness

### DIFF
--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -149,6 +149,7 @@ br_verilog_sim_test_tools_suite(
 verilog_library(
     name = "br_fifo_shared_test_harness",
     srcs = ["br_fifo_shared_test_harness.sv"],
+    deps = ["//pkg:br_math_pkg"],
 )
 
 verilog_library(

--- a/fifo/sim/br_fifo_shared_test_harness.sv
+++ b/fifo/sim/br_fifo_shared_test_harness.sv
@@ -23,7 +23,7 @@ module br_fifo_shared_test_harness #(
     input logic [NumFifos-1:0][Width-1:0] pop_data
 );
 
-  localparam int WritePortIdWidth = $clog2(NumWritePorts);
+  localparam int WritePortIdWidth = br_math::max2(1, $clog2(NumWritePorts));
   // Reserve some bits to indicate write port.
   // The remaining bits can be randomly assigned.
   localparam int MaxRandomValue = 2 ** (Width - WritePortIdWidth) - 1;


### PR DESCRIPTION
A signal had width 0 when the number of write ports was 1. Dsim elaboration caught it.. but somehow VCS didn't??