### PR TITLE
Fix staging buffer in shared multi-FIFO pop

### DIFF
--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -219,6 +219,10 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
+        "TotalItemsIncludesStaged": [
+            "0",
+            "1",
+        ],
     },
     deps = [":br_fifo_staging_buffer"],
 )

--- a/fifo/rtl/internal/br_fifo_shared_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_pop_ctrl.sv
@@ -95,7 +95,8 @@ module br_fifo_shared_pop_ctrl #(
           .BufferDepth(StagingBufferDepth),
           .Width(Width),
           .RegisterPopOutputs(RegisterPopOutputs),
-          .RamReadLatency(RamReadLatency)
+          .RamReadLatency(RamReadLatency),
+          .TotalItemsIncludesStaged(0)
       ) br_fifo_staging_buffer (
           .clk,
           .rst,


### PR DESCRIPTION
The total_items input to the staging buffer is treated as inclusive of the items in the staging buffer itself (or inflight from the RAM). However, ram_items in the shared FIFO is actually exclusive of the staged entries. This causes the staging buffer to incorrectly believe no further items are available to stage, leading to underutilization of the staging buffer. Add a parameter to deal with this properly.