### PR TITLE
Add static-FIFO option for read tracker in amba_axi_isolate_sub

### DIFF
--- a/amba/fpv/br_amba_axi_isolate_sub_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_isolate_sub_fpv_monitor.sv
@@ -58,10 +58,10 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     parameter bit [DataWidth-1:0] IsolateRData = '0,
     // Number of pipeline stages to use for the pointer RAM read
     // data. Has no effect if AxiIdCount == 1.
-    parameter int FifoPointerRamReadDataDepthStages = 0,
+    parameter int DynamicFifoPointerRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the data RAM read data.
     // Has no effect if AxiIdCount == 1.
-    parameter int FifoDataRamReadDataDepthStages = 0,
+    parameter int DynamicFifoDataRamReadDataDepthStages = 0,
     localparam int AxiBurstLenWidth = br_math::clamped_clog2(MaxAxiBurstLen),
     localparam int StrobeWidth = DataWidth / 8
 ) (
@@ -293,6 +293,6 @@ bind br_amba_axi_isolate_sub br_amba_axi_isolate_sub_fpv_monitor #(
     .IsolateBUser(IsolateBUser),
     .IsolateRUser(IsolateRUser),
     .IsolateRData(IsolateRData),
-    .FifoPointerRamReadDataDepthStages(FifoPointerRamReadDataDepthStages),
-    .FifoDataRamReadDataDepthStages(FifoDataRamReadDataDepthStages)
+    .DynamicFifoPointerRamReadDataDepthStages(DynamicFifoPointerRamReadDataDepthStages),
+    .DynamicFifoDataRamReadDataDepthStages(DynamicFifoDataRamReadDataDepthStages)
 ) monitor (.*);

--- a/amba/rtl/br_amba_axi_isolate_sub.sv
+++ b/amba/rtl/br_amba_axi_isolate_sub.sv
@@ -85,36 +85,46 @@ module br_amba_axi_isolate_sub #(
     parameter bit [RUserWidth-1:0] IsolateRUser = '0,
     // RDATA data to generate for isolated transactions.
     parameter bit [DataWidth-1:0] IsolateRData = '0,
-    // Number of pipeline stages to use for the pointer RAM read
-    // data in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    // Number of pipeline stages to use for the pointer RAM read data in the
+    // response tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoPointerRamReadDataDepthStages = 0,
-    // Number of pipeline stages to use for the data RAM read data
-    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    // Number of pipeline stages to use for the data RAM read data in the
+    // response tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoDataRamReadDataDepthStages = 0,
-    // Number of pipeline stages to use for the pointer RAM address
-    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    // Number of pipeline stages to use for the pointer RAM address in the
+    // response tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoPointerRamAddressDepthStages = 1,
-    // Number of pipeline stages to use for the data RAM address
-    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    // Number of pipeline stages to use for the data RAM address in the
+    // response tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoDataRamAddressDepthStages = 1,
-    // Number of linked lists per FIFO in the response tracker FIFO. Has
-    // no effect if AxiIdCount == 1.
+    // Number of linked lists per FIFO in the response tracker FIFO. Has no
+    // effect if AxiIdCount == 1 or UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoNumLinkedListsPerFifo = 2,
-    // Number of pipeline stages to use for the staging buffer
-    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    // Number of pipeline stages to use for the staging buffer in the response
+    // tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoStagingBufferDepth = 2,
-    // Number of pipeline stages to use for the pop outputs
-    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    // Number of pipeline stages to use for the pop outputs in the response
+    // tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoRegisterPopOutputs = 1,
-    // Number of pipeline stages to use for the deallocation
-    // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
+    // Number of pipeline stages to use for the deallocation in the response
+    // tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoRegisterDeallocation = 1,
     //
