### PR TITLE
[amba] Allow AXI-Lite splitter to handle multiple address ranges

### DIFF
--- a/amba/rtl/BUILD.bazel
+++ b/amba/rtl/BUILD.bazel
@@ -242,6 +242,10 @@ br_verilog_elab_and_lint_test_suite(
             "4",
             "16",
         ],
+        "NumBranchAddrRanges": [
+            "1",
+            "2",
+        ],
     },
     deps = [":br_amba_axil_split"],
 )


### PR DESCRIPTION
In some cases, the addresses assigned to the branch won't fall into
a single contiguous address ranges. Allow the splitter to generalize
branch routing to arbitrary number of ranges.