### PR TITLE
[Bazel] Specialize the license flag resources per tool

### DIFF
--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -53,6 +53,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_arb_fixed_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_arb_fixed_fpv_monitor"],
 )
 
@@ -95,6 +96,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_arb_rr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_arb_rr_fpv_monitor"],
 )
 
@@ -128,6 +130,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_arb_lru_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_arb_lru_fpv_monitor"],
 )
 
@@ -160,6 +163,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_arb_pri_rr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_arb_pri_rr_fpv_monitor"],
 )
 
@@ -196,6 +200,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_arb_weighted_rr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_arb_weighted_rr_fpv_monitor"],
 )
 
@@ -247,6 +252,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_arb_multi_rr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_arb_multi_rr_fpv_monitor"],
 )
 

--- a/arb/sim/chipstack/BUILD.bazel
+++ b/arb/sim/chipstack/BUILD.bazel
@@ -29,6 +29,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_arb_fixed_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_arb_fixed_gen_tb"],
 )
 
@@ -53,6 +54,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_arb_lru_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_arb_lru_gen_tb"],
 )
 
@@ -77,6 +79,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_arb_rr_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_arb_rr_gen_tb"],
 )
 

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -17,6 +17,35 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_hdl//verilog:providers.bzl", "VerilogInfo", "verilog_library")
 
