### PR TITLE
Add scoreboard to test back pressure for axi/axil_timing_slice 

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -167,6 +167,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_timing_slice_test_suite",
+    gui = True,
     tools = {
         "jg": "br_amba_axil_timing_slice_fpv.jg.tcl",
         "vcf": "",

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -167,7 +167,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_timing_slice_test_suite",
-    gui = True,
     tools = {
         "jg": "br_amba_axil_timing_slice_fpv.jg.tcl",
         "vcf": "",

--- a/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
@@ -17,10 +17,15 @@ clock clk
 reset rst
 get_design_info
 
-# target ar/aw/w ready won't backpressure
+# AW/W, AR/R backpressure at one side is not guaranteed in timing slice
+# target side
 assert -disable <embedded>::br_amba_axi_timing_slice.monitor.target.genPropChksRDInf.genNoRdTblOverflow.genSlv.slave_ar_rd_tbl_no_overflow
 assert -disable <embedded>::br_amba_axi_timing_slice.monitor.target.genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow
 assert -disable <embedded>::br_amba_axi_timing_slice.monitor.target.genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow
+# init side
+assert -disable <embedded>::br_amba_axi_timing_slice.monitor.init.genPropChksRDInf.genNoRdTblOverflow.genMas.master_ar_rd_tbl_no_overflow
+assert -disable <embedded>::br_amba_axi_timing_slice.monitor.init.genPropChksWRInf.genNoWrTblOverflow.genMas.master_aw_wr_tbl_no_overflow
+assert -disable <embedded>::br_amba_axi_timing_slice.monitor.init.genPropChksWRInf.genNoWrDatTblOverflow.genMas.master_w_wr_tbl_no_overflow
 
 # TODO: disable covers to make nightly clean
 cover -disable *

--- a/amba/fpv/br_amba_axi_timing_slice_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_timing_slice_fpv_monitor.sv
@@ -113,6 +113,28 @@ module br_amba_axi_timing_slice_fpv_monitor #(
     input logic                                  init_rready
 );
 
+  // ABVIP should send more than DUT to test backpressure
+  localparam int MaxInit = 2;
+  localparam int MaxTarget = MaxInit + 2;
+  localparam int AwPayloadWidth = AddrWidth +
+                                  IdWidth +
+                                  br_amba::AxiBurstLenWidth +
+                                  br_amba::AxiBurstSizeWidth +
+                                  br_amba::AxiBurstTypeWidth +
+                                  br_amba::AxiProtWidth +
+                                  AWUserWidth;
+  localparam int WPayloadWidth = DataWidth + StrobeWidth + WUserWidth + 1;  // +1 for wlast
+  localparam int BPayloadWidth = IdWidth + BUserWidth + br_amba::AxiRespWidth;
+  localparam int ARPayloadWidth = AddrWidth +
+                                  IdWidth +
+                                  br_amba::AxiBurstLenWidth +
+                                  br_amba::AxiBurstSizeWidth +
+                                  br_amba::AxiBurstTypeWidth +
+                                  br_amba::AxiProtWidth +
+                                  ARUserWidth;
+  localparam int RPayloadWidth = IdWidth + DataWidth + RUserWidth +
+                                 br_amba::AxiRespWidth + 1; // +1 for rlast
+
   // AXI4 target interface
   axi4_master #(
       .ADDR_WIDTH(AddrWidth),
@@ -123,7 +145,8 @@ module br_amba_axi_timing_slice_fpv_monitor #(
       .WUSER_WIDTH(WUserWidth),
       .BUSER_WIDTH(BUserWidth),
       .RUSER_WIDTH(RUserWidth),
-      .CONFIG_WDATA_MASKED(0)
+      .CONFIG_WDATA_MASKED(0),
+      .MAX_PENDING(MaxTarget)
   ) target (
       // Global signals
       .aclk    (clk),
@@ -192,7 +215,8 @@ module br_amba_axi_timing_slice_fpv_monitor #(
       .WUSER_WIDTH(WUserWidth),
       .BUSER_WIDTH(BUserWidth),
       .RUSER_WIDTH(RUserWidth),
-      .CONFIG_RDATA_MASKED(0)
+      .CONFIG_RDATA_MASKED(0),
+      .MAX_PENDING(MaxInit)
   ) init (
       // Global signals
       .aclk    (clk),
@@ -249,6 +273,102 @@ module br_amba_axi_timing_slice_fpv_monitor #(
       .rdata   (init_rdata),
       .rresp   (init_rresp),
       .rlast   (init_rlast)
+  );
+
+  // ----------across target and init, no command is dropped or reordered----------
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(AwPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) aw_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(target_awvalid & target_awready),
+      .incoming_data({
+        target_awaddr,
+        target_awid,
+        target_awlen,
+        target_awsize,
+        target_awburst,
+        target_awprot,
+        target_awuser
+      }),
+      .outgoing_vld(init_awvalid & init_awready),
+      .outgoing_data({
+        init_awaddr, init_awid, init_awlen, init_awsize, init_awburst, init_awprot, init_awuser
+      })
+  );
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(WPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) w_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(target_wvalid & target_wready),
+      .incoming_data({target_wdata, target_wstrb, target_wuser, target_wlast}),
+      .outgoing_vld(init_wvalid & init_wready),
+      .outgoing_data({init_wdata, init_wstrb, init_wuser, init_wlast})
+  );
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(BPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) b_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(init_bvalid & init_bready),
+      .incoming_data({init_bid, init_buser, init_bresp}),
+      .outgoing_vld(target_bvalid & target_bready),
+      .outgoing_data({target_bid, target_buser, target_bresp})
+  );
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(ARPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) ar_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(target_arvalid & target_arready),
+      .incoming_data({
+        target_araddr,
+        target_arid,
+        target_arlen,
+        target_arsize,
+        target_arburst,
+        target_arprot,
+        target_aruser
+      }),
+      .outgoing_vld(init_arvalid & init_arready),
+      .outgoing_data({
+        init_araddr, init_arid, init_arlen, init_arsize, init_arburst, init_arprot, init_aruser
+      })
+  );
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(RPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) r_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(init_rvalid & init_rready),
+      .incoming_data({init_rid, init_rdata, init_ruser, init_rresp, init_rlast}),
+      .outgoing_vld(target_rvalid & target_rready),
+      .outgoing_data({target_rid, target_rdata, target_ruser, target_rresp, target_rlast})
   );
 
 endmodule : br_amba_axi_timing_slice_fpv_monitor

