### PR TITLE
Add full and empty flags to dynamic FIFOs

### DIFF
--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
@@ -107,11 +107,13 @@ module br_fifo_shared_dynamic_ctrl #(
     output logic [NumWritePorts-1:0] push_ready,
     input logic [NumWritePorts-1:0][Width-1:0] push_data,
     input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+    output logic push_full,
 
     // Pop side
     output logic [NumFifos-1:0] pop_valid,
     input logic [NumFifos-1:0] pop_ready,
     output logic [NumFifos-1:0][Width-1:0] pop_data,
+    output logic [NumFifos-1:0] pop_empty,
 
     // Data RAM Ports
     output logic [NumWritePorts-1:0] data_ram_wr_valid,
@@ -172,6 +174,7 @@ module br_fifo_shared_dynamic_ctrl #(
       .push_ready,
       .push_data,
       .push_fifo_id,
+      .push_full,
       .data_ram_wr_valid,
       .data_ram_wr_addr,
       .data_ram_wr_data,
@@ -240,6 +243,7 @@ module br_fifo_shared_dynamic_ctrl #(
       .pop_valid,
       .pop_ready,
       .pop_data,
+      .pop_empty,
       .data_ram_rd_addr_valid,
       .data_ram_rd_addr,
       .data_ram_rd_data_valid,

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
@@ -106,6 +106,7 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
     input logic [NumWritePorts-1:0] push_valid,
     input logic [NumWritePorts-1:0][Width-1:0] push_data,
     input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+    output logic push_full,
 
     input  logic [CountWidth-1:0] credit_initial_push,
     input  logic [CountWidth-1:0] credit_withhold_push,
@@ -116,6 +117,7 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
     output logic [NumFifos-1:0] pop_valid,
     input logic [NumFifos-1:0] pop_ready,
     output logic [NumFifos-1:0][Width-1:0] pop_data,
+    output logic [NumFifos-1:0] pop_empty,
 
     // Data RAM Ports
     output logic [NumWritePorts-1:0] data_ram_wr_valid,
@@ -180,6 +182,7 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
       .push_valid,
       .push_data,
       .push_fifo_id,
+      .push_full,
       .credit_initial_push,
       .credit_withhold_push,
       .credit_available_push,
@@ -249,6 +252,7 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
       .pop_valid,
       .pop_ready,
       .pop_data,
+      .pop_empty,
       .data_ram_rd_addr_valid,
       .data_ram_rd_addr,
       .data_ram_rd_data_valid,

--- a/fifo/rtl/br_fifo_shared_dynamic_flops.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_flops.sv
@@ -126,11 +126,13 @@ module br_fifo_shared_dynamic_flops #(
     output logic [NumWritePorts-1:0] push_ready,
     input logic [NumWritePorts-1:0][Width-1:0] push_data,
     input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+    output logic push_full,
 
     // Pop side
     output logic [NumFifos-1:0] pop_valid,
     input logic [NumFifos-1:0] pop_ready,
-    output logic [NumFifos-1:0][Width-1:0] pop_data
+    output logic [NumFifos-1:0][Width-1:0] pop_data,
+    output logic [NumFifos-1:0] pop_empty
 );
   // Integration Checks
   // Rely on checks in the submodules
@@ -234,9 +236,11 @@ module br_fifo_shared_dynamic_flops #(
       .push_ready,
       .push_data,
       .push_fifo_id,
+      .push_full,
       .pop_valid,
       .pop_ready,
       .pop_data,
+      .pop_empty,
       .data_ram_wr_valid,
       .data_ram_wr_addr,
       .data_ram_wr_data,

--- a/fifo/rtl/br_fifo_shared_dynamic_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_flops_push_credit.sv
@@ -124,6 +124,7 @@ module br_fifo_shared_dynamic_flops_push_credit #(
     input logic [NumWritePorts-1:0] push_valid,
     input logic [NumWritePorts-1:0][Width-1:0] push_data,
     input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+    output logic push_full,
 
     input  logic [CountWidth-1:0] credit_initial_push,
     input  logic [CountWidth-1:0] credit_withhold_push,
@@ -133,7 +134,8 @@ module br_fifo_shared_dynamic_flops_push_credit #(
     // Pop side
     output logic [NumFifos-1:0] pop_valid,
     input logic [NumFifos-1:0] pop_ready,
-    output logic [NumFifos-1:0][Width-1:0] pop_data
+    output logic [NumFifos-1:0][Width-1:0] pop_data,
+    output logic [NumFifos-1:0] pop_empty
 );
   // Integration Checks
   // Rely on checks in the submodules
@@ -241,6 +243,7 @@ module br_fifo_shared_dynamic_flops_push_credit #(
       .push_valid,
       .push_data,
       .push_fifo_id,
+      .push_full,
       .credit_initial_push,
       .credit_withhold_push,
       .credit_available_push,
@@ -248,6 +251,7 @@ module br_fifo_shared_dynamic_flops_push_credit #(
       .pop_valid,
       .pop_ready,
       .pop_data,