+TOOLS_THAT_NEED_LICENSES = [
+    "ascentlint",
+    "jg",
+    "vcf",
+    "vcs",
+    "xrun",
+]
+
+def extra_tags(kind, tool):
+    """Returns a list of extra tags that should be added to a target.
+
+    Args:
+        kind: The kind of target.
+        tool: The tool name.
+
+    Returns:
+        A list of extra tags. Specifically:
+            * The kind of target -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<kind>
+            * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+            * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+    """
+    extra_tags = [
+        kind,
+        tool,
+    ]
+    if tool in TOOLS_THAT_NEED_LICENSES:
+        extra_tags.append("resources:verilog_test_tool_licenses_" + tool + ":1")
+    return extra_tags
+
 def get_transitive(ctx, srcs_not_hdrs):
     """Returns a depset of all Verilog source or header files in the transitive closure of the deps attribute."""
     transitive_depset = depset(
@@ -91,8 +120,7 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
     args.append("--tcl=" + tcl)
     args.append("--script=" + script)
     args.append("--log=" + log)
-    if ctx.attr.tool:
-        args.append("--tool='" + ctx.attr.tool + "'")
+    args.append("--tool='" + ctx.attr.tool + "'")
     if not test:
         args.append("--dry-run")
     if ctx.attr.custom_tcl_header:
@@ -226,9 +254,6 @@ def _verilog_sim_test_impl(ctx):
     extra_args.append("--seed='" + str(ctx.attr.seed) + "'")
     if ctx.attr.waves:
         extra_args.append("--waves")
-    if len(ctx.attr.opts) > 0 and ctx.attr.tool == "":
-        fail("If opts are provided, then tool must also be set.")
-
     for opt in ctx.attr.opts:
         extra_args.append("--opt='" + opt + "'")
 
@@ -244,8 +269,6 @@ def _verilog_fpv_args(ctx):
         extra_args.append("--elab_only")
     if ctx.attr.gui:
         extra_args.append("--gui")
-    if len(ctx.attr.opts) > 0 and ctx.attr.tool == "":
-        fail("If opts are provided, then tool must also be set.")
     for opt in ctx.attr.opts:
         extra_args.append("--opt='" + opt + "'")
     for opt in ctx.attr.elab_opts:
@@ -291,7 +314,7 @@ rule_verilog_elab_test = rule(
             allow_files = True,
             doc = "Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.",
         ),
-        "tool": attr.string(doc = "Elaboration tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins."),
+        "tool": attr.string(doc = "Elaboration tool to use.", mandatory = True),
         "custom_tcl_header": attr.label(
             doc = ("Tcl script file containing custom tool-specific commands to insert at the beginning of the generated tcl script." +
                    "The tcl header (custom or not) is unconditionally followed by analysis and elaborate commands, and then the tcl body." +
@@ -310,22 +333,26 @@ rule_verilog_elab_test = rule(
 
 def verilog_elab_test(
         name,
+        tool,
         tags = [],
         custom_tcl_header = None,
         custom_tcl_header_cmds = [],
         **kwargs):
-    """Wraps rule_verilog_elab_test with extra tags.
+    """Wraps rule_verilog_elab_test with a default tool and appends extra tags.
 
     Args:
         name: test name
-        tags: The tags to add to the test. If not provided, then defaults to:
-            * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
-            * resources:verilog_elab_test_tool_licenses:1 -- indicates that the test requires a elaboration tool license.
-            * elab -- useful for test filtering, e.g., bazel test //... --test_tag_filters=elab
-            * If the tool is provided in kwargs, then the tool name is added to the above tags.
+        tool: The elaboration tool to use.
+        tags: The tags to add to the test.
         custom_tcl_header: custom tcl header file. If not provided, then a default one will be generated.
         custom_tcl_header_cmds: custom tcl commands
         **kwargs: Other arguments to pass to the rule_verilog_elab_test rule.
+
+    The following extra tags are unconditionally appended to the list of tags:
+        * elab -- useful for test filtering, e.g., bazel test //... --test_tag_filters=elab
+        * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+        * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+        * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
     """
     if not custom_tcl_header:
         custom_tcl_header = name + "_custom_header.tcl"
@@ -339,18 +366,10 @@ def verilog_elab_test(
             ] + custom_tcl_header_cmds,
         )
 
-    extra_tags = [
-        "no-sandbox",  # Preserves miscellaneous undeclared EDA tool outputs for debugging
-        "resources:verilog_elab_test_tool_licenses:1",
-        "elab",
-    ]
-
-    if "tool" in kwargs:
-        extra_tags.append(kwargs["tool"])
-
     rule_verilog_elab_test(
         name = name,
-        tags = tags + extra_tags,
+        tool = tool,
+        tags = tags + extra_tags("elab", tool) + ["no-sandbox"],
         custom_tcl_header = ":" + custom_tcl_header,
         **kwargs
     )
@@ -383,7 +402,7 @@ rule_verilog_lint_test = rule(
             allow_files = True,
             doc = "Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.",
         ),
-        "tool": attr.string(doc = "Lint tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins."),
+        "tool": attr.string(doc = "Lint tool to use.", mandatory = True),
         "custom_tcl_header": attr.label(
             doc = ("Tcl script file containing custom tool-specific commands to insert at the beginning of the generated tcl script." +
                    "The tcl header (custom or not) is unconditionally followed by analysis and elaborate commands, and then the tcl body." +
@@ -400,29 +419,24 @@ rule_verilog_lint_test = rule(
     test = True,
 )
 
-def verilog_lint_test(tags = [], **kwargs):
-    """Wraps rule_verilog_lint_test with extra tags.
+def verilog_lint_test(tool, tags = [], **kwargs):
+    """Wraps rule_verilog_lint_test with a default tool and appends extra tags.
 
     Args:
-        tags: The tags to add to the test. If not provided, then defaults to:
-            * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
-            * resources:verilog_lint_test_tool_licenses:1 -- indicates that the test requires a lint tool license.
-            * lint -- useful for test filtering, e.g., bazel test //... --test_tag_filters=lint
-            * If the tool is provided in kwargs, then the tool name is added to the above tags.
+        tool: The lint tool to use.
+        tags: The tags to add to the test.
         **kwargs: Other arguments to pass to the rule_verilog_lint_test rule.
+
+    The following extra tags are unconditionally appended to the list of tags:
+        * lint -- useful for test filtering, e.g., bazel test //... --test_tag_filters=lint
+        * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+        * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+        * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
     """
 
-    extra_tags = [
-        "no-sandbox",  # Preserves miscellaneous undeclared EDA tool outputs for debugging
-        "resources:verilog_lint_test_tool_licenses:1",
-        "lint",
-    ]
-
-    if "tool" in kwargs:
-        extra_tags.append(kwargs["tool"])
-
     rule_verilog_lint_test(
-        tags = tags + extra_tags,
+        tool = tool,
+        tags = tags + extra_tags("lint", tool) + ["no-sandbox"],
         **kwargs
     )
 
@@ -464,7 +478,8 @@ rule_verilog_sim_test = rule(
             doc = "Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.",
         ),
         "tool": attr.string(
-            doc = "Simulator tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins.",
+            doc = "Simulator tool to use.",
+            mandatory = True,
         ),
         "custom_tcl_header": attr.label(
             doc = ("Tcl script file containing custom tool-specific commands to insert at the beginning of the generated tcl script." +
@@ -490,26 +505,21 @@ rule_verilog_sim_test = rule(
     test = True,
 )
 
-def verilog_sim_test(tool = None, opts = [], tags = [], **kwargs):
-    """Wraps rule_verilog_sim_test with extra tags.
+def verilog_sim_test(tool, opts = [], tags = [], **kwargs):
+    """Wraps rule_verilog_sim_test with a default tool and appends extra tags.
 
     Args:
         tool: The simulation tool to use.
         opts: Tool-specific options not covered by other arguments.
-        tags: The tags to add to the test. If not provided, then defaults to:
-            * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
-            * resources:verilog_sim_test_tool_licenses:1 -- indicates that the test requires a simulation tool license.
-            * sim -- useful for test filtering, e.g., bazel test //... --test_tag_filters=sim
-            * If the tool is provided, then the tool name is added to the above tags.
+        tags: The tags to add to the test.
         **kwargs: Other arguments to pass to the rule_verilog_sim_test rule.
-    """
 
-    extra_tags = [
-        "no-sandbox",  # Preserves miscellaneous undeclared EDA tool outputs for debugging
-        "resources:verilog_sim_test_tool_licenses:1",
-        "sim",
-        tool,
-    ]
+    The following extra tags are unconditionally appended to the list of tags:
+        * sim -- useful for test filtering, e.g., bazel test //... --test_tag_filters=sim
+        * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+        * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+        * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+    """
 
     # Make sure we fail the test ASAP after any error occurs (assertion or otherwise).
     extra_opts = []
@@ -521,7 +531,7 @@ def verilog_sim_test(tool = None, opts = [], tags = [], **kwargs):
     rule_verilog_sim_test(
         tool = tool,
         opts = opts + extra_opts,
-        tags = tags + extra_tags,
+        tags = tags + extra_tags("sim", tool) + ["no-sandbox"],
         **kwargs
     )
 
@@ -565,7 +575,8 @@ rule_verilog_fpv_test = rule(
             doc = "Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.",
         ),
         "tool": attr.string(
-            doc = "Formal tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins.",
+            doc = "Formal tool to use.",
+            mandatory = True,
         ),
         "custom_tcl_header": attr.label(
             doc = ("Tcl script file containing custom tool-specific commands to insert at the beginning of the generated tcl script." +
@@ -587,27 +598,23 @@ rule_verilog_fpv_test = rule(
     test = True,
 )
 
-def verilog_fpv_test(tags = [], **kwargs):
-    """Wraps rule_verilog_fpv_test with extra tags.
+def verilog_fpv_test(tool, tags = [], **kwargs):
+    """Wraps rule_verilog_fpv_test with a default tool and appends extra tags.
 
     Args:
-        tags: The tags to add to the test. If not provided, then defaults to:
-            * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
-            * resources:verilog_fpv_test_tool_licenses:1 -- indicates that the test requires a formal tool license.
-            * fpv -- useful for test filtering, e.g., bazel test //... --test_tag_filters=fpv
-            * If the tool is provided in kwargs, then the tool name is added to the above tags.
+        tool: The formal verification tool to use.
+        tags: The tags to add to the test.
         **kwargs: Other arguments to pass to the rule_verilog_fpv_test rule.
-    """
-    extra_tags = [
-        "no-sandbox",  # Preserves miscellaneous undeclared EDA tool outputs for debugging
-        "resources:verilog_fpv_test_tool_licenses:1",
-        "fpv",
-    ]
-    if "tool" in kwargs:
-        extra_tags.append(kwargs["tool"])
 
+    The following extra tags are unconditionally appended to the list of tags:
+        * fpv -- useful for test filtering, e.g., bazel test //... --test_tag_filters=fpv
+        * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+        * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+        * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+    """
     rule_verilog_fpv_test(
-        tags = tags + extra_tags,
+        tool = tool,
+        tags = tags + extra_tags("fpv", tool) + ["no-sandbox"],
         **kwargs
     )
 
@@ -630,7 +637,7 @@ rule_verilog_fpv_sandbox = rule(
             doc = "The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.",
         ),
         "opts": attr.string_list(
-            doc = "Tool-specific options not covered by other arguments. If provided, then 'tool' must also be set.",
+            doc = "Tool-specific options not covered by other arguments.",
         ),
         "elab_opts": attr.string_list(
             doc = "custom elab options",
@@ -649,7 +656,8 @@ rule_verilog_fpv_sandbox = rule(
             doc = "Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.",
         ),
         "tool": attr.string(
-            doc = "Tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins.",
+            doc = "Formal tool to use.",
+            mandatory = True,
         ),
         "custom_tcl_header": attr.label(
             doc = ("Tcl script file containing custom tool-specific commands to insert at the beginning of the generated tcl script." +
@@ -695,6 +703,8 @@ def verilog_elab_and_lint_test_suite(
         deps = [],
         defines = [],
         params = {},
+        elab_tool = "verific",
+        lint_tool = "ascentlint",
         disable_lint_rules = [],
         **kwargs):
     """Creates a suite of Verilog elaboration and lint tests for each combination of the provided parameters.
@@ -709,6 +719,8 @@ def verilog_elab_and_lint_test_suite(
         name (str): The base name for the test suite.
         defines (list): A list of defines.
         params (dict): A dictionary where keys are parameter names and values are lists of possible values for those parameters.
+        elab_tool (str): The tool to use for elaboration.
+        lint_tool (str): The tool to use for linting.
         disable_lint_rules (list): A list of lint rules to disable in the generated files.
         **kwargs: Additional common keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.
     """
@@ -739,6 +751,7 @@ def verilog_elab_and_lint_test_suite(
 
     verilog_elab_test(
         name = name + "_elab_test",
+        tool = elab_tool,
         deps = [":" + name + "_wrapper"],
         defines = defines,
         **kwargs
@@ -746,6 +759,7 @@ def verilog_elab_and_lint_test_suite(
 
     verilog_lint_test(
         name = name + "_lint_test",
+        tool = lint_tool,
         deps = [":" + name + "_wrapper"],
         defines = defines,
         **kwargs

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -340,6 +340,12 @@ def verilog_elab_test(
         **kwargs):
     """Wraps rule_verilog_elab_test with a default tool and appends extra tags.
 
+    The following extra tags are unconditionally appended to the list of tags:
+        * elab -- useful for test filtering, e.g., bazel test //... --test_tag_filters=elab
+        * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+        * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+        * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+
     Args:
         name: test name
         tool: The elaboration tool to use.
@@ -347,12 +353,6 @@ def verilog_elab_test(
         custom_tcl_header: custom tcl header file. If not provided, then a default one will be generated.
         custom_tcl_header_cmds: custom tcl commands
         **kwargs: Other arguments to pass to the rule_verilog_elab_test rule.
-
-    The following extra tags are unconditionally appended to the list of tags:
-        * elab -- useful for test filtering, e.g., bazel test //... --test_tag_filters=elab
-        * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
-        * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
-        * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
     """
     if not custom_tcl_header:
         custom_tcl_header = name + "_custom_header.tcl"
@@ -422,16 +422,16 @@ rule_verilog_lint_test = rule(
 def verilog_lint_test(tool, tags = [], **kwargs):
     """Wraps rule_verilog_lint_test with a default tool and appends extra tags.
 
-    Args:
-        tool: The lint tool to use.
-        tags: The tags to add to the test.
-        **kwargs: Other arguments to pass to the rule_verilog_lint_test rule.
-
     The following extra tags are unconditionally appended to the list of tags:
         * lint -- useful for test filtering, e.g., bazel test //... --test_tag_filters=lint
         * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
         * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
         * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+
+    Args:
+        tool: The lint tool to use.
+        tags: The tags to add to the test.
+        **kwargs: Other arguments to pass to the rule_verilog_lint_test rule.
     """
 
     rule_verilog_lint_test(
@@ -508,17 +508,17 @@ rule_verilog_sim_test = rule(
 def verilog_sim_test(tool, opts = [], tags = [], **kwargs):
     """Wraps rule_verilog_sim_test with a default tool and appends extra tags.
 
-    Args:
-        tool: The simulation tool to use.
-        opts: Tool-specific options not covered by other arguments.
-        tags: The tags to add to the test.
-        **kwargs: Other arguments to pass to the rule_verilog_sim_test rule.
-
     The following extra tags are unconditionally appended to the list of tags:
         * sim -- useful for test filtering, e.g., bazel test //... --test_tag_filters=sim
         * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
         * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
         * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+
+    Args:
+        tool: The simulation tool to use.
+        opts: Tool-specific options not covered by other arguments.
+        tags: The tags to add to the test.
+        **kwargs: Other arguments to pass to the rule_verilog_sim_test rule.
     """
 
     # Make sure we fail the test ASAP after any error occurs (assertion or otherwise).
@@ -601,16 +601,16 @@ rule_verilog_fpv_test = rule(
 def verilog_fpv_test(tool, tags = [], **kwargs):
     """Wraps rule_verilog_fpv_test with a default tool and appends extra tags.
 
-    Args:
-        tool: The formal verification tool to use.
-        tags: The tags to add to the test.
-        **kwargs: Other arguments to pass to the rule_verilog_fpv_test rule.
-
     The following extra tags are unconditionally appended to the list of tags:
         * fpv -- useful for test filtering, e.g., bazel test //... --test_tag_filters=fpv
         * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
         * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
         * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+
+    Args:
+        tool: The formal verification tool to use.
+        tags: The tags to add to the test.
+        **kwargs: Other arguments to pass to the rule_verilog_fpv_test rule.
     """
     rule_verilog_fpv_test(
         tool = tool,

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -74,7 +74,7 @@ Tests that a Verilog or SystemVerilog design elaborates. Needs VERILOG_RUNNER_PL
 | <a id="rule_verilog_elab_test-custom_tcl_header"></a>custom_tcl_header |  Tcl script file containing custom tool-specific commands to insert at the beginning of the generated tcl script.The tcl header (custom or not) is unconditionally followed by analysis and elaborate commands, and then the tcl body.Do not include Tcl commands that manipulate sources, headers, defines, or parameters, as those will be handled by the rule implementation.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="rule_verilog_elab_test-defines"></a>defines |  Preprocessor defines to pass to the Verilog compiler.   | List of strings | optional |  `[]`  |
 | <a id="rule_verilog_elab_test-params"></a>params |  Verilog module parameters to set in the instantiation of the top-level module.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
-| <a id="rule_verilog_elab_test-tool"></a>tool |  Elaboration tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins.   | String | optional |  `""`  |
+| <a id="rule_verilog_elab_test-tool"></a>tool |  Elaboration tool to use.   | String | required |  |
 | <a id="rule_verilog_elab_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_elab_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
 | <a id="rule_verilog_elab_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
@@ -108,9 +108,9 @@ Writes FPV files and run scripts into a tarball for independent execution outsid
 | <a id="rule_verilog_fpv_sandbox-elab_only"></a>elab_only |  Only run elaboration.   | Boolean | optional |  `False`  |
 | <a id="rule_verilog_fpv_sandbox-elab_opts"></a>elab_opts |  custom elab options   | List of strings | optional |  `[]`  |
 | <a id="rule_verilog_fpv_sandbox-gui"></a>gui |  Enable GUI.   | Boolean | optional |  `False`  |
-| <a id="rule_verilog_fpv_sandbox-opts"></a>opts |  Tool-specific options not covered by other arguments. If provided, then 'tool' must also be set.   | List of strings | optional |  `[]`  |
+| <a id="rule_verilog_fpv_sandbox-opts"></a>opts |  Tool-specific options not covered by other arguments.   | List of strings | optional |  `[]`  |
 | <a id="rule_verilog_fpv_sandbox-params"></a>params |  Verilog module parameters to set in the instantiation of the top-level module.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
-| <a id="rule_verilog_fpv_sandbox-tool"></a>tool |  Tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins.   | String | optional |  `""`  |
+| <a id="rule_verilog_fpv_sandbox-tool"></a>tool |  Formal tool to use.   | String | required |  |
 | <a id="rule_verilog_fpv_sandbox-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_fpv_sandbox-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
 | <a id="rule_verilog_fpv_sandbox-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
@@ -146,7 +146,7 @@ Runs Verilog/SystemVerilog compilation and formal verification in one command. T
 | <a id="rule_verilog_fpv_test-gui"></a>gui |  Enable GUI.   | Boolean | optional |  `False`  |
 | <a id="rule_verilog_fpv_test-opts"></a>opts |  Tool-specific options not covered by other arguments. If provided, then 'tool' must also be set.   | List of strings | optional |  `[]`  |
 | <a id="rule_verilog_fpv_test-params"></a>params |  Verilog module parameters to set in the instantiation of the top-level module.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
-| <a id="rule_verilog_fpv_test-tool"></a>tool |  Formal tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins.   | String | optional |  `""`  |
+| <a id="rule_verilog_fpv_test-tool"></a>tool |  Formal tool to use.   | String | required |  |
 | <a id="rule_verilog_fpv_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_fpv_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
 | <a id="rule_verilog_fpv_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
@@ -177,7 +177,7 @@ Tests that a Verilog or SystemVerilog design passes a set of static lint checks.
 | <a id="rule_verilog_lint_test-defines"></a>defines |  Preprocessor defines to pass to the Verilog compiler.   | List of strings | optional |  `[]`  |
 | <a id="rule_verilog_lint_test-params"></a>params |  Verilog module parameters to set in the instantiation of the top-level module.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="rule_verilog_lint_test-policy"></a>policy |  The lint policy file to use. If not provided, then the default tool policy is used (typically provided through an environment variable).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="rule_verilog_lint_test-tool"></a>tool |  Lint tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins.   | String | optional |  `""`  |
+| <a id="rule_verilog_lint_test-tool"></a>tool |  Lint tool to use.   | String | required |  |
 | <a id="rule_verilog_lint_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_lint_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
 | <a id="rule_verilog_lint_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
@@ -211,12 +211,40 @@ Runs Verilog/SystemVerilog compilation and simulation in one command. This rule 
 | <a id="rule_verilog_sim_test-opts"></a>opts |  Tool-specific options not covered by other arguments. If provided, then 'tool' must also be set.   | List of strings | optional |  `[]`  |
 | <a id="rule_verilog_sim_test-params"></a>params |  Verilog module parameters to set in the instantiation of the top-level module.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="rule_verilog_sim_test-seed"></a>seed |  Random seed to use in simulation.   | Integer | optional |  `0`  |
-| <a id="rule_verilog_sim_test-tool"></a>tool |  Simulator tool to use. If not provided, default is decided by the Verilog Runner tool implementation with available plugins.   | String | optional |  `""`  |
+| <a id="rule_verilog_sim_test-tool"></a>tool |  Simulator tool to use.   | String | required |  |
 | <a id="rule_verilog_sim_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_sim_test-uvm"></a>uvm |  Run UVM test.   | Boolean | optional |  `False`  |
 | <a id="rule_verilog_sim_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
 | <a id="rule_verilog_sim_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
 | <a id="rule_verilog_sim_test-waves"></a>waves |  Enable waveform dumping.   | Boolean | optional |  `False`  |
+
+
+<a id="extra_tags"></a>
+
+## extra_tags
+
+<pre>
+load("@bedrock-rtl//bazel:verilog.bzl", "extra_tags")
+
+extra_tags(<a href="#extra_tags-kind">kind</a>, <a href="#extra_tags-tool">tool</a>)
+</pre>
+
+Returns a list of extra tags that should be added to a target.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="extra_tags-kind"></a>kind |  The kind of target.   |  none |
+| <a id="extra_tags-tool"></a>tool |  The tool name.   |  none |
+
+**RETURNS**
+
+A list of extra tags. Specifically:
+      * The kind of target -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<kind>
+      * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+      * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
 
 
 <a id="get_transitive"></a>
@@ -247,7 +275,8 @@ Returns a depset of all Verilog source or header files in the transitive closure
 <pre>
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_elab_and_lint_test_suite")
 
-verilog_elab_and_lint_test_suite(<a href="#verilog_elab_and_lint_test_suite-name">name</a>, <a href="#verilog_elab_and_lint_test_suite-top">top</a>, <a href="#verilog_elab_and_lint_test_suite-deps">deps</a>, <a href="#verilog_elab_and_lint_test_suite-defines">defines</a>, <a href="#verilog_elab_and_lint_test_suite-params">params</a>, <a href="#verilog_elab_and_lint_test_suite-disable_lint_rules">disable_lint_rules</a>, <a href="#verilog_elab_and_lint_test_suite-kwargs">kwargs</a>)
+verilog_elab_and_lint_test_suite(<a href="#verilog_elab_and_lint_test_suite-name">name</a>, <a href="#verilog_elab_and_lint_test_suite-top">top</a>, <a href="#verilog_elab_and_lint_test_suite-deps">deps</a>, <a href="#verilog_elab_and_lint_test_suite-defines">defines</a>, <a href="#verilog_elab_and_lint_test_suite-params">params</a>, <a href="#verilog_elab_and_lint_test_suite-elab_tool">elab_tool</a>, <a href="#verilog_elab_and_lint_test_suite-lint_tool">lint_tool</a>,
+                                 <a href="#verilog_elab_and_lint_test_suite-disable_lint_rules">disable_lint_rules</a>, <a href="#verilog_elab_and_lint_test_suite-kwargs">kwargs</a>)
 </pre>
 
 Creates a suite of Verilog elaboration and lint tests for each combination of the provided parameters.
@@ -267,6 +296,8 @@ to the base name followed by the parameter key-values.
 | <a id="verilog_elab_and_lint_test_suite-deps"></a>deps |  The dependencies of the test suite.   |  `[]` |
 | <a id="verilog_elab_and_lint_test_suite-defines"></a>defines |  A list of defines.   |  `[]` |
 | <a id="verilog_elab_and_lint_test_suite-params"></a>params |  A dictionary where keys are parameter names and values are lists of possible values for those parameters.   |  `{}` |
+| <a id="verilog_elab_and_lint_test_suite-elab_tool"></a>elab_tool |  The tool to use for elaboration.   |  `"verific"` |
+| <a id="verilog_elab_and_lint_test_suite-lint_tool"></a>lint_tool |  The tool to use for linting.   |  `"ascentlint"` |
 | <a id="verilog_elab_and_lint_test_suite-disable_lint_rules"></a>disable_lint_rules |  A list of lint rules to disable in the generated files.   |  `[]` |
 | <a id="verilog_elab_and_lint_test_suite-kwargs"></a>kwargs |  Additional common keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.   |  none |
 
@@ -278,10 +309,17 @@ to the base name followed by the parameter key-values.
 <pre>
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_elab_test")
 
-verilog_elab_test(<a href="#verilog_elab_test-name">name</a>, <a href="#verilog_elab_test-tags">tags</a>, <a href="#verilog_elab_test-custom_tcl_header_cmds">custom_tcl_header_cmds</a>, <a href="#verilog_elab_test-kwargs">kwargs</a>)
+verilog_elab_test(<a href="#verilog_elab_test-name">name</a>, <a href="#verilog_elab_test-tool">tool</a>, <a href="#verilog_elab_test-tags">tags</a>, <a href="#verilog_elab_test-custom_tcl_header">custom_tcl_header</a>, <a href="#verilog_elab_test-custom_tcl_header_cmds">custom_tcl_header_cmds</a>, <a href="#verilog_elab_test-kwargs">kwargs</a>)
 </pre>
 
-Wraps rule_verilog_elab_test with extra tags.
+Wraps rule_verilog_elab_test with a default tool and appends extra tags.
+
+The following extra tags are unconditionally appended to the list of tags:
+    * elab -- useful for test filtering, e.g., bazel test //... --test_tag_filters=elab
+    * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+    * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+    * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+
 
 **PARAMETERS**
 
@@ -289,7 +327,9 @@ Wraps rule_verilog_elab_test with extra tags.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="verilog_elab_test-name"></a>name |  test name   |  none |
-| <a id="verilog_elab_test-tags"></a>tags |  The tags to add to the test. If not provided, then defaults to: * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging. * resources:verilog_elab_test_tool_licenses:1 -- indicates that the test requires a elaboration tool license. * elab -- useful for test filtering, e.g., bazel test //... --test_tag_filters=elab * If the tool is provided in kwargs, then the tool name is added to the above tags.   |  `[]` |
+| <a id="verilog_elab_test-tool"></a>tool |  The elaboration tool to use.   |  none |
+| <a id="verilog_elab_test-tags"></a>tags |  The tags to add to the test.   |  `[]` |
+| <a id="verilog_elab_test-custom_tcl_header"></a>custom_tcl_header |  custom tcl header file. If not provided, then a default one will be generated.   |  `None` |
 | <a id="verilog_elab_test-custom_tcl_header_cmds"></a>custom_tcl_header_cmds |  custom tcl commands   |  `[]` |
 | <a id="verilog_elab_test-kwargs"></a>kwargs |  Other arguments to pass to the rule_verilog_elab_test rule.   |  none |
 
@@ -301,17 +341,25 @@ Wraps rule_verilog_elab_test with extra tags.
 <pre>
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_fpv_test")
 
-verilog_fpv_test(<a href="#verilog_fpv_test-tags">tags</a>, <a href="#verilog_fpv_test-kwargs">kwargs</a>)
+verilog_fpv_test(<a href="#verilog_fpv_test-tool">tool</a>, <a href="#verilog_fpv_test-tags">tags</a>, <a href="#verilog_fpv_test-kwargs">kwargs</a>)
 </pre>
 
-Wraps rule_verilog_fpv_test with extra tags.
+Wraps rule_verilog_fpv_test with a default tool and appends extra tags.
+
+The following extra tags are unconditionally appended to the list of tags:
+    * fpv -- useful for test filtering, e.g., bazel test //... --test_tag_filters=fpv
+    * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+    * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+    * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="verilog_fpv_test-tags"></a>tags |  The tags to add to the test. If not provided, then defaults to: * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging. * resources:verilog_fpv_test_tool_licenses:1 -- indicates that the test requires a formal tool license. * fpv -- useful for test filtering, e.g., bazel test //... --test_tag_filters=fpv * If the tool is provided in kwargs, then the tool name is added to the above tags.   |  `[]` |
+| <a id="verilog_fpv_test-tool"></a>tool |  The formal verification tool to use.   |  none |
+| <a id="verilog_fpv_test-tags"></a>tags |  The tags to add to the test.   |  `[]` |
 | <a id="verilog_fpv_test-kwargs"></a>kwargs |  Other arguments to pass to the rule_verilog_fpv_test rule.   |  none |
 
 
@@ -352,17 +400,25 @@ to the base name followed by the parameter key-values.
 <pre>
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_lint_test")
 
-verilog_lint_test(<a href="#verilog_lint_test-tags">tags</a>, <a href="#verilog_lint_test-kwargs">kwargs</a>)
+verilog_lint_test(<a href="#verilog_lint_test-tool">tool</a>, <a href="#verilog_lint_test-tags">tags</a>, <a href="#verilog_lint_test-kwargs">kwargs</a>)
 </pre>
 
-Wraps rule_verilog_lint_test with extra tags.
+Wraps rule_verilog_lint_test with a default tool and appends extra tags.
+
+The following extra tags are unconditionally appended to the list of tags:
+    * lint -- useful for test filtering, e.g., bazel test //... --test_tag_filters=lint
+    * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+    * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+    * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="verilog_lint_test-tags"></a>tags |  The tags to add to the test. If not provided, then defaults to: * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging. * resources:verilog_lint_test_tool_licenses:1 -- indicates that the test requires a lint tool license. * lint -- useful for test filtering, e.g., bazel test //... --test_tag_filters=lint * If the tool is provided in kwargs, then the tool name is added to the above tags.   |  `[]` |
+| <a id="verilog_lint_test-tool"></a>tool |  The lint tool to use.   |  none |
+| <a id="verilog_lint_test-tags"></a>tags |  The tags to add to the test.   |  `[]` |
 | <a id="verilog_lint_test-kwargs"></a>kwargs |  Other arguments to pass to the rule_verilog_lint_test rule.   |  none |
 
 
@@ -376,16 +432,23 @@ load("@bedrock-rtl//bazel:verilog.bzl", "verilog_sim_test")
 verilog_sim_test(<a href="#verilog_sim_test-tool">tool</a>, <a href="#verilog_sim_test-opts">opts</a>, <a href="#verilog_sim_test-tags">tags</a>, <a href="#verilog_sim_test-kwargs">kwargs</a>)
 </pre>
 
-Wraps rule_verilog_sim_test with extra tags.
+Wraps rule_verilog_sim_test with a default tool and appends extra tags.
+
+The following extra tags are unconditionally appended to the list of tags:
+    * sim -- useful for test filtering, e.g., bazel test //... --test_tag_filters=sim
+    * The tool name -- useful for test filtering, e.g., bazel test //... --test_tag_filters=<tool>
+    * resources:verilog_test_tool_licenses_<tool>:1 -- only if the tool appears in TOOLS_THAT_NEED_LICENSES.
+    * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging.
+
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="verilog_sim_test-tool"></a>tool |  The simulation tool to use.   |  `None` |
+| <a id="verilog_sim_test-tool"></a>tool |  The simulation tool to use.   |  none |
 | <a id="verilog_sim_test-opts"></a>opts |  Tool-specific options not covered by other arguments.   |  `[]` |
-| <a id="verilog_sim_test-tags"></a>tags |  The tags to add to the test. If not provided, then defaults to: * no-sandbox -- Loosens some Bazel hermeticity features so that undeclared EDA tool test outputs are preserved for debugging. * resources:verilog_sim_test_tool_licenses:1 -- indicates that the test requires a simulation tool license. * sim -- useful for test filtering, e.g., bazel test //... --test_tag_filters=sim * If the tool is provided, then the tool name is added to the above tags.   |  `[]` |
+| <a id="verilog_sim_test-tags"></a>tags |  The tags to add to the test.   |  `[]` |
 | <a id="verilog_sim_test-kwargs"></a>kwargs |  Other arguments to pass to the rule_verilog_sim_test rule.   |  none |
 
 

--- a/bazelrc
+++ b/bazelrc
@@ -9,8 +9,20 @@
 # The environment variable must be set to some string even if it's empty.
 common --action_env=VERILOG_RUNNER_PLUGIN_PATH=""
 
-# These flags are required -- otherwise the Verilog Bazel test rules will crash.
-common --local_resources=verilog_elab_test_tool_licenses=10000
-common --local_resources=verilog_lint_test_tool_licenses=10000
-common --local_resources=verilog_sim_test_tool_licenses=10000
-common --local_resources=verilog_fpv_test_tool_licenses=10000
+# The following flags are used by Bazel to self-throttle the number of concurrent
+# jobs that can run for a given proprietary license-limited EDA tool.
+# However, this doesn't limit the use of licenses by other workflows that may exist
+# outside of this Bazel workspace.
+#
+# The values for each of these flags must be set to some integer >= 1 or the Bazel
+# Verilog test rules will crash.
+#
+# Set the values to match the number of EDA tool licenses available in your environment.
+# If you don't want limits, set the values to some large positive number.
+#
+# See TOOLS_THAT_NEED_LICENSES in //bazel/verilog.bzl for the list of tools that need licenses.
+common --local_resources=verilog_test_tool_licenses_ascentlint=10000
+common --local_resources=verilog_test_tool_licenses_jg=10000
+common --local_resources=verilog_test_tool_licenses_vcf=10000
+common --local_resources=verilog_test_tool_licenses_vcs=10000
+common --local_resources=verilog_test_tool_licenses_xrun=10000

--- a/cdc/fpv/BUILD.bazel
+++ b/cdc/fpv/BUILD.bazel
@@ -51,6 +51,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_flops_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_cdc_fifo_flops_fpv_monitor"],
 )
 
@@ -123,6 +124,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_flops_push_credit_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_cdc_fifo_flops_push_credit_fpv_monitor"],
 )
 
@@ -188,6 +190,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_ctrl_1r1w_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_cdc_fifo_ctrl_1r1w_fpv_monitor"],
 )
 
@@ -279,6 +282,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
 )
 
@@ -366,6 +370,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor"],
 )
 
@@ -460,6 +465,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor"],
 )
 

--- a/cdc/sim/BUILD.bazel
+++ b/cdc/sim/BUILD.bazel
@@ -31,6 +31,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_flops_tb_elab_test",
+    tool = "verific",
     top = "br_cdc_fifo_flops_tb",
     deps = [
         ":br_cdc_fifo_flops_tb",
@@ -89,6 +90,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_cdc_fifo_flops_push_credit_tb_elab_test",
+    tool = "verific",
     top = "br_cdc_fifo_flops_push_credit_tb",
     deps = [
         ":br_cdc_fifo_flops_push_credit_tb",

--- a/counter/fpv/BUILD.bazel
+++ b/counter/fpv/BUILD.bazel
@@ -31,6 +31,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_counter_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_counter_fpv_monitor"],
 )
 

--- a/counter/fpv/BUILD.bazel
+++ b/counter/fpv/BUILD.bazel
@@ -94,6 +94,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_counter_decr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_counter_decr_fpv_monitor"],
 )
 
@@ -146,6 +147,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_counter_incr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_counter_incr_fpv_monitor"],
 )
 

--- a/counter/sim/BUILD.bazel
+++ b/counter/sim/BUILD.bazel
@@ -26,6 +26,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_counter_incr_tb_elab_test",
+    tool = "verific",
     deps = [":br_counter_incr_tb"],
 )
 
@@ -68,6 +69,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_counter_tb_elab_test",
+    tool = "verific",
     deps = [":br_counter_tb"],
 )
 
@@ -110,6 +112,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_counter_decr_tb_elab_test",
+    tool = "verific",
     deps = [":br_counter_decr_tb"],
 )
 

--- a/counter/sim/chipstack/BUILD.bazel
+++ b/counter/sim/chipstack/BUILD.bazel
@@ -29,6 +29,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_counter_decr_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_counter_decr_gen_tb"],
 )
 
@@ -53,6 +54,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_counter_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_counter_gen_tb"],
 )
 
@@ -77,6 +79,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_counter_incr_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_counter_incr_gen_tb"],
 )
 

--- a/credit/fpv/BUILD.bazel
+++ b/credit/fpv/BUILD.bazel
@@ -31,6 +31,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_credit_counter_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_credit_counter_fpv_monitor"],
 )
 
@@ -76,6 +77,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_credit_receiver_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_credit_receiver_fpv_monitor"],
 )
 
@@ -154,6 +156,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_credit_sender_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_credit_sender_fpv_monitor"],
 )
 

--- a/credit/sim/BUILD.bazel
+++ b/credit/sim/BUILD.bazel
@@ -29,6 +29,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_credit_receiver_tb_elab_test",
+    tool = "verific",
     deps = [":br_credit_receiver_tb"],
 )
 

--- a/delay/fpv/BUILD.bazel
+++ b/delay/fpv/BUILD.bazel
@@ -31,6 +31,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_delay_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_delay_fpv_monitor"],
 )
 
@@ -66,6 +67,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_delay_nr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_delay_nr_fpv_monitor"],
 )
 
@@ -102,6 +104,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_delay_valid_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_delay_valid_fpv_monitor"],
 )
 
