### PR TITLE
Add br_amba_axil_msi FPV

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 The Bedrock-RTL Authors
+# Copyright 2025 The Bedrock-RTL Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -235,4 +235,31 @@ br_verilog_fpv_test_tools_suite(
     },
     top = "br_amba_atb_funnel",
     deps = [":br_amba_atb_funnel_fpv_monitor"],
+)
+
+# Bedrock-RTL AXI4-Lite MSI Generator
+
+verilog_library(
+    name = "br_amba_axil_msi_fpv_monitor",
+    srcs = ["br_amba_axil_msi_fpv_monitor.sv"],
+    deps = [
+        "//amba/rtl:br_amba_axil_msi",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_amba_axil_msi_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_amba_axil_msi_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_amba_axil_msi_test_suite",
+    tools = {
+        "jg": "br_amba_axil_msi_fpv.jg.tcl",
+        "vcf": "",
+    },
+    top = "br_amba_axil_msi",
+    deps = [":br_amba_axil_msi_fpv_monitor"],
 )

--- a/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
@@ -1,0 +1,25 @@
+# Copyright 2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# clock/reset set up
+clock clk
+reset rst
+get_design_info
+
+# aw/w valid won't backpressure
+assert -disable <embedded>::br_amba_axil_msi.monitor.axi.genPropChksWRInf.genNoWrTblOverflow.genMas.master_aw_wr_tbl_no_overflow
+assert -disable <embedded>::br_amba_axil_msi.monitor.axi.genPropChksWRInf.genNoWrDatTblOverflow.genMas.master_w_wr_tbl_no_overflow
+
+# prove command
+prove -all

--- a/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
@@ -1,0 +1,195 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL AXI4-Lite MSI Generator
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_amba_axil_msi_fpv_monitor #(
+    parameter int AddrWidth = 40,  // must be at least 12
+    parameter int DataWidth = 64,  // must be 32 or 64
+    parameter int NumInterrupts = 2,  // must be at least 2
+    parameter int DeviceIdWidth = 16,  // must be less than or equal to AddrWidth
+    parameter int EventIdWidth = 16,  // must be less than or equal to DataWidth
+    parameter int ThrottleCntrWidth = 16,  // must be at least 1
+    localparam int StrobeWidth = (DataWidth + 7) / 8
+) (
+    input clk,
+    input rst,  // Synchronous, active-high reset
+
+    // Interrupt inputs
+    input logic [NumInterrupts-1:0] irq,
+
+    // MSI Configuration
+    input logic [AddrWidth-1:0] msi_base_addr,
+    input logic [NumInterrupts-1:0] msi_enable,
+    input logic [NumInterrupts-1:0][DeviceIdWidth-1:0] device_id_per_irq,
+    input logic [NumInterrupts-1:0][EventIdWidth-1:0] event_id_per_irq,
+
+    // Throttle configuration
+    input logic throttle_en,
+    input logic [ThrottleCntrWidth-1:0] throttle_cntr_threshold,
+
+    // Error output
+    input logic error,
+
+    // AXI4-Lite write-only initiator interface
+    input logic [            AddrWidth-1:0] init_awaddr,
+    input logic                             init_awvalid,
+    input logic                             init_awready,
+    input logic [            DataWidth-1:0] init_wdata,
+    input logic [          StrobeWidth-1:0] init_wstrb,
+    input logic                             init_wvalid,
+    input logic                             init_wready,
+    input logic [br_amba::AxiRespWidth-1:0] init_bresp,
+    input logic                             init_bvalid,
+    input logic                             init_bready
+);
+
+  // ----------FV assumptions----------
+  `BR_ASSUME(throttle_en_stable_a, $stable(throttle_en))
+  `BR_ASSUME(throttle_cntr_stable_a, $stable(throttle_cntr_threshold)
+             && throttle_cntr_threshold != 'd0)
+  `BR_ASSUME(msi_enable_stable_a, $stable(msi_enable))
+  `BR_ASSUME(msi_base_addr_stable_a, $stable(msi_base_addr))
+  `BR_ASSUME(device_id_stable_a, $stable(device_id_per_irq))
+  `BR_ASSUME(event_id_stable_a, $stable(event_id_per_irq))
+
+  // ----------FV assertions----------
+  localparam int AddrWidthPadding = (AddrWidth - DeviceIdWidth) - 2;
+  localparam int DataWidthPadding = DataWidth - EventIdWidth;
+  localparam int EventIdStrobeWidth = (EventIdWidth + 7) / 8;
+  localparam int StrobeWidthPadding = StrobeWidth - EventIdStrobeWidth;
+
+  logic [NumInterrupts-1:0][AddrWidth-1:0] fv_init_awaddr;
+  logic [NumInterrupts-1:0][DataWidth-1:0] fv_init_wdata;
+  logic [NumInterrupts-1:0][StrobeWidth-1:0] fv_init_wstrb;
+  logic awaddr_match;
+  logic wdata_match;
+  logic wstrb_match;
+
+  always_comb begin
+    for (int i = 0; i < NumInterrupts; i++) begin
+      fv_init_awaddr[i] = msi_base_addr + {{AddrWidthPadding{1'b0}}, device_id_per_irq[i], 2'b00};
+      fv_init_wdata[i]  = {{DataWidthPadding{1'b0}}, event_id_per_irq[i]};
+      fv_init_wstrb[i]  = {{StrobeWidthPadding{1'b0}}, {EventIdStrobeWidth{1'b1}}};
+    end
+  end
+
+  // There is no 1-to-1 correspondence bwteen irq and AXI interface.
+  // irq can drop before it's sent out at AXI interface.
+  // as long as AXI won't send out spurious payload, it's fine
+  always_comb begin
+    awaddr_match = 1'b0;
+    wdata_match  = 1'b0;
+    wstrb_match  = 1'b0;
+    for (int i = 0; i < NumInterrupts; i++) begin
+      if (init_awvalid && (init_awaddr == fv_init_awaddr[i])) begin
+        awaddr_match = 1'b1;
+      end
+      if (init_wvalid && (init_wdata == fv_init_wdata[i])) begin
+        wdata_match = 1'b1;
+      end
+      if (init_wvalid && (init_wstrb == fv_init_wstrb[i])) begin
+        wstrb_match = 1'b1;
+      end
+    end
+  end
+
+  // device_id/event_id encoding check
+  `BR_ASSERT(awaddr_match_a, init_awvalid |-> awaddr_match)
+  `BR_ASSERT(wdata_match_a, init_wvalid |-> wdata_match)
+  `BR_ASSERT(wstrb_match_a, init_wvalid |-> wstrb_match)
+
+  // throttle check
+  logic [ThrottleCntrWidth-1:0] aw_throttle_cntr;
+  logic [ThrottleCntrWidth-1:0] w_throttle_cntr;
+  logic aw_in_progress;
+  logic w_in_progress;
+
+  always_ff @(posedge clk or posedge rst) begin
+    if (rst) begin
+      aw_throttle_cntr <= 'd0;
+    end else begin
+      if ($rose(init_awvalid) & throttle_en) begin
+        aw_throttle_cntr <= throttle_cntr_threshold - 'd1;
+      end else begin
+        aw_throttle_cntr <= aw_throttle_cntr != 'd0 ? aw_throttle_cntr - 'd1 : 'd0;
+      end
+    end
+  end
+
+  always_ff @(posedge clk or posedge rst) begin
+    if (rst) begin
+      w_throttle_cntr <= 'd0;
+    end else begin
+      if ($rose(init_wvalid) & throttle_en) begin
+        w_throttle_cntr <= throttle_cntr_threshold - 'd1;
+      end else begin
+        w_throttle_cntr <= w_throttle_cntr != 'd0 ? w_throttle_cntr - 'd1 : 'd0;
+      end
+    end
+  end
+
+  assign aw_in_progress = aw_throttle_cntr != 'd0;
+  assign w_in_progress  = w_throttle_cntr != 'd0;
+
+  `BR_ASSERT(awvalid_throttle_a, aw_in_progress |-> !$rose(init_awvalid))
+  `BR_ASSERT(wvalid_throttle_a, w_in_progress |-> !$rose(init_wvalid))
+
+  // AXI4-Lite write-only initiator interface
+  axi4_slave #(
+      .AXI4_LITE (1),
+      .ADDR_WIDTH(AddrWidth),
+      .DATA_WIDTH(DataWidth)
+  ) axi (
+      // Global signals
+      .aclk   (clk),
+      .aresetn(!rst),
+      .csysreq(1'b1),
+      .csysack(1'b1),
+      .cactive(1'b1),
+      // Write Address Channel
+      .awvalid(init_awvalid),
+      .awready(init_awready),
+      .awaddr (init_awaddr),
+      .awprot ('d0),
+      // Write Channel
+      .wvalid (init_wvalid),
+      .wready (init_wready),
+      .wdata  (init_wdata),
+      .wstrb  (init_wstrb),
+      // Write Response channel
+      .bvalid (init_bvalid),
+      .bready (init_bready),
+      .bresp  (init_bresp),
+      // Read Address Channel
+      .arvalid('d0),
+      .arready('d0),
+      // Read Channel
+      .rvalid ('d0),
+      .rready ('d0)
+  );
+
+endmodule : br_amba_axil_msi_fpv_monitor
+
+bind br_amba_axil_msi br_amba_axil_msi_fpv_monitor #(
+    .AddrWidth(AddrWidth),
+    .DataWidth(DataWidth),
+    .NumInterrupts(NumInterrupts),
+    .DeviceIdWidth(DeviceIdWidth),
+    .EventIdWidth(EventIdWidth),
+    .ThrottleCntrWidth(ThrottleCntrWidth)
+) monitor (.*);


### PR DESCRIPTION
1. there is no 1-to-1 correspondence between irq and AXI interface, so FV only checked AXI payload is not spurious.
2. throttle is checked.
3. AXI_LITE protocol compliance is checked.