### PR TITLE
Allow NumLinkedListsPerFifo to be configured independently

### DIFF
--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -371,6 +371,10 @@ br_verilog_elab_and_lint_test_suite(
             "1",
             "2",
         ],
+        "NumLinkedListsPerFifo": [
+            "1",
+            "2",
+        ],
         "PointerRamAddressDepthStages": [
             "0",
             "1",

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
@@ -45,12 +45,15 @@
 //
 // Because the pop bandwidth of a linked list is limited by the pointer RAM read
 // latency, the multi-FIFO supports using multiple linked lists per logical
-// FIFO. The linked list controller will cycle through the linked list heads in
-// round-robin fashion. The number of linked lists per FIFO is determined by the
-// staging buffer depth.  The bandwidth of a single logical FIFO is thus
-// determined by the formula `StagingBufferDepth / (PointerRamReadLatency + 1)`.
-// To get one pop per cycle bandwidth for a single logical FIFO, the staging
-// buffer depth should be set to `PointerRamReadLatency + 1`.
+// FIFO, configured by the `NumLinkedListsPerFifo` parameter. The linked list
+// controller will cycle through the linked list heads in round-robin fashion.
+// The bandwidth is also limited by the staging buffer depth and data RAM read
+// latency. Up to `StagingBufferDepth` reads can be inflight to the RAM at any
+// time. Thus, the bandwidth of a single logical FIFO is capped at
+// the minimum of `NumLinkedListsPerFifo / (PointerRamReadLatency + 1)` and
+// `StagingBufferDepth / (DataRamReadLatency + 1)`. To get full bandwidth,
+// the number of linked lists per FIFO should be set to `PointerRamReadLatency +
+// 1` and the staging buffer depth should be set to `DataRamReadLatency + 1`.
 
 `include "br_asserts_internal.svh"
 
@@ -70,6 +73,10 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
     // This affects the pop bandwidth of each logical FIFO.
     // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
+    // The number of sub-linked lists used by each logical FIFO.
+    // This affects the pop bandwidth of each logical FIFO.
+    // The max bandwidth will be `NumLinkedListsPerFifo / (PointerRamReadLatency + 1)`.
+    parameter int NumLinkedListsPerFifo = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.
     parameter bit RegisterPopOutputs = 0,
@@ -208,7 +215,7 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
       .NumWritePorts(NumWritePorts),
       .NumReadPorts(NumReadPorts),
       .NumFifos(NumFifos),
-      .NumLinkedListsPerFifo(StagingBufferDepth),
+      .NumLinkedListsPerFifo(NumLinkedListsPerFifo),
       .Depth(Depth),
       .RamReadLatency(PointerRamReadLatency)
   ) br_fifo_shared_dynamic_ptr_mgr (

--- a/fifo/rtl/br_fifo_shared_dynamic_flops.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_flops.sv
@@ -43,18 +43,23 @@
 //
 // Because the pop bandwidth of a linked list is limited by the pointer RAM read
 // latency, the multi-FIFO supports using multiple linked lists per logical
-// FIFO. The linked list controller will cycle through the linked list heads in
-// round-robin fashion. The number of linked lists per FIFO is determined by the
-// staging buffer depth.  The bandwidth of a single logical FIFO is thus
-// determined by the formula `StagingBufferDepth / (PointerRamReadLatency + 1)`,
-// where `PointerRamReadLatency = PointerRamAddressDepthStages +
-// PointerRamReadDataDepthStages + PointerRamReadDataWidthStages`. To get one
-// pop per cycle bandwidth for a single logical FIFO, the staging buffer depth
-// should be set to `PointerRamReadLatency + 1`.
+// FIFO, configured by the `NumLinkedListsPerFifo` parameter. The linked list
+// controller will cycle through the linked list heads in round-robin fashion.
+// The bandwidth is also limited by the staging buffer depth and data RAM read
+// latency. Up to `StagingBufferDepth` reads can be inflight to the RAM at any
+// time. Thus, the bandwidth of a single logical FIFO is capped at
+// the minimum of `NumLinkedListsPerFifo / (PointerRamReadLatency + 1)` and
+// `StagingBufferDepth / (DataRamReadLatency + 1)`. To get full bandwidth,
+// the number of linked lists per FIFO should be set to `PointerRamReadLatency +
+// 1` and the staging buffer depth should be set to `DataRamReadLatency + 1`.
+//
+// `PointerRamReadLatency = PointerRamAddressDepthStages + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages`
+//
+// `DataRamReadLatency = DataRamReadAddressDepthStages + DataRamReadDataDepthStages + DataRamReadDataWidthStages`
 //
 // For example, to have zero retiming on the read path, full bandwidth, and
-// pop data registered at the output, set StagingBufferDepth = 1 and
-// RegisterPopOutputs = 1.
+// pop data registered at the output, set StagingBufferDepth = 1,
+// NumLinkedListsPerFifo = 1, and RegisterPopOutputs = 1.
 
 module br_fifo_shared_dynamic_flops #(
     // Number of write ports. Must be >=1.
@@ -73,6 +78,10 @@ module br_fifo_shared_dynamic_flops #(
     // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
     // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
     parameter int StagingBufferDepth = 1,
+    // The number of sub-linked lists used by each logical FIFO.
+    // This affects the pop bandwidth of each logical FIFO.
+    // The max bandwidth will be `NumLinkedListsPerFifo / (PointerRamReadLatency + 1)`.
+    parameter int NumLinkedListsPerFifo = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.
     parameter bit RegisterPopOutputs = 0,
@@ -221,6 +230,7 @@ module br_fifo_shared_dynamic_flops #(
       .Depth(Depth),
       .Width(Width),
       .StagingBufferDepth(StagingBufferDepth),
+      .NumLinkedListsPerFifo(NumLinkedListsPerFifo),
       .RegisterPopOutputs(RegisterPopOutputs),
       .RegisterDeallocation(RegisterDeallocation),
       .DataRamReadLatency(DataRamReadLatency),

--- a/fifo/rtl/br_fifo_shared_dynamic_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_flops_push_credit.sv
@@ -43,18 +43,23 @@
 //
 // Because the pop bandwidth of a linked list is limited by the pointer RAM read
 // latency, the multi-FIFO supports using multiple linked lists per logical
-// FIFO. The linked list controller will cycle through the linked list heads in
-// round-robin fashion. The number of linked lists per FIFO is determined by the
-// staging buffer depth.  The bandwidth of a single logical FIFO is thus
-// determined by the formula `StagingBufferDepth / (PointerRamReadLatency + 1)`,
-// where `PointerRamReadLatency = PointerRamAddressDepthStages +
-// PointerRamReadDataDepthStages + PointerRamReadDataWidthStages`. To get one
-// pop per cycle bandwidth for a single logical FIFO, the staging buffer depth
-// should be set to `PointerRamReadLatency + 1`.
+// FIFO, configured by the `NumLinkedListsPerFifo` parameter. The linked list
+// controller will cycle through the linked list heads in round-robin fashion.
+// The bandwidth is also limited by the staging buffer depth and data RAM read
+// latency. Up to `StagingBufferDepth` reads can be inflight to the RAM at any
+// time. Thus, the bandwidth of a single logical FIFO is capped at
+// the minimum of `NumLinkedListsPerFifo / (PointerRamReadLatency + 1)` and
+// `StagingBufferDepth / (DataRamReadLatency + 1)`. To get full bandwidth,
+// the number of linked lists per FIFO should be set to `PointerRamReadLatency +
+// 1` and the staging buffer depth should be set to `DataRamReadLatency + 1`.
+//
+// `PointerRamReadLatency = PointerRamAddressDepthStages + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages`
+//
+// `DataRamReadLatency = DataRamReadAddressDepthStages + DataRamReadDataDepthStages + DataRamReadDataWidthStages`
 //
 // For example, to have zero retiming on the read path, full bandwidth, and
-// pop data registered at the output, set StagingBufferDepth = 1 and
-// RegisterPopOutputs = 1.
+// pop data registered at the output, set StagingBufferDepth = 1,
+// NumLinkedListsPerFifo = 1, and RegisterPopOutputs = 1.
 
 module br_fifo_shared_dynamic_flops_push_credit #(
     // Number of write ports. Must be >=1.
@@ -72,6 +77,10 @@ module br_fifo_shared_dynamic_flops_push_credit #(
     // This affects the pop bandwidth of each logical FIFO.
     // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
+    // The number of sub-linked lists used by each logical FIFO.
+    // This affects the pop bandwidth of each logical FIFO.
+    // The max bandwidth will be `NumLinkedListsPerFifo / (PointerRamReadLatency + 1)`.
+    parameter int NumLinkedListsPerFifo = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.
     parameter bit RegisterPopOutputs = 0,
@@ -227,6 +236,7 @@ module br_fifo_shared_dynamic_flops_push_credit #(
       .Depth(Depth),
       .Width(Width),
       .StagingBufferDepth(StagingBufferDepth),
+      .NumLinkedListsPerFifo(NumLinkedListsPerFifo),
       .RegisterPopOutputs(RegisterPopOutputs),
       .RegisterDeallocation(RegisterDeallocation),
       .DataRamReadLatency(DataRamReadLatency),

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -189,6 +189,10 @@ br_verilog_sim_test_tools_suite(
             "1",
             "2",
         ],
+        "NumLinkedListsPerFifo": [
+            "1",
+            "2",
+        ],
         "RegisterPopOutputs": [
             "0",
             "1",
@@ -246,6 +250,10 @@ br_verilog_sim_test_tools_suite(
             "2",
         ],
         "StagingBufferDepth": [
+            "1",
+            "2",
+        ],
+        "NumLinkedListsPerFifo": [
             "1",
             "2",
         ],

--- a/fifo/sim/br_fifo_shared_dynamic_flops_push_credit_tb.sv
+++ b/fifo/sim/br_fifo_shared_dynamic_flops_push_credit_tb.sv
@@ -7,6 +7,7 @@ module br_fifo_shared_dynamic_flops_push_credit_tb;
   parameter int Depth = 5;
   parameter int Width = 8;
   parameter int StagingBufferDepth = 1;
+  parameter int NumLinkedListsPerFifo = 1;
   parameter bit RegisterPopOutputs = 0;
   parameter bit RegisterDeallocation = 0;
   parameter int DataRamAddressDepthStages = 0;
@@ -85,6 +86,7 @@ module br_fifo_shared_dynamic_flops_push_credit_tb;
       .Depth(Depth),
       .Width(Width),
       .StagingBufferDepth(StagingBufferDepth),
+      .NumLinkedListsPerFifo(NumLinkedListsPerFifo),
       .RegisterPopOutputs(RegisterPopOutputs),
       .RegisterDeallocation(RegisterDeallocation),
       .RegisterPushOutputs(1),

--- a/fifo/sim/br_fifo_shared_dynamic_flops_tb.sv
+++ b/fifo/sim/br_fifo_shared_dynamic_flops_tb.sv
@@ -7,6 +7,7 @@ module br_fifo_shared_dynamic_flops_tb;
   parameter int Depth = 5;
   parameter int Width = 8;
   parameter int StagingBufferDepth = 1;
+  parameter int NumLinkedListsPerFifo = 1;
   parameter bit RegisterPopOutputs = 0;
   parameter bit RegisterDeallocation = 0;
   parameter int DataRamAddressDepthStages = 0;
@@ -36,6 +37,7 @@ module br_fifo_shared_dynamic_flops_tb;
       .Depth(Depth),
       .Width(Width),
       .StagingBufferDepth(StagingBufferDepth),
+      .NumLinkedListsPerFifo(NumLinkedListsPerFifo),
       .RegisterPopOutputs(RegisterPopOutputs),
       .RegisterDeallocation(RegisterDeallocation),
       .DataRamAddressDepthStages(DataRamAddressDepthStages),


### PR DESCRIPTION
We previously had this tied to StagingBufferDepth, but since the pointer RAM and data RAM can have different latencies, we likely want to set these independently.