@@ -137,6 +140,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_delay_valid_next_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_delay_valid_next_fpv_monitor"],
 )
 
@@ -171,6 +175,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_delay_valid_next_nr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_delay_valid_next_nr_fpv_monitor"],
 )
 

--- a/delay/fpv/chipstack/br_delay/BUILD.bazel
+++ b/delay/fpv/chipstack/br_delay/BUILD.bazel
@@ -26,6 +26,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_delay_monitor_elab_test",
+    tool = "verific",
     top = "br_delay_monitor",
     deps = [":br_delay_monitor"],
 )

--- a/delay/fpv/chipstack/br_delay_nr/BUILD.bazel
+++ b/delay/fpv/chipstack/br_delay_nr/BUILD.bazel
@@ -26,6 +26,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_delay_nr_monitor_elab_test",
+    tool = "verific",
     deps = [":br_delay_nr_monitor"],
 )
 

--- a/ecc/fpv/BUILD.bazel
+++ b/ecc/fpv/BUILD.bazel
@@ -132,6 +132,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_ecc_secded_error_fpv_monitor_elab_test",
+    tool = "verific",
     #TODO: RTL has bug
     deps = [":br_ecc_secded_error_fpv_monitor"],
 )

--- a/ecc/fpv/BUILD.bazel
+++ b/ecc/fpv/BUILD.bazel
@@ -32,6 +32,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_ecc_sed_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_ecc_sed_fpv_monitor"],
 )
 
