### PR TITLE
[bazel] Allow verilog_fpv_test_suite to use enhanced fpv test and san…

### DIFF
--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -827,7 +827,15 @@ def verilog_elab_and_lint_test_suite(
         **kwargs
     )
 
-def verilog_fpv_test_suite(name, defines = [], params = {}, illegal_param_combinations = {}, sandbox = True, **kwargs):
+def verilog_fpv_test_suite(
+        name,
+        defines = [],
+        params = {},
+        illegal_param_combinations = {},
+        sandbox = True,
+        verilog_fpv_test_func = None,
+        verilog_fpv_sandbox_func = None,
+        **kwargs):
     """Creates a suite of Verilog fpv tests for each combination of the provided parameters.
 
     The function generates all possible combinations of the provided parameters and creates a verilog_fpv_test
@@ -840,8 +848,17 @@ def verilog_fpv_test_suite(name, defines = [], params = {}, illegal_param_combin
         params (dict): A dictionary where keys are parameter names and values are lists of possible values for those parameters.
         illegal_param_combinations (dict): A dictionary where keys are parameter tuples and values are lists of illegal values for those parameters.
         sandbox (bool): Whether to create a sandbox for the test.
+        verilog_fpv_test_func (function): A function to use instead of verilog_fpv_test.
+        verilog_fpv_sandbox_func (function): A function to use instead of rule_verilog_fpv_sandbox.
         **kwargs: Additional keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.
     """
+
+    # Set defaults if none provided
+    if verilog_fpv_test_func == None:
+        verilog_fpv_test_func = verilog_fpv_test
+    if verilog_fpv_sandbox_func == None:
+        verilog_fpv_sandbox_func = rule_verilog_fpv_sandbox
+
     param_keys = sorted(params.keys())
     param_values_list = [params[key] for key in param_keys]
     param_combinations = _cartesian_product(param_values_list)
@@ -858,14 +875,14 @@ def verilog_fpv_test_suite(name, defines = [], params = {}, illegal_param_combin
                 skip = True
                 break
         if not skip:
-            verilog_fpv_test(
+            verilog_fpv_test_func(
                 name = _make_test_name(name, "fpv_test", param_keys, param_combination),
                 defines = defines,
                 params = params,
                 **kwargs
             )
             if sandbox:
-                rule_verilog_fpv_sandbox(
+                verilog_fpv_sandbox_func(
                     name = _make_test_name(name, "fpv_sandbox", param_keys, param_combination),
                     defines = defines,
                     params = params,

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -415,7 +415,8 @@ The following extra tags are unconditionally appended to the list of tags:
 <pre>
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_fpv_test_suite")
 
-verilog_fpv_test_suite(<a href="#verilog_fpv_test_suite-name">name</a>, <a href="#verilog_fpv_test_suite-defines">defines</a>, <a href="#verilog_fpv_test_suite-params">params</a>, <a href="#verilog_fpv_test_suite-illegal_param_combinations">illegal_param_combinations</a>, <a href="#verilog_fpv_test_suite-sandbox">sandbox</a>, <a href="#verilog_fpv_test_suite-kwargs">kwargs</a>)
+verilog_fpv_test_suite(<a href="#verilog_fpv_test_suite-name">name</a>, <a href="#verilog_fpv_test_suite-defines">defines</a>, <a href="#verilog_fpv_test_suite-params">params</a>, <a href="#verilog_fpv_test_suite-illegal_param_combinations">illegal_param_combinations</a>, <a href="#verilog_fpv_test_suite-sandbox">sandbox</a>,
+                       <a href="#verilog_fpv_test_suite-verilog_fpv_test_func">verilog_fpv_test_func</a>, <a href="#verilog_fpv_test_suite-verilog_fpv_sandbox_func">verilog_fpv_sandbox_func</a>, <a href="#verilog_fpv_test_suite-kwargs">kwargs</a>)
 </pre>
 
 Creates a suite of Verilog fpv tests for each combination of the provided parameters.
@@ -435,6 +436,8 @@ to the base name followed by the parameter key-values.
 | <a id="verilog_fpv_test_suite-params"></a>params |  A dictionary where keys are parameter names and values are lists of possible values for those parameters.   |  `{}` |
 | <a id="verilog_fpv_test_suite-illegal_param_combinations"></a>illegal_param_combinations |  A dictionary where keys are parameter tuples and values are lists of illegal values for those parameters.   |  `{}` |
 | <a id="verilog_fpv_test_suite-sandbox"></a>sandbox |  Whether to create a sandbox for the test.   |  `True` |
+| <a id="verilog_fpv_test_suite-verilog_fpv_test_func"></a>verilog_fpv_test_func |  A function to use instead of verilog_fpv_test.   |  `None` |
+| <a id="verilog_fpv_test_suite-verilog_fpv_sandbox_func"></a>verilog_fpv_sandbox_func |  A function to use instead of rule_verilog_fpv_sandbox.   |  `None` |
 | <a id="verilog_fpv_test_suite-kwargs"></a>kwargs |  Additional keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.   |  none |
 
 


### PR DESCRIPTION
…dbox rules.

This allows custom FPV test and sandbox wrappers to be used in other repos.