### PR TITLE
add amba APB related FV checker

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -121,8 +121,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_timing_slice_test_suite",
-    # TODO: in debug stage now
-    gui = True,
     tools = {
         "jg": "br_amba_axi_timing_slice_fpv.jg.tcl",
         "vcf": "",
@@ -156,4 +154,62 @@ br_verilog_fpv_test_tools_suite(
     },
     top = "br_amba_axil_timing_slice",
     deps = [":br_amba_axil_timing_slice_fpv_monitor"],
+)
+
+# Bedrock-RTL AXI4-Lite to APB Bridge
+
+verilog_library(
+    name = "br_amba_axil2apb_fpv_monitor",
+    srcs = ["br_amba_axil2apb_fpv_monitor.sv"],
+    deps = [
+        "//amba/rtl:br_amba_axil2apb",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_amba_axil2apb_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_amba_axil2apb_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_amba_axil2apb_test_suite",
+    # TODO: in debug stage now
+    gui = True,
+    tools = {
+        "jg": "",
+        "vcf": "",
+    },
+    top = "br_amba_axil2apb",
+    deps = [":br_amba_axil2apb_fpv_monitor"],
+)
+
+# Bedrock-RTL APB Timing Slice
+
+verilog_library(
+    name = "br_amba_apb_timing_slice_fpv_monitor",
+    srcs = ["br_amba_apb_timing_slice_fpv_monitor.sv"],
+    deps = [
+        "//amba/rtl:br_amba_apb_timing_slice",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_amba_apb_timing_slice_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_amba_apb_timing_slice_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_amba_apb_timing_slice_test_suite",
+    # TODO: in debug stage now
+    gui = True,
+    tools = {
+        "jg": "",
+        "vcf": "",
+    },
+    top = "br_amba_apb_timing_slice",
+    deps = [":br_amba_apb_timing_slice_fpv_monitor"],
 )

--- a/amba/fpv/br_amba_apb_timing_slice_fpv_monitor.sv
+++ b/amba/fpv/br_amba_apb_timing_slice_fpv_monitor.sv
@@ -1,0 +1,91 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL APB Timing Slice
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_amba_apb_timing_slice_fpv_monitor #(
+    parameter int AddrWidth = 12  // Must be at least 12
+) (
+    input clk,
+    input rst,  // Synchronous, active-high reset
+
+    // Upstream APB interface
+    input logic [            AddrWidth-1:0] paddr_in,
+    input logic                             psel_in,
+    input logic                             penable_in,
+    input logic [br_amba::ApbProtWidth-1:0] pprot_in,
+    input logic [                      3:0] pstrb_in,
+    input logic                             pwrite_in,
+    input logic [                     31:0] pwdata_in,
+    input logic [                     31:0] prdata_out,
+    input logic                             pready_out,
+    input logic                             pslverr_out,
+
+    // Downstream APB interface
+    input logic [            AddrWidth-1:0] paddr_out,
+    input logic                             psel_out,
+    input logic                             penable_out,
+    input logic [br_amba::ApbProtWidth-1:0] pprot_out,
+    input logic [                      3:0] pstrb_out,
+    input logic                             pwrite_out,
+    input logic [                     31:0] pwdata_out,
+    input logic [                     31:0] prdata_in,
+    input logic                             pready_in,
+    input logic                             pslverr_in
+);
+
+  // Upstream APB interface
+  apb4_master #(
+      .ABUS_WIDTH(AddrWidth)
+  ) upstream (
+      .pclk(clk),
+      .presetn(!rst),
+      .psel(psel_in),
+      .penable(penable_in),
+      .paddr(paddr_in),
+      .pwrite(pwrite_in),
+      .pwdata(pwdata_in),
+      .pstrb(pstrb_in),
+      .pprot(pprot_in),
+      .pready(pready_out),
+      .prdata(prdata_out),
+      .pslverr(pslverr_out)
+  );
+
+  // Downstream APB interface
+  apb4_slave #(
+      .ABUS_WIDTH(AddrWidth)
+  ) downstream (
+      .pclk(clk),
+      .presetn(!rst),
+      .psel(psel_out),
+      .penable(penable_out),
+      .paddr(paddr_out),
+      .pwrite(pwrite_out),
+      .pwdata(pwdata_out),
+      .pstrb(pstrb_out),
+      .pprot(pprot_out),
+      .pready(pready_in),
+      .prdata(prdata_in),
+      .pslverr(pslverr_in)
+  );
+
+endmodule : br_amba_apb_timing_slice_fpv_monitor
+
+bind br_amba_apb_timing_slice br_amba_apb_timing_slice_fpv_monitor #(
+    .AddrWidth(AddrWidth)
+) monitor (.*);

--- a/amba/fpv/br_amba_axi_timing_slice_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_timing_slice_fpv_monitor.sv
@@ -122,7 +122,8 @@ module br_amba_axi_timing_slice_fpv_monitor #(
       .ARUSER_WIDTH(ARUserWidth),
       .WUSER_WIDTH(WUserWidth),
       .BUSER_WIDTH(BUserWidth),
