### PR TITLE
Add br_ram_flops_tile different wr/rd clocks FPV

### DIFF
--- a/ram/fpv/BUILD.bazel
+++ b/ram/fpv/BUILD.bazel
@@ -227,3 +227,62 @@ br_verilog_fpv_test_tools_suite(
     top = "br_ram_flops_tile",
     deps = [":br_ram_flops_tile_fpv_monitor"],
 )
+
+# Bedrock-RTL Flop-RAM Tile (different wr/rd clocks)
+br_verilog_fpv_test_tools_suite(
+    name = "br_ram_flops_tile_2clk_test_suite",
+    elab_opts = [
+        "-parameter EnableBypass 0",
+        "-parameter UseStructuredGates 1",
+    ],
+    illegal_param_combinations = {
+        (
+            "Width",
+            "WordWidth",
+        ): [
+            ("1", "2"),
+            ("1", "3"),
+        ],
+    },
+    params = {
+        "Depth": [
+            "1",
+            "4",
+            "6",
+        ],
+        "EnablePartialWrite": [
+            "0",
+            "1",
+        ],
+        "EnableReset": [
+            "0",
+            "1",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+            "3",
+        ],
+        "NumWritePorts": [
+            "1",
+            "4",
+            "6",
+        ],
+        "Width": [
+            "1",
+            "6",
+            "12",
+        ],
+        "WordWidth": [
+            "1",
+            "2",
+            "3",
+        ],
+    },
+    tools = {
+        "jg": "br_ram_flops_tile_2clk_fpv.jg.tcl",
+        "vcf": "",
+    },
+    top = "br_ram_flops_tile",
+    deps = [":br_ram_flops_tile_fpv_monitor"],
+)

--- a/ram/fpv/br_ram_flops_tile_2clk_fpv.jg.tcl
+++ b/ram/fpv/br_ram_flops_tile_2clk_fpv.jg.tcl
@@ -13,22 +13,26 @@
 # limitations under the License.
 
 # clock/reset set up
-clock clk
 clock wr_clk -from 1 -to 10 -both_edges
 clock rd_clk -from 1 -to 10 -both_edges
-reset rst wr_rst rd_rst
+reset wr_rst rd_rst
 
 # wr/rd primary input signals only toggle w.r.t its clock
 clock -rate {wr_rst \
             wr_valid \
             wr_addr \
             wr_data \
-            wr_word_en} wr_clk
+            wr_word_en \
+            monitor.fv_addr} wr_clk
 clock -rate {rd_rst \
             rd_addr_valid \
             rd_addr \
             rd_data_valid \
-            rd_data} rd_clk
+            rd_data \
+            monitor.fv_addr} rd_clk
+
+#TODO
+cover -disable *
 
 # prove command
 prove -all

--- a/ram/fpv/br_ram_flops_tile_2clk_fpv.jg.tcl
+++ b/ram/fpv/br_ram_flops_tile_2clk_fpv.jg.tcl
@@ -31,8 +31,5 @@ clock -rate {rd_rst \
             rd_data \
             monitor.fv_addr} rd_clk
 
-#TODO
-cover -disable *
-
 # prove command
 prove -all


### PR DESCRIPTION
FV got full proof on all parameter sweep.
In this set up, wr_clk and rd_clk can have different phase as well as different ratios. 