### PR TITLE
remove duplicated report_fv

### DIFF
--- a/arb/fpv/br_arb_fixed_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_fixed_fpv.vcf.tcl
@@ -28,4 +28,3 @@ sim_save_reset
 
 #run properties
 check_fv -block
-report_fv -list

--- a/arb/fpv/br_arb_lru_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_lru_fpv.vcf.tcl
@@ -37,4 +37,3 @@ report_fv
 
 fvtask special
 check_fv -block
-report_fv

--- a/arb/fpv/br_arb_multi_rr_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_multi_rr_fpv.vcf.tcl
@@ -39,4 +39,3 @@ report_fv
 
 fvtask special
 check_fv -block
-report_fv

--- a/arb/fpv/br_arb_pri_rr_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_pri_rr_fpv.vcf.tcl
@@ -34,8 +34,6 @@ fvdisable {special::*round_robin_a}
 #run properties
 fvtask standard
 check_fv -block
-report_fv
 
 fvtask special
 check_fv -block
-report_fv

--- a/arb/fpv/br_arb_rr_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_rr_fpv.vcf.tcl
@@ -38,4 +38,3 @@ report_fv
 
 fvtask special
 check_fv -block
-report_fv

--- a/arb/fpv/br_arb_weighted_rr_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_weighted_rr_fpv.vcf.tcl
@@ -40,8 +40,6 @@ fvdisable {special::*forward_progress_a}
 #run properties
 fvtask standard
 check_fv -block
-report_fv
 
 fvtask special
 check_fv -block
-report_fv


### PR DESCRIPTION
Due to default footer inside VCF flow, we don't need to add "report_fv" again.

```
    def tcl_footer(self) -> str:
        footer = ["report_fv -list"]
        if not self.gui:
            footer.append("exit")
        return "\n".join(footer)
```