### PR TITLE
Add the ability to use an external arbiter for the shared fifo

### DIFF
--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
@@ -102,6 +102,9 @@ module br_fifo_shared_dynamic_ctrl #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, it is assumed an external arbiter is used on the pop ready side,
+    // and requires a maximum of one asserted bit in pop_ready per cycle.
+    parameter bit PopArbiterIsExternal = 0,
 
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth   = br_math::clamped_clog2(Depth)
@@ -238,7 +241,8 @@ module br_fifo_shared_dynamic_ctrl #(
       .StagingBufferDepth(StagingBufferDepth),
       .RamReadLatency(DataRamReadLatency),
       .RegisterPopOutputs(RegisterPopOutputs),
-      .RegisterDeallocation(RegisterDeallocation)
+      .RegisterDeallocation(RegisterDeallocation),
+      .PopArbiterIsExternal(PopArbiterIsExternal)
   ) br_fifo_shared_pop_ctrl (
       .clk,
       .rst,

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
@@ -96,6 +96,9 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, it is assumed an external arbiter is used on the pop ready side,
+    // and requires a maximum of one asserted bit in pop_ready per cycle.
+    parameter bit PopArbiterIsExternal = 0,
 
     localparam int PushCreditWidth = $clog2(NumWritePorts + 1),
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
@@ -247,7 +250,8 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
       .StagingBufferDepth(StagingBufferDepth),
       .RamReadLatency(DataRamReadLatency),
       .RegisterPopOutputs(RegisterPopOutputs),
-      .RegisterDeallocation(RegisterDeallocation)
+      .RegisterDeallocation(RegisterDeallocation),
+      .PopArbiterIsExternal(PopArbiterIsExternal)
   ) br_fifo_shared_pop_ctrl (
       .clk,
       .rst(either_rst),

--- a/fifo/rtl/br_fifo_shared_dynamic_flops.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_flops.sv
@@ -123,6 +123,9 @@ module br_fifo_shared_dynamic_flops #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, it is assumed an external arbiter is used on the pop ready side,
+    // and requires a maximum of one asserted bit in pop_ready per cycle.
+    parameter bit PopArbiterIsExternal = 0,
 
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth   = br_math::clamped_clog2(Depth)
@@ -238,7 +241,8 @@ module br_fifo_shared_dynamic_flops #(
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .PopArbiterIsExternal(PopArbiterIsExternal)
   ) br_fifo_shared_dynamic_ctrl (
       .clk,
       .rst,

--- a/fifo/rtl/br_fifo_shared_dynamic_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_flops_push_credit.sv
@@ -116,6 +116,9 @@ module br_fifo_shared_dynamic_flops_push_credit #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, it is assumed an external arbiter is used on the pop ready side,
+    // and requires a maximum of one asserted bit in pop_ready per cycle.
+    parameter bit PopArbiterIsExternal = 0,
 
     localparam int PushCreditWidth = $clog2(NumWritePorts + 1),
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
@@ -242,7 +245,8 @@ module br_fifo_shared_dynamic_flops_push_credit #(
       .DataRamReadLatency(DataRamReadLatency),
       .PointerRamReadLatency(PointerRamReadLatency),
       .RegisterPushOutputs(RegisterPushOutputs),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .PopArbiterIsExternal(PopArbiterIsExternal)
   ) br_fifo_shared_dynamic_ctrl (
       .clk,
       .rst,

--- a/fifo/rtl/br_fifo_shared_pop_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl.sv
@@ -56,6 +56,9 @@ module br_fifo_shared_pop_ctrl #(
     parameter bit RegisterDeallocation = 0,
     // The number of cycles between data ram read address and read data. Must be >=0.
     parameter int RamReadLatency = 0,
+    // If 1, it is assumed an external arbiter is used on the pop ready side,
+    // and requires a maximum of one asserted bit in pop_ready per cycle.
+    parameter bit PopArbiterIsExternal = 0,
 
     localparam int AddrWidth  = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
@@ -195,7 +198,8 @@ module br_fifo_shared_pop_ctrl #(
       .RamReadLatency(RamReadLatency),
       // If there is no staging buffer, the read request can be revoked if
       // pop_ready becomes low.
-      .EnableAssertPushValidStability(HasStagingBuffer)
+      .EnableAssertPushValidStability(HasStagingBuffer),
+      .ArbiterIsExternal(PopArbiterIsExternal)
   ) br_fifo_shared_read_xbar (
       .clk,
       .rst,

--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -233,8 +233,10 @@ verilog_library(
     deps = [
         "//delay/rtl:br_delay_valid",
         "//demux/rtl:br_demux_bin",
+        "//enc/rtl:br_enc_onehot2bin",
         "//flow/rtl:br_flow_demux_select_unstable",
         "//flow/rtl:br_flow_mux_lru",
+        "//flow/rtl:br_flow_mux_select_unstable",
         "//macros:br_asserts_internal",
         "//mux/rtl:br_mux_onehot",
         "//pkg:br_math_pkg",


### PR DESCRIPTION
Not sure this is the best way to do this, but this saves logic in the case where an external arbiter is used to pop the dynamic shared fifo.