### PR TITLE
don't expose entry_id from reordered_resp interface in reorder_buffer

### DIFF
--- a/tracker/rtl/BUILD.bazel
+++ b/tracker/rtl/BUILD.bazel
@@ -128,6 +128,7 @@ verilog_library(
         "//fifo/rtl:br_fifo_flops",
         "//flow/rtl:br_flow_join",
         "//macros:br_asserts",
+        "//macros:br_unused",
     ],
 )
 

--- a/tracker/rtl/br_tracker_reorder_buffer_flops.sv
+++ b/tracker/rtl/br_tracker_reorder_buffer_flops.sv
@@ -34,15 +34,14 @@ module br_tracker_reorder_buffer_flops #(
     output logic alloc_valid,
     output logic [EntryIdWidth-1:0] alloc_entry_id,
 
-    // Deallocation Request Interface
+    // Unordered Response Interface
     input logic unordered_resp_push_valid,
     input logic [EntryIdWidth-1:0] unordered_resp_push_entry_id,
     input logic [DataWidth-1:0] unordered_resp_push_data,
 
-    // Deallocation Complete Interface
+    // Reordered Response Interface
     input logic reordered_resp_pop_ready,
     output logic reordered_resp_pop_valid,
-    output logic [EntryIdWidth-1:0] reordered_resp_pop_entry_id,
     output logic [DataWidth-1:0] reordered_resp_pop_data
 );
   localparam int MinEntryIdWidth = $clog2(NumEntries);
@@ -75,7 +74,6 @@ module br_tracker_reorder_buffer_flops #(
       //
       .reordered_resp_pop_ready,
       .reordered_resp_pop_valid,
-      .reordered_resp_pop_entry_id,
       .reordered_resp_pop_data,
       //
       .ram_wr_addr,

--- a/tracker/sim/br_tracker_reorder_buffer_flops_tb.sv
+++ b/tracker/sim/br_tracker_reorder_buffer_flops_tb.sv
@@ -33,7 +33,6 @@ module br_tracker_reorder_buffer_flops_tb;
 
   logic reordered_resp_pop_ready;
   logic reordered_resp_pop_valid;
-  logic [EntryIdWidth-1:0] reordered_resp_pop_entry_id;
   logic [DataWidth-1:0]    reordered_resp_pop_data;
 
   // For capturing the allocated IDs (in the order they were allocated)
@@ -58,10 +57,9 @@ module br_tracker_reorder_buffer_flops_tb;
       .unordered_resp_push_entry_id(unordered_resp_push_entry_id),
       .unordered_resp_push_data    (unordered_resp_push_data),
 
-      .reordered_resp_pop_ready   (reordered_resp_pop_ready),
-      .reordered_resp_pop_valid   (reordered_resp_pop_valid),
-      .reordered_resp_pop_entry_id(reordered_resp_pop_entry_id),
-      .reordered_resp_pop_data    (reordered_resp_pop_data)
+      .reordered_resp_pop_ready(reordered_resp_pop_ready),
+      .reordered_resp_pop_valid(reordered_resp_pop_valid),
+      .reordered_resp_pop_data (reordered_resp_pop_data)
   );
 
   // Clock generation
@@ -160,19 +158,13 @@ module br_tracker_reorder_buffer_flops_tb;
 
       @(negedge clk);
 
-      // Check ID at this point
-      if (reordered_resp_pop_entry_id !== allocated_ids[k]) begin
-        $display("ERROR: expected reordered_resp_pop_entry_id %0d, got %0d", allocated_ids[k],
-                 reordered_resp_pop_entry_id);
-        $fatal;
-      end
+      // Check data at this point
       if (reordered_resp_pop_data !== entry_data[allocated_ids[k]]) begin
         $display("ERROR: data mismatch for entry %0d. Expected: 0x%0h, Got: 0x%0h",
                  allocated_ids[k], entry_data[allocated_ids[k]], reordered_resp_pop_data);
         $fatal;
       end
-      $display("  Received correct ID=%0d, data=0x%0h at cycle %0t", reordered_resp_pop_entry_id,
-               reordered_resp_pop_data, $time);
+      $display("  Received correct data=0x%0h at cycle %0t", reordered_resp_pop_data, $time);
 
       // Consume it
       @(negedge clk);


### PR DESCRIPTION
in the reorder_buffer, the reordered response is returned after the tracking tag is retired (it gets buffered in an output FIFO), so returning the entry_id (tag) is meaningless (since it is back in the free pool)