### PR TITLE
Fix sim scheduling race in BR_ASSERT_IMM with #0 delay

### DIFF
--- a/demux/rtl/br_demux_bin.sv
+++ b/demux/rtl/br_demux_bin.sv
@@ -45,9 +45,8 @@ module br_demux_bin #(
   //------------------------------------------
   `BR_ASSERT_STATIC(legal_num_symbols_out_a, NumSymbolsOut >= 1)
   `BR_ASSERT_STATIC(legal_symbol_width_a, SymbolWidth >= 1)
-  // TODO(zhemao): Figure out why this spuriously triggers in some cases
   // ri lint_check_waive ALWAYS_COMB
-  //`BR_ASSERT_COMB_INTG(select_in_range_a, !in_valid || (select < NumSymbolsOut))
+  `BR_ASSERT_COMB_INTG(select_in_range_a, !in_valid || (select < NumSymbolsOut))
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_in_valid_a, !in_valid)

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -218,7 +218,7 @@ __name__ : assert property (@(posedge __clk__) disable iff (__rst__ === 1'b1 || 
 `ifdef BR_ASSERT_ON
 `ifndef BR_DISABLE_ASSERT_IMM
 `define BR_ASSERT_IMM(__name__, __expr__) \
-assert ($isunknown(__expr__) || (__expr__)) else `BR_ASSERT_ERROR(__name__, ($isunknown(__expr__) || (__expr__)));
+assert #0 ($isunknown(__expr__) || (__expr__)) else `BR_ASSERT_ERROR(__name__, ($isunknown(__expr__) || (__expr__)));
 `else  // BR_DISABLE_ASSERT_IMM
 `define BR_ASSERT_IMM(__name__, __expr__) \
 `BR_NOOP

--- a/mux/rtl/br_mux_onehot.sv
+++ b/mux/rtl/br_mux_onehot.sv
@@ -38,9 +38,7 @@ module br_mux_onehot #(
   `BR_ASSERT_STATIC(legal_num_symbols_in_a, NumSymbolsIn >= 2)
   `BR_ASSERT_STATIC(legal_symbol_width_a, SymbolWidth >= 1)
   // ri lint_check_waive ALWAYS_COMB
-  // TODO(mgottscho): Figure out why this is not working right. I think you
-  // can't use $onehot0() inside of isunknown().
-  //`BR_ASSERT_COMB_INTG(select_onehot0_a, $onehot0(select))
+  `BR_ASSERT_COMB_INTG(select_onehot0_a, $onehot0(select))
 
   //------------------------------------------
   // Implementation


### PR DESCRIPTION
Also re-enable some commented-out assertions in br_mux_onehot and br_demux_bin that previously had failed due to races.