### PR TITLE
[FPV] Update the gen_all to split FPV jobs differently.

### DIFF
--- a/python/regression_gen/regression_gen_lib.py
+++ b/python/regression_gen/regression_gen_lib.py
@@ -67,7 +67,7 @@ _ENV = Environment(
     trim_blocks=True,
     lstrip_blocks=True,
 )
-# Cache the template – re-loading from disk every call is not necessary.
+# Cache the template - re-loading from disk every call is not necessary.
 _TEMPLATE_CACHE: dict[str, Template] = {}
 
 
@@ -158,7 +158,7 @@ def render_yaml(
     if not job_dicts:
         raise ValueError("Job list must contain at least one element.")
 
-    # Unique blocks – preserve deterministic ordering for reproducibility.
+    # Unique blocks - preserve deterministic ordering for reproducibility.
     blocks = sorted({job["block"] for job in job_dicts})
 
     context = {


### PR DESCRIPTION
This PR updated the FPV YAML generation, it splits FIFO jobs based on https://github.com/xlsynth/bedrock-rtl/pull/764.

- br_fifo_ext_arb 2 → Wednesday
- br_fifo: 518 → Thursday
- br_fifo_shared_dynamic: 1796 → Friday
- br_fifo_shared_pstatic: 210 → Sunday

Also added a validation check at end of `gen_all.py` - it will compare the total number of FPV jobs against the ones generated into each YAML. It will assert an error if some of the FPV jobs are not in any of the YAML.