### PR TITLE
Set default width of MaxValue/MaxChange back to 32

### DIFF
--- a/amba/rtl/br_amba_axil_msi.sv
+++ b/amba/rtl/br_amba_axil_msi.sv
@@ -19,7 +19,7 @@
 // the address field of the MSI message (4-byte aligned), and the event ID is
 // encoded in the lower bits of the data field.
 //
-// The configuration of the MSI address and data fields are done through inputs.
+
 // It is expected that the configuration will be done through a register interface
 // which is not part of this module.
 //
@@ -172,8 +172,6 @@ module br_amba_axil_msi #(
 
   // Throttle counter
   br_counter_decr #(
-      .ValueWidth(ThrottleCntrWidth),
-      .DecrementWidth(1),
       .MaxValue({ThrottleCntrWidth{1'b1}}),
       .EnableSaturate(1),
       .MaxDecrement(1)

--- a/amba/rtl/br_amba_axil_split.sv
+++ b/amba/rtl/br_amba_axil_split.sv
@@ -185,10 +185,8 @@ module br_amba_axil_split #(
 
   // Counters to track outstanding read transactions
   br_counter #(
-      .ValueWidth(ReadCounterWidth),
-      .ChangeWidth(1),
-      .MaxValue(MaxOutstandingReads),
-      .MaxChange(1),
+      .MaxValue  (MaxOutstandingReads),
+      .MaxChange (1),
       .EnableWrap(0)
   ) br_counter_outstanding_reads (
       .clk,
@@ -218,10 +216,8 @@ module br_amba_axil_split #(
 
   // Counters to track outstanding write transactions
   br_counter #(
-      .ValueWidth(WriteCounterWidth),
-      .ChangeWidth(1),
-      .MaxValue(MaxOutstandingWrites),
-      .MaxChange(1),
+      .MaxValue  (MaxOutstandingWrites),
+      .MaxChange (1),
       .EnableWrap(0)
   ) br_counter_outstanding_writes (
       .clk,

--- a/amba/rtl/internal/br_amba_axi2axil_core.sv
+++ b/amba/rtl/internal/br_amba_axi2axil_core.sv
@@ -256,8 +256,6 @@ module br_amba_axi2axil_core #(
 
   // Request count
   br_counter_incr #(
-      .ValueWidth(br_amba::AxiBurstLenWidth),
-      .IncrementWidth(1),
       .MaxValue({br_amba::AxiBurstLenWidth{1'b1}}),
       .MaxIncrement(1),
       .EnableReinitAndIncr(0)

--- a/amba/rtl/internal/br_amba_iso_req_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_req_tracker.sv
@@ -88,8 +88,6 @@ module br_amba_iso_req_tracker #(
   assign decr_valid = downstream_xvalid && downstream_xready && downstream_xlast;
 
   br_counter #(
-      .ValueWidth(RespCountWidth),
-      .ChangeWidth(1),
       .MaxValue(MaxOutstanding),
       .MaxChange(1),
       .EnableWrap(0),

--- a/amba/rtl/internal/br_amba_iso_resp_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_resp_tracker.sv
@@ -312,8 +312,6 @@ module br_amba_iso_resp_tracker #(
     assign req_tracker_free_slots_init = MaxOutstanding;
 
     br_counter #(
-        .ValueWidth(OutstandingWidth),
-        .ChangeWidth(1),
         .MaxValue(MaxOutstanding),
         .MaxChange(1),
         .EnableWrap(0),
@@ -435,8 +433,6 @@ module br_amba_iso_resp_tracker #(
     `BR_UNUSED(incr_count)
   end else begin : gen_counter
     br_counter_incr #(
-        .ValueWidth(AxiBurstLenWidth),
-        .IncrementWidth(1),
         .MaxValue(MaxAxiBurstLen - 1),
         .MaxIncrement(1),
         .EnableSaturate(0),

--- a/amba/rtl/internal/br_amba_iso_wdata_align.sv
+++ b/amba/rtl/internal/br_amba_iso_wdata_align.sv
@@ -204,8 +204,6 @@ module br_amba_iso_wdata_align #(
   //
 
   br_counter #(
-      .ValueWidth(MaxExcessCountWidth),
-      .ChangeWidth(MaxBurstLenWidth),
       .MaxValue(MaxExcessCount),
       .MaxChange(MaxAxiBurstLen),
       .EnableWrap(0),
@@ -231,8 +229,6 @@ module br_amba_iso_wdata_align #(
   //
 
   br_counter #(
-      .ValueWidth(MaxExcessCountWidth),
-      .ChangeWidth(MaxBurstLenWidth),
       .MaxValue(MaxExcessCount),
       .MaxChange(MaxAxiBurstLen),
       .EnableWrap(0),
@@ -303,8 +299,6 @@ module br_amba_iso_wdata_align #(
     end else begin : gen_beat_count_multi_beat
       logic [AxiBurstLenWidth-1:0] beat_count;
       br_counter_incr #(
-          .ValueWidth(AxiBurstLenWidth),
-          .IncrementWidth(1),
           .MaxValue(MaxAxiBurstLen - 1),
           .MaxIncrement(1),
           .EnableReinitAndIncr(0),

--- a/arb/rtl/br_arb_weighted_rr.sv
+++ b/arb/rtl/br_arb_weighted_rr.sv
@@ -118,8 +118,6 @@ module br_arb_weighted_rr #(
 
   for (genvar i = 0; i < NumRequesters; i++) begin : gen_accumulated_weight
     br_counter #(
-        .ValueWidth(AccumulatedWeightWidth),
-        .ChangeWidth(WeightWidth),
         .MaxValue(MaxAccumulatedWeight),
         .MaxChange(MaxWeight),
         .EnableSaturate(1),

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -110,7 +110,7 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
     args = (["--hdr=" + hdr for hdr in hdr_files] +
             ["--define=" + define for define in ctx.attr.defines] +
             ["--top=" + top] +
-            ["--param=" + key + "=" + value for key, value in ctx.attr.params.items()])
+            ["--param=" + key + "=\"" + value + "\"" for key, value in ctx.attr.params.items()])
     filelist = ctx.label.name + ".f"
     tcl = ctx.label.name + ".tcl"
     script = ctx.label.name + ".sh"

--- a/cdc/rtl/internal/br_cdc_fifo_pop_flag_mgr.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_pop_flag_mgr.sv
@@ -52,8 +52,6 @@ module br_cdc_fifo_pop_flag_mgr #(
   logic [CountWidth-1:0] push_count_visible;
 
   br_counter_incr #(
-      .ValueWidth(CountWidth),
-      .IncrementWidth(1),
       .MaxValue(MaxCount)
   ) br_counter_incr_pop_count (
       .clk,

--- a/cdc/rtl/internal/br_cdc_fifo_push_flag_mgr.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_flag_mgr.sv
@@ -55,8 +55,6 @@ module br_cdc_fifo_push_flag_mgr #(
   logic [CountWidth-1:0] pop_count_visible;
 
   br_counter_incr #(
-      .ValueWidth(CountWidth),
-      .IncrementWidth(1),
       .MaxValue(MaxCount)
   ) br_counter_incr_push_count (
       .clk,

--- a/counter/rtl/BUILD.bazel
+++ b/counter/rtl/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_lint_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -50,12 +51,6 @@ verilog_library(
 br_verilog_elab_and_lint_test_suite(
     name = "br_counter_incr_test_suite0",
     params = {
-        "ValueWidth": [
-            "2",
-        ],
-        "IncrementWidth": [
-            "1",
-        ],
         "MaxValue": [
             "1",
             "2",
@@ -71,12 +66,6 @@ br_verilog_elab_and_lint_test_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_counter_incr_test_suite1",
     params = {
-        "ValueWidth": [
-            "2",
-        ],
-        "IncrementWidth": [
-            "2",
-        ],
         "MaxValue": [
             "2",
             "3",
@@ -95,12 +84,6 @@ br_verilog_elab_and_lint_test_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_counter_incr_test_suite2",
     params = {
-        "ValueWidth": [
-            "2",
-        ],
-        "IncrementWidth": [
-            "2",
-        ],
         "MaxValue": [
             "2",
             "3",
@@ -116,15 +99,36 @@ br_verilog_elab_and_lint_test_suite(
     deps = [":br_counter_incr"],
 )
 
+# Need to use the base verilog_elab_test/verilog_lint_test rules here
+# since topstitch doesn't support >32-bit parameter overrides.
+# TODO(zhemao): Switch back to topstitch-based sweeps once the issue is fixed.
+verilog_elab_test(
+    name = "br_counter_incr_64bit_elab_test",
+    params = {
+        "MaxValueWidth": "64",
+        "MaxIncrementWidth": "64",
+        "MaxValue": "64'd18446744073709551615",
+        "MaxIncrement": "64'd18446744073709551615",
+    },
+    tool = "verific",
+    deps = [":br_counter_incr"],
+)
+
+verilog_lint_test(
+    name = "br_counter_incr_64bit_lint_test",
+    params = {
+        "MaxValueWidth": "64",
+        "MaxIncrementWidth": "64",
+        "MaxValue": "64'd18446744073709551615",
+        "MaxIncrement": "64'd18446744073709551615",
+    },
+    tool = "ascentlint",
+    deps = [":br_counter_incr"],
+)
+
 br_verilog_elab_and_lint_test_suite(
     name = "br_counter_decr_test_suite0",
     params = {
-        "ValueWidth": [
-            "2",
-        ],
-        "DecrementWidth": [
-            "1",
-        ],
         "MaxValue": [
             "1",
             "2",
@@ -144,12 +148,6 @@ br_verilog_elab_and_lint_test_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_counter_decr_test_suite1",
     params = {
-        "ValueWidth": [
-            "2",
-        ],
-        "DecrementWidth": [
-            "2",
-        ],
         "MaxValue": [
             "2",
             "3",
@@ -164,12 +162,6 @@ br_verilog_elab_and_lint_test_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_counter_decr_test_suite2",
     params = {
-        "ValueWidth": [
-            "2",
-        ],
-        "DecrementWidth": [
-            "2",
-        ],
         "MaxValue": [
             "2",
             "3",
@@ -185,15 +177,36 @@ br_verilog_elab_and_lint_test_suite(
     deps = [":br_counter_decr"],
 )
 
+# Need to use the base verilog_elab_test/verilog_lint_test rules here
+# since topstitch doesn't support >32-bit parameter overrides.
+# TODO(zhemao): Switch back to topstitch-based sweeps once the issue is fixed.
+verilog_elab_test(
+    name = "br_counter_decr_64bit_elab_test",
+    params = {
+        "MaxValueWidth": "64",
+        "MaxDecrementWidth": "64",
+        "MaxValue": "64'd18446744073709551615",
+        "MaxDecrement": "64'd18446744073709551615",
+    },
+    tool = "verific",
+    deps = [":br_counter_decr"],
+)
+
+verilog_lint_test(
+    name = "br_counter_decr_64bit_lint_test",
+    params = {
+        "MaxValueWidth": "64",
+        "MaxDecrementWidth": "64",
+        "MaxValue": "64'd18446744073709551615",
+        "MaxDecrement": "64'd18446744073709551615",
+    },
+    tool = "ascentlint",
+    deps = [":br_counter_decr"],
+)
+
 br_verilog_elab_and_lint_test_suite(
     name = "br_counter_test_suite0",
     params = {
-        "ValueWidth": [
-            "2",
-        ],
-        "ChangeWidth": [
-            "1",
-        ],
         "MaxValue": [
             "1",
             "2",
@@ -213,12 +226,6 @@ br_verilog_elab_and_lint_test_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_counter_test_suite1",
     params = {
-        "ValueWidth": [
-            "2",
-        ],
-        "ChangeWidth": [
-            "2",
-        ],
         "MaxValue": [
             "2",
             "3",
@@ -237,12 +244,6 @@ br_verilog_elab_and_lint_test_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_counter_test_suite2",
     params = {
-        "ValueWidth": [
-            "2",
-        ],
-        "ChangeWidth": [
-            "2",
-        ],
         "MaxValue": [
             "2",
             "3",
@@ -257,5 +258,32 @@ br_verilog_elab_and_lint_test_suite(
             "1",
         ],
     },
+    deps = [":br_counter"],
+)
+
+# Need to use the base verilog_elab_test/verilog_lint_test rules here
+# since topstitch doesn't support >32-bit parameter overrides.
+# TODO(zhemao): Switch back to topstitch-based sweeps once the issue is fixed.
+verilog_elab_test(
+    name = "br_counter_64bit_elab_test",
+    params = {
+        "MaxValueWidth": "64",
+        "MaxChangeWidth": "64",
+        "MaxValue": "64'd18446744073709551615",
+        "MaxChange": "64'd18446744073709551615",
+    },
+    tool = "verific",
+    deps = [":br_counter"],
+)
+
+verilog_lint_test(
+    name = "br_counter_64bit_lint_test",
+    params = {
+        "MaxValueWidth": "64",
+        "MaxChangeWidth": "64",
+        "MaxValue": "64'd18446744073709551615",
+        "MaxChange": "64'd18446744073709551615",
+    },
+    tool = "ascentlint",
     deps = [":br_counter"],
 )

--- a/counter/rtl/br_counter_decr.sv
+++ b/counter/rtl/br_counter_decr.sv
@@ -45,14 +45,18 @@
 `include "br_unused.svh"
 
 module br_counter_decr #(
-    // Must be at least 1. Inclusive.
-    parameter int ValueWidth = 1,
-    // Must be at least 1. Inclusive.
-    parameter int DecrementWidth = 1,
+    // Width of the MaxValue parameter.
+    // You might need to override this if you need a counter that's larger than 32 bits.
+    // Must be at least 1.
+    parameter int MaxValueWidth = 32,
+    // Width of the MaxDecrement parameter.
+    // You might need to override this if you need a counter that's larger than 32 bits.
+    // Must be at least 1.
+    parameter int MaxDecrementWidth = 32,
     // Must be at least 1. Inclusive. Also the initial value.
-    parameter logic [ValueWidth-1:0] MaxValue = 1,
+    parameter logic [MaxValueWidth-1:0] MaxValue = 1,
     // Must be at least 1 and at most MaxValue. Inclusive.
-    parameter logic [DecrementWidth-1:0] MaxDecrement = 1,
+    parameter logic [MaxDecrementWidth-1:0] MaxDecrement = 1,
     // If 1, then when reinit is asserted together with decr_valid,
     // the decrement is applied to the initial value rather than the current value, i.e.,
     // value_next == initial_value - applicable decr.
@@ -63,7 +67,11 @@ module br_counter_decr #(
     // If 0, the counter value wraps around at 0.
     parameter bit EnableSaturate = 0,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    localparam int MaxValueP1Width = MaxValueWidth + 1,
+    localparam int MaxDecrementP1Width = MaxDecrementWidth + 1,
+    localparam int ValueWidth = $clog2(MaxValueP1Width'(MaxValue) + 1),
+    localparam int DecrementWidth = $clog2(MaxDecrementP1Width'(MaxDecrement) + 1)
 ) (
     // Posedge-triggered clock.
     input  logic                      clk,
@@ -80,8 +88,8 @@ module br_counter_decr #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(value_width_gte_1_a, ValueWidth >= 1)
-  `BR_ASSERT_STATIC(decrement_width_gte_1_a, DecrementWidth >= 1)
+  `BR_ASSERT_STATIC(max_value_width_gte_1_a, MaxValueWidth >= 1)
+  `BR_ASSERT_STATIC(max_decrement_width_gte_1_a, MaxDecrementWidth >= 1)
   `BR_ASSERT_STATIC(max_value_gte_1_a, MaxValue >= 1)
   `BR_ASSERT_STATIC(max_decrement_gte_1_a, MaxDecrement >= 1)
   `BR_ASSERT_STATIC(max_decrement_lte_max_value_a, MaxDecrement <= MaxValue)
@@ -96,7 +104,7 @@ module br_counter_decr #(
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  localparam int MaxValueP1 = MaxValue + 1;
+  localparam logic [MaxValueP1Width-1:0] MaxValueP1 = MaxValue + 1;
   localparam bit IsMaxValueP1PowerOf2 = (MaxValueP1 & (MaxValueP1 - 1)) == 0;
 
   logic [ValueWidth-1:0] value_temp;
@@ -124,7 +132,7 @@ module br_counter_decr #(
     `BR_UNUSED(underflow)
   end else begin : gen_non_power_of_2_wrap
     // For MaxValueP1 not being a power of 2, handle wrap-around explicitly
-    localparam int Margin = ((2 ** ValueWidth) - 1) - MaxValue;
+    localparam logic [ValueWidth-1:0] Margin = ((2 ** ValueWidth) - 1) - MaxValue;
     logic [ValueWidth-1:0] value_temp_wrapped;
     assign value_temp_wrapped = value_temp - Margin;
     assign value_next = underflow ? value_temp_wrapped : value_temp;
@@ -156,7 +164,7 @@ module br_counter_decr #(
 
     // If there is an underflow, we can treat value_temp as a negative number.
     // By adding MaxValue + 1 to it, we should get to the correct wrap-around value.
-    assign value_temp_adjusted = value_temp + MaxValue + 1;
+    assign value_temp_adjusted = value_temp + ValueWidth'(MaxValue + 1);
 `endif
 `endif
     `BR_ASSERT_IMPL(value_underflow_a,

--- a/counter/sim/br_counter_decr_tb.sv
+++ b/counter/sim/br_counter_decr_tb.sv
@@ -38,8 +38,6 @@ module br_counter_decr_tb;
 
   // Instantiate the design under test (DUT)
   br_counter_decr #(
-      .ValueWidth(ValueWidth),
-      .DecrementWidth(DecrementWidth),
       .MaxValue(MaxValue),
       .MaxDecrement(MaxDecrement),
       .EnableSaturate(EnableSaturate),

--- a/counter/sim/br_counter_incr_tb.sv
+++ b/counter/sim/br_counter_incr_tb.sv
@@ -38,8 +38,6 @@ module br_counter_incr_tb;
 
   // Instantiate the module under test (MUT)
   br_counter_incr #(
-      .ValueWidth(ValueWidth),
-      .IncrementWidth(IncrementWidth),
       .MaxValue(MaxValue),
       .MaxIncrement(MaxIncrement),
       .EnableSaturate(EnableSaturate),

--- a/counter/sim/br_counter_tb.sv
+++ b/counter/sim/br_counter_tb.sv
@@ -40,8 +40,6 @@ module br_counter_tb;
 
   // Instantiate the design under test (DUT)
   br_counter #(
-      .ValueWidth(ValueWidth),
-      .ChangeWidth(ChangeWidth),
       .MaxValue(MaxValue),
       .MaxChange(MaxChange),
       .EnableSaturate(EnableSaturate),

--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -120,8 +120,6 @@ module br_fifo_pop_ctrl #(
 
   // Status flags
   br_counter #(
-      .ValueWidth(CountWidth),
-      .ChangeWidth(1),
       .MaxValue(Depth),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_counter_items (

--- a/fifo/rtl/internal/br_fifo_pop_ctrl_core.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl_core.sv
@@ -85,8 +85,6 @@ module br_fifo_pop_ctrl_core #(
 
   if (RamDepth > 1) begin : gen_ram_rd_addr_counter
     br_counter_incr #(
-        .ValueWidth(AddrWidth),
-        .IncrementWidth(1),
         .MaxValue(RamDepth - 1),
         .MaxIncrement(1),
         .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -115,8 +115,6 @@ module br_fifo_push_ctrl #(
 
   // Status flags
   br_counter #(
-      .ValueWidth(CountWidth),
-      .ChangeWidth(1),
       .MaxValue(Depth),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_counter_slots (

--- a/fifo/rtl/internal/br_fifo_push_ctrl_core.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_core.sv
@@ -95,8 +95,6 @@ module br_fifo_push_ctrl_core #(
   // RAM path
   if (Depth > 1) begin : gen_wr_addr_counter
     br_counter_incr #(
-        .ValueWidth(AddrWidth),
-        .IncrementWidth(1),
         .MaxValue(Depth - 1),
         .MaxIncrement(1),
         .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -148,8 +148,6 @@ module br_fifo_push_ctrl_credit #(
 
   // Status flags
   br_counter #(
-      .ValueWidth(CountWidth),
-      .ChangeWidth(1),
       .MaxValue(Depth),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_counter_slots (

--- a/fifo/rtl/internal/br_fifo_staging_buffer.sv
+++ b/fifo/rtl/internal/br_fifo_staging_buffer.sv
@@ -126,8 +126,6 @@ module br_fifo_staging_buffer #(
   logic                        pop_valid_nonbypass;
 
   br_counter #(
-      .ValueWidth(BufferCountWidth),
-      .ChangeWidth(1),
       .MaxValue(BufferDepth),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
       .EnableWrap(0)

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -207,8 +207,6 @@ module br_flow_deserializer #(
     logic                      pop;
 
     br_counter_incr #(
-        .ValueWidth(SerFlitIdWidth),
-        .IncrementWidth(1),
         .MaxValue(DrMinus1),
         .MaxIncrement(1),
         .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/rtl/br_flow_serializer.sv
+++ b/flow/rtl/br_flow_serializer.sv
@@ -200,8 +200,6 @@ module br_flow_serializer #(
     logic [SerFlitIdWidth-1:0] pop_flit_id;
 
     br_counter_incr #(
-        .ValueWidth(SerFlitIdWidth),
-        .IncrementWidth(1),
         .MaxValue(SrMinus1),
         .MaxIncrement(1),
         .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/tracker/rtl/br_tracker_linked_list_ctrl.sv
+++ b/tracker/rtl/br_tracker_linked_list_ctrl.sv
@@ -255,10 +255,8 @@ module br_tracker_linked_list_ctrl #(
     assign counter_decr = ChangeWidth'(1'b1);
 
     br_counter #(
-        .ValueWidth(CountWidth),
-        .ChangeWidth(ChangeWidth),
-        .MaxValue(Depth),
-        .MaxChange(NumWritePorts),
+        .MaxValue  (Depth),
+        .MaxChange (NumWritePorts),
         .EnableWrap(0)
     ) br_counter_ll_count (
         .clk,

--- a/tracker/rtl/br_tracker_reorder.sv
+++ b/tracker/rtl/br_tracker_reorder.sv
@@ -99,8 +99,6 @@ module br_tracker_reorder #(
   logic [CounterValueWidth-1:0] dealloc_complete_counter_value;
 
   br_counter_incr #(
-      .ValueWidth(CounterValueWidth),
-      .IncrementWidth(1),
       .MaxValue(NumEntries - 1),
       .MaxIncrement(1),
       .EnableSaturate(0),

--- a/tracker/rtl/br_tracker_sequence.sv
+++ b/tracker/rtl/br_tracker_sequence.sv
@@ -97,8 +97,6 @@ module br_tracker_sequence #(
   end
 
   br_counter_incr #(
-      .ValueWidth(AllocCounterValueWidth),
-      .IncrementWidth(AllocCounterIncrWidth),
       .MaxValue(NumEntries - 1),
       .MaxIncrement(MaxIncrementAllocCounter),
       .EnableSaturate(0),
@@ -129,8 +127,6 @@ module br_tracker_sequence #(
   // Free Entry Counter
 
   br_counter #(
-      .ValueWidth(EntryCountWidth),
-      .ChangeWidth(MaxAllocSizeWidth),
       .MaxValue(NumEntries),
       .MaxChange(MaxAllocSize),
       .EnableWrap(0),


### PR DESCRIPTION
This will allow the counter modules to be instantiated the same way as
before with no overriding of widths unless a >32 bit counter is needed.

Also fix an issue with bazel verilog rules preventing passing >32 bit
literals as parameters.