### PR TITLE
Fix inconsistent default value for RegisterPopOutputs in push-credit FIFOs

### DIFF
--- a/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
+++ b/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
@@ -72,7 +72,7 @@ module br_fifo_ctrl_1r1w_push_credit #(
     // at the cost of an additional cycle of cut-through latency.
     // If 0, pop_valid/pop_data comes directly from push_valid (if bypass is enabled)
     // and/or ram_wr_data.
-    parameter bit RegisterPopOutputs = 1,
+    parameter bit RegisterPopOutputs = 0,
     // The number of cycles between when ram_rd_addr_valid is asserted and
     // ram_rd_data_valid is asserted.
     parameter int RamReadLatency = 0,

--- a/fifo/rtl/br_fifo_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_flops_push_credit.sv
@@ -60,7 +60,7 @@ module br_fifo_flops_push_credit #(
     // at the cost of an additional cycle of cut-through latency.
     // If 0, pop_valid/pop_data comes directly from push_valid (if bypass is enabled)
     // and/or ram_wr_data.
-    parameter bit RegisterPopOutputs = 1,
+    parameter bit RegisterPopOutputs = 0,
     // Number of tiles in the depth (address) dimension. Must be at least 1 and evenly divide Depth.
     parameter int FlopRamDepthTiles = 1,
     // Number of tiles along the width (data) dimension. Must be at least 1 and evenly divide Width.


### PR DESCRIPTION
Made a mistake when setting this originally. Change the default to 0 to
make this consistent with the push_ready variants.