--- a/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
@@ -17,10 +17,15 @@ clock clk
 reset rst
 get_design_info
 
-# target ar/aw/w ready won't backpressure
+# AW/W, AR/R backpressure at one side is not guaranteed in timing slice
+# target side
 assert -disable <embedded>::br_amba_axil_timing_slice.monitor.target.genPropChksRDInf.genNoRdTblOverflow.genSlv.slave_ar_rd_tbl_no_overflow
 assert -disable <embedded>::br_amba_axil_timing_slice.monitor.target.genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow
 assert -disable <embedded>::br_amba_axil_timing_slice.monitor.target.genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow
+# init side
+assert -disable <embedded>::br_amba_axil_timing_slice.monitor.init.genPropChksRDInf.genNoRdTblOverflow.genMas.master_ar_rd_tbl_no_overflow
+assert -disable <embedded>::br_amba_axil_timing_slice.monitor.init.genPropChksWRInf.genNoWrTblOverflow.genMas.master_aw_wr_tbl_no_overflow
+assert -disable <embedded>::br_amba_axil_timing_slice.monitor.init.genPropChksWRInf.genNoWrDatTblOverflow.genMas.master_w_wr_tbl_no_overflow
 
 # TODO: disable covers to make nightly clean
 cover -disable *

--- a/amba/fpv/br_amba_axil_timing_slice_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil_timing_slice_fpv_monitor.sv
@@ -102,6 +102,7 @@ module br_amba_axil_timing_slice_fpv_monitor #(
       .ARUSER_WIDTH(ARUserWidth),
       .RUSER_WIDTH(RUserWidth),
       .BUSER_WIDTH(BUserWidth),
+      .CONFIG_WDATA_MASKED(0),
       .MAX_PENDING(MaxTarget)
   ) target (
       // Global signals
@@ -171,6 +172,7 @@ module br_amba_axil_timing_slice_fpv_monitor #(
       .ARUSER_WIDTH(ARUserWidth),
       .RUSER_WIDTH(RUserWidth),
       .BUSER_WIDTH(BUserWidth),
+      .CONFIG_RDATA_MASKED(0),
       .MAX_PENDING(MaxInit)
   ) init (
       // Global signals

--- a/amba/fpv/br_amba_axil_timing_slice_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil_timing_slice_fpv_monitor.sv
@@ -83,6 +83,15 @@ module br_amba_axil_timing_slice_fpv_monitor #(
     input logic                             init_rready
 );
 
