### PR TITLE
Fix RTL assertion and FV TB of br_arb_grant_hold

### DIFF
--- a/arb/fpv/br_arb_grant_hold_fpv_monitor.sv
+++ b/arb/fpv/br_arb_grant_hold_fpv_monitor.sv
@@ -36,7 +36,7 @@ module br_arb_grant_hold_fpv_monitor #(
 
   // only when grant_hold[i] and grant[i] are both 1, the grant will be held
   logic fv_hold;
-  assign fv_hold = |(grant_hold & grant);
+  assign fv_hold = |(grant_hold & grant) && enable_grant_hold_update;
 
   // ----------FV assumptions----------
   `BR_ASSUME(grant_onehot_a, $onehot0(grant_from_arb))
@@ -44,8 +44,6 @@ module br_arb_grant_hold_fpv_monitor #(
   // ----------FV assertions----------
   `BR_ASSERT(grant_stable_if_hold_a, fv_hold |=> $stable(grant))
   `BR_ASSERT(enable_priority_hold_a, fv_hold |=> enable_priority_update_to_arb == 1'b0)
-  `BR_ASSERT(enable_priority_passthrough_a,
-             ~|grant_hold |=> enable_priority_update_to_arb == enable_grant_hold_update)
 
 endmodule : br_arb_grant_hold_fpv_monitor
 

--- a/arb/rtl/br_arb_grant_hold.sv
+++ b/arb/rtl/br_arb_grant_hold.sv
@@ -58,8 +58,7 @@ module br_arb_grant_hold #(
   assign enable_priority_update_to_arb = !(|hold) && enable_grant_hold_update;
   assign hold_next = grant & grant_hold;
   assign grant = |hold ? hold : grant_from_arb;
-  `BR_ASSERT_IMPL(grants_actually_hold_a, |hold |-> grant == $past(grant))
+  `BR_ASSERT_IMPL(grants_actually_hold_a, |hold |-> $stable(grant))
   `BR_ASSERT_IMPL(enable_priority_update_mask_a, |hold |-> !enable_priority_update_to_arb)
-  `BR_ASSERT_IMPL(enable_grant_hold_update_mask_a, !enable_grant_hold_update |-> hold == $past
-                                                   (hold))
+  `BR_ASSERT_IMPL(enable_grant_hold_update_mask_a, !enable_grant_hold_update |=> $stable(hold))
 endmodule : br_arb_grant_hold


### PR DESCRIPTION
1. enable_grant_hold_update_mask_a is failing in FV, so changed |-> to |=>, which means |-> ##1.
2. Changed signal == $past(signal) to $stable(signal)
3. Fixed FV TB. when grant_hold == 0, enable_priority_update_to_arb is no longer a passthrough from enable_grant_hold_update. if enable_grant_hold_update = 0, hold will stuck there as expected. 