### PR TITLE
disable AXI ABVIP assertions in amba_timing_slice

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -37,8 +37,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_default_target_test_suite",
-    # TODO: in debug stage now
-    gui = True,
     tools = {
         "jg": "",
         "vcf": "",
@@ -69,8 +67,6 @@ br_verilog_fpv_test_tools_suite(
     elab_opts = [
         "-parameter MaxOutstandingReqs 4",
     ],
-    # TODO: in debug stage now
-    gui = True,
     tools = {
         "jg": "br_amba_axi2axil_fpv.jg.tcl",
         "vcf": "",
@@ -98,8 +94,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_split_test_suite",
-    # TODO: in debug stage now
-    gui = True,
     tools = {
         "jg": "",
         "vcf": "",
@@ -130,7 +124,7 @@ br_verilog_fpv_test_tools_suite(
     # TODO: in debug stage now
     gui = True,
     tools = {
-        "jg": "",
+        "jg": "br_amba_axi_timing_slice_fpv.jg.tcl",
         "vcf": "",
     },
     top = "br_amba_axi_timing_slice",
@@ -156,10 +150,8 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_timing_slice_test_suite",
-    # TODO: in debug stage now
-    gui = True,
     tools = {
-        "jg": "",
+        "jg": "br_amba_axil_timing_slice_fpv.jg.tcl",
         "vcf": "",
     },
     top = "br_amba_axil_timing_slice",

--- a/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
@@ -1,0 +1,26 @@
+# Copyright 2024-2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# target ar/aw/w ready won't backpressure
+assert -disable <embedded>::br_amba_axi_timing_slice.monitor.target.genPropChksRDInf.genNoRdTblOverflow.genSlv.slave_ar_rd_tbl_no_overflow
+assert -disable <embedded>::br_amba_axi_timing_slice.monitor.target.genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow
+assert -disable <embedded>::br_amba_axi_timing_slice.monitor.target.genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow
+
+# prove command
+prove -all

--- a/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
@@ -1,0 +1,26 @@
+# Copyright 2024-2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# target ar/aw/w ready won't backpressure
+assert -disable <embedded>::br_amba_axil_timing_slice.monitor.target.genPropChksRDInf.genNoRdTblOverflow.genSlv.slave_ar_rd_tbl_no_overflow
+assert -disable <embedded>::br_amba_axil_timing_slice.monitor.target.genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow
+assert -disable <embedded>::br_amba_axil_timing_slice.monitor.target.genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow
+
+# prove command
+prove -all

--- a/amba/fpv/br_amba_axil_timing_slice_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil_timing_slice_fpv_monitor.sv
@@ -104,7 +104,7 @@ module br_amba_axil_timing_slice_fpv_monitor #(
       .awprot  (target_awprot),
       .awid    (),
       .awlen   (),
-      .awsize  (),                // (DataWidth> 8) ? $clog2(DataWidth/8) : 1
+      .awsize  (),
       .awburst (),
       .awlock  (),
       .awcache (),

--- a/amba/rtl/br_amba_axil_split.sv
+++ b/amba/rtl/br_amba_axil_split.sv
@@ -156,7 +156,7 @@ module br_amba_axil_split #(
   // AXI handshake signals
   assign ar_handshake_valid = root_arvalid && root_arready;
   assign r_handshake_valid = root_rvalid && root_rready;
-  assign aw_handshake_valid = root_awvalid && root_wvalid;
+  assign aw_handshake_valid = root_awvalid && root_awready;
   assign b_handshake_valid = root_bvalid && root_bready;
 
   // ri lint_check_off INVALID_COMPARE

--- a/amba/rtl/br_amba_axil_split.sv
+++ b/amba/rtl/br_amba_axil_split.sv
@@ -156,7 +156,7 @@ module br_amba_axil_split #(
   // AXI handshake signals
   assign ar_handshake_valid = root_arvalid && root_arready;
   assign r_handshake_valid = root_rvalid && root_rready;
-  assign aw_handshake_valid = root_awvalid && root_awready;
+  assign aw_handshake_valid = root_awvalid && root_wvalid;
   assign b_handshake_valid = root_bvalid && root_bready;
 
   // ri lint_check_off INVALID_COMPARE


### PR DESCRIPTION
As discussed with @tbunker-openai , axi/axil_timing_slice target will not backpressure by itself.
Therefore, checks on ar/aw/w ready should drop when DUT is full will fail spuriously.
Disabled in FV.
