### PR TITLE
Enable (and plumb) pipelining options for shared FIFO in isolate_sub

### DIFF
--- a/amba/fpv/br_amba_axi_isolate_sub_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_isolate_sub_fpv_monitor.sv
@@ -58,10 +58,10 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     parameter bit [DataWidth-1:0] IsolateRData = '0,
     // Number of pipeline stages to use for the pointer RAM read
     // data. Has no effect if AxiIdCount == 1.
-    parameter bit FlopPtrRamRd = 0,
+    parameter bit FifoFlopPtrRamRd = 0,
     // Number of pipeline stages to use for the data RAM read data.
     // Has no effect if AxiIdCount == 1.
-    parameter bit FlopDataRamRd = 0,
+    parameter bit FifoFlopDataRamRd = 0,
     localparam int AxiBurstLenWidth = br_math::clamped_clog2(MaxAxiBurstLen),
     localparam int StrobeWidth = DataWidth / 8
 ) (
@@ -293,6 +293,6 @@ bind br_amba_axi_isolate_sub br_amba_axi_isolate_sub_fpv_monitor #(
     .IsolateBUser(IsolateBUser),
     .IsolateRUser(IsolateRUser),
     .IsolateRData(IsolateRData),
-    .FlopPtrRamRd(FlopPtrRamRd),
-    .FlopDataRamRd(FlopDataRamRd)
+    .FifoFlopPtrRamRd(FifoFlopPtrRamRd),
+    .FifoFlopDataRamRd(FifoFlopDataRamRd)
 ) monitor (.*);

--- a/amba/fpv/br_amba_axi_isolate_sub_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_isolate_sub_fpv_monitor.sv
@@ -58,10 +58,10 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     parameter bit [DataWidth-1:0] IsolateRData = '0,
     // Number of pipeline stages to use for the pointer RAM read
     // data. Has no effect if AxiIdCount == 1.
-    parameter bit FifoFlopPtrRamRd = 0,
+    parameter int FifoPointerRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the data RAM read data.
     // Has no effect if AxiIdCount == 1.
-    parameter bit FifoFlopDataRamRd = 0,
+    parameter int FifoDataRamReadDataDepthStages = 0,
     localparam int AxiBurstLenWidth = br_math::clamped_clog2(MaxAxiBurstLen),
     localparam int StrobeWidth = DataWidth / 8
 ) (
@@ -293,6 +293,6 @@ bind br_amba_axi_isolate_sub br_amba_axi_isolate_sub_fpv_monitor #(
     .IsolateBUser(IsolateBUser),
     .IsolateRUser(IsolateRUser),
     .IsolateRData(IsolateRData),
-    .FifoFlopPtrRamRd(FifoFlopPtrRamRd),
-    .FifoFlopDataRamRd(FifoFlopDataRamRd)
+    .FifoPointerRamReadDataDepthStages(FifoPointerRamReadDataDepthStages),
+    .FifoDataRamReadDataDepthStages(FifoDataRamReadDataDepthStages)
 ) monitor (.*);

--- a/amba/rtl/br_amba_axi_isolate_sub.sv
+++ b/amba/rtl/br_amba_axi_isolate_sub.sv
@@ -87,19 +87,19 @@ module br_amba_axi_isolate_sub #(
     parameter bit [DataWidth-1:0] IsolateRData = '0,
     // Number of pipeline stages to use for the pointer RAM read
     // data in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoFlopPtrRamRd = 0,
+    parameter int FifoPointerRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the data RAM read data
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoFlopDataRamRd = 0,
+    parameter int FifoDataRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the pointer RAM address
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoFlopPtrRamAddr = 1,
+    parameter int FifoPointerRamAddressDepthStages = 1,
     // Number of pipeline stages to use for the data RAM address
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoFlopDataRamAddr = 1,
+    parameter int FifoDataRamAddressDepthStages = 1,
     // Number of linked lists per FIFO in the response tracker FIFO. Has
     // no effect if AxiIdCount == 1.
-    parameter int FifoLlPerFifo = 2,
+    parameter int FifoNumLinkedListsPerFifo = 2,
     // Number of pipeline stages to use for the staging buffer
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
     parameter int FifoStagingBufferDepth = 2,
