### PR TITLE
br_ram_flops: delete rd_data_valid final assertion

### DIFF
--- a/ram/rtl/br_ram_flops.sv
+++ b/ram/rtl/br_ram_flops.sv
@@ -383,6 +383,4 @@ module br_ram_flops #(
 `endif
 `endif
 
-  `BR_ASSERT_FINAL(final_not_rd_data_valid_a, !rd_data_valid)
-
 endmodule : br_ram_flops


### PR DESCRIPTION
This is already being checked in the br_ram_rd_data_pipe module.