### PR TITLE
Fix multi_xfer data stability check

### DIFF
--- a/multi_xfer/rtl/internal/BUILD.bazel
+++ b/multi_xfer/rtl/internal/BUILD.bazel
@@ -22,6 +22,7 @@ verilog_library(
     srcs = ["br_multi_xfer_checks_sendable_data_intg.sv"],
     deps = [
         "//macros:br_asserts_internal",
+        "//macros:br_registers",
         "//macros:br_unused",
     ],
 )
@@ -51,6 +52,7 @@ verilog_library(
     srcs = ["br_multi_xfer_checks_sendable_data_impl.sv"],
     deps = [
         "//macros:br_asserts_internal",
+        "//macros:br_registers",
         "//macros:br_unused",
     ],
 )

--- a/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_impl.sv
+++ b/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_impl.sv
@@ -20,6 +20,7 @@
 // conform to the multi-transfer interface protocol.
 
 `include "br_asserts_internal.svh"
+`include "br_registers.svh"
 `include "br_unused.svh"
 
 // ri lint_check_off NO_OUTPUT
@@ -44,24 +45,38 @@ module br_multi_xfer_checks_sendable_data_impl #(
   `BR_ASSERT_IMPL(sendable_no_revocation_a, (sendable > receivable) |=> (sendable >= $past
                                             (sendable - receivable)))
 
-  for (genvar i = 0; i < NumSymbols; i++) begin : gen_data_checks
-    if (EnableAssertDataStability) begin : gen_data_stability_checks
+`ifdef BR_ASSERT_ON
+`ifdef BR_ENABLE_IMPL_CHECKS
+  // Untransferred symbols shifted down to LS position
+  logic [NumSymbols-1:0][SymbolWidth-1:0] data_shifted;
+  // Mask newly arriving data to zero
+  logic [NumSymbols-1:0][SymbolWidth-1:0] data_masked;
+  logic [CountWidth-1:0] xfer_count;
+  logic [CountWidth-1:0] hold_count, hold_count_d;
+
+  assign xfer_count = (sendable < receivable) ? sendable : receivable;
+  assign hold_count = (sendable > receivable) ? (sendable - receivable) : '0;
+
+  `BR_REG(hold_count_d, hold_count)
+
+  for (genvar i = 0; i < NumSymbols; i++) begin : gen_data_shifted
+    // ri lint_check_waive VAR_INDEX_RANGE
+    assign data_shifted[i] = (i < hold_count) ? data[i+xfer_count] : '0;
+    assign data_masked[i]  = (i < hold_count_d) ? data[i] : '0;
+  end
+`endif
+`endif
+  if (EnableAssertDataStability) begin : gen_data_stability_checks
+    for (genvar i = 0; i < NumSymbols; i++) begin : gen_data_known_checks
       // This isn't strictly needed for functionality, but if data is unknown,
       // the data_shifted_a assertion below will not work since unknown values
       // cannot be compared.
       `BR_ASSERT_IMPL(data_known_a, (sendable > i) |-> !$isunknown(data[i]))
-      `BR_ASSERT_IMPL(data_shifted_a,
-                      ((sendable > receivable) && ((sendable - receivable) > i))
-          |=>
-          (data[i] == $past(
-                          data[i+receivable]
-                      )))
-    end else begin : gen_data_instability_cover
-      `BR_COVER_IMPL(
-          data_instability_c,
-          ((sendable > receivable) && ((sendable - receivable) > i)) && (data[i] != $past(
-          data[i+receivable])))
     end
+    `BR_ASSERT_IMPL(data_shifted_a, (sendable > receivable) |=> data_masked == $past(data_shifted))
+  end else begin : gen_data_instability_cover
+    `BR_COVER_IMPL(data_instability_c,
+                   (sendable > receivable) ##1 data_masked != $past(data_shifted))
   end
 
   `BR_UNUSED_NAMED(all_unused, {rst, receivable, sendable, data})

--- a/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_intg.sv
+++ b/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_intg.sv
@@ -20,6 +20,7 @@
 // conform to the multi-transfer interface protocol.
 
 `include "br_asserts_internal.svh"
+`include "br_registers.svh"
 `include "br_unused.svh"
 
 // ri lint_check_off NO_OUTPUT
@@ -44,24 +45,38 @@ module br_multi_xfer_checks_sendable_data_intg #(
   `BR_ASSERT_INTG(sendable_no_revocation_a, (sendable > receivable) |=> (sendable >= $past
                                             (sendable - receivable)))
 
-  for (genvar i = 0; i < NumSymbols; i++) begin : gen_data_checks
-    if (EnableAssertDataStability) begin : gen_data_stability_checks
+`ifdef BR_ASSERT_ON
+`ifndef BR_DISABLE_INTG_CHECKS
+  // Untransferred symbols shifted down to LS position
+  logic [NumSymbols-1:0][SymbolWidth-1:0] data_shifted;
+  // Mask newly arriving data to zero
+  logic [NumSymbols-1:0][SymbolWidth-1:0] data_masked;
+  logic [CountWidth-1:0] xfer_count;
+  logic [CountWidth-1:0] hold_count, hold_count_d;
+
+  assign xfer_count = (sendable < receivable) ? sendable : receivable;
+  assign hold_count = (sendable > receivable) ? (sendable - receivable) : '0;
+
+  `BR_REG(hold_count_d, hold_count)
+
+  for (genvar i = 0; i < NumSymbols; i++) begin : gen_data_shifted
+    // ri lint_check_waive VAR_INDEX_RANGE
+    assign data_shifted[i] = (i < hold_count) ? data[i+xfer_count] : '0;
+    assign data_masked[i]  = (i < hold_count_d) ? data[i] : '0;
+  end
+`endif
+`endif
+  if (EnableAssertDataStability) begin : gen_data_stability_checks
+    for (genvar i = 0; i < NumSymbols; i++) begin : gen_data_known_checks
       // This isn't strictly needed for functionality, but if data is unknown,
       // the data_shifted_a assertion below will not work since unknown values
       // cannot be compared.
       `BR_ASSERT_INTG(data_known_a, (sendable > i) |-> !$isunknown(data[i]))
-      `BR_ASSERT_INTG(data_shifted_a,
-                      ((sendable > receivable) && ((sendable - receivable) > i))
-          |=>
-          (data[i] == $past(
-                          data[i+receivable]
-                      )))
-    end else begin : gen_data_instability_cover
-      `BR_COVER_INTG(
-          data_instability_c,
-          ((sendable > receivable) && ((sendable - receivable) > i)) && (data[i] != $past(
-          data[i+receivable])))
     end
+    `BR_ASSERT_INTG(data_shifted_a, (sendable > receivable) |=> data_masked == $past(data_shifted))
+  end else begin : gen_data_instability_cover
+    `BR_COVER_INTG(data_instability_c,
+                   (sendable > receivable) ##1 data_masked != $past(data_shifted))
   end
 
   `BR_UNUSED_NAMED(all_unused, {rst, receivable, sendable, data})


### PR DESCRIPTION
The instability cover didn't correctly delay the data check.
But also, writing the cover per symbol makes it very difficult to
satisfy in practice, since every position must independently be
unstable. Rewrite the assert and cover so that it checks across the
entire data.

---

**Stack**:
- #835
- #834
- #833
- #832
- #831
- #830
- #829 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*