@@ -301,11 +301,11 @@ module br_amba_axi_isolate_sub #(
       .AxiIdCount(AxiIdCount),
       .AxiIdWidth(IdWidth),
       .DataWidth(BUserWidth),
-      .FifoFlopPtrRamRd(FifoFlopPtrRamRd),
-      .FifoFlopPtrRamAddr(FifoFlopPtrRamAddr),
-      .FifoLlPerFifo(FifoLlPerFifo),
-      .FifoFlopDataRamRd(FifoFlopDataRamRd),
-      .FifoFlopDataRamAddr(FifoFlopDataRamAddr),
+      .FifoPointerRamReadDataDepthStages(FifoPointerRamReadDataDepthStages),
+      .FifoPointerRamAddressDepthStages(FifoPointerRamAddressDepthStages),
+      .FifoNumLinkedListsPerFifo(FifoNumLinkedListsPerFifo),
+      .FifoDataRamReadDataDepthStages(FifoDataRamReadDataDepthStages),
+      .FifoDataRamAddressDepthStages(FifoDataRamAddressDepthStages),
       .FifoStagingBufferDepth(FifoStagingBufferDepth),
       .FifoRegisterPopOutputs(FifoRegisterPopOutputs),
       .FifoRegisterDeallocation(FifoRegisterDeallocation),
@@ -416,11 +416,11 @@ module br_amba_axi_isolate_sub #(
       .AxiIdCount(AxiIdCount),
       .AxiIdWidth(IdWidth),
       .DataWidth(RUserWidth + DataWidth),
-      .FifoFlopPtrRamRd(FifoFlopPtrRamRd),
-      .FifoFlopPtrRamAddr(FifoFlopPtrRamAddr),
-      .FifoLlPerFifo(FifoLlPerFifo),
-      .FifoFlopDataRamRd(FifoFlopDataRamRd),
-      .FifoFlopDataRamAddr(FifoFlopDataRamAddr),
+      .FifoPointerRamReadDataDepthStages(FifoPointerRamReadDataDepthStages),
+      .FifoPointerRamAddressDepthStages(FifoPointerRamAddressDepthStages),
+      .FifoNumLinkedListsPerFifo(FifoNumLinkedListsPerFifo),
+      .FifoDataRamReadDataDepthStages(FifoDataRamReadDataDepthStages),
+      .FifoDataRamAddressDepthStages(FifoDataRamAddressDepthStages),
       .FifoStagingBufferDepth(FifoStagingBufferDepth),
       .FifoRegisterPopOutputs(FifoRegisterPopOutputs),
       .FifoRegisterDeallocation(FifoRegisterDeallocation),

--- a/amba/rtl/br_amba_axi_isolate_sub.sv
+++ b/amba/rtl/br_amba_axi_isolate_sub.sv
@@ -86,11 +86,29 @@ module br_amba_axi_isolate_sub #(
     // RDATA data to generate for isolated transactions.
     parameter bit [DataWidth-1:0] IsolateRData = '0,
     // Number of pipeline stages to use for the pointer RAM read
