### PR TITLE
Reduce parameter sweep combinations for nightly regression

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -51,7 +51,6 @@ br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_default_target_test_suite",
     tools = {
         "jg": "br_amba_axil_default_target_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axil_default_target",
     deps = [":br_amba_axil_default_target_fpv_monitor"],
@@ -88,7 +87,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_amba_axi_default_target_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axi_default_target",
     deps = [":br_amba_axi_default_target_fpv_monitor"],
@@ -118,7 +116,6 @@ br_verilog_fpv_test_tools_suite(
     ],
     tools = {
         "jg": "br_amba_axi2axil_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axi2axil",
     deps = [":br_amba_axi2axil_fpv_monitor"],
@@ -152,7 +149,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_amba_axil_split_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axil_split",
     deps = [":br_amba_axil_split_fpv_monitor"],
@@ -179,7 +175,6 @@ br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_timing_slice_test_suite",
     tools = {
         "jg": "br_amba_axi_timing_slice_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axi_timing_slice",
     deps = [":br_amba_axi_timing_slice_fpv_monitor"],
@@ -206,7 +201,6 @@ br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_timing_slice_test_suite",
     tools = {
         "jg": "br_amba_axil_timing_slice_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axil_timing_slice",
     deps = [":br_amba_axil_timing_slice_fpv_monitor"],
@@ -233,7 +227,6 @@ br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil2apb_test_suite",
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_amba_axil2apb",
     deps = [":br_amba_axil2apb_fpv_monitor"],
@@ -260,7 +253,6 @@ br_verilog_fpv_test_tools_suite(
     name = "br_amba_apb_timing_slice_test_suite",
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_amba_apb_timing_slice",
     deps = [":br_amba_apb_timing_slice_fpv_monitor"],
@@ -287,7 +279,6 @@ br_verilog_fpv_test_tools_suite(
     name = "br_amba_atb_funnel_test_suite",
     tools = {
         "jg": "br_amba_atb_funnel_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_atb_funnel",
     deps = [":br_amba_atb_funnel_fpv_monitor"],
@@ -314,7 +305,6 @@ br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_msi_test_suite",
     tools = {
         "jg": "br_amba_axil_msi_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axil_msi",
     deps = [":br_amba_axil_msi_fpv_monitor"],
@@ -351,7 +341,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_amba_axi_isolate_mgr_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axi_isolate_mgr",
     deps = [":br_amba_axi_isolate_mgr_fpv_monitor"],
@@ -393,7 +382,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_amba_axi_isolate_sub_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axi_isolate_sub",
     deps = [":br_amba_axi_isolate_sub_fpv_monitor"],
@@ -438,7 +426,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_amba_axi_demux_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_amba_axi_demux",
     deps = [":br_amba_axi_demux_fpv_monitor"],

--- a/amba/fpv/br_amba_atb_funnel_fpv.jg.tcl
+++ b/amba/fpv/br_amba_atb_funnel_fpv.jg.tcl
@@ -25,5 +25,8 @@ assert -disable <embedded>::br_amba_atb_funnel.monitor.gen_src\[*\].src.ATB_v1_0
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
@@ -24,5 +24,8 @@ assume -from_assert <embedded>::br_amba_axi2axil.monitor.axi4_lite.genPropChksWR
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axi_default_target_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_default_target_fpv.jg.tcl
@@ -20,5 +20,8 @@ get_design_info
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axi_demux_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_demux_fpv.jg.tcl
@@ -20,5 +20,8 @@ get_design_info
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axi_isolate_mgr_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_isolate_mgr_fpv.jg.tcl
@@ -30,5 +30,8 @@ assert -disable {*upstream.genPropChksWRInf.slave_b_aw_bid_match}
 assert -disable {*upstream.genPropChksWRInf.genAXI4FullWrResp.slave_b_aw_bid_order_within_id}
 assert -disable {*upstream.genPropChksWRInf.genMasterLiveW.genreadyW.slave_w_no_aw_wready_eventually}
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
@@ -26,5 +26,8 @@ assert -disable {*downstream.genStableChksRDInf.genARStableChks.master_ar_arvali
 assert -disable {*downstream.genStableChksWRInf.genAWStableChks.master_aw_awvalid_stable}
 assert -disable {*downstream.genStableChksWRInf.genWStableChks.master_w_wvalid_stable}
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
@@ -30,5 +30,8 @@ assert -disable <embedded>::br_amba_axi_timing_slice.monitor.init.genPropChksWRI
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axil_default_target_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_default_target_fpv.jg.tcl
@@ -20,5 +20,8 @@ get_design_info
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
@@ -24,5 +24,8 @@ assert -disable <embedded>::br_amba_axil_msi.monitor.axi.genPropChksWRInf.genNoW
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axil_split_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_split_fpv.jg.tcl
@@ -20,5 +20,8 @@ get_design_info
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
@@ -30,5 +30,8 @@ assert -disable <embedded>::br_amba_axil_timing_slice.monitor.init.genPropChksWR
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/cdc/fpv/BUILD.bazel
+++ b/cdc/fpv/BUILD.bazel
@@ -27,6 +27,7 @@ verilog_library(
     ],
 )
 
+####################################################################################
 # Bedrock-RTL CDC FIFO (Internal 1R1W Flop-RAM, Push Ready/Valid, Pop Ready/Valid Variant)
 
 verilog_library(
@@ -52,8 +53,9 @@ verilog_elab_test(
     ],
 )
 
+# test valid ready protocol
 br_verilog_fpv_test_tools_suite(
-    name = "br_cdc_fifo_flops_test_suite",
+    name = "br_cdc_fifo_flops_test_backpressure",
     illegal_param_combinations = {
         (
             "EnableCoverPushBackpressure",
@@ -67,11 +69,6 @@ br_verilog_fpv_test_tools_suite(
         ],
     },
     params = {
-        "Depth": [
-            "2",
-            "5",
-            "6",
-        ],
         "EnableAssertPushDataStability": [
             "0",
             "1",
@@ -84,6 +81,26 @@ br_verilog_fpv_test_tools_suite(
             "0",
             "1",
         ],
+    },
+    tools = {
+        "jg": "br_cdc_fifo_flops_fpv.jg.tcl",
+    },
+    top = "br_cdc_fifo_flops_fpv_monitor",
+    deps = [
+        ":br_cdc_fifo_flops_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+        "//mux/rtl:br_mux_bin_structured_gates_mock",
+    ],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_fifo_flops_test_suite",
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
         "NumSyncStages": [
             "2",
             "3",
@@ -95,13 +112,10 @@ br_verilog_fpv_test_tools_suite(
         ],
         "Width": [
             "1",
-            "3",
-            "4",
         ],
     },
     tools = {
         "jg": "br_cdc_fifo_flops_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_cdc_fifo_flops_fpv_monitor",
     deps = [
@@ -111,6 +125,7 @@ br_verilog_fpv_test_tools_suite(
     ],
 )
 
+####################################################################################
 # Bedrock-RTL CDC FIFO (Internal 1R1W Flop-RAM, Push Credit/Valid, Pop Ready/Valid Variant)
 
 verilog_library(
@@ -129,6 +144,38 @@ verilog_elab_test(
     name = "br_cdc_fifo_flops_push_credit_fpv_monitor_elab_test",
     custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
     tool = "verific",
+    top = "br_cdc_fifo_flops_push_credit_fpv_monitor",
+    deps = [
+        ":br_cdc_fifo_flops_push_credit_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+        "//mux/rtl:br_mux_bin_structured_gates_mock",
+    ],
+)
+
+# test focuses on delay
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_fifo_flops_push_credit_test_delay",
+    params = {
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_cdc_fifo_flops_push_credit_fpv.jg.tcl",
+    },
     top = "br_cdc_fifo_flops_push_credit_fpv_monitor",
     deps = [
         ":br_cdc_fifo_flops_push_credit_fpv_monitor",
@@ -159,28 +206,12 @@ br_verilog_fpv_test_tools_suite(
             "6",
             "8",
         ],
-        "NumSyncStages": [
-            "2",
-            "3",
-            "4",
-        ],
-        "RegisterPopOutputs": [
-            "0",
-            "1",
-        ],
-        "RegisterPushOutputs": [
-            "0",
-            "1",
-        ],
         "Width": [
             "1",
-            "3",
-            "4",
         ],
     },
     tools = {
         "jg": "br_cdc_fifo_flops_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_cdc_fifo_flops_push_credit_fpv_monitor",
     deps = [
@@ -190,6 +221,7 @@ br_verilog_fpv_test_tools_suite(
     ],
 )
 
+####################################################################################
 # Bedrock-RTL CDC FIFO Controller (1R1W, Push Ready/Valid, Pop Ready/Valid Variant)
 
 verilog_library(
@@ -210,8 +242,9 @@ verilog_elab_test(
     deps = [":br_cdc_fifo_ctrl_1r1w_fpv_monitor"],
 )
 
+# test valid ready protocol
 br_verilog_fpv_test_tools_suite(
-    name = "br_cdc_fifo_ctrl_1r1w_test_suite",
+    name = "br_cdc_fifo_ctrl_1r1w_test_backpressure",
     illegal_param_combinations = {
         (
             "EnableCoverPushBackpressure",
@@ -223,22 +256,8 @@ br_verilog_fpv_test_tools_suite(
             ("0", "1", "1"),
             ("1", "0", "1"),
         ],
-        (
-            "Depth",
-            "RamReadLatency",
-        ): [
-            ("2", "3"),
-            ("2", "5"),
-            ("5", "5"),
-            ("6", "5"),
-        ],
     },
     params = {
-        "Depth": [
-            "2",
-            "5",
-            "6",
-        ],
         "EnableAssertPushDataStability": [
             "0",
             "1",
@@ -251,20 +270,43 @@ br_verilog_fpv_test_tools_suite(
             "0",
             "1",
         ],
+        "Width": [
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl",
+    },
+    top = "br_cdc_fifo_ctrl_1r1w_fpv_monitor",
+    deps = [":br_cdc_fifo_ctrl_1r1w_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_fifo_ctrl_1r1w_test_suite",
+    illegal_param_combinations = {
+        (
+            "Depth",
+            "RamReadLatency",
+        ): [
+            ("2", "3"),
+        ],
+    },
+    params = {
+        "Depth": [
+            "2",
+            "6",
+        ],
         "NumSyncStages": [
             "2",
             "3",
-            "4",
         ],
         "RamReadLatency": [
             "0",
             "3",
-            "5",
         ],
         "RamWriteLatency": [
             "1",
             "3",
-            "5",
         ],
         "RegisterPopOutputs": [
             "0",
@@ -272,18 +314,16 @@ br_verilog_fpv_test_tools_suite(
         ],
         "Width": [
             "1",
-            "3",
-            "4",
         ],
     },
     tools = {
         "jg": "br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_cdc_fifo_ctrl_1r1w_fpv_monitor",
     deps = [":br_cdc_fifo_ctrl_1r1w_fpv_monitor"],
 )
 
+####################################################################################
 # Bedrock-RTL CDC FIFO Controller (1R1W, Push Ready/Valid, Pop Credit/Valid Variant)
 
 verilog_library(
@@ -305,18 +345,47 @@ verilog_elab_test(
     deps = [":br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
 )
 
+# test delay
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_fifo_ctrl_1r1w_push_credit_test_delay",
+    params = {
+        "Depth": [
+            "6",
+        ],
+        "NumSyncStages": [
+            "2",
+            "4",
+        ],
+        "RamReadLatency": [
+            "0",
+            "3",
+        ],
+        "RamWriteLatency": [
+            "1",
+            "3",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl",
+    },
+    top = "br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor",
+    deps = [":br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
+)
+
 br_verilog_fpv_test_tools_suite(
     name = "br_cdc_fifo_ctrl_1r1w_push_credit_test_suite",
     illegal_param_combinations = {
-        (
-            "Depth",
-            "RamReadLatency",
-        ): [
-            ("2", "3"),
-            ("2", "5"),
-            ("5", "5"),
-            ("6", "5"),
-        ],
         (
             "Depth",
             "MaxCredit",
@@ -336,43 +405,18 @@ br_verilog_fpv_test_tools_suite(
             "6",
             "8",
         ],
-        "NumSyncStages": [
-            "2",
-            "3",
-            "4",
-        ],
-        "RamReadLatency": [
-            "0",
-            "3",
-            "5",
-        ],
-        "RamWriteLatency": [
-            "1",
-            "3",
-            "5",
-        ],
-        "RegisterPopOutputs": [
-            "0",
-            "1",
-        ],
-        "RegisterPushOutputs": [
-            "0",
-            "1",
-        ],
         "Width": [
             "1",
-            "3",
-            "4",
         ],
     },
     tools = {
         "jg": "br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor",
     deps = [":br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
 )
 
+####################################################################################
 # Combined FV env:
 # Push-side of Bedrock-RTL CDC FIFO Controller (1R1W, Ready/Valid Variant)
 # Pop-side of Bedrock-RTL CDC FIFO Controller (1R1W, Ready/Valid Variant)
@@ -396,8 +440,9 @@ verilog_elab_test(
     deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor"],
 )
 
+# test valid ready protocol
 br_verilog_fpv_test_tools_suite(
-    name = "br_cdc_fifo_ctrl_push_pop_1r1w_test_suite",
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_test_backpressure",
     illegal_param_combinations = {
         (
             "EnableCoverPushBackpressure",
@@ -409,22 +454,8 @@ br_verilog_fpv_test_tools_suite(
             ("0", "1", "1"),
             ("1", "0", "1"),
         ],
-        (
-            "Depth",
-            "RamReadLatency",
-        ): [
-            ("2", "3"),
-            ("2", "5"),
-            ("5", "5"),
-            ("6", "5"),
-        ],
     },
     params = {
-        "Depth": [
-            "2",
-            "5",
-            "6",
-        ],
         "EnableAssertPushDataStability": [
             "0",
             "1",
@@ -437,20 +468,43 @@ br_verilog_fpv_test_tools_suite(
             "0",
             "1",
         ],
+        "Width": [
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_cdc_fifo_ctrl_push_pop_1r1w_fpv.jg.tcl",
+    },
+    top = "br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor",
+    deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_test_suite",
+    illegal_param_combinations = {
+        (
+            "Depth",
+            "RamReadLatency",
+        ): [
+            ("2", "3"),
+        ],
+    },
+    params = {
+        "Depth": [
+            "2",
+            "5",
+        ],
         "NumSyncStages": [
             "2",
             "3",
-            "4",
         ],
         "RamReadLatency": [
             "0",
             "3",
-            "5",
         ],
         "RamWriteLatency": [
             "1",
             "3",
-            "5",
         ],
         "RegisterPopOutputs": [
             "0",
@@ -458,18 +512,16 @@ br_verilog_fpv_test_tools_suite(
         ],
         "Width": [
             "1",
-            "3",
-            "4",
         ],
     },
     tools = {
         "jg": "br_cdc_fifo_ctrl_push_pop_1r1w_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor",
     deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor"],
 )
 
+####################################################################################
 # Combined FV env:
 # Push-side of Bedrock-RTL CDC FIFO Controller (1R1W, Push Credit/Valid)
 # Pop-side of Bedrock-RTL CDC FIFO Controller (1R1W, Ready/Valid Variant)
@@ -494,18 +546,55 @@ verilog_elab_test(
     deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor"],
 )
 
+# test delay
 br_verilog_fpv_test_tools_suite(
-    name = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_test_suite",
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_test_delay",
     illegal_param_combinations = {
         (
             "Depth",
             "RamReadLatency",
         ): [
             ("2", "3"),
-            ("2", "5"),
-            ("5", "5"),
-            ("6", "5"),
         ],
+    },
+    params = {
+        "Depth": [
+            "5",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+        ],
+        "RamReadLatency": [
+            "0",
+            "3",
+        ],
+        "RamWriteLatency": [
+            "1",
+            "3",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl",
+    },
+    top = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor",
+    deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_test_suite",
+    illegal_param_combinations = {
         (
             "Depth",
             "MaxCredit",
@@ -525,38 +614,12 @@ br_verilog_fpv_test_tools_suite(
             "6",
             "8",
         ],
-        "NumSyncStages": [
-            "2",
-            "3",
-            "4",
-        ],
-        "RamReadLatency": [
-            "0",
-            "3",
-            "5",
-        ],
-        "RamWriteLatency": [
-            "1",
-            "3",
-            "5",
-        ],
-        "RegisterPopOutputs": [
-            "0",
-            "1",
-        ],
-        "RegisterPushOutputs": [
-            "0",
-            "1",
-        ],
         "Width": [
             "1",
-            "3",
-            "4",
         ],
     },
     tools = {
         "jg": "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor",
     deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor"],

--- a/counter/fpv/BUILD.bazel
+++ b/counter/fpv/BUILD.bazel
@@ -78,7 +78,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_counter_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_counter",
     deps = [":br_counter_fpv_monitor"],
@@ -133,7 +132,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_counter_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_counter_decr",
     deps = [":br_counter_decr_fpv_monitor"],
@@ -188,7 +186,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_counter_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_counter_incr",
     deps = [":br_counter_incr_fpv_monitor"],

--- a/credit/fpv/BUILD.bazel
+++ b/credit/fpv/BUILD.bazel
@@ -61,7 +61,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_credit_counter_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_credit_counter",
     deps = [":br_credit_counter_fpv_monitor"],
@@ -143,7 +142,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_credit_receiver_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_credit_receiver",
     deps = [":br_credit_receiver_fpv_monitor"],
@@ -167,8 +165,9 @@ verilog_elab_test(
     deps = [":br_credit_sender_fpv_monitor"],
 )
 
+# test valid ready protocol
 br_verilog_fpv_test_tools_suite(
-    name = "br_credit_sender_test_suite",
+    name = "br_credit_sender_test_backpressure",
     illegal_param_combinations = {
         (
             "EnableCoverPushBackpressure",
@@ -180,6 +179,31 @@ br_verilog_fpv_test_tools_suite(
             ("0", "1", "1"),
             ("1", "0", "1"),
         ],
+    },
+    params = {
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_credit_sender_fpv.jg.tcl",
+    },
+    top = "br_credit_sender",
+    deps = [":br_credit_sender_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_credit_sender_test_suite",
+    illegal_param_combinations = {
         (
             "PopCreditMaxChange",
             "MaxCredit",
@@ -196,18 +220,6 @@ br_verilog_fpv_test_tools_suite(
         ],
     },
     params = {
-        "EnableCoverPushBackpressure": [
-            "0",
-            "1",
-        ],
-        "EnableAssertPushDataStability": [
-            "0",
-            "1",
-        ],
-        "EnableAssertPushValidStability": [
-            "0",
-            "1",
-        ],
         "MaxCredit": [
             "1",
             "5",
@@ -235,7 +247,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_credit_sender_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_credit_sender",
     deps = [":br_credit_sender_fpv_monitor"],

--- a/delay/fpv/BUILD.bazel
+++ b/delay/fpv/BUILD.bazel
@@ -46,12 +46,10 @@ br_verilog_fpv_test_tools_suite(
         "Width": [
             "1",
             "5",
-            "6",
         ],
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_delay",
     deps = [":br_delay_fpv_monitor"],
@@ -85,12 +83,10 @@ br_verilog_fpv_test_tools_suite(
         "Width": [
             "1",
             "5",
-            "6",
         ],
     },
     tools = {
         "jg": "br_delay_nr_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_delay_nr",
     deps = [":br_delay_nr_fpv_monitor"],
@@ -124,12 +120,10 @@ br_verilog_fpv_test_tools_suite(
         "Width": [
             "1",
             "5",
-            "6",
         ],
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_delay_valid",
     deps = [":br_delay_valid_fpv_monitor"],
@@ -162,13 +156,11 @@ br_verilog_fpv_test_tools_suite(
         ],
         "Width": [
             "1",
-            "5",
             "6",
         ],
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_delay_valid_next",
     deps = [":br_delay_valid_next_fpv_monitor"],
@@ -201,12 +193,10 @@ br_verilog_fpv_test_tools_suite(
         "Width": [
             "1",
             "5",
-            "6",
         ],
     },
     tools = {
         "jg": "br_delay_nr_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_delay_valid_next_nr",
     deps = [":br_delay_valid_next_nr_fpv_monitor"],

--- a/ecc/fpv/BUILD.bazel
+++ b/ecc/fpv/BUILD.bazel
@@ -64,7 +64,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_ecc_sed_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_ecc_sed_fpv_monitor",
     deps = [":br_ecc_sed_fpv_monitor"],
@@ -117,7 +116,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_ecc_secded_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_ecc_secded_fpv_monitor",
     deps = [":br_ecc_secded_fpv_monitor"],
@@ -201,7 +199,6 @@ br_verilog_fpv_test_tools_suite(
     params = {"DataWidth": DATA_WIDTHS},
     tools = {
         "jg": "br_ecc_secded_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_ecc_secded_fpv_monitor",
     deps = [":br_ecc_secded_fpv_monitor"],
@@ -253,7 +250,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_ecc_secded_error_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_ecc_secded_error_fpv_monitor",
     deps = [":br_ecc_secded_error_fpv_monitor"],
@@ -264,7 +260,6 @@ br_verilog_fpv_test_tools_suite(
     params = {"DataWidth": DATA_WIDTHS},
     tools = {
         "jg": "br_ecc_secded_error_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_ecc_secded_error_fpv_monitor",
     deps = [":br_ecc_secded_error_fpv_monitor"],

--- a/fifo/fpv/BUILD.bazel
+++ b/fifo/fpv/BUILD.bazel
@@ -79,9 +79,9 @@ verilog_elab_test(
     deps = [":br_fifo_ctrl_1r1w_fpv_monitor"],
 )
 
-# Normal tests
+# test valid ready protocol
 br_verilog_fpv_test_tools_suite(
-    name = "br_fifo_ctrl_1r1w_test_suite",
+    name = "br_fifo_ctrl_1r1w_test_backpressure",
     illegal_param_combinations = {
         (
             "EnableCoverPushBackpressure",
@@ -93,6 +93,32 @@ br_verilog_fpv_test_tools_suite(
             ("0", "1", "1"),
             ("1", "0", "1"),
         ],
+    },
+    params = {
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_ctrl_1r1w_fpv.jg.tcl",
+    },
+    top = "br_fifo_ctrl_1r1w",
+    deps = [":br_fifo_ctrl_1r1w_fpv_monitor"],
+)
+
+# Normal tests
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_ctrl_1r1w_test_suite",
+    illegal_param_combinations = {
         # Depth > RamReadLatency + 1
         (
             "Depth",
@@ -112,18 +138,6 @@ br_verilog_fpv_test_tools_suite(
             "1",
             "0",
         ],
-        "EnableAssertPushDataStability": [
-            "0",
-            "1",
-        ],
-        "EnableAssertPushValidStability": [
-            "0",
-            "1",
-        ],
-        "EnableCoverPushBackpressure": [
-            "0",
-            "1",
-        ],
         "RamReadLatency": [
             "2",
             "1",
@@ -135,12 +149,10 @@ br_verilog_fpv_test_tools_suite(
         ],
         "Width": [
             "1",
-            "5",
         ],
     },
     tools = {
         "jg": "br_fifo_ctrl_1r1w_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_ctrl_1r1w",
     deps = [":br_fifo_ctrl_1r1w_fpv_monitor"],
@@ -191,7 +203,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_ctrl_1r1w_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_ctrl_1r1w",
     deps = [":br_fifo_ctrl_1r1w_fpv_monitor"],
@@ -216,9 +227,9 @@ verilog_elab_test(
     deps = [":br_fifo_flops_fpv_monitor"],
 )
 
-# Normal tests
+# test valid ready protocol
 br_verilog_fpv_test_tools_suite(
-    name = "br_fifo_flops_test_suite",
+    name = "br_fifo_flops_test_backpressure",
     illegal_param_combinations = {
         (
             "EnableCoverPushBackpressure",
@@ -232,15 +243,6 @@ br_verilog_fpv_test_tools_suite(
         ],
     },
     params = {
-        "Depth": [
-            "2",
-            "5",
-            "6",
-        ],
-        "EnableBypass": [
-            "1",
-            "0",
-        ],
         "EnableAssertPushDataStability": [
             "0",
             "1",
@@ -252,6 +254,27 @@ br_verilog_fpv_test_tools_suite(
         "EnableCoverPushBackpressure": [
             "0",
             "1",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_flops_fpv.jg.tcl",
+    },
+    top = "br_fifo_flops",
+    deps = [":br_fifo_flops_fpv_monitor"],
+)
+
+# Normal tests
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_flops_test_suite",
+    params = {
+        "Depth": [
+            "2",
+            "5",
+            "6",
+        ],
+        "EnableBypass": [
+            "1",
+            "0",
         ],
         "RegisterPopOutputs": [
             "1",
@@ -265,7 +288,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_flops_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_flops",
     deps = [":br_fifo_flops_fpv_monitor"],
@@ -312,7 +334,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_flops_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_flops",
     deps = [":br_fifo_flops_fpv_monitor"],
@@ -377,12 +398,10 @@ br_verilog_fpv_test_tools_suite(
         ],
         "Width": [
             "1",
-            "5",
         ],
     },
     tools = {
         "jg": "br_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_ctrl_1r1w_push_credit",
     deps = [":br_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
@@ -437,7 +456,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_ctrl_1r1w_push_credit",
     deps = [":br_fifo_ctrl_1r1w_push_credit_fpv_monitor"],
@@ -486,13 +504,10 @@ br_verilog_fpv_test_tools_suite(
         ],
         "Width": [
             "1",
-            "5",
-            "6",
         ],
     },
     tools = {
         "jg": "br_fifo_flops_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_flops_push_credit",
     deps = [":br_fifo_flops_push_credit_fpv_monitor"],
@@ -543,7 +558,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_flops_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_flops_push_credit",
     deps = [":br_fifo_flops_push_credit_fpv_monitor"],
@@ -613,7 +627,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_flops",
     deps = [":br_fifo_shared_dynamic_flops_fpv_monitor"],
@@ -662,7 +675,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_flops",
     deps = [":br_fifo_shared_dynamic_flops_fpv_monitor"],
@@ -699,7 +711,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_flops",
     deps = [":br_fifo_shared_dynamic_flops_fpv_monitor"],
@@ -772,7 +783,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_flops_push_credit",
     deps = [":br_fifo_shared_dynamic_flops_push_credit_fpv_monitor"],
@@ -825,7 +835,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_flops_push_credit",
     deps = [":br_fifo_shared_dynamic_flops_push_credit_fpv_monitor"],
@@ -896,7 +905,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_ctrl_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_ctrl",
     deps = [":br_fifo_shared_dynamic_ctrl_fpv_monitor"],
@@ -931,7 +939,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_ctrl_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_ctrl",
     deps = [":br_fifo_shared_dynamic_ctrl_fpv_monitor"],
@@ -968,7 +975,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_ctrl_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_ctrl",
     deps = [":br_fifo_shared_dynamic_ctrl_fpv_monitor"],
@@ -1032,7 +1038,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_ctrl_push_credit",
     deps = [":br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor"],
@@ -1071,7 +1076,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_dynamic_ctrl_push_credit",
     deps = [":br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor"],
@@ -1146,7 +1150,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_pstatic_ctrl_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_pstatic_ctrl",
     deps = [":br_fifo_shared_pstatic_ctrl_fpv_monitor"],
@@ -1193,7 +1196,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_pstatic_ctrl_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_pstatic_ctrl",
     deps = [":br_fifo_shared_pstatic_ctrl_fpv_monitor"],
@@ -1265,7 +1267,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_pstatic_ctrl_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_pstatic_ctrl_push_credit",
     deps = [":br_fifo_shared_pstatic_ctrl_push_credit_fpv_monitor"],
@@ -1323,7 +1324,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_pstatic_flops_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_pstatic_flops",
     deps = [":br_fifo_shared_pstatic_flops_fpv_monitor"],
@@ -1354,7 +1354,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_pstatic_flops_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_pstatic_flops",
     deps = [":br_fifo_shared_pstatic_flops_fpv_monitor"],
@@ -1393,7 +1392,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_pstatic_flops_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_pstatic_flops",
     deps = [":br_fifo_shared_pstatic_flops_fpv_monitor"],
@@ -1446,7 +1444,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_pstatic_flops_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_pstatic_flops_push_credit",
     deps = [":br_fifo_shared_pstatic_flops_push_credit_fpv_monitor"],
@@ -1489,7 +1486,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_fifo_shared_pstatic_flops_push_credit_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_fifo_shared_pstatic_flops_push_credit",
     deps = [":br_fifo_shared_pstatic_flops_push_credit_fpv_monitor"],

--- a/flow/fpv/arb/BUILD.bazel
+++ b/flow/fpv/arb/BUILD.bazel
@@ -69,7 +69,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_flow_arb_fixed",
     deps = [":br_flow_arb_fixed_fpv_monitor"],
@@ -121,7 +120,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_flow_arb_lru",
     deps = [":br_flow_arb_lru_fpv_monitor"],
@@ -173,7 +171,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_flow_arb_rr",
     deps = [":br_flow_arb_rr_fpv_monitor"],

--- a/flow/fpv/demux/BUILD.bazel
+++ b/flow/fpv/demux/BUILD.bazel
@@ -82,7 +82,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_demux_select_unstable_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_demux_select_unstable",
     deps = [":br_flow_demux_select_unstable_fpv_monitor"],
@@ -146,7 +145,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_demux_select_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_demux_select",
     deps = [":br_flow_demux_select_fpv_monitor"],

--- a/flow/fpv/fork/BUILD.bazel
+++ b/flow/fpv/fork/BUILD.bazel
@@ -49,7 +49,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_flow_fork",
     deps = [":br_flow_fork_fpv_monitor"],
@@ -110,7 +109,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_fork_select_multihot_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_fork_select_multihot",
     deps = [":br_flow_fork_select_multihot_fpv_monitor"],

--- a/flow/fpv/mux/BUILD.bazel
+++ b/flow/fpv/mux/BUILD.bazel
@@ -82,7 +82,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_mux_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_mux_fixed",
     deps = [":br_flow_mux_fixed_fpv_monitor"],
@@ -148,7 +147,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_mux_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_mux_lru",
     deps = [":br_flow_mux_lru_fpv_monitor"],
@@ -214,7 +212,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_mux_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_mux_rr",
     deps = [":br_flow_mux_rr_fpv_monitor"],
@@ -278,7 +275,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_mux_select_unstable_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_mux_select_unstable",
     deps = [":br_flow_mux_select_unstable_fpv_monitor"],
@@ -342,7 +338,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_mux_select_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_mux_select",
     deps = [":br_flow_mux_select_fpv_monitor"],
@@ -410,7 +405,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_mux_stable_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_mux_fixed_stable",
     deps = [":br_flow_mux_fixed_stable_fpv_monitor"],
@@ -480,7 +474,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_mux_stable_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_mux_lru_stable",
     deps = [":br_flow_mux_lru_stable_fpv_monitor"],
@@ -550,7 +543,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_mux_stable_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_mux_rr_stable",
     deps = [":br_flow_mux_rr_stable_fpv_monitor"],

--- a/flow/fpv/reg/BUILD.bazel
+++ b/flow/fpv/reg/BUILD.bazel
@@ -70,14 +70,11 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
         "Width": [
-            "1",
-            "3",
             "4",
         ],
     },
     tools = {
         "jg": "br_flow_reg_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_reg_both",
     deps = [":br_flow_reg_both_fpv_monitor"],
@@ -129,14 +126,11 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
         "Width": [
-            "1",
             "3",
-            "4",
         ],
     },
     tools = {
         "jg": "br_flow_reg_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_reg_fwd",
     deps = [":br_flow_reg_fwd_fpv_monitor"],
@@ -189,13 +183,10 @@ br_verilog_fpv_test_tools_suite(
         ],
         "Width": [
             "1",
-            "3",
-            "4",
         ],
     },
     tools = {
         "jg": "br_flow_reg_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_reg_rev",
     deps = [":br_flow_reg_rev_fpv_monitor"],
@@ -247,14 +238,11 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
         "Width": [
-            "1",
             "3",
-            "4",
         ],
     },
     tools = {
         "jg": "br_flow_reg_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_reg_none",
     deps = [":br_flow_reg_none_fpv_monitor"],

--- a/flow/fpv/serializer/BUILD.bazel
+++ b/flow/fpv/serializer/BUILD.bazel
@@ -66,7 +66,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_serializer_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_serializer",
     deps = [":br_flow_serializer_fpv_monitor"],
@@ -120,7 +119,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_deserializer_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_deserializer",
     deps = [":br_flow_deserializer_fpv_monitor"],

--- a/flow/fpv/xbar/BUILD.bazel
+++ b/flow/fpv/xbar/BUILD.bazel
@@ -43,8 +43,9 @@ verilog_elab_test(
     deps = [":br_flow_xbar_fixed_fpv_monitor"],
 )
 
+# test valid ready protocol
 br_verilog_fpv_test_tools_suite(
-    name = "br_flow_xbar_fixed_test_suite",
+    name = "br_flow_xbar_fixed_test_backpressure",
     illegal_param_combinations = {
         (
             "EnableCoverPushBackpressure",
@@ -70,6 +71,17 @@ br_verilog_fpv_test_tools_suite(
             "0",
             "1",
         ],
+    },
+    tools = {
+        "jg": "br_flow_xbar_fpv.jg.tcl",
+    },
+    top = "br_flow_xbar_fixed",
+    deps = [":br_flow_xbar_fixed_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_flow_xbar_fixed_test_suite",
+    params = {
         "NumPopFlows": [
             "2",
             "3",
@@ -95,7 +107,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_xbar_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_xbar_fixed",
     deps = [":br_flow_xbar_fixed_fpv_monitor"],
@@ -121,8 +132,9 @@ verilog_elab_test(
     deps = [":br_flow_xbar_rr_fpv_monitor"],
 )
 
+# test valid ready protocol
 br_verilog_fpv_test_tools_suite(
-    name = "br_flow_xbar_rr_test_suite",
+    name = "br_flow_xbar_rr_test_backpressure",
     illegal_param_combinations = {
         (
             "EnableCoverPushBackpressure",
@@ -148,6 +160,17 @@ br_verilog_fpv_test_tools_suite(
             "0",
             "1",
         ],
+    },
+    tools = {
+        "jg": "br_flow_xbar_fpv.jg.tcl",
+    },
+    top = "br_flow_xbar_rr",
+    deps = [":br_flow_xbar_rr_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_flow_xbar_rr_test_suite",
+    params = {
         "NumPopFlows": [
             "2",
             "3",
@@ -173,7 +196,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_xbar_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_xbar_rr",
     deps = [":br_flow_xbar_rr_fpv_monitor"],
@@ -199,8 +221,9 @@ verilog_elab_test(
     deps = [":br_flow_xbar_lru_fpv_monitor"],
 )
 
+# test valid ready protocol
 br_verilog_fpv_test_tools_suite(
-    name = "br_flow_xbar_lru_test_suite",
+    name = "br_flow_xbar_lru_test_backpressure",
     illegal_param_combinations = {
         (
             "EnableCoverPushBackpressure",
@@ -226,6 +249,17 @@ br_verilog_fpv_test_tools_suite(
             "0",
             "1",
         ],
+    },
+    tools = {
+        "jg": "br_flow_xbar_fpv.jg.tcl",
+    },
+    top = "br_flow_xbar_lru",
+    deps = [":br_flow_xbar_lru_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_flow_xbar_lru_test_suite",
+    params = {
         "NumPopFlows": [
             "2",
             "3",
@@ -251,7 +285,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_flow_xbar_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_flow_xbar_lru",
     deps = [":br_flow_xbar_lru_fpv_monitor"],

--- a/multi_xfer/fpv/BUILD.bazel
+++ b/multi_xfer/fpv/BUILD.bazel
@@ -51,7 +51,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_multi_xfer_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_multi_xfer_reg_fwd",
     deps = [":br_multi_xfer_reg_fwd_fpv_monitor"],
@@ -106,7 +105,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_multi_xfer_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_multi_xfer_distributor_rr",
     deps = [":br_multi_xfer_distributor_rr_fpv_monitor"],

--- a/ram/fpv/BUILD.bazel
+++ b/ram/fpv/BUILD.bazel
@@ -60,7 +60,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_ram_initializer",
     deps = [":br_ram_initializer_fpv_monitor"],
@@ -121,7 +120,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_ram_addr_decoder",
     deps = [":br_ram_addr_decoder_fpv_monitor"],
@@ -183,7 +181,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "",
-        "vcf": "",
     },
     top = "br_ram_data_rd_pipe",
     deps = [":br_ram_data_rd_pipe_fpv_monitor"],
@@ -360,7 +357,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_ram_flops_tile_2clk_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_ram_flops_tile",
     deps = [":br_ram_flops_tile_fpv_monitor"],
@@ -395,7 +391,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_ram_flops_tile_2clk_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_ram_flops_tile",
     deps = [":br_ram_flops_tile_fpv_monitor"],

--- a/tracker/fpv/BUILD.bazel
+++ b/tracker/fpv/BUILD.bazel
@@ -98,7 +98,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_tracker_freelist_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_tracker_freelist",
     deps = [":br_tracker_freelist_fpv_monitor"],
@@ -132,7 +131,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_tracker_freelist_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_tracker_freelist",
     deps = [":br_tracker_freelist_fpv_monitor"],
@@ -189,7 +187,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_tracker_linked_list_ctrl_fpv.jg.tcl",
-        "vcf": "",
     },
     top = "br_tracker_linked_list_ctrl",
     deps = [":br_tracker_linked_list_ctrl_fpv_monitor"],
@@ -251,7 +248,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_tracker_sequence_fpv.tcl",
-        "vcf": "",
     },
     top = "br_tracker_sequence",
     deps = [":br_tracker_sequence_fpv_monitor"],
@@ -301,7 +297,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_tracker_reorder_fpv.tcl",
-        "vcf": "",
     },
     top = "br_tracker_reorder",
     deps = [":br_tracker_reorder_fpv_monitor"],
@@ -357,7 +352,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_tracker_reorder_buffer_flops_fpv.tcl",
-        "vcf": "",
     },
     top = "br_tracker_reorder_buffer_flops",
     deps = [":br_tracker_reorder_buffer_flops_fpv_monitor"],
@@ -418,7 +412,6 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_tracker_reorder_buffer_ctrl_1r1w_fpv.tcl",
-        "vcf": "",
     },
     top = "br_tracker_reorder_buffer_ctrl_1r1w",
     deps = [":br_tracker_reorder_buffer_ctrl_1r1w_fpv_monitor"],


### PR DESCRIPTION
1. removed VCF if there is no VCF FV TB (for accurate test count purpose now)
2. reduced parameter sweep by case splitting and removed DataWidth parameter sweep (never encountered a bug when working on bedrock)
3. Added 30-mins time out for all amba blocks