+      .pop_empty,
       .data_ram_wr_valid,
       .data_ram_wr_addr,
       .data_ram_wr_data,

--- a/fifo/rtl/internal/br_fifo_pop_ctrl_core.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl_core.sv
@@ -145,7 +145,8 @@ module br_fifo_pop_ctrl_core #(
 
         .pop_ready,
         .pop_valid,
-        .pop_data
+        .pop_data,
+        .pop_empty()
     );
     `BR_UNUSED(empty)
   end

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
@@ -57,6 +57,7 @@ module br_fifo_shared_dynamic_push_ctrl #(
     input logic [NumWritePorts-1:0] push_valid,
     input logic [NumWritePorts-1:0][Width-1:0] push_data,
     input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+    output logic push_full,
 
     // Data RAM write ports
     output logic [NumWritePorts-1:0] data_ram_wr_valid,
@@ -126,6 +127,8 @@ module br_fifo_shared_dynamic_push_ctrl #(
       .dealloc_entry_id,
       .dealloc_count
   );
+
+  assign push_full = alloc_sendable == '0;
 
   if (NumWritePorts > 1) begin : gen_alloc_mapping
     // Distribute the allocatable entries to the active push ports using multi-grant

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl_credit.sv
@@ -34,6 +34,7 @@ module br_fifo_shared_dynamic_push_ctrl_credit #(
     input logic [NumWritePorts-1:0] push_valid,
     input logic [NumWritePorts-1:0][Width-1:0] push_data,
     input logic [NumWritePorts-1:0][FifoIdWidth-1:0] push_fifo_id,
+    output logic push_full,
 
     input  logic [CountWidth-1:0] credit_initial_push,
     input  logic [CountWidth-1:0] credit_withhold_push,
@@ -118,6 +119,7 @@ module br_fifo_shared_dynamic_push_ctrl_credit #(
       .push_ready(internal_push_ready),
       .push_data(internal_push_data),
       .push_fifo_id(internal_push_fifo_id),
+      .push_full,
       .data_ram_wr_valid,
       .data_ram_wr_addr,
       .data_ram_wr_data,

--- a/fifo/rtl/internal/br_fifo_staging_buffer.sv
+++ b/fifo/rtl/internal/br_fifo_staging_buffer.sv
@@ -69,7 +69,8 @@ module br_fifo_staging_buffer #(
 
     input  logic             pop_ready,
     output logic             pop_valid,
-    output logic [Width-1:0] pop_data
+    output logic [Width-1:0] pop_data,
+    output logic             pop_empty
 );
   // ===================
   // Integration Checks
@@ -109,6 +110,7 @@ module br_fifo_staging_buffer #(
   // Staged items must increment when read is issued or data is bypassed
   // and decrement when popped.
   logic [BufferCountWidth-1:0] staged_items;
+  logic [BufferCountWidth-1:0] staged_items_next;
   logic                        staged_items_incr;
   logic                        bypass_beat;
   logic                        pop_beat;
@@ -140,11 +142,12 @@ module br_fifo_staging_buffer #(
       .decr_valid(pop_beat),
       .decr      (1'b1),
 
-      .value_next(),
+      .value_next(staged_items_next),
       .value     (staged_items)
   );
 
   assign pop_beat = pop_valid && pop_ready;
+  `BR_REGLI(pop_empty, staged_items_next == '0, staged_items_incr || pop_beat, 1'b1)
 
   if (RamReadLatency == 0) begin : gen_zero_lat_space_available
     // If there is no read latency, the cut-through latency is always 0,

--- a/fifo/sim/br_fifo_shared_dynamic_flops_push_credit_tb.sv
+++ b/fifo/sim/br_fifo_shared_dynamic_flops_push_credit_tb.sv
@@ -100,13 +100,15 @@ module br_fifo_shared_dynamic_flops_push_credit_tb;
       .push_valid(dut_push_valid),
       .push_data(dut_push_data),
       .push_fifo_id(dut_push_fifo_id),
+      .push_full(),
       .credit_initial_push,
       .credit_withhold_push,
       .credit_available_push(),
       .credit_count_push(),
       .pop_ready,
       .pop_valid,
-      .pop_data
+      .pop_data,
+      .pop_empty()
   );
 
   br_test_driver td (

--- a/fifo/sim/br_fifo_shared_dynamic_flops_tb.sv
+++ b/fifo/sim/br_fifo_shared_dynamic_flops_tb.sv
@@ -47,9 +47,11 @@ module br_fifo_shared_dynamic_flops_tb;
       .push_valid,
       .push_data,
       .push_fifo_id,
+      .push_full(),
       .pop_ready,
       .pop_valid,
-      .pop_data
+      .pop_data,
+      .pop_empty()
   );
 
   br_test_driver td (


### PR DESCRIPTION
These changes are needed for the AXI isolator block.
Don't want to expose slots/items since it's confusing to do that
with staging buffers. Full and empty should be unambiguous though.