-    // data. Has no effect if AxiIdCount == 1.
-    parameter bit FlopPtrRamRd = 0,
-    // Number of pipeline stages to use for the data RAM read data.
-    // Has no effect if AxiIdCount == 1.
-    parameter bit FlopDataRamRd = 0,
+    // data in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    parameter int FifoFlopPtrRamRd = 0,
+    // Number of pipeline stages to use for the data RAM read data
+    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    parameter int FifoFlopDataRamRd = 0,
+    // Number of pipeline stages to use for the pointer RAM address
+    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    parameter int FifoFlopPtrRamAddr = 1,
+    // Number of pipeline stages to use for the data RAM address
+    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    parameter int FifoFlopDataRamAddr = 1,
+    // Number of linked lists per FIFO in the response tracker FIFO. Has
+    // no effect if AxiIdCount == 1.
+    parameter int FifoLlPerFifo = 2,
+    // Number of pipeline stages to use for the staging buffer
+    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    parameter int FifoStagingBufferDepth = 2,
+    // Number of pipeline stages to use for the pop outputs
+    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    parameter int FifoRegisterPopOutputs = 1,
+    // Number of pipeline stages to use for the deallocation
+    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    parameter int FifoRegisterDeallocation = 1,
     localparam int AxiBurstLenWidth = br_math::clamped_clog2(MaxAxiBurstLen),
     localparam int StrobeWidth = DataWidth / 8
 ) (
@@ -283,8 +301,14 @@ module br_amba_axi_isolate_sub #(
       .AxiIdCount(AxiIdCount),
       .AxiIdWidth(IdWidth),
       .DataWidth(BUserWidth),
-      .FlopPtrRamRd(FlopPtrRamRd),
-      .FlopDataRamRd(FlopDataRamRd),
+      .FifoFlopPtrRamRd(FifoFlopPtrRamRd),
+      .FifoFlopPtrRamAddr(FifoFlopPtrRamAddr),
+      .FifoLlPerFifo(FifoLlPerFifo),
+      .FifoFlopDataRamRd(FifoFlopDataRamRd),
+      .FifoFlopDataRamAddr(FifoFlopDataRamAddr),
+      .FifoStagingBufferDepth(FifoStagingBufferDepth),
+      .FifoRegisterPopOutputs(FifoRegisterPopOutputs),
+      .FifoRegisterDeallocation(FifoRegisterDeallocation),
       .IsolateResp(IsolateResp),
       .IsolateData(IsolateBUser),
       // Single write response beat per write transaction
@@ -392,8 +416,14 @@ module br_amba_axi_isolate_sub #(
       .AxiIdCount(AxiIdCount),
       .AxiIdWidth(IdWidth),
       .DataWidth(RUserWidth + DataWidth),
-      .FlopPtrRamRd(FlopPtrRamRd),
-      .FlopDataRamRd(FlopDataRamRd),
+      .FifoFlopPtrRamRd(FifoFlopPtrRamRd),
+      .FifoFlopPtrRamAddr(FifoFlopPtrRamAddr),
+      .FifoLlPerFifo(FifoLlPerFifo),
+      .FifoFlopDataRamRd(FifoFlopDataRamRd),
+      .FifoFlopDataRamAddr(FifoFlopDataRamAddr),
+      .FifoStagingBufferDepth(FifoStagingBufferDepth),
+      .FifoRegisterPopOutputs(FifoRegisterPopOutputs),
+      .FifoRegisterDeallocation(FifoRegisterDeallocation),
       .IsolateResp(IsolateResp),
       .IsolateData({IsolateRUser, IsolateRData}),
       // MaxAxiBurstLen response beats per read transaction

--- a/amba/rtl/internal/br_amba_iso_resp_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_resp_tracker.sv
@@ -57,15 +57,15 @@ module br_amba_iso_resp_tracker #(
     // Width of the data field.
     parameter int DataWidth = 1,
     // Number of pipeline stages to use for the pointer RAM read data.
-    parameter int FifoFlopPtrRamRd = 0,
+    parameter int FifoPointerRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the data RAM read data.
-    parameter int FifoFlopDataRamRd = 0,
+    parameter int FifoDataRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the pointer RAM address.
-    parameter int FifoFlopPtrRamAddr = 1,
+    parameter int FifoPointerRamAddressDepthStages = 1,
     // Number of pipeline stages to use for the data RAM address.
-    parameter int FifoFlopDataRamAddr = 1,
+    parameter int FifoDataRamAddressDepthStages = 1,
     // Number of linked lists per FIFO.
-    parameter int FifoLlPerFifo = 2,
+    parameter int FifoNumLinkedListsPerFifo = 2,
     // Number of pipeline stages to use for the staging buffer.
     parameter int FifoStagingBufferDepth = 2,
     // Number of pipeline stages to use for the pop outputs.
@@ -417,11 +417,11 @@ module br_amba_iso_resp_tracker #(
         .NumFifos(AxiIdCount),
         .Depth(MaxOutstanding),
         .Width(AxiBurstLenWidth),
-        .PointerRamReadDataDepthStages(FifoFlopPtrRamRd),
-        .PointerRamAddressDepthStages(FifoFlopPtrRamAddr),
-        .NumLinkedListsPerFifo(FifoLlPerFifo),
-        .DataRamReadDataDepthStages(FifoFlopDataRamRd),
-        .DataRamAddressDepthStages(FifoFlopDataRamAddr),
+        .PointerRamReadDataDepthStages(FifoPointerRamReadDataDepthStages),
+        .PointerRamAddressDepthStages(FifoPointerRamAddressDepthStages),
+        .NumLinkedListsPerFifo(FifoNumLinkedListsPerFifo),
+        .DataRamReadDataDepthStages(FifoDataRamReadDataDepthStages),
+        .DataRamAddressDepthStages(FifoDataRamAddressDepthStages),
         .StagingBufferDepth(FifoStagingBufferDepth),
         .RegisterPopOutputs(FifoRegisterPopOutputs),
         .RegisterDeallocation(FifoRegisterDeallocation),

--- a/amba/rtl/internal/br_amba_iso_resp_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_resp_tracker.sv
@@ -406,7 +406,11 @@ module br_amba_iso_resp_tracker #(
         .Depth(MaxOutstanding),
         .Width(AxiBurstLenWidth),
         .PointerRamReadDataDepthStages(FlopPtrRamRd),
+        .PointerRamAddressDepthStages(1),
+        .NumLinkedListsPerFifo(2),
         .DataRamReadDataDepthStages(FlopDataRamRd),
+        .DataRamAddressDepthStages(1),
+        .StagingBufferDepth(2),
         .RegisterPopOutputs(1),
         .RegisterDeallocation(1),
         // When EnableWlastTracking=0, valid can deassert if downstream_axready deasserts

--- a/amba/rtl/internal/br_amba_iso_resp_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_resp_tracker.sv
@@ -57,9 +57,21 @@ module br_amba_iso_resp_tracker #(
     // Width of the data field.
     parameter int DataWidth = 1,
     // Number of pipeline stages to use for the pointer RAM read data.
-    parameter int FlopPtrRamRd = 0,
+    parameter int FifoFlopPtrRamRd = 0,
     // Number of pipeline stages to use for the data RAM read data.
-    parameter int FlopDataRamRd = 0,
+    parameter int FifoFlopDataRamRd = 0,
+    // Number of pipeline stages to use for the pointer RAM address.
+    parameter int FifoFlopPtrRamAddr = 1,
+    // Number of pipeline stages to use for the data RAM address.
+    parameter int FifoFlopDataRamAddr = 1,
+    // Number of linked lists per FIFO.
+    parameter int FifoLlPerFifo = 2,
+    // Number of pipeline stages to use for the staging buffer.
+    parameter int FifoStagingBufferDepth = 2,
+    // Number of pipeline stages to use for the pop outputs.
+    parameter int FifoRegisterPopOutputs = 1,
+    // Number of pipeline stages to use for the deallocation.
+    parameter int FifoRegisterDeallocation = 1,
     // Response to generate for isolated transactions.
     parameter br_amba::axi_resp_t IsolateResp = br_amba::AxiRespSlverr,
     // Data to generate for isolated transactions.
@@ -405,14 +417,14 @@ module br_amba_iso_resp_tracker #(
         .NumFifos(AxiIdCount),
         .Depth(MaxOutstanding),
         .Width(AxiBurstLenWidth),
-        .PointerRamReadDataDepthStages(FlopPtrRamRd),
-        .PointerRamAddressDepthStages(1),
-        .NumLinkedListsPerFifo(2),
-        .DataRamReadDataDepthStages(FlopDataRamRd),
-        .DataRamAddressDepthStages(1),
-        .StagingBufferDepth(2),
-        .RegisterPopOutputs(1),
-        .RegisterDeallocation(1),
+        .PointerRamReadDataDepthStages(FifoFlopPtrRamRd),
+        .PointerRamAddressDepthStages(FifoFlopPtrRamAddr),
+        .NumLinkedListsPerFifo(FifoLlPerFifo),
+        .DataRamReadDataDepthStages(FifoFlopDataRamRd),
+        .DataRamAddressDepthStages(FifoFlopDataRamAddr),
+        .StagingBufferDepth(FifoStagingBufferDepth),
+        .RegisterPopOutputs(FifoRegisterPopOutputs),
+        .RegisterDeallocation(FifoRegisterDeallocation),
         // When EnableWlastTracking=0, valid can deassert if downstream_axready deasserts
         .EnableAssertPushValidStability(EnableWlastTracking)
     ) br_fifo_shared_dynamic_flops_req_tracker (


### PR DESCRIPTION
Needed access to params to help timing closure