### PR TITLE
Isolate sub FPV bugfixes

### DIFF
--- a/amba/fpv/isolate_axi_protocol_fv_check.sv
+++ b/amba/fpv/isolate_axi_protocol_fv_check.sv
@@ -204,7 +204,7 @@ module isolate_axi_protocol_fv_check #(
       .RUSER_WIDTH(RUserWidth),
       .MAX_PENDING(MaxOutstanding),
       .AXI4_LITE(MaxAxiBurstLen == 1),
-      .READ_INTERLEAVE_ON(0) // not supported by br_amba_axi_isolate_sub
+      .READ_INTERLEAVE_ON(0)  // not supported by br_amba_axi_isolate_sub
   ) downstream (
       // Global signals
       .aclk    (clk),

--- a/amba/fpv/isolate_axi_protocol_fv_check.sv
+++ b/amba/fpv/isolate_axi_protocol_fv_check.sv
@@ -203,7 +203,8 @@ module isolate_axi_protocol_fv_check #(
       .BUSER_WIDTH(BUserWidth),
       .RUSER_WIDTH(RUserWidth),
       .MAX_PENDING(MaxOutstanding),
-      .AXI4_LITE(MaxAxiBurstLen == 1)
+      .AXI4_LITE(MaxAxiBurstLen == 1),
+      .READ_INTERLEAVE_ON(0) // not supported by br_amba_axi_isolate_sub
   ) downstream (
       // Global signals
       .aclk    (clk),

--- a/amba/rtl/br_amba_axi_isolate_sub.sv
+++ b/amba/rtl/br_amba_axi_isolate_sub.sv
@@ -224,6 +224,8 @@ module br_amba_axi_isolate_sub #(
   logic downstream_awvalid_iso;
   logic upstream_awready_holdoff;
   logic upstream_awvalid_holdoff;
+  logic upstream_wready_holdoff;
+  logic upstream_wvalid_holdoff;
   //
   logic isolate_done_w;
   logic align_and_hold_req_w;
@@ -267,8 +269,8 @@ module br_amba_axi_isolate_sub #(
       .downstream_awready (upstream_awready_holdoff),
       .downstream_awvalid (upstream_awvalid_holdoff),
       //
-      .downstream_wready  (downstream_wready_iso),
-      .downstream_wvalid  (downstream_wvalid_iso),
+      .downstream_wready  (upstream_wready_holdoff),
+      .downstream_wvalid  (upstream_wvalid_holdoff),
       .downstream_wlast   ()
   );
 
@@ -282,7 +284,8 @@ module br_amba_axi_isolate_sub #(
       .IsolateResp(IsolateResp),
       .IsolateData(IsolateBUser),
       // Single write response beat per write transaction
