### PR TITLE
Add br_fifo_shared_dynamic_ctrl_push_credit FPV

### DIFF
--- a/fifo/fpv/BUILD.bazel
+++ b/fifo/fpv/BUILD.bazel
@@ -962,3 +962,107 @@ br_verilog_fpv_test_tools_suite(
     top = "br_fifo_shared_dynamic_ctrl",
     deps = [":br_fifo_shared_dynamic_ctrl_fpv_monitor"],
 )
+
+#################################################################
+# Bedrock-RTL Shared Dynamic Multi-FIFO Controller (Push Valid/Credit Interface)
+verilog_library(
+    name = "br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor",
+    srcs = ["br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor.sv"],
+    deps = [
+        ":br_credit_receiver_fpv_monitor",
+        ":br_fifo_fv_ram",
+        ":br_fifo_shared_dynamic_basic_fpv_monitor",
+        "//fifo/rtl:br_fifo_shared_dynamic_ctrl_push_credit",
+        "//macros:br_fv",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor"],
+)
+
+# Test focuses on testing NumFifos and NumPorts
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_shared_dynamic_ctrl_push_credit_test_ports",
+    gui = True,
+    illegal_param_combinations = {
+        # Depth > 2 * NumWritePorts
+        (
+            "Depth",
+            "NumWritePorts",
+        ): [
+            ("3", "2"),
+            ("3", "3"),
+            ("5", "3"),
+        ],
+    },
+    params = {
+        "Depth": [
+            "3",
+            "5",
+            "8",
+        ],
+        "NumFifos": [
+            "2",
+            "3",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+            "4",
+        ],
+        "NumWritePorts": [
+            "1",
+            "2",
+            "3",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl",
+        "vcf": "",
+    },
+    top = "br_fifo_shared_dynamic_ctrl_push_credit",
+    deps = [":br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor"],
+)
+
+# Test focuses on testing delays
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_shared_dynamic_ctrl_push_credit_test_delay",
+    params = {
+        "DataRamReadLatency": [
+            "0",
+            "1",
+            "2",
+        ],
+        "PointerRamReadLatency": [
+            "0",
+            "1",
+            "2",
+        ],
+        "RegisterDeallocation": [
+            "1",
+            "0",
+        ],
+        "RegisterPopOutputs": [
+            "1",
+            "0",
+        ],
+        "RegisterPushOutputs": [
+            "1",
+            "0",
+        ],
+        "StagingBufferDepth": [
+            "1",
+            "2",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl",
+        "vcf": "",
+    },
+    top = "br_fifo_shared_dynamic_ctrl_push_credit",
+    deps = [":br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor"],
+)

--- a/fifo/fpv/br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl
@@ -14,11 +14,17 @@
 
 # clock/reset set up
 clock clk
-reset rst
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+
 get_design_info
 
 # primary input control signal should be legal during reset
-assume -name no_push_valid_during_reset {rst |-> push_valid == 'd0}
+assume -name initial_value_during_reset {rst | push_sender_in_reset |-> \
+(credit_initial_push <= Depth) && $stable(credit_initial_push)}
+assume -name no_push_valid_during_reset {rst | push_sender_in_reset |-> push_valid == 'd0}
 assume -name no_data_ram_rd_data_valid {rst | push_sender_in_reset |-> data_ram_rd_data_valid == 'd0}
 assume -name no_ptr_ram_rd_data_valid {rst | push_sender_in_reset |-> ptr_ram_rd_data_valid == 'd0}
 

--- a/fifo/fpv/br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor.sv
@@ -1,0 +1,193 @@
+// Copyright 2025 The Bedrock-RTL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bedrock-RTL Shared Dynamic Multi-FIFO Controller (Push Valid/Ready Interface) FPV monitor
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor #(
+    // Number of write ports. Must be >=1.
+    parameter int NumWritePorts = 1,
+    // Number of read ports. Must be >=1 and a power of 2.
+    parameter int NumReadPorts = 1,
+    // Number of logical FIFOs. Must be >=2.
+    parameter int NumFifos = 2,
+    // Total depth of the FIFO.
+    // Must be greater than two times the number of write ports.
+    parameter int Depth = 3,
+    // Width of the data. Must be >=1.
+    parameter int Width = 1,
+    // The depth of the pop-side staging buffer.
+    // This affects the pop bandwidth of each logical FIFO.
+    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    parameter int StagingBufferDepth = 1,
+    // If 1, make sure pop_valid/pop_data are registered at the output
+    // of the staging buffer. This adds a cycle of cut-through latency.
+    parameter bit RegisterPopOutputs = 0,
+    // If 1, add a retiming stage to the push_credit signal so that it is
+    // driven directly from a flop. This comes at the expense of one additional
+    // cycle of credit loop latency.
+    parameter bit RegisterPushOutputs = 0,
+    // If 1, place a register on the deallocation path from the pop-side
+    // staging buffer to the freelist. This improves timing at the cost of
+    // adding a cycle of backpressure latency.
+    parameter bit RegisterDeallocation = 0,
+    // The number of cycles between data ram read address and read data. Must be >=0.
+    parameter int DataRamReadLatency = 0,
+    // The number of cycles between pointer ram read address and read data. Must be >=0.
+    parameter int PointerRamReadLatency = 0,
+    parameter bit EnableAssertFinalNotValid = 1,
+
+    localparam int PushCreditWidth = $clog2(NumWritePorts + 1),
+    localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
+    localparam int AddrWidth = br_math::clamped_clog2(Depth),
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push side
+    input logic push_sender_in_reset,
+    input logic push_receiver_in_reset,
+    input logic push_credit_stall,
+    input logic [PushCreditWidth-1:0] push_credit,
+    input logic [NumWritePorts-1:0] push_valid,
+    input logic [NumWritePorts-1:0][Width-1:0] push_data,
+    input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+
+    input logic [CountWidth-1:0] credit_initial_push,
+    input logic [CountWidth-1:0] credit_withhold_push,
+    input logic [CountWidth-1:0] credit_available_push,
+    input logic [CountWidth-1:0] credit_count_push,
+
+    // Pop side
+    input logic [NumFifos-1:0] pop_valid,
+    input logic [NumFifos-1:0] pop_ready,
+    input logic [NumFifos-1:0][Width-1:0] pop_data,
+
+    // Data RAM Ports
+    input logic [NumWritePorts-1:0] data_ram_wr_valid,
+    input logic [NumWritePorts-1:0][AddrWidth-1:0] data_ram_wr_addr,
+    input logic [NumWritePorts-1:0][Width-1:0] data_ram_wr_data,
+
+    input logic [NumReadPorts-1:0] data_ram_rd_addr_valid,
+    input logic [NumReadPorts-1:0][AddrWidth-1:0] data_ram_rd_addr,
+    input logic [NumReadPorts-1:0] data_ram_rd_data_valid,
+    input logic [NumReadPorts-1:0][Width-1:0] data_ram_rd_data,
+
+    // Pointer RAM Ports
+    input logic [NumWritePorts-1:0] ptr_ram_wr_valid,
+    input logic [NumWritePorts-1:0][AddrWidth-1:0] ptr_ram_wr_addr,
+    input logic [NumWritePorts-1:0][AddrWidth-1:0] ptr_ram_wr_data,
+
+    input logic [NumReadPorts-1:0] ptr_ram_rd_addr_valid,
+    input logic [NumReadPorts-1:0][AddrWidth-1:0] ptr_ram_rd_addr,
+    input logic [NumReadPorts-1:0] ptr_ram_rd_data_valid,
+    input logic [NumReadPorts-1:0][AddrWidth-1:0] ptr_ram_rd_data
+);
+
+  // ----------Instantiate credit FV checker----------
+  br_credit_receiver_fpv_monitor #(
+      .MaxCredit(Depth),
+      .NumWritePorts(NumWritePorts)
+  ) fv_credit (
+      .clk,
+      .rst,
+      .push_sender_in_reset,
+      .push_receiver_in_reset,
+      .push_credit_stall,
+      .push_credit,
+      .push_valid,
+      .credit_initial_push,
+      .credit_withhold_push,
+      .credit_count_push,
+      .credit_available_push
+  );
+
+  // ----------Data Ram FV model----------
+  br_fifo_fv_ram #(
+      .NumWritePorts(NumWritePorts),
+      .NumReadPorts(NumReadPorts),
+      .Depth(Depth),
+      .Width(Width),
+      .RamReadLatency(DataRamReadLatency)
+  ) fv_data_ram (
+      .clk,
+      .rst,
+      .ram_wr_valid(data_ram_wr_valid),
+      .ram_wr_addr(data_ram_wr_addr),
+      .ram_wr_data(data_ram_wr_data),
+      .ram_rd_addr_valid(data_ram_rd_addr_valid),
+      .ram_rd_addr(data_ram_rd_addr),
+      .ram_rd_data_valid(data_ram_rd_data_valid),
+      .ram_rd_data(data_ram_rd_data)
+  );
+
+  // ----------Ptr Ram FV model----------
+  br_fifo_fv_ram #(
+      .NumWritePorts(NumWritePorts),
+      .NumReadPorts(NumReadPorts),
+      .Depth(Depth),
+      .Width(AddrWidth),
+      .RamReadLatency(PointerRamReadLatency)
+  ) fv_ptr_ram (
+      .clk,
+      .rst,
+      .ram_wr_valid(ptr_ram_wr_valid),
+      .ram_wr_addr(ptr_ram_wr_addr),
+      .ram_wr_data(ptr_ram_wr_data),
+      .ram_rd_addr_valid(ptr_ram_rd_addr_valid),
+      .ram_rd_addr(ptr_ram_rd_addr),
+      .ram_rd_data_valid(ptr_ram_rd_data_valid),
+      .ram_rd_data(ptr_ram_rd_data)
+  );
+
+  // ----------FIFO basic checks----------
+  br_fifo_shared_dynamic_basic_fpv_monitor #(
+      .NumWritePorts(NumWritePorts),
+      .NumReadPorts(NumReadPorts),
+      .NumFifos(NumFifos),
+      .Depth(Depth),
+      .Width(Width),
+      .StagingBufferDepth(StagingBufferDepth),
+      .EnableCoverPushBackpressure(1)
+  ) fv_checker (
+      .clk,
+      .rst,
+      .push_valid,
+      .push_ready({NumWritePorts{1'b1}}),
+      .push_data,
+      .push_fifo_id,
+      .pop_valid,
+      .pop_ready,
+      .pop_data
+  );
+
+endmodule : br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor
+
+bind br_fifo_shared_dynamic_ctrl_push_credit br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor #(
+    .NumWritePorts(NumWritePorts),
+    .NumReadPorts(NumReadPorts),
+    .NumFifos(NumFifos),
+    .Depth(Depth),
+    .Width(Width),
+    .StagingBufferDepth(StagingBufferDepth),
+    .RegisterPopOutputs(RegisterPopOutputs),
+    .RegisterPushOutputs(RegisterPushOutputs),
+    .RegisterDeallocation(RegisterDeallocation),
+    .DataRamReadLatency(DataRamReadLatency),
+    .PointerRamReadLatency(PointerRamReadLatency),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);


### PR DESCRIPTION
If FV allow same cycle push_valid assertion and push_credit release, RTL will drop data.
Checking in FPV temporarily.