### PR TITLE
[regression] fix wednesday regression time out

### DIFF
--- a/credit/fpv/br_credit_counter_fpv.jg.tcl
+++ b/credit/fpv/br_credit_counter_fpv.jg.tcl
@@ -26,5 +26,8 @@ assume -name initial_value_during_reset {rst |-> initial_value <= MaxValue}
 # TODO: disable covers to make nightly clean
 cover -disable *
 
+# limit run time to 30-mins
+set_prove_time_limit 1800s
+
 # prove command
 prove -all


### PR DESCRIPTION
[failed]  bedrock/credit/credit/fpv/br_credit_counter_test_max_override_jg [Elapsed: 0:40:44] 
newly added br_credit_counter test timed out.
Adding 30m time out.