### PR TITLE
Add ExtraDelay to cdc_fifo basic FV checker

### DIFF
--- a/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
@@ -33,6 +33,7 @@ module br_cdc_fifo_basic_fpv_monitor #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter int RamWriteLatency = 1,
     parameter int RamReadLatency = 1,
+    parameter int ExtraDelay = 0,
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
     // FV system clk and rst
@@ -63,13 +64,15 @@ module br_cdc_fifo_basic_fpv_monitor #(
 );
 
   localparam int ResetActiveDelay = 1;
+  // Adding ExtraDelay to account for any extra flops when instantiating br_cdc_fifo.
   // Need to make sure that on push reset, the updated push_count is not visible
   // to the pop side before reset_active is.
-  localparam int PushCountDelay = (ResetActiveDelay + 1) >= RamWriteLatency ?
-  (ResetActiveDelay + 1) : RamWriteLatency;
+  localparam int PushCountDelay = ExtraDelay +
+                                  (ResetActiveDelay + 1) >= RamWriteLatency ?
+                                  (ResetActiveDelay + 1) : RamWriteLatency;
   // Need to make sure that on pop reset, the updated pop_count is not visible
   // to the push side before reset_active is.
-  localparam int PopCountDelay = ResetActiveDelay + 1;
+  localparam int PopCountDelay = ResetActiveDelay + 1 + ExtraDelay;
 
   // ----------FV assumptions----------
   `BR_ASSUME_CR(pop_ready_liveness_a, s_eventually (pop_ready), pop_clk, pop_rst)


### PR DESCRIPTION
When working on internal br_cdc_fifo wrapper, I realized wrapper might add extra flops(delay) when receiving signal from the other side. 
Add ExtraDelay parameter, so we can reuse this checker.