@@ -81,6 +82,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_ecc_secded_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_ecc_secded_fpv_monitor"],
 )
 

--- a/ecc/sim/BUILD.bazel
+++ b/ecc/sim/BUILD.bazel
@@ -32,6 +32,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_ecc_sed_encoder_decoder_tb_elab_test",
+    tool = "verific",
     deps = [":br_ecc_sed_encoder_decoder_tb"],
 )
 
@@ -45,9 +46,9 @@ br_verilog_sim_test_tools_suite(
     deps = [":br_ecc_sed_encoder_decoder_tb"],
 )
 
-##################3
+##################
 # SECDED
-##################3
+##################
 verilog_library(
     name = "br_ecc_secded_encoder_decoder_tb",
     srcs = ["br_ecc_secded_encoder_decoder_tb.sv"],
@@ -59,6 +60,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_ecc_secded_encoder_decoder_tb_elab_test",
+    tool = "verific",
     deps = [":br_ecc_secded_encoder_decoder_tb"],
 )
 

--- a/enc/sim/BUILD.bazel
+++ b/enc/sim/BUILD.bazel
@@ -47,6 +47,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_enc_bin2onehot_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_bin2onehot_tb"],
 )
 
@@ -67,6 +68,7 @@ br_verilog_sim_test_tools_suite(
 
 verilog_elab_test(
     name = "br_enc_gray_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_gray_tb"],
 )
 