-      .MaxAxiBurstLen(1)
+      .MaxAxiBurstLen(1),
+      .MaxTransactionSkew(MaxTransactionSkew)
   ) br_amba_iso_resp_tracker_w (
       .clk,
       .rst,
@@ -303,10 +306,18 @@ module br_amba_axi_isolate_sub #(
       .upstream_xlast(),
       .upstream_xdata(upstream_buser_int),
       //
+      .upstream_wready(upstream_wready_holdoff),
+      .upstream_wvalid(upstream_wvalid_holdoff),
+      .upstream_wlast(upstream_wlast),
+      //
       .downstream_axready(downstream_awready_iso),
       .downstream_axvalid(downstream_awvalid_iso),
       .downstream_axid(downstream_awid),
       .downstream_axlen(),
+      //
+      .downstream_wready(downstream_wready_iso),
+      .downstream_wvalid(downstream_wvalid_iso),
+      .downstream_wlast(downstream_wlast),
       //
       .downstream_xready(downstream_bready),
       .downstream_xvalid(downstream_bvalid),
@@ -335,7 +346,6 @@ module br_amba_axi_isolate_sub #(
   assign downstream_wdata = upstream_wdata;
   assign downstream_wstrb = upstream_wstrb;
   assign downstream_wuser = upstream_wuser;
-  assign downstream_wlast = upstream_wlast;
 
   //
   // Read Path
@@ -394,6 +404,10 @@ module br_amba_axi_isolate_sub #(
       .upstream_axid(upstream_arid),
       .upstream_axlen(upstream_arlen),
       //
+      .upstream_wready(),
+      .upstream_wvalid(1'b1),
+      .upstream_wlast(1'b1),
+      //
       .upstream_xready(upstream_rready_int),
       .upstream_xvalid(upstream_rvalid_int),
       .upstream_xid(upstream_rid_int),
@@ -405,6 +419,10 @@ module br_amba_axi_isolate_sub #(
       .downstream_axvalid(downstream_arvalid_iso),
       .downstream_axid(downstream_arid),
       .downstream_axlen(downstream_arlen),
+      //
+      .downstream_wready(1'b1),
+      .downstream_wvalid(),
+      .downstream_wlast(),
       //
       .downstream_xready(downstream_rready),
       .downstream_xvalid(downstream_rvalid),

--- a/amba/rtl/internal/BUILD.bazel
+++ b/amba/rtl/internal/BUILD.bazel
@@ -96,6 +96,7 @@ verilog_library(
     deps = [
         "//amba/rtl:br_amba_pkg",
         "//arb/rtl:br_arb_rr",
+        "//counter/rtl:br_counter",
         "//counter/rtl:br_counter_incr",
         "//fifo/rtl:br_fifo_flops",
         "//fifo/rtl:br_fifo_shared_dynamic_flops",

--- a/amba/rtl/internal/BUILD.bazel
+++ b/amba/rtl/internal/BUILD.bazel
@@ -99,6 +99,8 @@ verilog_library(
         "//counter/rtl:br_counter_incr",
         "//fifo/rtl:br_fifo_flops",
         "//fifo/rtl:br_fifo_shared_dynamic_flops",
+        "//flow/rtl:br_flow_fork",
+        "//flow/rtl:br_flow_join",
         "//flow/rtl:br_flow_mux_select_unstable",
         "//macros:br_asserts_internal",
         "//macros:br_registers",

--- a/amba/rtl/internal/br_amba_iso_resp_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_resp_tracker.sv
@@ -183,7 +183,9 @@ module br_amba_iso_resp_tracker #(
 
   br_fifo_flops #(
       .Depth(MaxTransactionSkew),
-      .Width(AxiBurstLenWidth + MinIdWidth)
+      .Width(AxiBurstLenWidth + MinIdWidth),
+      // valid can deassert if downstream_axready deasserts
+      .EnableAssertPushValidStability(0)
   ) br_fifo_flops_aw_staging (
       .clk,
       .rst,
@@ -207,7 +209,10 @@ module br_amba_iso_resp_tracker #(
   );
 
   br_flow_fork #(
-      .NumFlows(2)
+      .NumFlows(2),
+      // If W beats are in excess when wdata alignment (during isolation) is requested, the
+      // upstream valid can deassert without ready asserting.
+      .EnableAssertPushValidStability(0)
   ) br_flow_fork_wlast_staging (
       .clk,
       .rst,
@@ -223,7 +228,9 @@ module br_amba_iso_resp_tracker #(
 
   br_fifo_flops #(
       .Depth(MaxTransactionSkew),
-      .Width(1)
+      .Width(1),
+      // valid can deassert if downstream_wready deasserts
+      .EnableAssertPushValidStability(0)
   ) br_fifo_flops_wlast_staging (
       .clk,
       .rst,
@@ -269,9 +276,7 @@ module br_amba_iso_resp_tracker #(
         .Depth(MaxOutstanding),
         .Width(AxiBurstLenWidth),
         .EnableBypass(1),
-        .RegisterPopOutputs(1),
-        // valid can deassert if downstream_axready deasserts
-        .EnableAssertPushValidStability(0)
+        .RegisterPopOutputs(1)
     ) br_fifo_flops_req_tracker (
         .clk,
         .rst,
@@ -303,9 +308,7 @@ module br_amba_iso_resp_tracker #(
         .Width(AxiBurstLenWidth),
         .PointerRamReadDataDepthStages(FlopPtrRamRd),
         .DataRamReadDataDepthStages(FlopDataRamRd),
-        .RegisterPopOutputs(1),
-        // valid can deassert if downstream_axready deasserts
-        .EnableAssertPushValidStability(0)
+        .RegisterPopOutputs(1)
     ) br_fifo_shared_dynamic_flops_req_tracker (
         .clk,
         .rst,


### PR DESCRIPTION
- disable read response interleave on axi subordinate VIP
- fix several push valid stability related issues
- add tracking of wlast pushes to ensure that we can never return (generated) BRESP for a write before receiving all of the write data

With these fixes, the only remaining FPV failures I see I believe should be cleaned up by properly disabling checks on the subordinate VIP during isolation entry window (which Sai will need to do).