### PR TITLE
Add br_fifo_shared_dynamic_flops_push_credit FPV

### DIFF
--- a/fifo/fpv/BUILD.bazel
+++ b/fifo/fpv/BUILD.bazel
@@ -117,7 +117,6 @@ br_verilog_fpv_test_tools_suite(
             "5",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_ctrl_1r1w_fpv.jg.tcl",
         "vcf": "",
@@ -169,7 +168,6 @@ br_verilog_fpv_test_tools_suite(
             "0",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_ctrl_1r1w_fpv.jg.tcl",
         "vcf": "",
@@ -244,7 +242,6 @@ br_verilog_fpv_test_tools_suite(
             "6",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_flops_fpv.jg.tcl",
         "vcf": "",
@@ -292,7 +289,6 @@ br_verilog_fpv_test_tools_suite(
             "6",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_flops_fpv.jg.tcl",
         "vcf": "",
@@ -362,7 +358,6 @@ br_verilog_fpv_test_tools_suite(
             "5",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl",
         "vcf": "",
@@ -418,7 +413,6 @@ br_verilog_fpv_test_tools_suite(
             "0",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl",
         "vcf": "",
@@ -474,7 +468,6 @@ br_verilog_fpv_test_tools_suite(
             "6",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_flops_push_credit_fpv.jg.tcl",
         "vcf": "",
@@ -526,7 +519,6 @@ br_verilog_fpv_test_tools_suite(
             "6",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_flops_push_credit_fpv.jg.tcl",
         "vcf": "",
@@ -597,7 +589,6 @@ br_verilog_fpv_test_tools_suite(
             "0",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_fpv.jg.tcl",
         "vcf": "",
@@ -647,7 +638,6 @@ br_verilog_fpv_test_tools_suite(
             "2",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_fpv.jg.tcl",
         "vcf": "",
@@ -685,7 +675,6 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_fpv.jg.tcl",
         "vcf": "",

--- a/fifo/fpv/BUILD.bazel
+++ b/fifo/fpv/BUILD.bazel
@@ -117,6 +117,7 @@ br_verilog_fpv_test_tools_suite(
             "5",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_ctrl_1r1w_fpv.jg.tcl",
         "vcf": "",
@@ -168,6 +169,7 @@ br_verilog_fpv_test_tools_suite(
             "0",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_ctrl_1r1w_fpv.jg.tcl",
         "vcf": "",
@@ -242,6 +244,7 @@ br_verilog_fpv_test_tools_suite(
             "6",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_flops_fpv.jg.tcl",
         "vcf": "",
@@ -289,6 +292,7 @@ br_verilog_fpv_test_tools_suite(
             "6",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_flops_fpv.jg.tcl",
         "vcf": "",
@@ -358,6 +362,7 @@ br_verilog_fpv_test_tools_suite(
             "5",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl",
         "vcf": "",
@@ -413,6 +418,7 @@ br_verilog_fpv_test_tools_suite(
             "0",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl",
         "vcf": "",
@@ -468,6 +474,7 @@ br_verilog_fpv_test_tools_suite(
             "6",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_flops_push_credit_fpv.jg.tcl",
         "vcf": "",
@@ -519,6 +526,7 @@ br_verilog_fpv_test_tools_suite(
             "6",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_flops_push_credit_fpv.jg.tcl",
         "vcf": "",
@@ -589,6 +597,7 @@ br_verilog_fpv_test_tools_suite(
             "0",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_fpv.jg.tcl",
         "vcf": "",
@@ -638,6 +647,7 @@ br_verilog_fpv_test_tools_suite(
             "2",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_fpv.jg.tcl",
         "vcf": "",
@@ -675,10 +685,137 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_fpv.jg.tcl",
         "vcf": "",
     },
     top = "br_fifo_shared_dynamic_flops",
     deps = [":br_fifo_shared_dynamic_flops_fpv_monitor"],
+)
+
+#################################################################
+# Bedrock-RTL Shared Dynamic Multi-FIFO with Flop-based Storage (Push Valid/Credit Interface)
+
+verilog_library(
+    name = "br_fifo_shared_dynamic_flops_push_credit_fpv_monitor",
+    srcs = ["br_fifo_shared_dynamic_flops_push_credit_fpv_monitor.sv"],
+    deps = [
+        ":br_credit_receiver_fpv_monitor",
+        ":br_fifo_shared_dynamic_basic_fpv_monitor",
+        "//fifo/rtl:br_fifo_shared_dynamic_flops_push_credit",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_shared_dynamic_flops_push_credit_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_fifo_shared_dynamic_flops_push_credit_fpv_monitor"],
+)
+
+# Test focuses on testing NumFifos and NumPorts
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_shared_dynamic_flops_push_credit_test_ports",
+    illegal_param_combinations = {
+        # Depth > 2 * NumWritePorts
+        (
+            "Depth",
+            "NumWritePorts",
+        ): [
+            ("3", "2"),
+            ("3", "3"),
+            ("5", "3"),
+        ],
+    },
+    params = {
+        "Depth": [
+            "3",
+            "5",
+        ],
+        "NumFifos": [
+            "2",
+            "3",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+        ],
+        "NumWritePorts": [
+            "1",
+            "3",
+        ],
+        "RegisterDeallocation": [
+            "1",
+            "0",
+        ],
+        "RegisterPopOutputs": [
+            "1",
+            "0",
+        ],
+        "RegisterPushOutputs": [
+            "1",
+            "0",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl",
+        "vcf": "",
+    },
+    top = "br_fifo_shared_dynamic_flops_push_credit",
+    deps = [":br_fifo_shared_dynamic_flops_push_credit_fpv_monitor"],
+)
+
+# Test focuses on testing delays
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_shared_dynamic_flops_push_credit_test_delay",
+    params = {
+        "DataRamAddressDepthStages": [
+            "0",
+            "1",
+        ],
+        "DataRamReadDataDepthStages": [
+            "0",
+            "2",
+        ],
+        "DataRamReadDataWidthStages": [
+            "0",
+            "1",
+        ],
+        "PointerRamAddressDepthStages": [
+            "0",
+            "2",
+        ],
+        "PointerRamReadDataDepthStages": [
+            "0",
+            "1",
+        ],
+        "PointerRamReadDataWidthStages": [
+            "0",
+            "2",
+        ],
+        "RegisterDeallocation": [
+            "1",
+            "0",
+        ],
+        "RegisterPopOutputs": [
+            "1",
+            "0",
+        ],
+        "RegisterPushOutputs": [
+            "1",
+            "0",
+        ],
+        "StagingBufferDepth": [
+            "1",
+            "2",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl",
+        "vcf": "",
+    },
+    top = "br_fifo_shared_dynamic_flops_push_credit",
+    deps = [":br_fifo_shared_dynamic_flops_push_credit_fpv_monitor"],
 )

--- a/fifo/fpv/br_credit_receiver_fpv_monitor.sv
+++ b/fifo/fpv/br_credit_receiver_fpv_monitor.sv
@@ -18,7 +18,9 @@
 `include "br_registers.svh"
 
 module br_credit_receiver_fpv_monitor #(
-    parameter  int MaxCredit   = 1,
+    parameter int MaxCredit = 1,
+    parameter int NumWritePorts = 1,
+    localparam int PushCreditWidth = $clog2(NumWritePorts + 1),
     localparam int CreditWidth = $clog2(MaxCredit + 1)
 ) (
     input logic clk,
@@ -28,8 +30,8 @@ module br_credit_receiver_fpv_monitor #(
     input logic push_sender_in_reset,
     input logic push_receiver_in_reset,
     input logic push_credit_stall,
-    input logic push_credit,
-    input logic push_valid,
+    input logic [PushCreditWidth-1:0] push_credit,
+    input logic [NumWritePorts-1:0] push_valid,
 
     // Push-side credits
     input logic [CreditWidth-1:0] credit_initial_push,
@@ -44,17 +46,17 @@ module br_credit_receiver_fpv_monitor #(
   logic [CreditWidth-1:0] fv_max_credit;
 
   assign fv_rst = rst | push_sender_in_reset;
-  `BR_REG(fv_credit_cnt, fv_credit_cnt + push_credit - push_valid)
+  `BR_REG(fv_credit_cnt, fv_credit_cnt + $countones(push_credit) - $countones(push_valid))
   `BR_REGIX(fv_max_credit, fv_max_credit, credit_initial_push, clk, fv_rst)
 
   // ----------FV assumptions----------
   `BR_ASSUME(push_sender_in_reset_a, !push_sender_in_reset |=> !push_sender_in_reset)
   `BR_ASSUME(credit_withhold_push_a, credit_withhold_push <= MaxCredit)
   `BR_ASSUME(credit_withhold_liveness_a, s_eventually (credit_withhold_push < fv_max_credit))
-  `BR_ASSUME(no_spurious_push_valid_a, fv_credit_cnt == 'd0 |-> !push_valid)
+  `BR_ASSUME(no_spurious_push_valid_a, fv_credit_cnt == 'd0 |-> push_valid == 'd0)
 
   // ----------FV assertions----------
   `BR_ASSERT(fv_credit_sanity_a, fv_credit_cnt <= fv_max_credit)
-  `BR_ASSERT(push_credit_deadlock_a, push_valid |-> s_eventually (fv_credit_cnt != 'd0))
+  `BR_ASSERT(push_credit_deadlock_a, push_valid != 'd0 |-> s_eventually (fv_credit_cnt != 'd0))
 
 endmodule : br_credit_receiver_fpv_monitor

--- a/fifo/fpv/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
@@ -85,7 +85,8 @@ module br_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
 
   // ----------Instantiate credit FV checker----------
   br_credit_receiver_fpv_monitor #(
-      .MaxCredit(MaxCredit)
+      .MaxCredit(MaxCredit),
+      .NumWritePorts(1)
   ) br_credit_receiver_fpv_monitor (
       .clk,
       .rst,

--- a/fifo/fpv/br_fifo_flops_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_flops_push_credit_fpv_monitor.sv
@@ -71,7 +71,8 @@ module br_fifo_flops_push_credit_fpv_monitor #(
 
   // ----------Instantiate credit FV checker----------
   br_credit_receiver_fpv_monitor #(
-      .MaxCredit(MaxCredit)
+      .MaxCredit(MaxCredit),
+      .NumWritePorts(1)
   ) br_credit_receiver_fpv_monitor (
       .clk,
       .rst,

--- a/fifo/fpv/br_fifo_shared_dynamic_basic_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic_basic_fpv_monitor.sv
@@ -34,13 +34,6 @@ module br_fifo_shared_dynamic_basic_fpv_monitor #(
     // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
     // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
     parameter int StagingBufferDepth = 1,
-    // If 1, make sure pop_valid/pop_data are registered at the output
-    // of the staging buffer. This adds a cycle of cut-through latency.
-    parameter bit RegisterPopOutputs = 0,
-    // If 1, place a register on the deallocation path from the pop-side
-    // staging buffer to the freelist. This improves timing at the cost of
-    // adding a cycle of backpressure latency.
-    parameter bit RegisterDeallocation = 0,
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,

--- a/fifo/fpv/br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl
@@ -1,0 +1,44 @@
+# Copyright 2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# clock/reset set up
+clock clk
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name initial_value_during_reset {rst | push_sender_in_reset |-> \
+(credit_initial_push <= Depth) && $stable(credit_initial_push)}
+assume -name no_push_valid_during_reset {rst | push_sender_in_reset |-> push_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_push_credit {rst | push_sender_in_reset |-> push_credit == 'd0}
+assert -name fv_rst_check_pop_valid {rst | push_sender_in_reset |-> pop_valid == 'd0}
+
+# TODO: disable due to many unreachable covers in RTL
+cover -disable *
+
+# If assertion bound - pre-condition reachable cycle >= 2:
+# it's marked as "bounded_proven (auto) instead of "undetermined"
+# this only affects the status report, not the proof
+set_prove_inferred_target_bound on
+# limit run time to 10-mins
+set_prove_time_limit 600s
+
+# prove command
+prove -all

--- a/fifo/fpv/br_fifo_shared_dynamic_flops_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic_flops_push_credit_fpv_monitor.sv
@@ -17,13 +17,13 @@
 `include "br_asserts.svh"
 `include "br_registers.svh"
 
-module br_fifo_shared_dynamic_flops_fpv_monitor #(
+module br_fifo_shared_dynamic_flops_push_credit_fpv_monitor #(
     // Number of write ports. Must be >=1.
     parameter int NumWritePorts = 1,
     // Number of read ports. Must be >=1 and a power of 2.
     parameter int NumReadPorts = 1,
-    // Number of logical FIFOs. Must be >=1.
-    parameter int NumFifos = 1,
+    // Number of logical FIFOs. Must be >=2.
+    parameter int NumFifos = 2,
     // Total depth of the FIFO.
     // Must be greater than two times the number of write ports.
     parameter int Depth = 3,
@@ -31,12 +31,15 @@ module br_fifo_shared_dynamic_flops_fpv_monitor #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
-    // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.
     parameter bit RegisterPopOutputs = 0,
+    // If 1, add a retiming stage to the push_credit signal so that it is
+    // driven directly from a flop. This comes at the expense of one additional
+    // cycle of credit loop latency.
+    parameter bit RegisterPushOutputs = 0,
     // If 1, place a register on the deallocation path from the pop-side
     // staging buffer to the freelist. This improves timing at the cost of
     // adding a cycle of backpressure latency.
@@ -61,38 +64,56 @@ module br_fifo_shared_dynamic_flops_fpv_monitor #(
     parameter int PointerRamReadDataDepthStages = 0,
     // Number of stages in the width dimension on the pointer flop RAM.
     parameter int PointerRamReadDataWidthStages = 0,
-    // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
-    parameter bit EnableCoverPushBackpressure = 1,
-    // If 1, assert that push_valid is stable when backpressured.
-    // If 0, cover that push_valid can be unstable.
-    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
-    // If 1, assert that push_data is stable when backpressured.
-    // If 0, cover that push_data can be unstable.
-    // ri lint_check_waive PARAM_NOT_USED
-    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
 
+    localparam int PushCreditWidth = $clog2(NumWritePorts + 1),
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
-    localparam int AddrWidth   = br_math::clamped_clog2(Depth)
+    localparam int AddrWidth = br_math::clamped_clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
 ) (
     input logic clk,
     input logic rst,
 
     // Push side
+    input logic push_sender_in_reset,
+    input logic push_receiver_in_reset,
+    input logic push_credit_stall,
+    input logic [PushCreditWidth-1:0] push_credit,
     input logic [NumWritePorts-1:0] push_valid,
-    input logic [NumWritePorts-1:0] push_ready,
     input logic [NumWritePorts-1:0][Width-1:0] push_data,
     input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+
+    input logic [CountWidth-1:0] credit_initial_push,
+    input logic [CountWidth-1:0] credit_withhold_push,
+    input logic [CountWidth-1:0] credit_available_push,
+    input logic [CountWidth-1:0] credit_count_push,
 
     // Pop side
     input logic [NumFifos-1:0] pop_valid,
     input logic [NumFifos-1:0] pop_ready,
     input logic [NumFifos-1:0][Width-1:0] pop_data
 );
+
+  // ----------Instantiate credit FV checker----------
+  br_credit_receiver_fpv_monitor #(
+      .MaxCredit(Depth),
+      .NumWritePorts(NumWritePorts)
+  ) fv_credit (
+      .clk,
+      .rst,
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push
+  );
 
   // ----------FIFO basic checks----------
   br_fifo_shared_dynamic_basic_fpv_monitor #(
@@ -102,14 +123,12 @@ module br_fifo_shared_dynamic_flops_fpv_monitor #(
       .Depth(Depth),
       .Width(Width),
       .StagingBufferDepth(StagingBufferDepth),
-      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
-      .EnableAssertPushValidStability(EnableAssertPushValidStability),
-      .EnableAssertPushDataStability(EnableAssertPushDataStability)
+      .EnableCoverPushBackpressure(1)
   ) fv_checker (
       .clk,
       .rst,
       .push_valid,
-      .push_ready,
+      .push_ready({NumWritePorts{1'b1}}),
       .push_data,
       .push_fifo_id,
       .pop_valid,
@@ -117,9 +136,10 @@ module br_fifo_shared_dynamic_flops_fpv_monitor #(
       .pop_data
   );
 
-endmodule : br_fifo_shared_dynamic_flops_fpv_monitor
+endmodule : br_fifo_shared_dynamic_flops_push_credit_fpv_monitor
 
-bind br_fifo_shared_dynamic_flops br_fifo_shared_dynamic_flops_fpv_monitor #(
+bind br_fifo_shared_dynamic_flops_push_credit
+     br_fifo_shared_dynamic_flops_push_credit_fpv_monitor #(
     .NumWritePorts(NumWritePorts),
     .NumReadPorts(NumReadPorts),
     .NumFifos(NumFifos),
@@ -127,6 +147,7 @@ bind br_fifo_shared_dynamic_flops br_fifo_shared_dynamic_flops_fpv_monitor #(
     .Width(Width),
     .StagingBufferDepth(StagingBufferDepth),
     .RegisterPopOutputs(RegisterPopOutputs),
+    .RegisterPushOutputs(RegisterPushOutputs),
     .RegisterDeallocation(RegisterDeallocation),
     .DataRamDepthTiles(DataRamDepthTiles),
     .DataRamWidthTiles(DataRamWidthTiles),
@@ -138,8 +159,5 @@ bind br_fifo_shared_dynamic_flops br_fifo_shared_dynamic_flops_fpv_monitor #(
     .PointerRamAddressDepthStages(PointerRamAddressDepthStages),
     .PointerRamReadDataDepthStages(PointerRamReadDataDepthStages),
     .PointerRamReadDataWidthStages(PointerRamReadDataWidthStages),
-    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
-    .EnableAssertPushValidStability(EnableAssertPushValidStability),
-    .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
 ) monitor (.*);


### PR DESCRIPTION
FV has run all parameter sweep.
Due to the complexity of this block, each run is limited to 10-mins.
There are no failures.