-    // Set to 1 to use a dynamic storage shared FIFO for the read tracking list.
-    parameter bit UseDynamicFifoForReadTracker = 0,
-    // When UseDynamicFifoForReadTracker=0, this parameter controls the depth of the Per-ID
-    // tracking FIFO.
-    parameter int StaticPerIdReadTrackerFifoDepth = 2,
+    // Set to 1 to use a dynamic storage shared FIFO for the read tracking
+    // list.
+    parameter bit UseDynamicFifoForReadTracker = 1,
+    // When UseDynamicFifoForReadTracker=0, this parameter controls the depth
+    // of the Per-ID tracking FIFO. This defaults to MaxOutstanding, but may
+    // need to be set to a smaller value as the storage will be replicated for
+    // each ID.
+    parameter int StaticPerIdReadTrackerFifoDepth = MaxOutstanding,
     localparam int AxiBurstLenWidth = br_math::clamped_clog2(MaxAxiBurstLen),
     localparam int StrobeWidth = DataWidth / 8
 ) (

--- a/amba/rtl/br_amba_axi_isolate_sub.sv
+++ b/amba/rtl/br_amba_axi_isolate_sub.sv
@@ -87,28 +87,34 @@ module br_amba_axi_isolate_sub #(
     parameter bit [DataWidth-1:0] IsolateRData = '0,
     // Number of pipeline stages to use for the pointer RAM read
     // data in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoPointerRamReadDataDepthStages = 0,
+    parameter int DynamicFifoPointerRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the data RAM read data
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoDataRamReadDataDepthStages = 0,
+    parameter int DynamicFifoDataRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the pointer RAM address
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoPointerRamAddressDepthStages = 1,
+    parameter int DynamicFifoPointerRamAddressDepthStages = 1,
     // Number of pipeline stages to use for the data RAM address
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoDataRamAddressDepthStages = 1,
+    parameter int DynamicFifoDataRamAddressDepthStages = 1,
     // Number of linked lists per FIFO in the response tracker FIFO. Has
     // no effect if AxiIdCount == 1.
-    parameter int FifoNumLinkedListsPerFifo = 2,
+    parameter int DynamicFifoNumLinkedListsPerFifo = 2,
     // Number of pipeline stages to use for the staging buffer
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoStagingBufferDepth = 2,
+    parameter int DynamicFifoStagingBufferDepth = 2,
     // Number of pipeline stages to use for the pop outputs
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoRegisterPopOutputs = 1,
+    parameter int DynamicFifoRegisterPopOutputs = 1,
     // Number of pipeline stages to use for the deallocation
     // in the response tracker FIFO. Has no effect if AxiIdCount == 1.
-    parameter int FifoRegisterDeallocation = 1,
+    parameter int DynamicFifoRegisterDeallocation = 1,
+    //
+    // Set to 1 to use a dynamic storage shared FIFO for the read tracking list.
+    parameter bit UseDynamicFifoForReadTracker = 0,
+    // When UseDynamicFifoForReadTracker=0, this parameter controls the depth of the Per-ID
+    // tracking FIFO.
+    parameter int StaticPerIdReadTrackerFifoDepth = 2,
     localparam int AxiBurstLenWidth = br_math::clamped_clog2(MaxAxiBurstLen),
     localparam int StrobeWidth = DataWidth / 8
 ) (
@@ -301,20 +307,22 @@ module br_amba_axi_isolate_sub #(
       .AxiIdCount(AxiIdCount),
       .AxiIdWidth(IdWidth),
       .DataWidth(BUserWidth),
-      .FifoPointerRamReadDataDepthStages(FifoPointerRamReadDataDepthStages),
-      .FifoPointerRamAddressDepthStages(FifoPointerRamAddressDepthStages),
-      .FifoNumLinkedListsPerFifo(FifoNumLinkedListsPerFifo),
-      .FifoDataRamReadDataDepthStages(FifoDataRamReadDataDepthStages),
-      .FifoDataRamAddressDepthStages(FifoDataRamAddressDepthStages),
-      .FifoStagingBufferDepth(FifoStagingBufferDepth),
-      .FifoRegisterPopOutputs(FifoRegisterPopOutputs),
-      .FifoRegisterDeallocation(FifoRegisterDeallocation),
+      .DynamicFifoPointerRamReadDataDepthStages(DynamicFifoPointerRamReadDataDepthStages),
+      .DynamicFifoPointerRamAddressDepthStages(DynamicFifoPointerRamAddressDepthStages),
+      .DynamicFifoNumLinkedListsPerFifo(DynamicFifoNumLinkedListsPerFifo),
+      .DynamicFifoDataRamReadDataDepthStages(DynamicFifoDataRamReadDataDepthStages),
+      .DynamicFifoDataRamAddressDepthStages(DynamicFifoDataRamAddressDepthStages),
+      .DynamicFifoStagingBufferDepth(DynamicFifoStagingBufferDepth),
+      .DynamicFifoRegisterPopOutputs(DynamicFifoRegisterPopOutputs),
+      .DynamicFifoRegisterDeallocation(DynamicFifoRegisterDeallocation),
       .IsolateResp(IsolateResp),
       .IsolateData(IsolateBUser),
       // Single write response beat per write transaction
       .MaxAxiBurstLen(1),
       .MaxTransactionSkew(MaxTransactionSkew),
-      .EnableWlastTracking(1)
+      .EnableWlastTracking(1),
+      .UseDynamicFifo(0),
+      .PerIdFifoDepth(MaxOutstanding)
   ) br_amba_iso_resp_tracker_w (
       .clk,
       .rst,
@@ -416,19 +424,21 @@ module br_amba_axi_isolate_sub #(
       .AxiIdCount(AxiIdCount),
       .AxiIdWidth(IdWidth),
       .DataWidth(RUserWidth + DataWidth),
-      .FifoPointerRamReadDataDepthStages(FifoPointerRamReadDataDepthStages),
-      .FifoPointerRamAddressDepthStages(FifoPointerRamAddressDepthStages),
-      .FifoNumLinkedListsPerFifo(FifoNumLinkedListsPerFifo),
-      .FifoDataRamReadDataDepthStages(FifoDataRamReadDataDepthStages),
-      .FifoDataRamAddressDepthStages(FifoDataRamAddressDepthStages),
-      .FifoStagingBufferDepth(FifoStagingBufferDepth),
-      .FifoRegisterPopOutputs(FifoRegisterPopOutputs),
-      .FifoRegisterDeallocation(FifoRegisterDeallocation),
+      .DynamicFifoPointerRamReadDataDepthStages(DynamicFifoPointerRamReadDataDepthStages),
+      .DynamicFifoPointerRamAddressDepthStages(DynamicFifoPointerRamAddressDepthStages),
+      .DynamicFifoNumLinkedListsPerFifo(DynamicFifoNumLinkedListsPerFifo),
+      .DynamicFifoDataRamReadDataDepthStages(DynamicFifoDataRamReadDataDepthStages),
+      .DynamicFifoDataRamAddressDepthStages(DynamicFifoDataRamAddressDepthStages),
+      .DynamicFifoStagingBufferDepth(DynamicFifoStagingBufferDepth),
+      .DynamicFifoRegisterPopOutputs(DynamicFifoRegisterPopOutputs),
+      .DynamicFifoRegisterDeallocation(DynamicFifoRegisterDeallocation),
       .IsolateResp(IsolateResp),
       .IsolateData({IsolateRUser, IsolateRData}),
       // MaxAxiBurstLen response beats per read transaction
       .MaxAxiBurstLen(MaxAxiBurstLen),
-      .EnableWlastTracking(0)
+      .EnableWlastTracking(0),
+      .UseDynamicFifo(UseDynamicFifoForReadTracker),
+      .PerIdFifoDepth(StaticPerIdReadTrackerFifoDepth)
   ) br_amba_iso_resp_tracker_r (
       .clk,
       .rst,

--- a/amba/rtl/br_amba_axi_isolate_sub.sv
+++ b/amba/rtl/br_amba_axi_isolate_sub.sv
@@ -85,6 +85,14 @@ module br_amba_axi_isolate_sub #(
     parameter bit [RUserWidth-1:0] IsolateRUser = '0,
     // RDATA data to generate for isolated transactions.
     parameter bit [DataWidth-1:0] IsolateRData = '0,
+    // Set to 1 to use a dynamic storage shared FIFO for the read tracking
+    // list.
+    parameter bit UseDynamicFifoForReadTracker = 1,
+    // When UseDynamicFifoForReadTracker=0, this parameter controls the depth
+    // of the Per-ID tracking FIFO. This defaults to MaxOutstanding, but may
+    // need to be set to a smaller value as the storage will be replicated for
+    // each ID.
+    parameter int StaticPerIdReadTrackerFifoDepth = MaxOutstanding,
     // Number of pipeline stages to use for the pointer RAM read data in the
     // response tracker FIFO. Has no effect if AxiIdCount == 1 or
     // UseDynamicFifoForReadTracker == 0.
@@ -117,14 +125,6 @@ module br_amba_axi_isolate_sub #(
     // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoRegisterDeallocation = 1,
     //
-    // Set to 1 to use a dynamic storage shared FIFO for the read tracking
-    // list.
-    parameter bit UseDynamicFifoForReadTracker = 1,
-    // When UseDynamicFifoForReadTracker=0, this parameter controls the depth
-    // of the Per-ID tracking FIFO. This defaults to MaxOutstanding, but may
-    // need to be set to a smaller value as the storage will be replicated for
-    // each ID.
-    parameter int StaticPerIdReadTrackerFifoDepth = MaxOutstanding,
     localparam int AxiBurstLenWidth = br_math::clamped_clog2(MaxAxiBurstLen),
     localparam int StrobeWidth = DataWidth / 8
 ) (
@@ -331,6 +331,10 @@ module br_amba_axi_isolate_sub #(
       .MaxAxiBurstLen(1),
       .MaxTransactionSkew(MaxTransactionSkew),
       .EnableWlastTracking(1),
+      // When MaxAxiBurstLen=1, the static FIFO implementation becomes an
+      // array of counters (no actual FIFOs), which is always more efficient
+      // than a dynamic FIFO. So no external option is provided to select a
+      // dynamic FIFO.
       .UseDynamicFifo(0),
       .PerIdFifoDepth(MaxOutstanding)
   ) br_amba_iso_resp_tracker_w (

--- a/amba/rtl/internal/BUILD.bazel
+++ b/amba/rtl/internal/BUILD.bazel
@@ -122,6 +122,10 @@ br_verilog_elab_and_lint_test_suite(
             "2",
             "128",
         ],
+        "UseDynamicFifo": [
+            "1",
+            "0",
+        ],
     },
     deps = [":br_amba_iso_resp_tracker"],
 )

