### PR TITLE
Add parameters to control LFSR integration assertions

### DIFF
--- a/lfsr/rtl/br_lfsr.sv
+++ b/lfsr/rtl/br_lfsr.sv
@@ -43,12 +43,12 @@ module br_lfsr #(
     // for a maximal period LFSR. Disabling this checks allows the LFSR to be used
     // more flexibly (e.g. supporting adjustable period LFSRs by changing the taps).
     // ri lint_check_waive PARAM_NOT_USED
-    parameter bit EnableTapsMsbCheck = 1,
+    parameter bit EnableAssertTapsMsbIsSet = 1,
     // Enable check that initial state is non-zero. If the LFSR is initialized to zero,
     // it will never advance and the output will be zero forever. Generally, this is not
     // the behavior intended, but may be useful to support "disabling" the LFSR.
     // ri lint_check_waive PARAM_NOT_USED
-    parameter bit EnableInitialStateCheck = 1
+    parameter bit EnableAssertInitialStateNonZero = 1
 ) (
     // Posedge-triggered clock.
     input logic clk,
@@ -71,8 +71,12 @@ module br_lfsr #(
   // Integration checks
   //------------------------------------------
   `BR_ASSERT_STATIC(width_gte_two_a, Width >= 2)
-  `BR_ASSERT_INTG(taps_msb_set_a, EnableTapsMsbCheck && taps[Width-1] == 1'b1)
-  `BR_ASSERT_INTG(initial_state_non_zero_a, EnableInitialStateCheck && initial_state != '0)
+  if (EnableAssertTapsMsbIsSet) begin : gen_taps_msb_check
+    `BR_ASSERT_INTG(taps_msb_set_a, taps[Width-1] == 1'b1)
+  end
+  if (EnableAssertInitialStateNonZero) begin : gen_initial_state_check
+    `BR_ASSERT_INTG(initial_state_non_zero_a, initial_state != '0)
+  end
 
   //------------------------------------------
   // Implementation


### PR DESCRIPTION
These integration checks are useful, but limiting in some situations. Added parameters to enable them.