### PR TITLE
Drop useless LSB of internal priority encoder of br_enc_priority_dynamic

### DIFF
--- a/arb/fpv/br_arb_multi_rr_fpv.jg.tcl
+++ b/arb/fpv/br_arb_multi_rr_fpv.jg.tcl
@@ -30,9 +30,6 @@ assert -disable {special::*no_deadlock_a}
 assert -disable {special::*round_robin_a}
 assert -disable {special::*grant_ordered_priority_a}
 
-# TODO: disable covers to make nightly clean
-cover -disable *
-
 # prove command
 prove -task {standard}
 prove -task {special}

--- a/counter/fpv/br_counter_fpv.jg.tcl
+++ b/counter/fpv/br_counter_fpv.jg.tcl
@@ -23,8 +23,5 @@ get_design_info
 
 assume -name initial_value_during_reset {rst |-> initial_value <= MaxValue}
 
-# TODO: disable covers to make nightly clean
-cover -disable *
-
 # prove command
 prove -all

--- a/counter/fpv/br_counter_fpv_monitor.sv
+++ b/counter/fpv/br_counter_fpv_monitor.sv
@@ -121,8 +121,13 @@ module br_counter_fpv_monitor #(
   `BR_COVER(reinit_and_change_c, reinit && (incr_valid || decr_valid))
   // when EnableWrap or EnableSaturate is 1, counter handles overflow/underflow
   if (EnableWrap | EnableSaturate) begin : gen_over_underflow
-    `BR_COVER(overflow_c, (fv_decr < fv_incr) && (value + fv_incr - fv_decr > MaxValue))
-    `BR_COVER(underflow_c, (fv_decr > fv_incr) && (value_next > value))
+    // The cover shows up as unreachable if MaxValue is the largest number that
+    // can be represented. Just disable it in this case.
+    // TODO(zhemao): Figure out how to get this to work
+    if (MaxValue != {MaxValueWidth{1'b1}}) begin : gen_cover_overflow
+      `BR_COVER(overflow_c, (fv_decr < fv_incr) && (value + fv_incr - fv_decr > MaxValue))
+    end
+    `BR_COVER(underflow_c, (fv_decr > fv_incr) && (value < (fv_decr - fv_incr)))
   end
 
 endmodule : br_counter_fpv_monitor

--- a/counter/fpv/br_counter_incr_fpv_monitor.sv
+++ b/counter/fpv/br_counter_incr_fpv_monitor.sv
@@ -83,7 +83,7 @@ module br_counter_incr_fpv_monitor #(
 
   // ----------Critical Covers----------
   `BR_COVER(reinit_and_change_c, reinit && incr_valid)
-  `BR_COVER(overflow_c, fv_counter + fv_incr > MaxValue)
+  `BR_COVER(overflow_c, fv_counter + fv_incr > MaxValueP1Width'(MaxValue))
 
 endmodule
 

--- a/counter/rtl/BUILD.bazel
+++ b/counter/rtl/BUILD.bazel
@@ -44,6 +44,7 @@ verilog_library(
         "//macros:br_asserts_internal",
         "//macros:br_registers",
         "//macros:br_unused",
+        "//pkg:br_math_pkg",
     ],
 )
 

--- a/counter/rtl/br_counter.sv
+++ b/counter/rtl/br_counter.sv
@@ -129,7 +129,7 @@ module br_counter #(
   // Assertion-only helper logic for overflow/underflow detection
 `ifdef BR_ASSERT_ON
 `ifndef BR_DISABLE_INTG_CHECKS
-  localparam int ExtWidth = $clog2(MaxValue + MaxChange + 1);
+  localparam int ExtWidth = $clog2(MaxValueP1Width'(MaxValue) + MaxChangeP1Width'(MaxChange) + 1);
   logic [ExtWidth-1:0] value_extended;
   logic [ExtWidth-1:0] value_extended_next;
 
@@ -141,7 +141,8 @@ module br_counter #(
       value_extended + (incr_valid ? incr : '0) - (decr_valid ? decr : '0);
 
   if (EnableWrap || EnableSaturate) begin : gen_wrap_or_saturate_cover
