### PR TITLE
Update TopStitch to 0.57.0

### DIFF
--- a/stitch/Cargo.lock
+++ b/stitch/Cargo.lock
@@ -1364,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.15.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65422aaa27a4ea676df4f6c3be91f8270b887a0884b4675d3e0789808b5a52"
+checksum = "721e227e81c968cb3f66be9a0ad2b133f57afbb82b38536b879e287f329dc308"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1422,7 +1422,6 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
- "slang-rs",
  "topstitch",
 ]
 
@@ -1615,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "topstitch"
-version = "0.48.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a875d1dbb4810572b20f13d4fa47f6aeb116a4433e9a292757c32ae74eb9f8a"
+checksum = "4ec9279f9fabfb39b2ce70fab43893dbe390540603cc99db026611fc90ef0044"
 dependencies = [
  "indexmap",
  "itertools",

--- a/stitch/Cargo.toml
+++ b/stitch/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.26", features = ["derive"] }
-slang-rs = "0.15.0"
-topstitch = "0.48.0"
+topstitch = "0.57.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/stitch/src/common.rs
+++ b/stitch/src/common.rs
@@ -56,6 +56,10 @@ pub fn load_module(
         ignore_unknown_modules: true,
         skip_unsupported: true,
         timescale: None,
+        extra_arguments: &[
+            "--threads",
+            "1",
+        ],
         ..Default::default()
     };
 

--- a/stitch/src/common.rs
+++ b/stitch/src/common.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
-use slang_rs::SlangConfig;
-use topstitch::ModDef;
+use topstitch::{ModDef, ParserConfig};
 use clap::Args;
 
 #[derive(Args)]
@@ -50,14 +49,15 @@ pub fn load_module(
     incdirs.sort();
     incdirs.dedup();
 
-    let config = SlangConfig {
+    let config = ParserConfig {
         sources: &sources,
         incdirs: &incdirs,
         tops: &[name],
         ignore_unknown_modules: true,
+        skip_unsupported: true,
         timescale: None,
         ..Default::default()
     };
 
-    ModDef::from_verilog_using_slang(name, &config, true)
+    ModDef::from_verilog_with_config(name, &config)
 }


### PR DESCRIPTION
Also includes a commit to run slang single-threaded, to try to avoid thread clobbering when bazel is running multiple jobs.