### PR TITLE
Changes to br_fifo_push_ctrl_core to support pseudo-static shared FIFO

### DIFF
--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
@@ -93,6 +93,12 @@ module br_cdc_fifo_push_ctrl #(
   );
 
   // Core flow-control logic
+  logic [AddrWidth-1:0] addr_base;
+  logic [AddrWidth-1:0] addr_bound;
+
+  assign addr_base  = '0;
+  assign addr_bound = Depth - 1;
+
   br_fifo_push_ctrl_core #(
       .Depth(Depth),
       .Width(Width),
@@ -105,6 +111,9 @@ module br_cdc_fifo_push_ctrl #(
       .clk,
       .rst,
 
+      .addr_base,
+      .addr_bound,
+
       .push_ready,
       .push_valid,
       .push_data,
@@ -115,6 +124,7 @@ module br_cdc_fifo_push_ctrl #(
 
       .ram_wr_valid,
       .ram_wr_addr,
+      .ram_wr_addr_next(),
       .ram_wr_data,
 
       .full,

--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
@@ -137,6 +137,12 @@ module br_cdc_fifo_push_ctrl_credit #(
   );
 
   // Core flow-control logic
+  logic [AddrWidth-1:0] addr_base;
+  logic [AddrWidth-1:0] addr_bound;
+
+  assign addr_base  = '0;
+  assign addr_bound = Depth - 1;
+
   br_fifo_push_ctrl_core #(
       .Depth(Depth),
       .Width(Width),
@@ -148,6 +154,9 @@ module br_cdc_fifo_push_ctrl_credit #(
       .clk,
       .rst(either_rst),
 
+      .addr_base,
+      .addr_bound,
+
       .push_ready(),
       .push_valid(internal_valid),
       .push_data (internal_data),
@@ -157,6 +166,7 @@ module br_cdc_fifo_push_ctrl_credit #(
       .bypass_data_unstable(),  // Bypass not used
 
       .ram_wr_valid,
+      .ram_wr_addr_next(),
       .ram_wr_addr,
       .ram_wr_data,
 

--- a/counter/rtl/br_counter.sv
+++ b/counter/rtl/br_counter.sv
@@ -214,7 +214,7 @@ module br_counter #(
   // Value
   `BR_ASSERT_IMPL(value_in_range_a, value <= MaxValue)
   `BR_ASSERT_IMPL(value_next_in_range_a, value_next <= MaxValue)
-  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 value == $past(value_next))
+  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 !$past(rst) |-> value == $past(value_next))
 
   // Change corners
   `BR_COVER_IMPL(increment_max_c, incr_valid && incr == MaxChange)

--- a/counter/rtl/br_counter_decr.sv
+++ b/counter/rtl/br_counter_decr.sv
@@ -144,7 +144,7 @@ module br_counter_decr #(
   // Value
   `BR_ASSERT_IMPL(value_in_range_a, value <= MaxValue)
   `BR_ASSERT_IMPL(value_next_in_range_a, value_next <= MaxValue)
-  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 value == $past(value_next))
+  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 !$past(rst) |-> value == $past(value_next))
 
   // Underflow corners
   if (EnableSaturate) begin : gen_saturate_impl_checks

--- a/counter/rtl/br_counter_incr.sv
+++ b/counter/rtl/br_counter_incr.sv
@@ -152,7 +152,7 @@ module br_counter_incr #(
   // Value
   `BR_ASSERT_IMPL(value_in_range_a, value <= MaxValue)
   `BR_ASSERT_IMPL(value_next_in_range_a, value_next <= MaxValue)
-  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 value == $past(value_next))
+  `BR_ASSERT_IMPL(value_next_propagates_a, ##1 !$past(rst) |-> value == $past(value_next))
 
   // Overflow corners
   if (EnableSaturate) begin : gen_saturate_impl_check

--- a/delay/rtl/br_delay.sv
+++ b/delay/rtl/br_delay.sv
@@ -17,14 +17,16 @@
 // Delays an input signal by a fixed number of clock cycles.
 // There are NumStages pipeline registers. If NumStages is 0,
 // then the output is the input. The pipeline registers are reset
-// to 0.
+// to `InitValue`.
 
 `include "br_registers.svh"
 `include "br_asserts_internal.svh"
 
 module br_delay #(
     parameter int Width = 1,  // Must be at least 1
-    parameter int NumStages = 0  // Must be at least 0
+    parameter int NumStages = 0,  // Must be at least 0
+    // Initial value of the delay registers.
+    parameter logic [Width-1:0] InitValue = '0
 ) (
     // Positive edge-triggered. If NumStages is 0, then only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
@@ -58,7 +60,7 @@ module br_delay #(
 
   for (genvar i = 1; i <= NumStages; i++) begin : gen_stages
     // ri lint_check_waive BA_NBA_REG
-    `BR_REG(stages[i], stages[i-1])
+    `BR_REGI(stages[i], stages[i-1], InitValue)
   end
 
   assign out = stages[NumStages];

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -85,6 +85,13 @@ module br_fifo_push_ctrl #(
   //------------------------------------------
 
   // Core flow-control logic
+
+  logic [AddrWidth-1:0] addr_base;
+  logic [AddrWidth-1:0] addr_bound;
+
+  assign addr_base  = '0;
+  assign addr_bound = Depth - 1;
+
   br_fifo_push_ctrl_core #(
       .Depth(RamDepth),
       .Width(Width),
@@ -97,6 +104,9 @@ module br_fifo_push_ctrl #(
       .clk,
       .rst,
 
+      .addr_base,
+      .addr_bound,
+
       .push_ready,
       .push_valid,
       .push_data,
@@ -106,6 +116,7 @@ module br_fifo_push_ctrl #(
       .bypass_data_unstable,  // ri lint_check_waive CONST_OUTPUT
 
       .ram_wr_valid,
+      .ram_wr_addr_next(),
       .ram_wr_addr,
       .ram_wr_data,
 

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -119,6 +119,13 @@ module br_fifo_push_ctrl_credit #(
   );
 
   // Core flow-control logic
+
+  logic [AddrWidth-1:0] addr_base;
+  logic [AddrWidth-1:0] addr_bound;
+
+  assign addr_base  = '0;
+  assign addr_bound = Depth - 1;
+
   br_fifo_push_ctrl_core #(
       .Depth(RamDepth),
       .Width(Width),
@@ -130,6 +137,9 @@ module br_fifo_push_ctrl_credit #(
       .clk,
       .rst(either_rst),
 
+      .addr_base,
+      .addr_bound,
+
       .push_ready(),
       .push_valid(internal_valid),
       .push_data (internal_data),
@@ -139,6 +149,7 @@ module br_fifo_push_ctrl_credit #(
       .bypass_data_unstable,  // ri lint_check_waive CONST_OUTPUT
 
       .ram_wr_valid,
+      .ram_wr_addr_next(),
       .ram_wr_addr,
       .ram_wr_data,
 


### PR DESCRIPTION
Provide base and bound straps to the push control core so that
the address range can be a subset of the RAM range.

Expose the next ram write address.

---

**Stack**:
- #685
- #684
- #683
- #678
- #677
- #676 ⬅
- #675
- #674


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*