-    `BR_COVER_INTG(wrap_or_saturate_c, value_extended_next > MaxValue)
+    localparam int MaxValueExtWidth = br_math::max2(ExtWidth, MaxValueP1Width);
+    `BR_COVER_INTG(wrap_or_saturate_c, value_extended_next > MaxValueExtWidth'(MaxValue))
   end else begin : gen_no_wrap_or_saturate_assert
     `BR_ASSERT_INTG(no_wrap_or_saturate_a, value_extended_next <= MaxValue)
   end

--- a/enc/rtl/br_enc_priority_dynamic.sv
+++ b/enc/rtl/br_enc_priority_dynamic.sv
@@ -28,6 +28,7 @@
 // priority encoder with `MsbHighestPriority` set to 0.
 
 `include "br_asserts_internal.svh"
+`include "br_unused.svh"
 
 module br_enc_priority_dynamic #(
     parameter int NumRequesters = 2,
@@ -73,28 +74,35 @@ module br_enc_priority_dynamic #(
   // priority encoder. The last result will just be the
   // input with all the previous results masked off.
   localparam int InternalNumResults = br_math::min2(NumResults, NumRequesters - 1);
+  // Internally, use a double-wide priority encoder.
+  // However, the lowest bit of in_high_prio can never be set,
+  // so ignore that one.
+  localparam int InternalNumRequesters = 2 * NumRequesters - 1;
 
-  logic [InternalNumResults-1:0][2*NumRequesters-1:0] out_internal;
+  logic [InternalNumResults-1:0][InternalNumRequesters-1:0] out_internal;
 
   // Create a double-wide priority encoder with the
   // high priority inputs in the lower half and the
   // low priority inputs in the upper half.
   br_enc_priority_encoder #(
-      .NumRequesters(2 * NumRequesters),
+      .NumRequesters(InternalNumRequesters),
       .NumResults(InternalNumResults)
   ) br_enc_priority_encoder_inst (
       .clk,
       .rst,
-      .in ({in_low_prio, in_high_prio}),
+      .in ({in_low_prio, in_high_prio[NumRequesters-1:1]}),
       .out(out_internal)
   );
+
+  `BR_UNUSED_NAMED(in_high_prio_lsb, in_high_prio[0])
+  `BR_ASSERT_IMPL(in_high_prio_lsb_zero_a, !in_high_prio[0])
 
   // To get the final result, fold the double-wide results
   // together using bitwise OR.
   for (genvar i = 0; i < InternalNumResults; i++) begin : gen_out
     assign out[i] =
-        out_internal[i][2*NumRequesters-1:NumRequesters] |
-        out_internal[i][NumRequesters-1:0];
+        out_internal[i][2*NumRequesters-2:NumRequesters-1] |
+        {out_internal[i][NumRequesters-2:0], 1'b0};
   end
 
   // If there are as many results as requesters, the last result just gets

--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -122,7 +122,9 @@ module br_fifo_pop_ctrl #(
   br_counter #(
       .MaxValue(Depth),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
-      .EnableWrap(0)
+      .EnableWrap(0),
+      .EnableCoverZeroChange(0),
+      .EnableCoverReinit(0)
   ) br_counter_items (
       .clk,
       .rst,

--- a/fifo/rtl/internal/br_fifo_pop_ctrl_core.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl_core.sv
@@ -87,7 +87,9 @@ module br_fifo_pop_ctrl_core #(
     br_counter_incr #(
         .MaxValue(RamDepth - 1),
         .MaxIncrement(1),
-        .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+        .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+        .EnableCoverZeroIncrement(0),
+        .EnableCoverReinit(0)
     ) br_counter_incr_rd_addr (
         .clk,
         .rst,

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -131,7 +131,9 @@ module br_fifo_push_ctrl #(
   br_counter #(
       .MaxValue(Depth),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
-      .EnableWrap(0)
+      .EnableWrap(0),
+      .EnableCoverZeroChange(0),
+      .EnableCoverReinit(0)
   ) br_counter_slots (
       .clk,
       .rst,

--- a/fifo/rtl/internal/br_fifo_push_ctrl_core.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_core.sv
@@ -112,7 +112,12 @@ module br_fifo_push_ctrl_core #(
         .MaxValue(Depth - 1),
         .MaxIncrement(1),
         .EnableReinitAndIncr(0),
-        .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+        // There won't be any overflows since reinit will be asserted
+        // when the counter wraps around.
+        .EnableWrap(0),
+        .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+        .EnableCoverZeroIncrement(0),
+        .EnableCoverReinitNoIncr(0)
     ) br_counter_incr_wr_addr (
         .clk,
         .rst,

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -164,7 +164,9 @@ module br_fifo_push_ctrl_credit #(
   br_counter #(
       .MaxValue(Depth),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
-      .EnableWrap(0)
+      .EnableWrap(0),
+      .EnableCoverZeroChange(0),
+      .EnableCoverReinit(0)
   ) br_counter_slots (
       .clk,
       .rst(either_rst),

--- a/fifo/rtl/internal/br_fifo_staging_buffer.sv
+++ b/fifo/rtl/internal/br_fifo_staging_buffer.sv
@@ -128,7 +128,9 @@ module br_fifo_staging_buffer #(
   br_counter #(
       .MaxValue(BufferDepth),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
-      .EnableWrap(0)
+      .EnableWrap(0),
+      .EnableCoverZeroChange(0),
+      .EnableCoverReinit(0)
   ) br_counter (
       .clk,
       .rst,
@@ -312,7 +314,8 @@ module br_fifo_staging_buffer #(
     // shift_out becomes shift in
     br_delay_shift_reg #(
         .Width(1),
-        .NumStages(InternalDepth)
+        .NumStages(InternalDepth),
+        .EnableCoverReinit(0)
     ) br_delay_shift_reg_rd_ptr (
         .clk,
         .rst,
@@ -326,7 +329,8 @@ module br_fifo_staging_buffer #(
 
     br_delay_shift_reg #(
         .Width(1),
-        .NumStages(InternalDepth)
+        .NumStages(InternalDepth),
+        .EnableCoverReinit(0)
     ) br_delay_shift_reg_wr_ptr (
         .clk,
         .rst,


### PR DESCRIPTION
Because of how the priority_mask works, the LSB of in_high_prio can
never be set. This causes unreachable cover points in FPV. Decrease the
width by one to avoid this.

This allows covers to be enabled on br_arb_multi_rr FPV.

---

**Stack**:
- #818
- #817
- #816
- #815
- #811
- #810
- #809
- #808
- #807
- #806
- #805
- #804
- #803
- #802
- #801 ⬅
- #800
- #799
- #798


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*