### PR TITLE
Allow pipeline registers in br_delay to reset to non-zero value

### DIFF
--- a/counter/rtl/br_counter.sv
+++ b/counter/rtl/br_counter.sv
@@ -214,7 +214,7 @@ module br_counter #(
   // Value
   `BR_ASSERT_IMPL(value_in_range_a, value <= MaxValue)
   `BR_ASSERT_IMPL(value_next_in_range_a, value_next <= MaxValue)
-  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 value == $past(value_next))
+  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 !$past(rst) |-> value == $past(value_next))
 
   // Change corners
   `BR_COVER_IMPL(increment_max_c, incr_valid && incr == MaxChange)

--- a/counter/rtl/br_counter_decr.sv
+++ b/counter/rtl/br_counter_decr.sv
@@ -144,7 +144,7 @@ module br_counter_decr #(
   // Value
   `BR_ASSERT_IMPL(value_in_range_a, value <= MaxValue)
   `BR_ASSERT_IMPL(value_next_in_range_a, value_next <= MaxValue)
-  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 value == $past(value_next))
+  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 !$past(rst) |-> value == $past(value_next))
 
   // Underflow corners
   if (EnableSaturate) begin : gen_saturate_impl_checks

--- a/counter/rtl/br_counter_incr.sv
+++ b/counter/rtl/br_counter_incr.sv
@@ -152,7 +152,7 @@ module br_counter_incr #(
   // Value
   `BR_ASSERT_IMPL(value_in_range_a, value <= MaxValue)
   `BR_ASSERT_IMPL(value_next_in_range_a, value_next <= MaxValue)
-  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 value == $past(value_next))
+  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 !$past(rst) |-> value == $past(value_next))
 
   // Overflow corners
   if (EnableSaturate) begin : gen_saturate_impl_check

--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -17,14 +17,16 @@
 // Delays an input signal by a fixed number of clock cycles.
 // There are NumStages pipeline registers. If NumStages is 0,
 // then the output is the input. The pipeline registers are reset
-// to 0.
+// to `InitValue`.
 
 `include "br_registers.svh"
 `include "br_asserts_internal.svh"
 
 module br_delay #(
     parameter int Width = 1,  // Must be at least 1
-    parameter int NumStages = 0  // Must be at least 0
+    parameter int NumStages = 0,  // Must be at least 0
+    // Initial value of the delay registers.
+    parameter logic [Width-1:0] InitValue = '0
 ) (
     // Positive edge-triggered. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
@@ -58,7 +60,7 @@ module br_delay #(
 
   for (genvar i = 1; i <= NumStages; i++) begin : gen_stages
     // ri lint_check_waive BA_NBA_REG
-    `BR_REG(stages[i], stages[i-1])
+    `BR_REGI(stages[i], stages[i-1], InitValue)
   end
 
   assign out = stages[NumStages];


### PR DESCRIPTION
**Stack**:
- #685
- #684
- #683
- #678
- #677
- #676
- #675 ⬅
- #674


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*