--- a/amba/rtl/internal/br_amba_iso_resp_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_resp_tracker.sv
@@ -37,6 +37,9 @@
 // Once the isolate_req signal is deasserted, the module will resume
 // normal operation, forwarding requests to the downstream interface,
 // and forwarding downstream responses to the upstream interface.
+//
+// Can be configured to use a dynamic shared-storage FIFO for the tracking
+// list with UseDynamicFifo=1, otherwise a static FIFO per-ID is used.
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"


### PR DESCRIPTION
The dynamic fifo gets challenging for timing when the number of IDs is large. Add an option to have dedicated FIFO per ID instead of a dynamically shared FIFO. This is less storage efficient, but sometimes the best compromise.

- Add support for array of static FIFOs (one per ID) instead of Dynamic FIFO.
- Special case the AxiMaxBurstLen=1 case to remove the static FIFOs altogether and replace with counters.
- Write tracking now *always* uses the static FIFO configuration. Because writes are only a single response beat, no actual FIFO storage is needed and this turns into an array of counters, rather than an array of FIFOs. This is always more efficient than using a Dynamic FIFO.
- Remove end-to-end WLAST count. This had little purpose before (other than to make it easy to predict exactly how many WLAST pushes could reside within the unit to make FPV life easier) and doesn't make sense with the static FIFO. So just getting rid of it.