### PR TITLE
Fix counter overflow in FIFO staging buffer

### DIFF
--- a/fifo/rtl/internal/br_fifo_staging_buffer.sv
+++ b/fifo/rtl/internal/br_fifo_staging_buffer.sv
@@ -121,6 +121,7 @@ module br_fifo_staging_buffer #(
   logic                        items_not_staged;
   logic                        push_valid;
   logic [           Width-1:0] push_data;
+  logic                        pop_valid_nonbypass;
 
   br_counter #(
       .MaxValue(BufferDepth),
@@ -144,7 +145,20 @@ module br_fifo_staging_buffer #(
   );
 
   assign pop_beat = pop_valid && pop_ready;
-  assign space_available = (staged_items < BufferDepth) || pop_ready;
+
+  if (RamReadLatency == 0) begin : gen_zero_lat_space_available
+    // If there is no read latency, the cut-through latency is always 0,
+    // so we can always accept more data if pop_ready=1
+    assign space_available = (staged_items < BufferDepth) || pop_ready;
+    `BR_UNUSED(pop_valid_nonbypass)
+  end else begin : gen_nonzero_lat_space_available
+    // If read latency is non-zero, we can't assume pop_ready means an item is being
+    // popped, since reads might still be inflight from the RAM.
+    // We have to check pop_valid instead. To ensure there is no combinational path from
+    // push_valid to push_ready, we need to check pop_valid_nonbypass signal, which omits
+    // the bypass path.
+    assign space_available = (staged_items < BufferDepth) || (pop_ready && pop_valid_nonbypass);
+  end
   if (TotalItemsIncludesStaged) begin : gen_items_not_staged_inclusive
     assign items_not_staged = TotalCountWidth'(staged_items) < total_items;
   end else begin : gen_items_not_staged_exclusive
@@ -179,6 +193,7 @@ module br_fifo_staging_buffer #(
   // Main Buffer Storage
   // ===================
   logic             internal_pop_valid;
+  logic             internal_pop_valid_nonbypass;
   logic             internal_pop_ready;
   logic [Width-1:0] internal_pop_data;
 
@@ -186,8 +201,9 @@ module br_fifo_staging_buffer #(
     // This can only be true if RegisterPopOutputs=1 and BufferDepth=1
     // Just pass the push_valid through to the flow register
 
+    assign internal_pop_valid_nonbypass = ram_rd_data_valid;
     assign internal_pop_valid = push_valid;
-    assign internal_pop_data  = push_data;
+    assign internal_pop_data = push_data;
 
     `BR_ASSERT_IMPL(no_double_push_a, !(ram_rd_data_valid && bypass_beat))
     `BR_ASSERT_IMPL(no_push_overflow_a, push_valid |-> internal_pop_ready)
@@ -207,6 +223,7 @@ module br_fifo_staging_buffer #(
     // have been issued in the previous cycle and the data is
     // returning on the same cycle. We just give priority to the
     // ram_rd_data and store the bypassed data in the buffer.
+    assign internal_pop_valid_nonbypass = buffer_valid || ram_rd_data_valid;
     assign internal_pop_valid = buffer_valid || push_valid;
     assign internal_pop_data = buffer_valid ? buffer_data : push_data;
 
@@ -413,6 +430,7 @@ module br_fifo_staging_buffer #(
       // This is true for read from the buffer or direct from read data,
       // since a slot is always allocated for a read.
       assign advance_rd_ptr = (head_valid || ram_rd_data_valid) && internal_pop_ready;
+      assign internal_pop_valid_nonbypass = head_valid || ram_rd_data_valid;
 
       `BR_ASSERT_IMPL(no_push_hazard_a, ~|(mem_wr_en_immediate & mem_wr_en_delayed))
       `BR_ASSERT_IMPL(no_push_overwrite_a, ~|(mem_wr_en & mem_valid & ~mem_rd_en))
@@ -433,6 +451,7 @@ module br_fifo_staging_buffer #(
       assign internal_pop_valid = !empty || push_valid;
       assign internal_pop_data = empty ? push_data : mem_rd_data;
       assign advance_rd_ptr = !empty && internal_pop_ready;
+      assign internal_pop_valid_nonbypass = internal_pop_valid;
     end
 
     // Not used in this configuration
@@ -458,10 +477,16 @@ module br_fifo_staging_buffer #(
         .pop_valid,
         .pop_data
     );
+    // If pop is registered, bypass path is broken up anyhow,
+    // so we don't need to do anything special to exclude bypass_valid
+    // from the combinational path.
+    assign pop_valid_nonbypass = pop_valid;
+    `BR_UNUSED(internal_pop_valid_nonbypass)
   end else begin : gen_pop_passthru
     assign pop_valid = internal_pop_valid;
     assign pop_data = internal_pop_data;
     assign internal_pop_ready = pop_ready;
