### PR TITLE
Update FV env to allow MaxValWidth, MaxChangeWidth override

### DIFF
--- a/counter/fpv/BUILD.bazel
+++ b/counter/fpv/BUILD.bazel
@@ -18,6 +18,7 @@ load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:public"])
 
+##################################################################
 # Bedrock-RTL Increment/Decrement Counter w/ Overflow Handling
 
 verilog_library(
@@ -83,6 +84,35 @@ br_verilog_fpv_test_tools_suite(
     deps = [":br_counter_fpv_monitor"],
 )
 
+br_verilog_fpv_test_tools_suite(
+    name = "br_counter_test_max",
+    elab_opts = [
+        "-parameter MaxChange 4294967295",
+        "-parameter MaxValue 4294967295",
+    ],
+    tools = {
+        "jg": "br_counter_fpv.jg.tcl",
+    },
+    top = "br_counter",
+    deps = [":br_counter_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_counter_test_max_override",
+    elab_opts = [
+        "-parameter MaxValueWidth 64",
+        "-parameter MaxChangeWidth 64",
+        "-parameter MaxChange 18446744073709551615",
+        "-parameter MaxValue 18446744073709551615",
+    ],
+    tools = {
+        "jg": "br_counter_fpv.jg.tcl",
+    },
+    top = "br_counter",
+    deps = [":br_counter_fpv_monitor"],
+)
+
+##################################################################
 # Bedrock-RTL Decrementing Counter
 verilog_library(
     name = "br_counter_decr_fpv_monitor",
@@ -137,6 +167,35 @@ br_verilog_fpv_test_tools_suite(
     deps = [":br_counter_decr_fpv_monitor"],
 )
 
+br_verilog_fpv_test_tools_suite(
+    name = "br_counter_decr_test_max",
+    elab_opts = [
+        "-parameter MaxDecrement 4294967295",
+        "-parameter MaxValue 4294967295",
+    ],
+    tools = {
+        "jg": "br_counter_fpv.jg.tcl",
+    },
+    top = "br_counter_decr",
+    deps = [":br_counter_decr_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_counter_decr_test_max_override",
+    elab_opts = [
+        "-parameter MaxValueWidth 64",
+        "-parameter MaxDecrementWidth 64",
+        "-parameter MaxDecrement 18446744073709551615",
+        "-parameter MaxValue 18446744073709551615",
+    ],
+    tools = {
+        "jg": "br_counter_fpv.jg.tcl",
+    },
+    top = "br_counter_decr",
+    deps = [":br_counter_decr_fpv_monitor"],
+)
+
+##################################################################
 # Bedrock-RTL Incrementing Counter
 verilog_library(
     name = "br_counter_incr_fpv_monitor",
@@ -184,6 +243,34 @@ br_verilog_fpv_test_tools_suite(
             "7",
         ],
     },
+    tools = {
+        "jg": "br_counter_fpv.jg.tcl",
+    },
+    top = "br_counter_incr",
+    deps = [":br_counter_incr_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_counter_incr_test_max",
+    elab_opts = [
+        "-parameter MaxIncrement 4294967295",
+        "-parameter MaxValue 4294967295",
+    ],
+    tools = {
+        "jg": "br_counter_fpv.jg.tcl",
+    },
+    top = "br_counter_incr",
+    deps = [":br_counter_incr_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_counter_incr_test_max_override",
+    elab_opts = [
+        "-parameter MaxValueWidth 64",
+        "-parameter MaxIncrementWidth 64",
+        "-parameter MaxIncrement 18446744073709551615",
+        "-parameter MaxValue 18446744073709551615",
+    ],
     tools = {
         "jg": "br_counter_fpv.jg.tcl",
     },

--- a/counter/fpv/br_counter_decr_fpv_monitor.sv
+++ b/counter/fpv/br_counter_decr_fpv_monitor.sv
@@ -18,13 +18,17 @@
 `include "br_fv.svh"
 
 module br_counter_decr_fpv_monitor #(
-    parameter int MaxValue = 1,  // Must be at least 1. Inclusive. Also the initial value.
-    parameter int MaxDecrement = 1,  // Must be at least 1 and at most MaxValue. Inclusive.
+    parameter int MaxValueWidth = 32,
+    parameter int MaxDecrementWidth = 32,
+    parameter logic [MaxValueWidth-1:0] MaxValue = 1,
+    parameter logic [MaxDecrementWidth-1:0] MaxDecrement = 1,
     parameter bit EnableReinitAndDecr = 1,
     parameter bit EnableSaturate = 0,
     parameter bit EnableAssertFinalNotValid = 1,
-    localparam int ValueWidth = $clog2(MaxValue + 1),
-    localparam int DecrementWidth = $clog2(MaxDecrement + 1)
+    localparam int MaxValueP1Width = MaxValueWidth + 1,
+    localparam int MaxDecrementP1Width = MaxDecrementWidth + 1,
+    localparam int ValueWidth = $clog2(MaxValueP1Width'(MaxValue) + 1),
+    localparam int DecrementWidth = $clog2(MaxDecrementP1Width'(MaxDecrement) + 1)
 ) (
     input logic                      clk,
     input logic                      rst,
@@ -44,7 +48,7 @@ module br_counter_decr_fpv_monitor #(
   // If underflow, wrap around after 0: 0 -> MaxValue -> MaxValue-1
   function automatic logic [ValueWidth-1:0] adjust(input logic [ValueWidth-1:0] base,
                                                    input logic [DecrementWidth-1:0] decr,
-                                                   input int max_value);
+                                                   input logic [MaxValueWidth-1:0] max_value);
 
     adjust = base < decr ?  // underflow
     (EnableSaturate ? 'd0 : base - decr + max_value + 'd1) : base - decr;
@@ -83,6 +87,8 @@ module br_counter_decr_fpv_monitor #(
 endmodule
 
 bind br_counter_decr br_counter_decr_fpv_monitor #(
+    .MaxValueWidth(MaxValueWidth),
+    .MaxDecrementWidth(MaxDecrementWidth),
     .MaxValue(MaxValue),
     .MaxDecrement(MaxDecrement),
     .EnableReinitAndDecr(EnableReinitAndDecr),

--- a/counter/fpv/br_counter_fpv_monitor.sv
+++ b/counter/fpv/br_counter_fpv_monitor.sv
@@ -18,14 +18,18 @@
 `include "br_fv.svh"
 
 module br_counter_fpv_monitor #(
-    parameter int MaxValue = 1,  // Must be at least 1. Inclusive.
-    parameter int MaxChange = 1,  // Must be at least 1 and at most MaxValue. Inclusive.
+    parameter int MaxValueWidth = 32,
+    parameter int MaxChangeWidth = 32,
+    parameter logic [MaxValueWidth-1:0] MaxValue = 1,
+    parameter logic [MaxChangeWidth-1:0] MaxChange = 1,
     parameter bit EnableWrap = 1,
     parameter bit EnableReinitAndChange = 1,
     parameter bit EnableSaturate = 0,
     parameter bit EnableAssertFinalNotValid = 1,
-    localparam int ValueWidth = $clog2(MaxValue + 1),
-    localparam int ChangeWidth = $clog2(MaxChange + 1)
+    localparam int MaxValueP1Width = MaxValueWidth + 1,
+    localparam int MaxChangeP1Width = MaxChangeWidth + 1,
+    localparam int ValueWidth = $clog2(MaxValueP1Width'(MaxValue) + 1),
+    localparam int ChangeWidth = $clog2(MaxChangeP1Width'(MaxChange) + 1)
 ) (
     input logic                   clk,
     input logic                   rst,
@@ -51,7 +55,7 @@ module br_counter_fpv_monitor #(
   // {EnableWrap, EnableSaturate} can be all combinations but not {1,1}
   function automatic logic [ValueWidth-1:0] adjust(
       input logic [ValueWidth-1:0] base, input logic [ChangeWidth-1:0] incr,
-      input logic [ChangeWidth-1:0] decr, input int max_value);
+      input logic [ChangeWidth-1:0] decr, input logic [MaxValueWidth-1:0] max_value);
     logic overflow, underflow;
     logic [ValueWidth:0] base_pad;
     base_pad = {1'b0, base};
@@ -124,6 +128,8 @@ module br_counter_fpv_monitor #(
 endmodule : br_counter_fpv_monitor
 
 bind br_counter br_counter_fpv_monitor #(
+    .MaxValueWidth(MaxValueWidth),
+    .MaxChangeWidth(MaxChangeWidth),
     .MaxValue(MaxValue),
     .MaxChange(MaxChange),
     .EnableWrap(EnableWrap),

--- a/counter/fpv/br_counter_incr_fpv_monitor.sv
+++ b/counter/fpv/br_counter_incr_fpv_monitor.sv
@@ -18,13 +18,17 @@
 `include "br_fv.svh"
 
 module br_counter_incr_fpv_monitor #(
-    parameter int MaxValue = 1,  // Must be at least 1. Inclusive. Also the initial value.
-    parameter int MaxIncrement = 1,  // Must be at least 1 and at most MaxValue. Inclusive.
+    parameter int MaxValueWidth = 32,
+    parameter int MaxIncrementWidth = 32,
+    parameter logic [MaxValueWidth-1:0] MaxValue = 1,
+    parameter logic [MaxIncrementWidth-1:0] MaxIncrement = 1,
     parameter bit EnableReinitAndIncr = 1,
     parameter bit EnableSaturate = 0,
     parameter bit EnableAssertFinalNotValid = 1,
-    localparam int ValueWidth = $clog2(MaxValue + 1),
-    localparam int IncrementWidth = $clog2(MaxIncrement + 1)
+    localparam int MaxValueP1Width = MaxValueWidth + 1,
+    localparam int MaxIncrementP1Width = MaxIncrementWidth + 1,
+    localparam int ValueWidth = $clog2(MaxValueP1Width'(MaxValue) + 1),
+    localparam int IncrementWidth = $clog2(MaxIncrementP1Width'(MaxIncrement) + 1)
 ) (
     input logic                      clk,
     input logic                      rst,
@@ -44,7 +48,7 @@ module br_counter_incr_fpv_monitor #(
   // If overflow, wrap around after MaxValue: MaxValue -> 0 -> 1
   function automatic logic [ValueWidth-1:0] adjust(input logic [ValueWidth-1:0] base,
                                                    input logic [IncrementWidth-1:0] incr,
-                                                   input int max_value);
+                                                   input logic [MaxValueWidth-1:0] max_value);
     logic [ValueWidth:0] base_pad;
     base_pad = {1'b0, base};
     adjust = base_pad + incr > MaxValue ?  // overflow
@@ -84,6 +88,8 @@ module br_counter_incr_fpv_monitor #(
 endmodule
 
 bind br_counter_incr br_counter_incr_fpv_monitor #(
+    .MaxValueWidth(MaxValueWidth),
+    .MaxIncrementWidth(MaxIncrementWidth),
     .MaxValue(MaxValue),
     .MaxIncrement(MaxIncrement),
     .EnableReinitAndIncr(EnableReinitAndIncr),


### PR DESCRIPTION
update FV env after RTL change.
Added 2 corner cases to test 2^32-1 and 2^64-1.
FV got full proof on all existing tests and new tests.