### PR TITLE
Update FV br_credit_counter to allow MaxValWidth, MaxChangeWidth override

### DIFF
--- a/credit/fpv/BUILD.bazel
+++ b/credit/fpv/BUILD.bazel
@@ -18,6 +18,7 @@ load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:public"])
 
+##################################################################
 # Bedrock-RTL Credit Counter
 
 verilog_library(
@@ -66,6 +67,35 @@ br_verilog_fpv_test_tools_suite(
     deps = [":br_credit_counter_fpv_monitor"],
 )
 
+br_verilog_fpv_test_tools_suite(
+    name = "br_credit_counter_test_max",
+    elab_opts = [
+        "-parameter MaxValue 4294967295",
+        "-parameter MaxChange 4294967295",
+    ],
+    tools = {
+        "jg": "br_credit_counter_fpv.jg.tcl",
+    },
+    top = "br_credit_counter",
+    deps = [":br_credit_counter_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_credit_counter_test_max_override",
+    elab_opts = [
+        "-parameter MaxValueWidth 64",
+        "-parameter MaxChangeWidth 64",
+        "-parameter MaxChange 18446744073709551615",
+        "-parameter MaxValue 18446744073709551615",
+    ],
+    tools = {
+        "jg": "br_credit_counter_fpv.jg.tcl",
+    },
+    top = "br_credit_counter",
+    deps = [":br_credit_counter_fpv_monitor"],
+)
+
+##################################################################
 # Bedrock-RTL Credit Receiver
 verilog_library(
     name = "br_credit_receiver_fpv_monitor",
@@ -147,6 +177,7 @@ br_verilog_fpv_test_tools_suite(
     deps = [":br_credit_receiver_fpv_monitor"],
 )
 
+##################################################################
 # Bedrock-RTL Credit Sender
 verilog_library(
     name = "br_credit_sender_fpv_monitor",

--- a/credit/fpv/br_credit_counter_fpv_monitor.sv
+++ b/credit/fpv/br_credit_counter_fpv_monitor.sv
@@ -19,11 +19,15 @@
 `include "br_fv.svh"
 
 module br_credit_counter_fpv_monitor #(
-    parameter int MaxValue = 1,
-    parameter int MaxChange = 1,
+    parameter int MaxValueWidth = 32,
+    parameter int MaxChangeWidth = 32,
+    parameter logic [MaxValueWidth-1:0] MaxValue = 1,
+    parameter logic [MaxChangeWidth-1:0] MaxChange = 1,
     parameter bit EnableAssertFinalNotValid = 1,
-    localparam int ValueWidth = $clog2(MaxValue + 1),
-    localparam int ChangeWidth = $clog2(MaxChange + 1)
+    localparam int MaxValueP1Width = MaxValueWidth + 1,
+    localparam int MaxChangeP1Width = MaxChangeWidth + 1,
+    localparam int ValueWidth = $clog2(MaxValueP1Width'(MaxValue) + 1),
+    localparam int ChangeWidth = $clog2(MaxChangeP1Width'(MaxChange) + 1)
 ) (
     input logic clk,
     input logic rst,
@@ -74,6 +78,8 @@ module br_credit_counter_fpv_monitor #(
 endmodule : br_credit_counter_fpv_monitor
 
 bind br_credit_counter br_credit_counter_fpv_monitor #(
+    .MaxValueWidth(MaxValueWidth),
+    .MaxChangeWidth(MaxChangeWidth),
     .MaxValue(MaxValue),
     .MaxChange(MaxChange),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)


### PR DESCRIPTION
Update FV env after #766 
Added 2 corner cases to test 2^32-1 and 2^64-1.
FV got full proof on all existing tests and new tests.