### PR TITLE
Switch implementation assertion to integration assertion in br_fifo_shared_pop_ctrl

### DIFF
--- a/fifo/rtl/br_fifo_shared_pop_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl.sv
@@ -83,12 +83,12 @@ module br_fifo_shared_pop_ctrl #(
     input logic [NumReadPorts-1:0][Width-1:0] data_ram_rd_data
 );
 
-  // Internal Integration Checks
+  // Integration Checks
 
-  br_flow_checks_valid_data_impl #(
+  br_flow_checks_valid_data_intg #(
       .NumFlows(NumFifos),
       .Width(AddrWidth)
-  ) br_flow_checks_valid_data_impl_head (
+  ) br_flow_checks_valid_data_intg_head (
       .clk,
       .rst,
       .valid(head_valid),


### PR DESCRIPTION
Now that this module is part of the public API, the integration
assertions should actually use the integration assertion macros.

---

**Stack**:
- #603
- #602 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*