@@ -87,6 +89,7 @@ br_verilog_sim_test_tools_suite(
 
 verilog_elab_test(
     name = "br_enc_priority_encoder_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_priority_encoder_tb"],
 )
 
@@ -122,6 +125,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_enc_priority_dynamic_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_priority_dynamic_tb"],
 )
 

--- a/enc/sim/chipstack/BUILD.bazel
+++ b/enc/sim/chipstack/BUILD.bazel
@@ -29,6 +29,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_enc_bin2gray_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_bin2gray_gen_tb"],
 )
 
@@ -53,6 +54,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_enc_bin2onehot_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_bin2onehot_gen_tb"],
 )
 
@@ -77,6 +79,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_enc_countones_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_countones_gen_tb"],
 )
 
@@ -101,6 +104,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_enc_gray2bin_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_gray2bin_gen_tb"],
 )
 
@@ -125,6 +129,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_enc_onehot2bin_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_onehot2bin_gen_tb"],
 )
 
@@ -149,6 +154,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_enc_priority_encoder_gen_tb_elab_test",
+    tool = "verific",
     deps = [":br_enc_priority_encoder_gen_tb"],
 )
 

--- a/fifo/fpv/BUILD.bazel
+++ b/fifo/fpv/BUILD.bazel
@@ -44,6 +44,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_fifo_ctrl_1r1w_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_fifo_ctrl_1r1w_fpv_monitor"],
 )
 
