### PR TITLE
Clean up br_isolate_mgr/sub FPV

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -346,6 +346,16 @@ br_verilog_fpv_test_tools_suite(
         "-sv09_strong_embedding",
     ],
     gui = True,
+    params = {
+        "MaxAxiBurstLen": [
+            "1",
+            "256",
+        ],
+        "IdWidth": [
+            "1",
+            "2",
+        ],
+    },
     tools = {
         "jg": "br_amba_axi_isolate_sub_fpv.jg.tcl",
         "vcf": "",

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -345,7 +345,6 @@ br_verilog_fpv_test_tools_suite(
         "-parameter MaxOutstanding 4",
         "-sv09_strong_embedding",
     ],
-    gui = True,
     params = {
         "MaxAxiBurstLen": [
             "1",

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -345,6 +345,7 @@ br_verilog_fpv_test_tools_suite(
         "-parameter MaxOutstanding 4",
         "-sv09_strong_embedding",
     ],
+    gui = True,
     params = {
         "MaxAxiBurstLen": [
             "1",

--- a/amba/fpv/br_amba_axi_isolate_mgr_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_isolate_mgr_fpv_monitor.sv
@@ -151,6 +151,7 @@ module br_amba_axi_isolate_mgr_fpv_monitor #(
   `BR_ASSERT(eventually_back_to_normal_a, $fell(isolate_req) |-> s_eventually $fell(isolate_done))
 
   isolate_axi_protocol_fv_check #(
+      .ReadInterleaveOn(1),
       .AddrWidth(AddrWidth),
       .DataWidth(DataWidth),
       .IdWidth(IdWidth),

--- a/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
@@ -21,7 +21,14 @@ get_design_info
 cover -disable *
 
 # during isolate_req & !isolate_done window, downstream assertions don't matter
-# TODO: add exclude when RTL is fixed
+# Coded same assertion with precondition: isolate_req & !isolate_done in br_amba_axi_isolate_sub_fpv.sv
+assert -disable {*downstream.genStableChksRDInf.genARStableChks.master_ar_arvalid_stable}
+assert -disable {*downstream.genStableChksWRInf.genAWStableChks.master_aw_awvalid_stable}
+assert -disable {*downstream.genStableChksWRInf.genWStableChks.master_w_wvalid_stable}
+# TODO: is it bug?
+assert -disable {*upstream.genPropChksRDInf.genNoRdTblOverflow.genSlv.slave_ar_rd_tbl_no_overflow}
+assert -disable {*upstream.genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow}
+assert -disable {*upstream.genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow}
 
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
@@ -25,10 +25,6 @@ cover -disable *
 assert -disable {*downstream.genStableChksRDInf.genARStableChks.master_ar_arvalid_stable}
 assert -disable {*downstream.genStableChksWRInf.genAWStableChks.master_aw_awvalid_stable}
 assert -disable {*downstream.genStableChksWRInf.genWStableChks.master_w_wvalid_stable}
-# TODO: is it bug?
-assert -disable {*upstream.genPropChksRDInf.genNoRdTblOverflow.genSlv.slave_ar_rd_tbl_no_overflow}
-assert -disable {*upstream.genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow}
-assert -disable {*upstream.genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow}
 
 # prove command
 prove -all

--- a/amba/fpv/isolate_axi_protocol_fv_check.sv
+++ b/amba/fpv/isolate_axi_protocol_fv_check.sv
@@ -141,7 +141,9 @@ module isolate_axi_protocol_fv_check #(
       .MAX_PENDING(MaxPending),
       .AXI4_LITE(MaxAxiBurstLen == 1),
       .READ_INTERLEAVE_ON(ReadInterleaveOn),
-      // not supported by br_amba_axi_isolate_mgr/sub
+      // when there is no valid, ready doesn't have to be high eventually
+      // This will only turn off assertion without precondition: `STRENGTH(##[0:$] arready
+      // (arvalid && !arready) |=> `STRENGTH(##[0:$] arready) is still enabled
       .CONFIG_WAIT_FOR_VALID_BEFORE_READY(ValidBeforeReady)
   ) upstream (
       // Global signals
@@ -214,7 +216,9 @@ module isolate_axi_protocol_fv_check #(
       .MAX_PENDING(MaxPending),
       .AXI4_LITE(MaxAxiBurstLen == 1),
       .READ_INTERLEAVE_ON(ReadInterleaveOn),  // not supported by br_amba_axi_isolate_sub
-      // not supported by br_amba_axi_isolate_mgr/sub
+      // when there is no valid, ready doesn't have to be high eventually
+      // This will only turn off assertion without precondition: `STRENGTH(##[0:$] arready
+      // (arvalid && !arready) |=> `STRENGTH(##[0:$] arready) is still enabled
       .CONFIG_WAIT_FOR_VALID_BEFORE_READY(ValidBeforeReady)
   ) downstream (
       // Global signals

--- a/amba/fpv/isolate_axi_protocol_fv_check.sv
+++ b/amba/fpv/isolate_axi_protocol_fv_check.sv
@@ -115,6 +115,9 @@ module isolate_axi_protocol_fv_check #(
     input logic                                  downstream_rready
 );
 
+  // ABVIP should send more than DUT to test backpressure
+  localparam int MaxPending = MaxOutstanding + 2;
+
   // FV 4-phase handshake modeling
   fv_4phase_handshake #(
       .Master(1)
@@ -135,7 +138,7 @@ module isolate_axi_protocol_fv_check #(
       .WUSER_WIDTH(WUserWidth),
       .BUSER_WIDTH(BUserWidth),
       .RUSER_WIDTH(RUserWidth),
-      .MAX_PENDING(MaxOutstanding),
+      .MAX_PENDING(MaxPending),
       .AXI4_LITE(MaxAxiBurstLen == 1),
       .READ_INTERLEAVE_ON(ReadInterleaveOn),
       // not supported by br_amba_axi_isolate_mgr/sub
@@ -208,7 +211,7 @@ module isolate_axi_protocol_fv_check #(
       .WUSER_WIDTH(WUserWidth),
       .BUSER_WIDTH(BUserWidth),
       .RUSER_WIDTH(RUserWidth),
-      .MAX_PENDING(MaxOutstanding),
+      .MAX_PENDING(MaxPending),
       .AXI4_LITE(MaxAxiBurstLen == 1),
       .READ_INTERLEAVE_ON(ReadInterleaveOn),  // not supported by br_amba_axi_isolate_sub
       // not supported by br_amba_axi_isolate_mgr/sub

--- a/amba/fpv/isolate_axi_protocol_fv_check.sv
+++ b/amba/fpv/isolate_axi_protocol_fv_check.sv
@@ -16,6 +16,9 @@
 `include "br_registers.svh"
 
 module isolate_axi_protocol_fv_check #(
+    parameter bit ReadInterleaveOn = 1,
+    // if there is no valid, ready doesn't have to be high eventually
+    parameter bit ValidBeforeReady = 1,
     parameter int AddrWidth = 12,
     parameter int DataWidth = 32,
     parameter int IdWidth = 1,
@@ -133,7 +136,10 @@ module isolate_axi_protocol_fv_check #(
       .BUSER_WIDTH(BUserWidth),
       .RUSER_WIDTH(RUserWidth),
       .MAX_PENDING(MaxOutstanding),
-      .AXI4_LITE(MaxAxiBurstLen == 1)
+      .AXI4_LITE(MaxAxiBurstLen == 1),
+      .READ_INTERLEAVE_ON(ReadInterleaveOn),
+      // not supported by br_amba_axi_isolate_mgr/sub
+      .CONFIG_WAIT_FOR_VALID_BEFORE_READY(ValidBeforeReady)
   ) upstream (
       // Global signals
       .aclk    (clk),
@@ -204,7 +210,9 @@ module isolate_axi_protocol_fv_check #(
       .RUSER_WIDTH(RUserWidth),
       .MAX_PENDING(MaxOutstanding),
       .AXI4_LITE(MaxAxiBurstLen == 1),
-      .READ_INTERLEAVE_ON(0)  // not supported by br_amba_axi_isolate_sub
+      .READ_INTERLEAVE_ON(ReadInterleaveOn),  // not supported by br_amba_axi_isolate_sub
+      // not supported by br_amba_axi_isolate_mgr/sub
+      .CONFIG_WAIT_FOR_VALID_BEFORE_READY(ValidBeforeReady)
   ) downstream (
       // Global signals
       .aclk    (clk),


### PR DESCRIPTION
1. ReadInterleave is enabled in mgr, not sub.
2. Enabled CONFIG_WAIT_FOR_VALID_BEFORE_READY:  if there is no valid, ready doesn't have to high eventually.
3. Add extra outstanding to ABVIP to test backpressure