+  // ABVIP should send more than DUT to test backpressure
+  localparam int MaxInit = 2;
+  localparam int MaxTarget = MaxInit + 2;
+  localparam int AwPayloadWidth = AddrWidth + br_amba::AxiProtWidth + AWUserWidth;
+  localparam int WPayloadWidth = DataWidth + StrobeWidth + WUserWidth;
+  localparam int BPayloadWidth = BUserWidth + br_amba::AxiRespWidth;
+  localparam int ARPayloadWidth = AddrWidth + br_amba::AxiProtWidth + ARUserWidth;
+  localparam int RPayloadWidth = DataWidth + RUserWidth + br_amba::AxiRespWidth;
+
   // AXI4-Lite target interface
   axi4_master #(
       .AXI4_LITE(1),
@@ -92,7 +101,8 @@ module br_amba_axil_timing_slice_fpv_monitor #(
       .WUSER_WIDTH(WUserWidth),
       .ARUSER_WIDTH(ARUserWidth),
       .RUSER_WIDTH(RUserWidth),
-      .BUSER_WIDTH(BUserWidth)
+      .BUSER_WIDTH(BUserWidth),
+      .MAX_PENDING(MaxTarget)
   ) target (
       // Global signals
       .aclk    (clk),
@@ -160,7 +170,8 @@ module br_amba_axil_timing_slice_fpv_monitor #(
       .WUSER_WIDTH(WUserWidth),
       .ARUSER_WIDTH(ARUserWidth),
       .RUSER_WIDTH(RUserWidth),
-      .BUSER_WIDTH(BUserWidth)
+      .BUSER_WIDTH(BUserWidth),
+      .MAX_PENDING(MaxInit)
   ) init (
       // Global signals
       .aclk    (clk),
@@ -217,6 +228,82 @@ module br_amba_axil_timing_slice_fpv_monitor #(
       .rresp   (init_rresp),
       .rid     (),
       .rlast   ()
+  );
+
+  // ----------across target and init, no command is dropped or reordered----------
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(AwPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) aw_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(target_awvalid & target_awready),
+      .incoming_data({target_awaddr, target_awprot, target_awuser}),
+      .outgoing_vld(init_awvalid & init_awready),
+      .outgoing_data({init_awaddr, init_awprot, init_awuser})
+  );
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(WPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) w_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(target_wvalid & target_wready),
+      .incoming_data({target_wdata, target_wstrb, target_wuser}),
+      .outgoing_vld(init_wvalid & init_wready),
+      .outgoing_data({init_wdata, init_wstrb, init_wuser})
+  );
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(BPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) b_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(init_bvalid & init_bready),
+      .incoming_data({init_bresp, init_buser}),
+      .outgoing_vld(target_bvalid & target_bready),
+      .outgoing_data({target_bresp, target_buser})
+  );
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(ARPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) ar_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(target_arvalid & target_arready),
+      .incoming_data({target_araddr, target_arprot, target_aruser}),
+      .outgoing_vld(init_arvalid & init_arready),
+      .outgoing_data({init_araddr, init_arprot, init_aruser})
+  );
+
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(RPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxTarget)
+  ) r_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(init_rvalid & init_rready),
+      .incoming_data({init_rdata, init_rresp, init_ruser}),
+      .outgoing_vld(target_rvalid & target_rready),
+      .outgoing_data({target_rdata, target_rresp, target_ruser})
   );
 
 endmodule : br_amba_axil_timing_slice_fpv_monitor


### PR DESCRIPTION
For **axi_timing_slice, axil_timing_slice and axil_msi,** FV disabled some ABVIP assertions.
Those assertions are testing back pressure between AW/W and AR/R.
Timing slice simply pass through each channel from manager to subordinate or the other way around, so this kind of back pressure is not guaranteed.

To make sure subordinate back pressure master, and no data is dropped, added FV scoreboard.
didn't add scoreboard to axil_msi in this PR, because this was already added.
