### PR TITLE
Add br_flow_xbar_fixed FPV

### DIFF
--- a/flow/fpv/xbar/BUILD.bazel
+++ b/flow/fpv/xbar/BUILD.bazel
@@ -1,0 +1,102 @@
+# Copyright 2024-2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_fpv_test_tools_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# Basic reg FV checker
+verilog_library(
+    name = "br_flow_xbar_basic_fpv_monitor",
+    srcs = ["br_flow_xbar_basic_fpv_monitor.sv"],
+)
+
+# Bedrock-RTL Flow-Controlled Crossbar (Fixed Priority Arbitration)
+
+verilog_library(
+    name = "br_flow_xbar_fixed_fpv_monitor",
+    srcs = ["br_flow_xbar_fixed_fpv_monitor.sv"],
+    deps = [
+        "br_flow_xbar_basic_fpv_monitor",
+        "//flow/rtl:br_flow_xbar_fixed",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_xbar_fixed_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_flow_xbar_fixed_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_flow_xbar_fixed_test_suite",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+        ): [
+            ("0", "0", "1"),
+            ("0", "1", "0"),
+            ("0", "1", "1"),
+            ("1", "0", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumPopFlows": [
+            "2",
+            "3",
+            "4",
+        ],
+        "NumPushFlows": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RegisterDemuxOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "3",
+            "4",
+        ],
+    },
+    tools = {
+        "jg": "br_flow_xbar_fixed_fpv.jg.tcl",
+        "vcf": "",
+    },
+    top = "br_flow_xbar_fixed",
+    deps = [":br_flow_xbar_fixed_fpv_monitor"],
+)

--- a/flow/fpv/xbar/br_flow_xbar_basic_fpv_monitor.sv
+++ b/flow/fpv/xbar/br_flow_xbar_basic_fpv_monitor.sv
@@ -100,6 +100,7 @@ module br_flow_xbar_basic_fpv_monitor #(
   end
 
   // ----------Data integrity Check----------
+  // data from same src/dest pair should be in order
   jasper_scoreboard_3 #(
       .CHUNK_WIDTH(Width),
       .IN_CHUNKS(1),

--- a/flow/fpv/xbar/br_flow_xbar_basic_fpv_monitor.sv
+++ b/flow/fpv/xbar/br_flow_xbar_basic_fpv_monitor.sv
@@ -100,7 +100,7 @@ module br_flow_xbar_basic_fpv_monitor #(
   end
 
   // ----------Data integrity Check----------
-  // data from same src/dest pair should be in order
+  // data from same src/dest pair should be in order.
   jasper_scoreboard_3 #(
       .CHUNK_WIDTH(Width),
       .IN_CHUNKS(1),

