### PR TITLE
[enc] Fix unentered loops in br_enc_priority_encoder and br_enc_onehot2bin

### DIFF
--- a/enc/rtl/br_enc_onehot2bin.sv
+++ b/enc/rtl/br_enc_onehot2bin.sv
@@ -68,24 +68,26 @@ module br_enc_onehot2bin #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(num_values_gte_2_a, NumValues >= 1)
+  `BR_ASSERT_STATIC(num_values_gte_1_a, NumValues >= 1)
   `BR_ASSERT_STATIC(binwidth_gte_log2_num_values_a, BinWidth >= br_math::clamped_clog2(NumValues))
+  // This is necessary to avoid an integer overflow in the for-loop below.
+  `BR_ASSERT_STATIC(binwidth_lt_32_a, BinWidth < 32)
   `BR_ASSERT_INTG(in_onehot_a, $onehot0(in))
 
   //------------------------------------------
   // Implementation
   //------------------------------------------
   assign out_valid = |in;
-  always_comb begin
-    out = '0;  // ri lint_check_waive CONST_OUTPUT
-    // ri lint_check_waive LOOP_NOT_ENTERED
-    for (int i = 1; i < NumValues; i++) begin
-      // If multiple bits are set, this is undefined behavior.
-      if (in[i]) begin
-        // This waiver is not a problem so long as we are not doing
-        // anything close to a 32-bit onehot2bin..
-        // ri lint_check_waive INTEGER ASSIGN_SIGN SIGNED_SIZE_CAST
-        out |= BinWidth'(i);  // ri lint_check_waive CONST_OUTPUT
+  if (NumValues == 1) begin : gen_single_value
+    assign out = '0;
+  end else begin : gen_multi_value
+    always_comb begin
+      out = '0;
+      for (int i = 1; i < NumValues; i++) begin
+        // If multiple bits are set, this is undefined behavior.
+        if (in[i]) begin
+          out |= BinWidth'($unsigned(i));
+        end
       end
     end
   end

--- a/enc/rtl/br_enc_priority_encoder.sv
+++ b/enc/rtl/br_enc_priority_encoder.sv
@@ -86,17 +86,18 @@ module br_enc_priority_encoder #(
   for (genvar out_idx = 0; out_idx < NumResults; out_idx++) begin : gen_out_internal
     logic [NumRequesters-1:0] in_masked;
 
-    // Generated the masked input
-    // Any bit that was set in a previous result
-    // should be cleared in the masked input.
-    always_comb begin
-      in_masked = in_internal;
-      // This for loop won't be entered if out_idx is 0
-      // This is expected since we just want in_masked to be in
-      // ri lint_check_waive LOOP_NOT_ENTERED
-      for (int prev_idx = 0; prev_idx < out_idx; prev_idx++) begin
-        in_masked &= ~out_internal[prev_idx];
+    if (out_idx > 0) begin : gen_masked_input
+      // Generated the masked input
+      // Any bit that was set in a previous result
+      // should be cleared in the masked input.
+      always_comb begin
+        in_masked = in_internal;
+        for (int prev_idx = 0; prev_idx < out_idx; prev_idx++) begin
+          in_masked &= ~out_internal[prev_idx];
+        end
       end
+    end else begin : gen_unmasked_input
+      assign in_masked = in_internal;
     end
 
     // in_masked[out_idx-1:0] will always be zero since


### PR DESCRIPTION
Some synthesis tools give warnings when there are constructs like this.
Use if-generate statements to remove the need for waivers.