### PR TITLE
add constraint for pop_ready

### DIFF
--- a/fifo/fpv/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv_monitor.sv
@@ -109,6 +109,14 @@ module br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv_monitor #(
     input logic [NumReadPorts-1:0] arb_enable_priority_update
 );
 
+  localparam bit HasStagingBuffer = (DataRamReadLatency > 0) || RegisterPopOutputs;
+  if (HasStagingBuffer == 0) begin : gen_no_staging_buffer
+    for (genvar i = 0; i < NumFifos; i++) begin : gen_asm
+      // pop_ready can't drop without its pop_valid
+      `BR_ASSUME(pop_ready_hold_a, pop_ready[i] && !pop_valid[i] |=> pop_ready[i])
+    end
+  end
+
   // ----------External arb model----------
   ext_arb_fv_monitor #(
       .NumReadPorts(NumReadPorts),

--- a/fifo/fpv/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_fpv_monitor.sv
@@ -113,6 +113,14 @@ module br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_fpv_monitor #(
     input logic [NumReadPorts-1:0] arb_enable_priority_update
 );
 
+  localparam bit HasStagingBuffer = (DataRamReadLatency > 0) || RegisterPopOutputs;
+  if (HasStagingBuffer == 0) begin : gen_no_staging_buffer
+    for (genvar i = 0; i < NumFifos; i++) begin : gen_asm
+      // pop_ready can't drop without its pop_valid
+      `BR_ASSUME(pop_ready_hold_a, pop_ready[i] && !pop_valid[i] |=> pop_ready[i])
+    end
+  end
+
   // ----------External arb model----------
   ext_arb_fv_monitor #(
       .NumReadPorts(NumReadPorts),

--- a/fifo/fpv/ext_arb_fv_monitor.sv
+++ b/fifo/fpv/ext_arb_fv_monitor.sv
@@ -37,7 +37,6 @@ module ext_arb_fv_monitor #(
     `BR_ASSUME(same_cyc_arb_grant_a, |arb_request[r] |-> |arb_grant[r])
     for (genvar f = 0; f < NumFifos; f++) begin : gen_arb_request
       `BR_ASSUME(arb_legal_grant_a, arb_grant[r][f] |-> arb_request[r][f])
-      // TODO: still under discussion
       // sanity check:
       // assumption arb_grant_eventually_a can only be added
       // if assertion arb_req_hold_until_grant_a is true


### PR DESCRIPTION
if there is no staging buffer, discussed with @zhemao-openai 
primary input pop_ready can not come and go, it should not drop before seeing its corresponding pop_valid.

RTL arb_request stopped dropping, deadlock assertion stopped failing.