### PR TITLE
add lint waivers for gates and reset synchronizer

### DIFF
--- a/cdc/rtl/br_cdc_rst_sync.sv
+++ b/cdc/rtl/br_cdc_rst_sync.sv
@@ -37,7 +37,7 @@ module br_cdc_rst_sync #(
   `BR_GATE_CDC_SYNC_ARST_STAGES(srst_n, 1'b1, clk, arst, NumStages)
 
   // The reset value of the synchronizer is 0, so we need to invert the output
-  // ri lint_check_waive ONE_CONN_PER_LINE
+  // ri lint_check_waive ONE_CONN_PER_LINE SAME_RESET_NAME
   `BR_GATE_INV(srst, srst_n)
 
 endmodule : br_cdc_rst_sync

--- a/gate/rtl/br_gate_mock.sv
+++ b/gate/rtl/br_gate_mock.sv
@@ -24,7 +24,7 @@
 `endif
 
 // verilog_lint: waive-start module-filename
-// ri lint_check_off ONE_PER_FILE FILE_NAME
+// ri lint_check_off ONE_PER_FILE FILE_NAME RESET_NAME RESET_DRIVER
 
 `include "br_asserts.svh"
 `include "br_registers.svh"
@@ -238,4 +238,4 @@ module br_gate_cdc_maxdel (
 endmodule : br_gate_cdc_maxdel
 
 // verilog_lint: waive-stop module-filename
-// ri lint_check_on ONE_PER_FILE FILE_NAME
+// ri lint_check_on ONE_PER_FILE FILE_NAME RESET_NAME RESET_DRIVER


### PR DESCRIPTION
Because some of these gates (e.g., AND, OR, INV) can be used to create reset signals, we are getting a lot of lint warnings like RESET_USE or SAME_RESET_NAME. These are not actually related to the cells in the br_gate library.