### PR TITLE
bazel: Disable sandbox only when waves is enabled

### DIFF
--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -523,6 +523,7 @@ def verilog_sim_test(tool, opts = [], tags = [], waves = False, **kwargs):
         tool = tool,
         opts = opts + extra_opts,
         tags = test_tags,
+        waves = waves,
         **kwargs
     )
 

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -491,7 +491,7 @@ rule_verilog_sim_test = rule(
     test = True,
 )
 
-def verilog_sim_test(tool, opts = [], tags = [], **kwargs):
+def verilog_sim_test(tool, opts = [], tags = [], waves = False, **kwargs):
     """Wraps rule_verilog_sim_test with a default tool and appends extra tags.
 
     The following extra tags are unconditionally appended to the list of tags:
@@ -504,11 +504,15 @@ def verilog_sim_test(tool, opts = [], tags = [], **kwargs):
         tool: The simulation tool to use.
         opts: Tool-specific options not covered by other arguments.
         tags: The tags to add to the test.
+        waves: Enable waveform dumping.
         **kwargs: Other arguments to pass to the rule_verilog_sim_test rule.
     """
 
     # Make sure we fail the test ASAP after any error occurs (assertion or otherwise).
     extra_opts = []
+    test_tags = tags + extra_tags("sim", tool)
+    if waves:
+        test_tags.append("no-sandbox")
     if tool == "vcs":
         # Make sure we fail the test if any assertions fail.
         extra_opts = ["-assert global_finish_maxfail=1+offending_values -error=TFIPC -error=PCWM-W -error=PCWM-L"]
@@ -518,7 +522,7 @@ def verilog_sim_test(tool, opts = [], tags = [], **kwargs):
     rule_verilog_sim_test(
         tool = tool,
         opts = opts + extra_opts,
-        tags = tags + extra_tags("sim", tool) + ["no-sandbox"],
+        tags = test_tags,
         **kwargs
     )
 

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -429,7 +429,7 @@ The following extra tags are unconditionally appended to the list of tags:
 <pre>
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_sim_test")
 
-verilog_sim_test(<a href="#verilog_sim_test-tool">tool</a>, <a href="#verilog_sim_test-opts">opts</a>, <a href="#verilog_sim_test-tags">tags</a>, <a href="#verilog_sim_test-kwargs">kwargs</a>)
+verilog_sim_test(<a href="#verilog_sim_test-tool">tool</a>, <a href="#verilog_sim_test-opts">opts</a>, <a href="#verilog_sim_test-tags">tags</a>, <a href="#verilog_sim_test-waves">waves</a>, <a href="#verilog_sim_test-kwargs">kwargs</a>)
 </pre>
 
 Wraps rule_verilog_sim_test with a default tool and appends extra tags.
@@ -449,6 +449,7 @@ The following extra tags are unconditionally appended to the list of tags:
 | <a id="verilog_sim_test-tool"></a>tool |  The simulation tool to use.   |  none |
 | <a id="verilog_sim_test-opts"></a>opts |  Tool-specific options not covered by other arguments.   |  `[]` |
 | <a id="verilog_sim_test-tags"></a>tags |  The tags to add to the test.   |  `[]` |
+| <a id="verilog_sim_test-waves"></a>waves |  Enable waveform dumping.   |  `False` |
 | <a id="verilog_sim_test-kwargs"></a>kwargs |  Other arguments to pass to the rule_verilog_sim_test rule.   |  none |
 
 


### PR DESCRIPTION
Disabling sandbox only when waves is enabled for the target. Ideally user should never check in a target with waves enabled. It should only used for debug purposes. I will remove all targets with `waves = True` in the internal repo