-      .RUSER_WIDTH(RUserWidth)
+      .RUSER_WIDTH(RUserWidth),
+      .CONFIG_WDATA_MASKED(0)
   ) target (
       // Global signals
       .aclk    (clk),
@@ -190,7 +191,8 @@ module br_amba_axi_timing_slice_fpv_monitor #(
       .ARUSER_WIDTH(ARUserWidth),
       .WUSER_WIDTH(WUserWidth),
       .BUSER_WIDTH(BUserWidth),
-      .RUSER_WIDTH(RUserWidth)
+      .RUSER_WIDTH(RUserWidth),
+      .CONFIG_RDATA_MASKED(0)
   ) init (
       // Global signals
       .aclk    (clk),

--- a/amba/fpv/br_amba_axil2apb_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil2apb_fpv_monitor.sv
@@ -1,0 +1,148 @@
+// Copyright 2024-2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL AXI4-Lite to APB Bridge
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_amba_axil2apb_fpv_monitor #(
+    parameter int AddrWidth = 12,  // Must be at least 12
+    parameter int DataWidth = 32   // Must be at least 32
+) (
+    input clk,
+    input rst,  // Synchronous, active-high reset
+
+    // AXI4-Lite interface
+    input logic [            AddrWidth-1:0] awaddr,
+    input logic [br_amba::AxiProtWidth-1:0] awprot,
+    input logic                             awvalid,
+    input logic                             awready,
+    input logic [            DataWidth-1:0] wdata,
+    input logic [        (DataWidth/8)-1:0] wstrb,
+    input logic                             wvalid,
+    input logic                             wready,
+    input logic [br_amba::AxiRespWidth-1:0] bresp,
+    input logic                             bvalid,
+    input logic                             bready,
+    input logic [            AddrWidth-1:0] araddr,
+    input logic [br_amba::AxiProtWidth-1:0] arprot,
+    input logic                             arvalid,
+    input logic                             arready,
+    input logic [            DataWidth-1:0] rdata,
+    input logic [br_amba::AxiRespWidth-1:0] rresp,
+    input logic                             rvalid,
+    input logic                             rready,
+
+    // APB interface
+    input logic [            AddrWidth-1:0] paddr,
+    input logic                             psel,
+    input logic                             penable,
+    input logic [br_amba::ApbProtWidth-1:0] pprot,
+    input logic [        (DataWidth/8)-1:0] pstrb,
+    input logic                             pwrite,
+    input logic [            DataWidth-1:0] pwdata,
+    input logic [            DataWidth-1:0] prdata,
+    input logic                             pready,
+    input logic                             pslverr
+);
+
+  // AXI4-Lite interface
+  axi4_master #(
+      .AXI4_LITE (1),
+      .ADDR_WIDTH(AddrWidth),
+      .DATA_WIDTH(DataWidth)
+  ) axi (
+      // Global signals
+      .aclk    (clk),
+      .aresetn (!rst),
+      .csysreq (1'b1),
+      .csysack (1'b1),
+      .cactive (1'b1),
+      // Write Address Channel
+      .awvalid (awvalid),
+      .awready (awready),
+      .awaddr  (awaddr),
+      .awprot  (awprot),
+      .awuser  (),
+      .awid    (),
+      .awlen   (),
+      .awsize  (),
+      .awburst (),
+      .awlock  (),
+      .awcache (),
+      .awqos   (),
+      .awregion(),
+      // Write Channel
+      .wvalid  (wvalid),
+      .wready  (wready),
+      .wdata   (wdata),
+      .wstrb   (wstrb),
+      .wuser   (),
+      .wlast   (),
+      // Write Response channel
+      .bvalid  (bvalid),
+      .bready  (bready),
+      .bresp   (bresp),
+      .buser   (),
+      .bid     (),
+      // Read Address Channel
+      .arvalid (arvalid),
+      .arready (arready),
+      .araddr  (araddr),
+      .arprot  (arprot),
+      .aruser  (),
+      .arid    (),
+      .arlen   (),
+      .arsize  (),
+      .arburst (),
+      .arlock  (),
+      .arcache (),
+      .arqos   (),
+      .arregion(),
+      // Read Channel
+      .rvalid  (rvalid),
+      .rready  (rready),
+      .rdata   (rdata),
+      .rresp   (rresp),
+      .ruser   (),
+      .rid     (),
+      .rlast   ()
+  );
+
+  // APB interface
+  apb4_slave #(
+      .ABUS_WIDTH(AddrWidth),
+      .DBUS_WIDTH(DataWidth)
+  ) apb (
+      .pclk(clk),
+      .presetn(!rst),
+      .psel,
+      .penable,
+      .paddr,
+      .pwrite,
+      .pwdata,
+      .pstrb,
+      .pprot,
+      .pready,
+      .prdata,
+      .pslverr
+  );
+
+endmodule : br_amba_axil2apb_fpv_monitor
+
+bind br_amba_axil2apb br_amba_axil2apb_fpv_monitor #(
+    .AddrWidth(AddrWidth),
+    .DataWidth(DataWidth)
+) monitor (.*);


### PR DESCRIPTION
run command:
bazel test //amba/fpv:br_amba_axil2apb_test_suite_jg_fpv_test --test_env=DISPLAY=$DISPLAY --test_timeout=18000
This is to reproduce the pstrb failure.

bazel test //amba/fpv:br_amba_apb_timing_slice_test_suite_jg_fpv_test --test_env=DISPLAY=$DISPLAY --test_timeout=18000
This is to reproduce downstream signals are not stable when pready is not high.