--- a/flow/fpv/xbar/br_flow_xbar_basic_fpv_monitor.sv
+++ b/flow/fpv/xbar/br_flow_xbar_basic_fpv_monitor.sv
@@ -1,0 +1,118 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Basic checker of br_flow_reg
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_flow_xbar_basic_fpv_monitor #(
+    parameter int NumPushFlows = 2,
+    parameter int NumPopFlows = 2,
+    parameter int Width = 1,
+    parameter bit RegisterDemuxOutputs = 0,
+    parameter bit RegisterPopOutputs = 0,
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    localparam int PushDestIdWidth = $clog2(NumPushFlows),
+    localparam int DestIdWidth = $clog2(NumPopFlows)
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [NumPushFlows-1:0] push_ready,
+    input logic [NumPushFlows-1:0] push_valid,
+    input logic [NumPushFlows-1:0][Width-1:0] push_data,
+    input logic [NumPushFlows-1:0][DestIdWidth-1:0] push_dest_id,
+
+    input logic [NumPopFlows-1:0] pop_ready,
+    input logic [NumPopFlows-1:0] pop_valid,
+    input logic [NumPopFlows-1:0][Width-1:0] pop_data,
+
+    input logic [PushDestIdWidth-1:0] fv_push_id,
+    input logic [DestIdWidth-1:0] fv_pop_id
+);
+
+  localparam int Latency = RegisterDemuxOutputs + RegisterPopOutputs;
+  // when push_valid & push_ready from fv_push_id are sending to fv_pop_id
+  logic fv_push_vr;
+  logic fv_pop_vr;
+
+  assign fv_push_vr = push_valid[fv_push_id] && push_ready[fv_push_id]
+                      && (push_dest_id[fv_push_id] == fv_pop_id);
+  assign fv_pop_vr = pop_valid[fv_pop_id] && pop_ready[fv_pop_id]
+                     && (pop_data[fv_pop_id][PushDestIdWidth-1:0] == fv_push_id);
+
+  // ----------FV assumptions----------
+  for (genvar i = 0; i < NumPushFlows; i++) begin : gen_push
+    `BR_ASSUME(push_dest_id_legal_a, push_valid[i] |-> push_dest_id[i] < NumPopFlows)
+    // color lower bits of push_data from each push port
+    // e.g: if NumPushFlows = 4:
+    // push_data[0][1:0] == 2'b00
+    // push_data[1][1:0] == 2'b01
+    // push_data[2][1:0] == 2'b10
+    // push_data[3][1:0] == 2'b11
+    // but higher bits can be random value
+    `BR_ASSUME(color_push_data_a, push_valid[i] |-> push_data[i][PushDestIdWidth-1:0] == i)
+    if (EnableAssertPushValidStability) begin : gen_push_valid
+      `BR_ASSUME(push_valid_stable_a, push_valid[i] && !push_ready[i] |=> push_valid[i])
+      `BR_ASSUME(push_dest_id_stable_a,
+                 push_valid[i] && !push_ready[i] |=> $stable(push_dest_id[i]))
+    end
+    if (EnableAssertPushDataStability) begin : gen_push_data
+      `BR_ASSUME(push_data_stable_a, push_valid[i] && !push_ready[i] |=> $stable(push_data[i]))
+    end
+  end
+
+  for (genvar j = 0; j < NumPopFlows; j++) begin : gen_pop
+    `BR_ASSUME(pop_ready_liveness_a, s_eventually (pop_ready[j]))
+  end
+
+  // ----------Sanity Check----------
+  // if RegisterPopOutputs = 0, pop_valid/pop_data come directly from the muxes and may be unstable
+  if (EnableAssertPushValidStability && RegisterPopOutputs) begin : gen_pop_valid
+    `BR_ASSERT(pop_valid_stable_a,
+               pop_valid[fv_pop_id] && !pop_ready[fv_pop_id] |=> pop_valid[fv_pop_id])
+  end
+  if (EnableAssertPushDataStability && RegisterPopOutputs) begin : gen_pop_data
+    `BR_ASSERT(pop_data_stable_a,
+               pop_valid[fv_pop_id] && !pop_ready[fv_pop_id] |=> $stable(pop_data[fv_pop_id]))
+  end
+
+  // If RegisterDemuxOutputs = 1, registers are inserted between the demux and mux to break up the
+  // timing path, increasing the cut-through latency by 1.
+  if (RegisterDemuxOutputs | RegisterPopOutputs) begin : gen_lat
+    `BR_ASSERT(pop_valid_forward_progress_a, |push_valid |-> ##Latency |pop_valid)
+  end else begin : gen_lat0
+    `BR_ASSERT(pop_valid_forward_progress_a, |push_valid |-> |pop_valid)
+  end
+
+  // ----------Data integrity Check----------
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(Width),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(NumPushFlows + Latency)
+  ) scoreboard (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(fv_push_vr),
+      .incoming_data(push_data[fv_push_id]),
+      .outgoing_vld(fv_pop_vr),
+      .outgoing_data(pop_data[fv_pop_id])
+  );
+
+endmodule : br_flow_xbar_basic_fpv_monitor

--- a/flow/fpv/xbar/br_flow_xbar_fixed_fpv.jg.tcl
+++ b/flow/fpv/xbar/br_flow_xbar_fixed_fpv.jg.tcl
@@ -1,0 +1,24 @@
+# Copyright 2024-2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# TODO: disable covers for now due to many unreachable covers
+cover -disable {*}
+
+# prove command
+prove -all

