### PR TITLE
[DO NOT MERGE] temp PR to debug axil_msi

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -186,3 +186,32 @@ br_verilog_fpv_test_tools_suite(
     top = "br_amba_axil2apb",
     deps = [":br_amba_axil2apb_fpv_monitor"],
 )
+
+# Bedrock-RTL AXI4-Lite MSI Generator
+
+verilog_library(
+    name = "br_amba_axil_msi_fpv_monitor",
+    srcs = ["br_amba_axil_msi_fpv_monitor.sv"],
+    deps = [
+        "//amba/rtl:br_amba_axil_msi",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_amba_axil_msi_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_amba_axil_msi_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_amba_axil_msi_test_suite",
+    # TODO: in debug stage now
+    gui = True,
+    tools = {
+        "jg": "",
+        "vcf": "",
+    },
+    top = "br_amba_axil_msi",
+    deps = [":br_amba_axil_msi_fpv_monitor"],
+)

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -157,3 +157,32 @@ br_verilog_fpv_test_tools_suite(
     top = "br_amba_axil_timing_slice",
     deps = [":br_amba_axil_timing_slice_fpv_monitor"],
 )
+
+# Bedrock-RTL AXI4-Lite to APB Bridge
+
+verilog_library(
+    name = "br_amba_axil2apb_fpv_monitor",
+    srcs = ["br_amba_axil2apb_fpv_monitor.sv"],
+    deps = [
+        "//amba/rtl:br_amba_axil2apb",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_amba_axil2apb_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_amba_axil2apb_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_amba_axil2apb_test_suite",
+    # TODO: in debug stage now
+    gui = True,
+    tools = {
+        "jg": "",
+        "vcf": "",
+    },
+    top = "br_amba_axil2apb",
+    deps = [":br_amba_axil2apb_fpv_monitor"],
+)

--- a/amba/fpv/br_amba_axi_timing_slice_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_timing_slice_fpv_monitor.sv
@@ -122,7 +122,8 @@ module br_amba_axi_timing_slice_fpv_monitor #(
       .ARUSER_WIDTH(ARUserWidth),
       .WUSER_WIDTH(WUserWidth),
       .BUSER_WIDTH(BUserWidth),
-      .RUSER_WIDTH(RUserWidth)
+      .RUSER_WIDTH(RUserWidth),
+      .CONFIG_WDATA_MASKED(0)
   ) target (
       // Global signals
       .aclk    (clk),
@@ -190,7 +191,8 @@ module br_amba_axi_timing_slice_fpv_monitor #(
       .ARUSER_WIDTH(ARUserWidth),
       .WUSER_WIDTH(WUserWidth),
       .BUSER_WIDTH(BUserWidth),
-      .RUSER_WIDTH(RUserWidth)
+      .RUSER_WIDTH(RUserWidth),
+      .CONFIG_RDATA_MASKED(0)
   ) init (
       // Global signals
       .aclk    (clk),

--- a/amba/fpv/br_amba_axil2apb_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil2apb_fpv_monitor.sv
@@ -1,0 +1,148 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL AXI4-Lite to APB Bridge
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_amba_axil2apb_fpv_monitor #(
+    parameter int AddrWidth = 12,  // Must be at least 12
+    parameter int DataWidth = 32   // Must be at least 32
+) (
+    input clk,
+    input rst,  // Synchronous, active-high reset
+
+    // AXI4-Lite interface
+    input logic [            AddrWidth-1:0] awaddr,
+    input logic [br_amba::AxiProtWidth-1:0] awprot,
+    input logic                             awvalid,
+    input logic                             awready,
+    input logic [            DataWidth-1:0] wdata,
+    input logic [        (DataWidth/8)-1:0] wstrb,
+    input logic                             wvalid,
+    input logic                             wready,
+    input logic [br_amba::AxiRespWidth-1:0] bresp,
+    input logic                             bvalid,
+    input logic                             bready,
+    input logic [            AddrWidth-1:0] araddr,
+    input logic [br_amba::AxiProtWidth-1:0] arprot,
+    input logic                             arvalid,
+    input logic                             arready,
+    input logic [            DataWidth-1:0] rdata,
+    input logic [br_amba::AxiRespWidth-1:0] rresp,
+    input logic                             rvalid,
+    input logic                             rready,
+
+    // APB interface
+    input logic [            AddrWidth-1:0] paddr,
+    input logic                             psel,
+    input logic                             penable,
+    input logic [br_amba::ApbProtWidth-1:0] pprot,
+    input logic [        (DataWidth/8)-1:0] pstrb,
+    input logic                             pwrite,
+    input logic [            DataWidth-1:0] pwdata,
+    input logic [            DataWidth-1:0] prdata,
+    input logic                             pready,
+    input logic                             pslverr
+);
+
+  // AXI4-Lite interface
+  axi4_slave #(
+      .AXI4_LITE (1),
+      .ADDR_WIDTH(AddrWidth),
+      .DATA_WIDTH(DataWidth)
+  ) axi (
+      // Global signals
+      .aclk    (clk),
+      .aresetn (!rst),
+      .csysreq (1'b1),
+      .csysack (1'b1),
+      .cactive (1'b1),
+      // Write Address Channel
+      .awvalid (awvalid),
+      .awready (awready),
+      .awaddr  (awaddr),
+      .awprot  (awprot),
+      .awuser  (),
+      .awid    (),
+      .awlen   (),
+      .awsize  (),
+      .awburst (),
+      .awlock  (),
+      .awcache (),
+      .awqos   (),
+      .awregion(),
+      // Write Channel
+      .wvalid  (wvalid),
+      .wready  (wready),
+      .wdata   (wdata),
+      .wstrb   (wstrb),
+      .wuser   (),
+      .wlast   (),
+      // Write Response channel
+      .bvalid  (bvalid),
+      .bready  (bready),
+      .bresp   (bresp),
+      .buser   (),
+      .bid     (),
+      // Read Address Channel
+      .arvalid (arvalid),
+      .arready (arready),
+      .araddr  (araddr),
+      .arprot  (arprot),
+      .aruser  (),
+      .arid    (),
+      .arlen   (),
+      .arsize  (),
+      .arburst (),
+      .arlock  (),
+      .arcache (),
+      .arqos   (),
+      .arregion(),
+      // Read Channel
+      .rvalid  (rvalid),
+      .rready  (rready),
+      .rdata   (rdata),
+      .rresp   (rresp),
+      .ruser   (),
+      .rid     (),
+      .rlast   ()
+  );
+
+  // APB interface
+  apb4_master #(
+      .ABUS_WIDTH(AddrWidth),
+      .DBUS_WIDTH(DataWidth)
+  ) apb (
+      .pclk(clk),
+      .presetn(!rst),
+      .psel,
+      .penable,
+      .paddr,
+      .pwrite,
+      .pwdata,
+      .pstrb,
+      .pprot,
+      .pready,
+      .prdata,
+      .pslverr
+  );
+
+endmodule : br_amba_axil2apb_fpv_monitor
+
+bind br_amba_axil2apb br_amba_axil2apb_fpv_monitor #(
+    .AddrWidth(AddrWidth),
+    .DataWidth(DataWidth)
+) monitor (.*);

--- a/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
@@ -1,0 +1,148 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL AXI4-Lite MSI Generator
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_amba_axil_msi_fpv_monitor #(
+    parameter int AddrWidth = 40,  // must be at least 12
+    parameter int DataWidth = 64,  // must be 32 or 64
+    parameter int NumInterrupts = 2,  // must be at least 2
+    parameter int DeviceIdWidth = 16,  // must be less than or equal to AddrWidth
+    parameter int EventIdWidth = 16,  // must be less than or equal to DataWidth
+    parameter int ThrottleCntrWidth = 16,  // must be at least 1
+    localparam int StrobeWidth = (DataWidth + 7) / 8
+) (
+    input clk,
+    input rst,  // Synchronous, active-high reset
+
+    // Interrupt inputs
+    input logic [NumInterrupts-1:0] irq,
+
+    // MSI Configuration
+    input logic [AddrWidth-1:0] msi_base_addr,
+    input logic [NumInterrupts-1:0] msi_enable,
+    input logic [NumInterrupts-1:0][DeviceIdWidth-1:0] device_id_per_irq,
+    input logic [NumInterrupts-1:0][EventIdWidth-1:0] event_id_per_irq,
+
+    // Throttle configuration
+    input logic throttle_en,
+    input logic [ThrottleCntrWidth-1:0] throttle_cntr_threshold,
+
+    // Error output
+    input logic error,
+
+    // AXI4-Lite write-only initiator interface
+    input logic [            AddrWidth-1:0] init_awaddr,
+    input logic                             init_awvalid,
+    input logic                             init_awready,
+    input logic [            DataWidth-1:0] init_wdata,
+    input logic [          StrobeWidth-1:0] init_wstrb,
+    input logic                             init_wvalid,
+    input logic                             init_wready,
+    input logic [br_amba::AxiRespWidth-1:0] init_bresp,
+    input logic                             init_bvalid,
+    input logic                             init_bready
+);
+
+  // ----------FV modeling code----------
+  localparam int AddrWidthPadding = (AddrWidth - DeviceIdWidth) - 2;
+  localparam int DataWidthPadding = DataWidth - EventIdWidth;
+  localparam int EventIdStrobeWidth = (EventIdWidth + 7) / 8;
+  localparam int StrobeWidthPadding = StrobeWidth - EventIdStrobeWidth;
+
+  logic [NumInterrupts-1:0][  AddrWidth-1:0] fv_init_awaddr;
+  logic [NumInterrupts-1:0][  DataWidth-1:0] fv_init_wdata;
+  logic [NumInterrupts-1:0][StrobeWidth-1:0] fv_init_wstrb;
+
+  always_comb begin
+    for (int i = 0; i < NumInterrupts; i++) begin
+      fv_init_awaddr[i] = msi_base_addr + {{AddrWidthPadding{1'b0}}, device_id_per_irq[i], 2'b00};
+      fv_init_wdata[i]  = {{DataWidthPadding{1'b0}}, event_id_per_irq[i]};
+      fv_init_wstrb[i]  = {{StrobeWidthPadding{1'b0}}, {EventIdStrobeWidth{1'b1}}};
+    end
+  end
+
+  // ----------FV assumptions----------
+  // TODO
+  `BR_ASSUME(no_throttle_en_a, !throttle_en)
+  `BR_ASSUME(msi_enable_a, $stable(msi_enable))
+  `BR_ASSUME(msi_base_addr_a, $stable(msi_base_addr))
+  for (genvar n = 0; n < NumInterrupts; n++) begin : gen_asm
+    `BR_ASSUME(interrupt_data_stable_a,
+               irq[n] && !$rose(irq[n]) |-> $stable({device_id_per_irq[n], event_id_per_irq[n]}))
+  end
+
+  // ----------Data integrity Check----------
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(AddrWidth),
+      .IN_CHUNKS(NumInterrupts),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(2)
+  ) addr_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(irq & msi_enable),
+      .incoming_data(fv_init_awaddr),
+      .outgoing_vld(init_awvalid & init_awready),
+      .outgoing_data(init_awaddr)
+  );
+
+  // AXI4-Lite write-only initiator interface
+  axi4_slave #(
+      .AXI4_LITE (1),
+      .ADDR_WIDTH(AddrWidth),
+      .DATA_WIDTH(DataWidth)
+  ) axi (
+      // Global signals
+      .aclk   (clk),
+      .aresetn(!rst),
+      .csysreq(1'b1),
+      .csysack(1'b1),
+      .cactive(1'b1),
+      // Write Address Channel
+      .awvalid(init_awvalid),
+      .awready(init_awready),
+      .awaddr (init_awaddr),
+      .awprot ('d0),
+      // Write Channel
+      .wvalid (init_wvalid),
+      .wready (init_wready),
+      .wdata  (init_wdata),
+      .wstrb  (init_wstrb),
+      // Write Response channel
+      .bvalid (init_bvalid),
+      .bready (init_bready),
+      .bresp  (init_bresp),
+      // Read Address Channel
+      .arvalid('d0),
+      .arready('d0),
+      // Read Channel
+      .rvalid ('d0),
+      .rready ('d0)
+  );
+
+endmodule : br_amba_axil_msi_fpv_monitor
+
+bind br_amba_axil_msi br_amba_axil_msi_fpv_monitor #(
+    .AddrWidth(AddrWidth),
+    .DataWidth(DataWidth),
+    .NumInterrupts(NumInterrupts),
+    .DeviceIdWidth(DeviceIdWidth),
+    .EventIdWidth(EventIdWidth),
+    .ThrottleCntrWidth(ThrottleCntrWidth)
+) monitor (.*);

--- a/amba/rtl/BUILD.bazel
+++ b/amba/rtl/BUILD.bazel
@@ -92,7 +92,7 @@ verilog_library(
     deps = [
         ":br_amba_pkg",
         "//counter/rtl:br_counter_decr",
-        "//flow/rtl:br_flow_mux_rr",
+        "//flow/rtl:br_flow_mux_rr_stable",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
     ],

--- a/amba/rtl/br_amba_axil_msi.sv
+++ b/amba/rtl/br_amba_axil_msi.sv
@@ -127,18 +127,19 @@ module br_amba_axil_msi #(
       ~(fifo_push_ready & fifo_push_valid);
 
   // Use round-robin arbitration to select the next irq to send
-  br_flow_mux_rr #(
+  br_flow_mux_rr_stable #(
+      .RegisterPopReady(1),
       .NumFlows(NumInterrupts),
       .Width(FifoWidth)
-  ) br_flow_mux_rr (
+  ) br_flow_mux_rr_stable (
       .clk,
       .rst,
       .push_ready(fifo_push_ready),
       .push_valid(fifo_push_valid),
-      .push_data(fifo_push_data),
-      .pop_ready(fifo_pop_ready),
-      .pop_valid_unstable(fifo_pop_valid),
-      .pop_data_unstable(fifo_pop_data)
+      .push_data (fifo_push_data),
+      .pop_ready (fifo_pop_ready),
+      .pop_valid (fifo_pop_valid),
+      .pop_data  (fifo_pop_data)
   );
   generate
     for (genvar i = 0; i < NumInterrupts; i++) begin : gen_loop


### PR DESCRIPTION
run command: bazel test //amba/fpv:br_amba_axil_msi_test_suite_jg_fpv_test --test_env=DISPLAY=$DISPLAY --test_timeout=18000
You can look at this assertion: <embedded>::br_amba_axil_msi.monitor.axi.genStableChksWRInf.genAWStableChks.master_aw_awvalid_stable

Please ignore the 2 overflow assertions, aw/w_valid will always be high, as long as ready is not asserted yet.
