### PR TITLE
axil2apb: save last grant

### DIFF
--- a/amba/rtl/br_amba_axil2apb.sv
+++ b/amba/rtl/br_amba_axil2apb.sv
@@ -85,8 +85,11 @@ module br_amba_axil2apb #(
   logic [br_amba::AxiProtWidth-1:0] prot_reg, prot_next;
   logic resp_reg;
   logic write_reg;
+  logic write_req_ready;
+  logic read_req_ready;
   logic arb_write_req, arb_write_grant;
   logic arb_read_req, arb_read_grant;
+  logic [1:0] last_grant;
   logic arb_any_grant;
 
   `BR_REGLN(addr_reg, addr_next, arb_any_grant)
@@ -96,7 +99,9 @@ module br_amba_axil2apb #(
   `BR_REGLN(prot_reg, prot_next, arb_any_grant)
   `BR_REGLN(resp_reg, pslverr, (apb_state == Access) && pready)
   `BR_REGLN(rdata, prdata, (apb_state == Access) && pready)
+  `BR_REGL(last_grant, {arb_write_grant, arb_read_grant}, arb_any_grant)
   `BR_REGI(apb_state, apb_state_next, Idle)
+
 
   // Arbitrate between read and write transactions
   br_arb_rr #(
@@ -110,8 +115,10 @@ module br_amba_axil2apb #(
   );
 
   // Arbiter request signals
-  assign arb_write_req = awvalid && wvalid && (apb_state == Idle);
-  assign arb_read_req = arvalid && (apb_state == Idle);
+  assign write_req_ready = awvalid && wvalid && (apb_state == Idle);
+  assign read_req_ready = arvalid && (apb_state == Idle);
+  assign arb_write_req = write_req_ready && (!last_grant[1] || !read_req_ready);
+  assign arb_read_req = read_req_ready && (!last_grant[0] || !write_req_ready);
   assign arb_any_grant = arb_write_grant || arb_read_grant;
 
   // Save the address and data for the transaction


### PR DESCRIPTION
The bedrock arbiter does not track previous grants if the request signals are deasserted.