### PR TITLE
Set EnableAssertPushValidStability correctly on push_ctrl_core in pstatic_push_ctrl

### DIFF
--- a/fifo/rtl/internal/br_fifo_shared_pstatic_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_pstatic_push_ctrl.sv
@@ -116,7 +116,10 @@ module br_fifo_shared_pstatic_push_ctrl #(
         // TODO(zhemao): Add bypass support.
         .EnableBypass(0),
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
-        .EnableAssertPushValidStability(EnableAssertPushValidStability),
+        // Core can only have valid stability if the fifo_id is stable,
+        // so pass the data stability parameter instead of the
+        // valid stability parameter.
+        .EnableAssertPushValidStability(EnableAssertPushDataStability),
         .EnableAssertPushDataStability(EnableAssertPushDataStability),
         .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
     ) br_fifo_push_ctrl_core_inst (


### PR DESCRIPTION
Since the push_valid of the core push control depends on the fifo ID,
the core can only have push valid stability if the shared FIFO has push
data stability.