+    assign pop_valid_nonbypass = internal_pop_valid_nonbypass;
   end
 
   // Implementation Checks

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -197,6 +197,14 @@ br_verilog_sim_test_tools_suite(
             "0",
             "1",
         ],
+        "DataRamAddressDepthStages": [
+            "0",
+            "1",
+        ],
+        "PointerRamAddressDepthStages": [
+            "0",
+            "1",
+        ],
     },
     # TODO(zhemao): dsim test is broken due to apparent simulator bug.
     # Re-enable when the bug is fixed.
@@ -246,6 +254,14 @@ br_verilog_sim_test_tools_suite(
             "1",
         ],
         "RegisterDeallocation": [
+            "0",
+            "1",
+        ],
+        "DataRamAddressDepthStages": [
+            "0",
+            "1",
+        ],
+        "PointerRamAddressDepthStages": [
             "0",
             "1",
         ],

--- a/fifo/sim/br_fifo_shared_dynamic_flops_push_credit_tb.sv
+++ b/fifo/sim/br_fifo_shared_dynamic_flops_push_credit_tb.sv
@@ -9,6 +9,8 @@ module br_fifo_shared_dynamic_flops_push_credit_tb;
   parameter int StagingBufferDepth = 1;
   parameter bit RegisterPopOutputs = 0;
   parameter bit RegisterDeallocation = 0;
+  parameter int DataRamAddressDepthStages = 0;
+  parameter int PointerRamAddressDepthStages = 0;
 
   localparam int FifoIdWidth = $clog2(NumFifos);
   localparam int CombinedWidth = Width + FifoIdWidth;
@@ -85,7 +87,9 @@ module br_fifo_shared_dynamic_flops_push_credit_tb;
       .StagingBufferDepth(StagingBufferDepth),
       .RegisterPopOutputs(RegisterPopOutputs),
       .RegisterDeallocation(RegisterDeallocation),
-      .RegisterPushOutputs(1)
+      .RegisterPushOutputs(1),
+      .DataRamAddressDepthStages(DataRamAddressDepthStages),
+      .PointerRamAddressDepthStages(PointerRamAddressDepthStages)
   ) dut (
       .clk,
       .rst,

--- a/fifo/sim/br_fifo_shared_dynamic_flops_tb.sv
+++ b/fifo/sim/br_fifo_shared_dynamic_flops_tb.sv
@@ -9,6 +9,8 @@ module br_fifo_shared_dynamic_flops_tb;
   parameter int StagingBufferDepth = 1;
   parameter bit RegisterPopOutputs = 0;
   parameter bit RegisterDeallocation = 0;
+  parameter int DataRamAddressDepthStages = 0;
+  parameter int PointerRamAddressDepthStages = 0;
 
   localparam int FifoIdWidth = $clog2(NumFifos);
 
@@ -35,7 +37,9 @@ module br_fifo_shared_dynamic_flops_tb;
       .Width(Width),
       .StagingBufferDepth(StagingBufferDepth),
       .RegisterPopOutputs(RegisterPopOutputs),
-      .RegisterDeallocation(RegisterDeallocation)
+      .RegisterDeallocation(RegisterDeallocation),
+      .DataRamAddressDepthStages(DataRamAddressDepthStages),
+      .PointerRamAddressDepthStages(PointerRamAddressDepthStages)
   ) dut (
       .clk,
       .rst,


### PR DESCRIPTION
We were assuming that if pop_ready was true and we are attempting to push when the staging buffer is full, we can pop on this cycle. However, this is not the case if the staged items are still inflight from the RAM. Need some additional logic to deal with this case when RamReadLatency > 0.

commit-id:67a1f315