### PR TITLE
add 10-min run limit on cdc FPV

### DIFF
--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
@@ -46,4 +46,11 @@ pop_rst |-> pop_valid == 'd0}
 assert -name fv_rst_check_pop_ram_rd_addr_valid {@(posedge pop_clk) \
 pop_rst |-> pop_ram_rd_addr_valid == 'd0}
 
+# If assertion bound - pre-condition reachable cycle >= 2:
+# it's marked as "bounded_proven (auto) instead of "undetermined"
+# this only affects the status report, not the proof
+set_prove_inferred_target_bound on
+# limit run time to 10-mins
+set_prove_time_limit 600s
+
 prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
@@ -67,4 +67,11 @@ pop_rst |-> pop_ram_rd_addr_valid == 'd0}
 # no push_ready signal in push credit interface
 assert -disable *fv_checker.no_ready_when_full_a*
 
+# If assertion bound - pre-condition reachable cycle >= 2:
+# it's marked as "bounded_proven (auto) instead of "undetermined"
+# this only affects the status report, not the proof
+set_prove_inferred_target_bound on
+# limit run time to 10-mins
+set_prove_time_limit 600s
+
 prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv.jg.tcl
@@ -52,5 +52,12 @@ pop_rst |-> pop_valid == 'd0}
 assert -name fv_rst_check_pop_ram_rd_addr_valid {@(posedge pop_clk) \
 pop_rst |-> pop_ram_rd_addr_valid == 'd0}
 
+# If assertion bound - pre-condition reachable cycle >= 2:
+# it's marked as "bounded_proven (auto) instead of "undetermined"
+# this only affects the status report, not the proof
+set_prove_inferred_target_bound on
+# limit run time to 10-mins
+set_prove_time_limit 600s
+
 # prove command
 prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl
@@ -67,4 +67,11 @@ pop_rst |-> pop_ram_rd_addr_valid == 'd0}
 # no push_ready signal in push credit interface
 assert -disable *fv_checker.no_ready_when_full_a*
 
+# If assertion bound - pre-condition reachable cycle >= 2:
+# it's marked as "bounded_proven (auto) instead of "undetermined"
+# this only affects the status report, not the proof
+set_prove_inferred_target_bound on
+# limit run time to 10-mins
+set_prove_time_limit 600s
+
 prove -all

--- a/cdc/fpv/br_cdc_fifo_flops_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_flops_fpv.jg.tcl
@@ -32,4 +32,11 @@ push_rst |-> push_valid == 'd0}
 assert -name fv_rst_check_pop_valid {@(posedge pop_clk) \
 pop_rst |-> pop_valid == 'd0}
 
+# If assertion bound - pre-condition reachable cycle >= 2:
+# it's marked as "bounded_proven (auto) instead of "undetermined"
+# this only affects the status report, not the proof
+set_prove_inferred_target_bound on
+# limit run time to 10-mins
+set_prove_time_limit 600s
+
 prove -all

--- a/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv.jg.tcl
@@ -55,4 +55,11 @@ pop_rst |-> pop_valid == 'd0}
 # no push_ready signal in push credit interface
 assert -disable *fv_checker.no_ready_when_full_a*
 
+# If assertion bound - pre-condition reachable cycle >= 2:
+# it's marked as "bounded_proven (auto) instead of "undetermined"
+# this only affects the status report, not the proof
+set_prove_inferred_target_bound on
+# limit run time to 10-mins
+set_prove_time_limit 600s
+
 prove -all


### PR DESCRIPTION
even if bazel timeout is 10min, if jasper run doesn't finish, the test status will be TIME_OUT in bazel run.