--- a/flow/fpv/xbar/br_flow_xbar_fixed_fpv_monitor.sv
+++ b/flow/fpv/xbar/br_flow_xbar_fixed_fpv_monitor.sv
@@ -1,0 +1,125 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Basic checker of br_flow_reg
+
+`include "br_asserts.svh"
+`include "br_fv.svh"
+
+module br_flow_xbar_fixed_fpv_monitor #(
+    // The number of input flows. Must be >=2.
+    parameter int NumPushFlows = 2,
+    // The number of output flows. Must be >=2.
+    parameter int NumPopFlows = 2,
+    // The width of the data bus.
+    parameter int Width = 1,
+    // If 1, registers are inserted between the demux and mux to break up the
+    // timing path, increasing the cut-through latency by 1. Note that this
+    // results in NumPushFlows x NumPopFlows x Width bits of registers being
+    // inserted.
+    parameter bit RegisterDemuxOutputs = 0,
+    // If 1, registers are inserted at the output of the muxes, ensuring that
+    // pop_valid/pop_data come directly from registers.
+    // If 0, pop_valid/pop_data come directly from the muxes and may be unstable.
+    parameter bit RegisterPopOutputs = 0,
+    // If 1, cover that the push_ready signal can be backpressured.
+    // If 0, assert that push backpressure is not possible.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable.
+    // Otherwise, cover that push_valid can be unstable.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push_data is stable.
+    // Otherwise, cover that push_data can be unstable.
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, assert that push_valid is 1 and all intermediate
+    // register stages are empty at end of simulation.
+    parameter bit EnableAssertFinalNotValid = 1,
+
+    localparam int DestIdWidth = $clog2(NumPopFlows)
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [NumPushFlows-1:0] push_ready,
+    input logic [NumPushFlows-1:0] push_valid,
+    input logic [NumPushFlows-1:0][Width-1:0] push_data,
+    input logic [NumPushFlows-1:0][DestIdWidth-1:0] push_dest_id,
+
+    input logic [NumPopFlows-1:0] pop_ready,
+    input logic [NumPopFlows-1:0] pop_valid,
+    input logic [NumPopFlows-1:0][Width-1:0] pop_data,
+
+    // RTL internal signals
+    input logic [NumPopFlows-1:0][NumPushFlows-1:0] grant
+);
+
+  // ----------FV Modeling Code----------
+  localparam int PushDestIdWidth = $clog2(NumPushFlows);
+  logic [$clog2(NumPushFlows)-1:0] i, j;
+  logic push_valid_i;
+  logic push_valid_j;
+  // pick a random pair of input/outout flow to check
+  logic [PushDestIdWidth-1:0] fv_push_id;
+  logic [DestIdWidth-1:0] fv_pop_id;
+  `BR_ASSUME(fv_push_id_stable_a, $stable(fv_push_id) && fv_push_id < NumPushFlows)
+  `BR_ASSUME(fv_pop_id_stable_a, $stable(fv_pop_id) && fv_pop_id < NumPopFlows)
+
+  `BR_FV_2RAND_IDX(i, j, NumPushFlows)
+  assign push_valid_i = push_valid[i] && (push_dest_id[i] == fv_pop_id);
+  assign push_valid_j = push_valid[j] && (push_dest_id[j] == fv_pop_id);
+
+  // ----------Instantiate basic checks----------
+  br_flow_xbar_basic_fpv_monitor #(
+      .NumPushFlows(NumPushFlows),
+      .NumPopFlows(NumPopFlows),
+      .Width(Width),
+      .RegisterDemuxOutputs(RegisterDemuxOutputs),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .push_dest_id,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .fv_push_id,
+      .fv_pop_id
+  );
+
+  // ----------FV assertions----------
+  if (RegisterDemuxOutputs) begin : gen_lat
+    `BR_ASSERT(strict_priority_a, (i < j) && push_valid_i && push_valid_j |=> !grant[fv_pop_id][j])
+  end else begin : gen_lat0
+    `BR_ASSERT(strict_priority_a, (i < j) && push_valid_i && push_valid_j |-> !grant[fv_pop_id][j])
+  end
+
+endmodule : br_flow_xbar_fixed_fpv_monitor
+
+bind br_flow_xbar_fixed br_flow_xbar_fixed_fpv_monitor #(
+    .NumPushFlows(NumPushFlows),
+    .NumPopFlows(NumPopFlows),
+    .Width(Width),
+    .RegisterDemuxOutputs(RegisterDemuxOutputs),
+    .RegisterPopOutputs(RegisterPopOutputs),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertPushDataStability(EnableAssertPushDataStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);


### PR DESCRIPTION
All parameter sweep got full proof.
Data order is only maintained if data is coming from the same source to same destination. (e.g: push[0] to pop[1])
Data from other src/dest pair can be popped in any order, as long as the data is not dropped or altered.