@@ -93,6 +94,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_fifo_flops_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_fifo_flops_fpv_monitor"],
 )
 
@@ -138,6 +140,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_fifo_ctrl_1r1w_push_credit_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
 )
 
@@ -192,6 +195,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_fifo_flops_push_credit_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_fifo_flops_push_credit_fpv_monitor"],
 )
 

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -25,6 +25,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_fifo_test_harness_elab_test",
+    tool = "verific",
     deps = [":br_fifo_test_harness"],
 )
 
@@ -40,6 +41,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_fifo_flops_tb_elab_test",
+    tool = "verific",
     deps = [":br_fifo_flops_tb"],
 )
 
@@ -113,6 +115,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_fifo_flops_push_credit_tb_elab_test",
+    tool = "verific",
     deps = [":br_fifo_flops_push_credit_tb"],
 )
 
@@ -164,6 +167,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_fifo_shared_dynamic_flops_tb_elab_test",
+    tool = "verific",
     deps = [":br_fifo_shared_dynamic_flops_tb"],
 )
 
@@ -214,6 +218,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_fifo_shared_dynamic_flops_push_credit_tb_elab_test",
+    tool = "verific",
     deps = [":br_fifo_shared_dynamic_flops_push_credit_tb"],
 )
 

--- a/flow/fpv/arb/BUILD.bazel
+++ b/flow/fpv/arb/BUILD.bazel
@@ -136,6 +136,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_arb_rr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_arb_rr_fpv_monitor"],
 )
 

