### PR TITLE
Fix documentation of CDC FIFO cut-through latency

### DIFF
--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
@@ -40,7 +40,7 @@
 //
 // Let PushT and PopT be the push period and pop period, respectively.
 //
-// The cut-through latency is max(RegisterResetActive + 1, RamWriteLatency + 1)
+// The cut-through latency is max(RegisterResetActive + 1, RamWriteLatency)
 // * PushT + (NumSyncStages + RamReadLatency + RegisterPopOutputs) * PopT.
 //
 // The backpressure latency is (RegisterResetActive + 1) * PopT + (NumSyncStages

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
@@ -40,7 +40,7 @@
 //
 // Let PushT and PopT be the push period and pop period, respectively.
 //
-// The cut-through latency is max(RegisterResetActive + 1, RamWriteLatency + 1)
+// The cut-through latency is max(RegisterResetActive + 1, RamWriteLatency)
 // * PushT + (NumSyncStages + RamReadLatency + RegisterPopOutputs) * PopT.
 //
 // The backpressure latency is (RegisterResetActive + 1) * PopT + (NumSyncStages

--- a/cdc/rtl/br_cdc_fifo_flops.sv
+++ b/cdc/rtl/br_cdc_fifo_flops.sv
@@ -33,7 +33,7 @@
 //
 // Let PushT and PopT be the push period and pop period, respectively.
 //
-// The cut-through latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 2) * PushT +
+// The cut-through latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 1) * PushT +
 // (NumSyncStages + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
 // FlopRamReadDataWidthStages + RegisterPopOutputs) * PopT.
 //

--- a/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
@@ -30,7 +30,7 @@
 //
 // Let PushT and PopT be the push period and pop period, respectively.
 //
-// The cut-through latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 2) * PushT +
+// The cut-through latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 1) * PushT +
 // (NumSyncStages + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
 // FlopRamReadDataWidthStages + RegisterPopOutputs) * PopT.
 //


### PR DESCRIPTION
The push-side cut-through delay should be just RamWriteLatency,
not `RamWriteLatency + 1`.