### PR TITLE
Allow bin2onehot of 1 output, to ease higher-level parameterizations.

### DIFF
--- a/demux/rtl/br_demux_bin.sv
+++ b/demux/rtl/br_demux_bin.sv
@@ -24,7 +24,7 @@
 
 module br_demux_bin #(
     // Number of outputs to distribute among. Must be >= 1.
-    parameter int NumSymbolsOut = 1,
+    parameter int NumSymbolsOut = 2,
     // The width of each symbol in bits. Must be >= 1.
     parameter int SymbolWidth = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.

--- a/enc/rtl/BUILD.bazel
+++ b/enc/rtl/BUILD.bazel
@@ -23,6 +23,7 @@ verilog_library(
     deps = [
         "//macros:br_asserts_internal",
         "//macros:br_registers",
+        "//pkg:br_math_pkg",
     ],
 )
 
@@ -78,6 +79,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_enc_bin2onehot_test_suite",
     params = {
         "NumValues": [
+            "1",
             "2",
             "3",
         ],

--- a/enc/rtl/br_enc_bin2onehot.sv
+++ b/enc/rtl/br_enc_bin2onehot.sv
@@ -47,12 +47,12 @@
 `include "br_asserts_internal.svh"
 
 module br_enc_bin2onehot #(
-    parameter int NumValues = 2,  // Must be at least 2
+    parameter int NumValues = 2,  // Must be at least 1
     parameter int EnableInputRangeCheck = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     // Width of the binary-encoded value. Must be at least $clog2(NumValues).
-    parameter int BinWidth = $clog2(NumValues)
+    parameter int BinWidth = br_math::clamped_clog2(NumValues)
 ) (
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,  // Used only for assertions
@@ -66,8 +66,8 @@ module br_enc_bin2onehot #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(num_values_gte_2_a, NumValues >= 2)
-  `BR_ASSERT_STATIC(binwidth_gte_log2_num_values_a, BinWidth >= $clog2(NumValues))
+  `BR_ASSERT_STATIC(num_values_gte_2_a, NumValues >= 1)
+  `BR_ASSERT_STATIC(binwidth_gte_log2_num_values_a, BinWidth >= br_math::clamped_clog2(NumValues))
   if (EnableInputRangeCheck) begin : gen_in_range_check
     `BR_ASSERT_INTG(in_within_range_a, in_valid |-> in < NumValues)
   end


### PR DESCRIPTION
Revert demux bin default to 2.

d'oh, I automerged https://github.com/xlsynth/bedrock-rtl/pull/763 without the revert..