--- a/flow/fpv/arb/BUILD.bazel
+++ b/flow/fpv/arb/BUILD.bazel
@@ -38,6 +38,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_arb_fixed_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_arb_fixed_fpv_monitor"],
 )
 
@@ -86,6 +87,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_arb_lru_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_arb_lru_fpv_monitor"],
 )
 

--- a/flow/fpv/demux/BUILD.bazel
+++ b/flow/fpv/demux/BUILD.bazel
@@ -38,6 +38,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_demux_select_unstable_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_demux_select_unstable_fpv_monitor"],
 )
 
@@ -99,6 +100,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_demux_select_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_demux_select_fpv_monitor"],
 )
 

--- a/flow/fpv/mux/BUILD.bazel
+++ b/flow/fpv/mux/BUILD.bazel
@@ -38,6 +38,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_mux_fixed_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_mux_fixed_fpv_monitor"],
 )
 
@@ -100,6 +101,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_mux_lru_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_mux_lru_fpv_monitor"],
 )
 
@@ -162,6 +164,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_mux_rr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_mux_rr_fpv_monitor"],
 )
 
@@ -223,6 +226,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_mux_select_unstable_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_mux_select_unstable_fpv_monitor"],
 )
 
@@ -284,6 +288,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_mux_select_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_mux_select_fpv_monitor"],
 )
 
@@ -345,6 +350,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_mux_fixed_stable_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_mux_fixed_stable_fpv_monitor"],
 )
 
@@ -411,6 +417,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_mux_lru_stable_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_mux_lru_stable_fpv_monitor"],
 )
 
@@ -477,6 +484,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_mux_rr_stable_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_mux_rr_stable_fpv_monitor"],
 )
 

--- a/flow/fpv/reg/BUILD.bazel
+++ b/flow/fpv/reg/BUILD.bazel
@@ -37,6 +37,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_reg_both_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_reg_both_fpv_monitor"],
 )
 
@@ -92,6 +93,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_reg_fwd_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_reg_fwd_fpv_monitor"],
 )
 
@@ -147,6 +149,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_reg_rev_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_reg_rev_fpv_monitor"],
 )
 

--- a/flow/fpv/serializer/BUILD.bazel
+++ b/flow/fpv/serializer/BUILD.bazel
@@ -30,6 +30,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_serializer_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_serializer_fpv_monitor"],
 )
 
@@ -73,6 +74,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_deserializer_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_flow_deserializer_fpv_monitor"],
 )
 

--- a/lfsr/rtl/BUILD.bazel
+++ b/lfsr/rtl/BUILD.bazel
@@ -50,5 +50,6 @@ verilog_library(
 verilog_elab_test(
     name = "br_lfsr_taps_elab_test",
     defines = ["BR_ASSERT_ON"],
+    tool = "verific",
     deps = [":br_lfsr_taps"],
 )

--- a/lfsr/sim/BUILD.bazel
+++ b/lfsr/sim/BUILD.bazel
@@ -30,6 +30,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_lfsr_tb_elab_test",
+    tool = "verific",
     deps = [":br_lfsr_tb"],
 )
 

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -64,11 +64,13 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_unused_tb_elab_test",
+    tool = "verific",
     deps = [":br_unused_tb"],
 )
 
 verilog_lint_test(
     name = "br_unused_tb_lint_test",
+    tool = "ascentlint",
     visibility = ["//visibility:public"],
     deps = [":br_unused_tb"],
 )
