### PR TITLE
eliminate count outputs that weren't coherent

### DIFF
--- a/tracker/rtl/BUILD.bazel
+++ b/tracker/rtl/BUILD.bazel
@@ -133,6 +133,7 @@ verilog_library(
     deps = [
         ":br_tracker_reorder",
         "//credit/rtl:br_credit_sender",
+        "//delay/rtl:br_delay",
         "//fifo/rtl:br_fifo_flops_push_credit",
         "//macros:br_asserts",
         "//macros:br_unused",

--- a/tracker/rtl/br_tracker_reorder_buffer_flops.sv
+++ b/tracker/rtl/br_tracker_reorder_buffer_flops.sv
@@ -28,8 +28,7 @@ module br_tracker_reorder_buffer_flops #(
     // additional cycle of latency.
     parameter bit RegisterPopOutputs = 0,
     // If 1, then assert unordered_resp_push_valid is low at the end of the test.
-    parameter bit EnableAssertFinalNotDeallocValid = 1,
-    localparam int EntryCountWidth = $clog2(NumEntries + 1)
+    parameter bit EnableAssertFinalNotDeallocValid = 1
 ) (
     input logic clk,
     input logic rst,
@@ -50,8 +49,7 @@ module br_tracker_reorder_buffer_flops #(
     output logic [DataWidth-1:0] reordered_resp_pop_data,
 
     // Count Information
-    output logic [EntryCountWidth-1:0] free_entry_count,
-    output logic [EntryCountWidth-1:0] allocated_entry_count
+    output logic resp_pending
 );
   localparam int MinEntryIdWidth = $clog2(NumEntries);
 
@@ -86,8 +84,7 @@ module br_tracker_reorder_buffer_flops #(
       .reordered_resp_pop_valid,
       .reordered_resp_pop_data,
       //
-      .free_entry_count,
-      .allocated_entry_count,
+      .resp_pending,
       //
       .ram_wr_addr,
       .ram_wr_valid,

--- a/tracker/sim/br_tracker_reorder_buffer_flops_tb.sv
+++ b/tracker/sim/br_tracker_reorder_buffer_flops_tb.sv
@@ -61,8 +61,7 @@ module br_tracker_reorder_buffer_flops_tb;
       .reordered_resp_pop_valid(reordered_resp_pop_valid),
       .reordered_resp_pop_data (reordered_resp_pop_data),
 
-      .free_entry_count(),
-      .allocated_entry_count()
+      .resp_pending()
   );
 
   // Clock generation


### PR DESCRIPTION
The entry count outputs weren't readily usable because they were not really coherent w.r.t. any of the external interfaces. Converted to a simple flag that indicates if the are responses outstanding.

Fix JAL-577.