### PR TITLE
[regression] fix Sunday time out tests

### DIFF
--- a/tracker/fpv/br_tracker_linked_list_ctrl_fpv.jg.tcl
+++ b/tracker/fpv/br_tracker_linked_list_ctrl_fpv.jg.tcl
@@ -20,5 +20,8 @@ get_design_info
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all

--- a/tracker/fpv/br_tracker_reorder_buffer_ctrl_1r1w_fpv.tcl
+++ b/tracker/fpv/br_tracker_reorder_buffer_ctrl_1r1w_fpv.tcl
@@ -20,5 +20,8 @@ get_design_info
 # TODO: ignore many unreachable RTL inline covers for now
 cover -disable {*br_tracker_reorder_buffer_ctrl_1r1w*}
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all


### PR DESCRIPTION
12 bedrock.tracker.br_tracker_reorder_buffer_ctrl_1r1w tests and 
1  LinkedList test bedrock.tracker.br_tracker_linked_list_ctrl_test_suite_jg_d4_nll2_nwp3_rrl4 
timed out in Sunday regression.

Added a FV time out of 30-mins.