@@ -91,11 +93,13 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_tieoff_tb_elab_test",
+    tool = "verific",
     deps = [":br_tieoff_tb"],
 )
 
 verilog_lint_test(
     name = "br_tieoff_tb_lint_test",
+    tool = "ascentlint",
     deps = [":br_tieoff_tb"],
 )
 
@@ -113,11 +117,13 @@ verilog_elab_test(
         "BR_ASSERT_ON",
         "BR_ENABLE_FPV",
     ],
+    tool = "verific",
     deps = [":br_asserts_test"],
 )
 
 verilog_elab_test(
     name = "br_asserts_elab_noassert_test",
+    tool = "verific",
     deps = [":br_asserts_test"],
 )
 
@@ -135,12 +141,14 @@ verilog_elab_test(
         "BR_ENABLE_FPV",
         "BR_ENABLE_IMPL_CHECKS",
     ],
+    tool = "verific",
     deps = [":br_asserts_internal_test"],
 )
 
 verilog_elab_test(
     name = "br_asserts_elab_internal_no_impl_test",
     defines = ["BR_ASSERT_ON"],
+    tool = "verific",
     deps = [":br_asserts_internal_test"],
 )
 
@@ -150,11 +158,13 @@ verilog_elab_test(
         "BR_ASSERT_ON",
         "BR_DISABLE_INTG_CHECKS",
     ],
+    tool = "verific",
     deps = [":br_asserts_internal_test"],
 )
 
 verilog_elab_test(
     name = "br_asserts_internal_elab_noassert_test",
+    tool = "verific",
     deps = [":br_asserts_internal_test"],
 )
 
@@ -171,6 +181,7 @@ verilog_library(
 verilog_elab_test(
     name = "br_gates_elab_test",
     defines = ["BR_ASSERT_ON"],
+    tool = "verific",
     deps = [":br_gates_test"],
 )
 
@@ -188,11 +199,13 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_assign_elab_test",
+    tool = "verific",
     deps = [":br_assign_test"],
 )
 
 verilog_lint_test(
     name = "br_assign_lint_test",
+    tool = "ascentlint",
     visibility = ["//visibility:public"],
     deps = [":br_assign_test"],
 )

--- a/misc/sim/BUILD.bazel
+++ b/misc/sim/BUILD.bazel
@@ -24,5 +24,6 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_test_driver_elab_test",
+    tool = "verific",
     deps = [":br_test_driver"],
 )

--- a/multi_xfer/fpv/BUILD.bazel
+++ b/multi_xfer/fpv/BUILD.bazel
@@ -30,6 +30,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_multi_xfer_reg_fwd_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_multi_xfer_reg_fwd_fpv_monitor"],
 )
 
@@ -64,6 +65,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_multi_xfer_distributor_rr_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_multi_xfer_distributor_rr_fpv_monitor"],
 )
 

--- a/multi_xfer/sim/BUILD.bazel
+++ b/multi_xfer/sim/BUILD.bazel
@@ -29,6 +29,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_multi_xfer_reg_fwd_tb_elab_test",
+    tool = "verific",
     deps = [":br_multi_xfer_reg_fwd_tb"],
 )
 

--- a/mux/sim/BUILD.bazel
+++ b/mux/sim/BUILD.bazel
@@ -29,6 +29,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_mux_bin_tb_elab_test",
+    tool = "verific",
     top = "br_mux_bin_tb",
     deps = [
         ":br_mux_bin_tb",

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -35,5 +35,6 @@ verilog_library(
 verilog_elab_test(
     name = "br_math_pkg_elab_test",
     defines = ["BR_ASSERT_ON"],
+    tool = "verific",
     deps = [":br_math_pkg_tb"],
 )

--- a/ram/fpv/chipstack/BUILD.bazel
+++ b/ram/fpv/chipstack/BUILD.bazel
@@ -26,6 +26,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_ram_initializer_gen_sva_monitor_elab_test",
+    tool = "verific",
     top = "br_ram_initializer",
     deps = [":br_ram_initializer_gen_sva_monitor"],
 )

--- a/ram/sim/BUILD.bazel
+++ b/ram/sim/BUILD.bazel
@@ -29,12 +29,14 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_ram_flops_1r1w_tb_elab_test",
+    tool = "verific",
     deps = [":br_ram_flops_1r1w_tb"],
 )
 
 verilog_elab_test(
     name = "br_ram_flops_1r1w_tb_mock_elab_test",
     params = {"EnableMock": "1"},
+    tool = "verific",
     deps = [":br_ram_flops_1r1w_tb"],
 )
 

--- a/ram/sim/chipstack/BUILD.bazel
+++ b/ram/sim/chipstack/BUILD.bazel
@@ -26,6 +26,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_ram_initializer_gen_unittest_elab_test",
+    tool = "verific",
     deps = [":br_ram_initializer_gen_unittest"],
 )
 

--- a/shift/sim/BUILD.bazel
+++ b/shift/sim/BUILD.bazel
@@ -29,6 +29,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_shift_rotate_tb_elab_test",
+    tool = "verific",
     deps = [":br_shift_rotate_tb"],
 )
 
@@ -65,6 +66,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_shift_right_tb_elab_test",
+    tool = "verific",
     deps = [":br_shift_right_tb"],
 )
 
@@ -97,6 +99,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_shift_left_tb_elab_test",
+    tool = "verific",
     deps = [":br_shift_left_tb"],
 )
 

--- a/tracker/fpv/BUILD.bazel
+++ b/tracker/fpv/BUILD.bazel
@@ -31,6 +31,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_tracker_freelist_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_tracker_freelist_fpv_monitor"],
 )
 
@@ -85,6 +86,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_tracker_linked_list_ctrl_fpv_monitor_elab_test",
+    tool = "verific",
     deps = [":br_tracker_linked_list_ctrl_fpv_monitor"],
 )
 

--- a/tracker/sim/BUILD.bazel
+++ b/tracker/sim/BUILD.bazel
@@ -29,6 +29,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_tracker_freelist_tb_elab_test",
+    tool = "verific",
     deps = [":br_tracker_freelist_tb"],
 )
 
@@ -69,6 +70,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_tracker_linked_list_ctrl_tb_elab_test",
+    tool = "verific",
     deps = [":br_tracker_linked_list_ctrl_tb"],
 )
 
@@ -109,6 +111,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_tracker_reorder_buffer_flops_tb_elab_test",
+    tool = "verific",
     deps = [":br_tracker_reorder_buffer_flops_tb"],
 )
 


### PR DESCRIPTION
* Make `tool` mandatory for the core rules (`rule_verilog_elab_test`, `rule_verilog_lint_test`, `rule_verilog_fpv_test`, `rule_verilog_sim_test`, `rule_verilog_fpv_sandbox`) and remove defaults on the first level macros
* List out specific tools that specifically require licenses (`ascentlint`, `jg`, `vcf`, `vcs`, `xrun`), rather than categories of tests (`elab`, `lint`, `sim`, `fpv`)
* Fix `BUILD.bazel` files that use `verilog_elab_test` directly by passing `tool = "verific"`

The elab and lint test sweep macros still default elab tool to verific and lint tool to ascentlint