### PR TITLE
Fix axi_msi FV TB to make TOT regression clean

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -303,6 +303,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_msi_test_suite",
+    gui = True,
     tools = {
         "jg": "br_amba_axil_msi_fpv.jg.tcl",
     },

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -225,7 +225,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil2apb_test_suite",
-    gui = True,
     tools = {
         "jg": "br_amba_axil2apb_fpv.jg.tcl",
     },
@@ -304,7 +303,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_msi_test_suite",
-    gui = True,
     tools = {
         "jg": "br_amba_axil_msi_fpv.jg.tcl",
     },

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -225,6 +225,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil2apb_test_suite",
+    gui = True,
     tools = {
         "jg": "br_amba_axil2apb_fpv.jg.tcl",
     },

--- a/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
@@ -21,6 +21,15 @@ get_design_info
 assert -disable <embedded>::br_amba_axil_msi.monitor.axi.genPropChksWRInf.genNoWrTblOverflow.genMas.master_aw_wr_tbl_no_overflow
 assert -disable <embedded>::br_amba_axil_msi.monitor.axi.genPropChksWRInf.genNoWrDatTblOverflow.genMas.master_w_wr_tbl_no_overflow
 
+# slave_ar_no_arvalid_arready_eventually : assume property (
+#     disable iff (!aresetn||(rd_tbl_full && !rd_tbl_pop_ready))
+#     `STRENGTH(##[0:$] arready))
+# else $display ("%0t: Slave should not wait for arvalid to assert arready; ARM IHI 0022F: None",$time);
+
+# above assumption is over-constraining FV TB, so jasper special cover :live is unreachable
+# this means: It is impossible to satisfy all fairness constraints infinitely often.
+assume -disable <embedded>::br_amba_axil_msi.monitor.axi.genPropChksRDInf.genSlaveLiveAR.slave_ar_no_arvalid_arready_eventually
+
 # TODO: disable covers to make nightly clean
 cover -disable *
 

--- a/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
@@ -66,7 +66,8 @@ module br_amba_axil_msi_fpv_monitor #(
   `BR_ASSUME(throttle_cntr_stable_a, $stable(throttle_cntr_threshold)
              && throttle_cntr_threshold != 'd0)
   `BR_ASSUME(msi_enable_stable_a, $stable(msi_enable))
-  `BR_ASSUME(msi_base_addr_stable_a, $stable(msi_base_addr))
+  `BR_ASSUME(msi_dest_addr_stable_a, $stable(msi_dest_addr))
+  `BR_ASSUME(msi_dest_idx_stable_a, $stable(msi_dest_idx))
   `BR_ASSUME(device_id_stable_a, $stable(device_id_per_irq))
   `BR_ASSUME(event_id_stable_a, $stable(event_id_per_irq))
 
@@ -156,9 +157,10 @@ module br_amba_axil_msi_fpv_monitor #(
 
   // AXI4-Lite write-only initiator interface
   axi4_slave #(
-      .AXI4_LITE (1),
+      .AXI4_LITE(1),
       .ADDR_WIDTH(AddrWidth),
-      .DATA_WIDTH(DataWidth)
+      .DATA_WIDTH(DataWidth),
+      .CONFIG_WAIT_FOR_VALID_BEFORE_READY(1)
   ) axi (
       // Global signals
       .aclk   (clk),

--- a/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
@@ -70,6 +70,9 @@ module br_amba_axil_msi_fpv_monitor #(
   `BR_ASSUME(msi_dest_idx_stable_a, $stable(msi_dest_idx))
   `BR_ASSUME(device_id_stable_a, $stable(device_id_per_irq))
   `BR_ASSUME(event_id_stable_a, $stable(event_id_per_irq))
+  for (genvar i = 0; i < NumInterrupts; i++) begin : gen_id
+    `BR_ASSUME(msi_dest_idx_in_range_a, msi_dest_idx[i] < NumMsiDestAddr)
+  end
 
   // ----------FV assertions----------
   localparam int AddrWidthPadding = (AddrWidth - DeviceIdWidth) - 2;


### PR DESCRIPTION
This work is not final, I have a task open to review all ABVIP parameters (because FV has missed bugs on narrow access)
This PR is to make existing checks clean on TOT.