### PR TITLE
ensure awready cannot be X

### DIFF
--- a/amba/rtl/internal/br_amba_iso_resp_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_resp_tracker.sv
@@ -287,7 +287,7 @@ module br_amba_iso_resp_tracker #(
         .NumSymbolsIn(AxiIdCount),
         .SymbolWidth (1)
     ) br_mux_bin_can_accept_new_req (
-        .select(upstream_axid[MinIdWidth-1:0]),
+        .select(can_accept_new_req_mux_select),
         .in(can_accept_new_req_per_id),
         .out(can_accept_new_req),
         .out_valid()


### PR DESCRIPTION
when max axlen is 1 (single beat) axready can be X if upstream_axid is X. This PR fixes this by ensuring the br_mux_bin_can_accept_new_req mux select has a defined value if upstream_axvaild is 0.