### PR TITLE
Allow some covers in credit modules to be disabled

### DIFF
--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
@@ -84,6 +84,15 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
     // Do not set this to 0 unless push_rst and pop_rst are driven directly by
     // registers. If set to 0, push_sender_in_reset must be tied to 0.
     parameter bit RegisterResetActive = 1,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
@@ -162,6 +171,9 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
       .RegisterResetActive(RegisterResetActive),
       .MaxCredit(MaxCredit),
       .NumSyncStages(NumSyncStages),
+      .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall(EnableCoverPushCreditStall),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_cdc_fifo_ctrl_push_1r1w_push_credit_inst (
       .push_clk,

--- a/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w_push_credit.sv
@@ -54,6 +54,15 @@ module br_cdc_fifo_ctrl_push_1r1w_push_credit #(
     // before synchronization to the pop clock domain. You also cannot set this
     // to 0 if push_sender_in_reset is not tied to 0.
     parameter bit RegisterResetActive = 1,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
@@ -120,6 +129,9 @@ module br_cdc_fifo_ctrl_push_1r1w_push_credit #(
       .RegisterPushOutputs(RegisterPushOutputs),
       .RegisterResetActive(RegisterResetActive),
       .MaxCredit(MaxCredit),
+      .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall(EnableCoverPushCreditStall),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_cdc_fifo_push_ctrl_credit (
       .clk              (push_clk),               // ri lint_check_waive SAME_CLOCK_NAME

--- a/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
@@ -79,6 +79,15 @@ module br_cdc_fifo_flops_push_credit #(
     // Number of pipeline register stages inserted along the read data path in the width dimension.
     // Must be at least 0.
     parameter int FlopRamReadDataWidthStages = 0,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
@@ -155,6 +164,9 @@ module br_cdc_fifo_flops_push_credit #(
       .RamWriteLatency(RamWriteLatency),
       .RamReadLatency(RamReadLatency),
       .NumSyncStages(NumSyncStages),
+      .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall(EnableCoverPushCreditStall),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_cdc_fifo_ctrl_1r1w_push_credit (
       .push_clk,

--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl_credit.sv
@@ -23,6 +23,15 @@ module br_cdc_fifo_push_ctrl_credit #(
     parameter int MaxCredit = Depth,
     parameter bit RegisterPushOutputs = 0,
     parameter bit RegisterResetActive = 1,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     parameter bit EnableAssertFinalNotValid = 1,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1),
@@ -94,11 +103,14 @@ module br_cdc_fifo_push_ctrl_credit #(
   logic [CountWidth-1:0] pop_count_delta;
 
   br_credit_receiver #(
-      .Width                    (Width),
-      .MaxCredit                (MaxCredit),
-      .RegisterPushOutputs      (RegisterPushOutputs),
-      .PopCreditMaxChange       (Depth),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .Width                       (Width),
+      .MaxCredit                   (MaxCredit),
+      .RegisterPushOutputs         (RegisterPushOutputs),
+      .PopCreditMaxChange          (Depth),
+      .EnableCoverCreditWithhold   (EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall  (EnableCoverPushCreditStall),
+      .EnableAssertFinalNotValid   (EnableAssertFinalNotValid)
   ) br_credit_receiver (
       .clk,
       // Not using either_rst here so that there is no path from

--- a/credit/rtl/br_credit_receiver.sv
+++ b/credit/rtl/br_credit_receiver.sv
@@ -75,6 +75,15 @@ module br_credit_receiver #(
     // Maximum pop credits that can be returned in a single cycle.
     // Must be at least 1 but cannot be greater than MaxCredit.
     parameter int PopCreditMaxChange = 1,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     localparam int CounterWidth = $clog2(MaxCredit + 1),
@@ -150,6 +159,18 @@ module br_credit_receiver #(
   `BR_ASSERT_INTG(no_push_overflow_a, (|push_valid) |-> (occupancy_next <= MaxCredit))
   `BR_ASSERT_INTG(pop_credit_in_range_a, pop_credit <= PopCreditMaxChange)
 
+  if (EnableCoverPushSenderInReset) begin : gen_cover_push_sender_in_reset
+    `BR_COVER_INCL_RST_INTG(push_sender_in_reset_a, push_sender_in_reset)
+  end else begin : gen_assert_no_push_sender_in_reset
+    `BR_ASSERT_INCL_RST_INTG(no_push_sender_in_reset_a, !push_sender_in_reset)
+  end
+
+  if (EnableCoverPushCreditStall) begin : gen_cover_push_credit_stall
+    `BR_COVER_INCL_RST_INTG(push_credit_stall_a, push_credit_stall)
+  end else begin : gen_assert_no_push_credit_stall
+    `BR_ASSERT_INCL_RST_INTG(no_push_credit_stall_a, !push_credit_stall)
+  end
+
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_push_valid_a, push_valid == '0)
     `BR_ASSERT_FINAL(final_not_pop_valid_a, pop_valid == '0)
@@ -184,6 +205,8 @@ module br_credit_receiver #(
       // than available. If ==1, decr will always be 1.
       .EnableCoverZeroDecrement(PushCreditMaxChange > 1),
       .EnableCoverDecrementBackpressure(PushCreditMaxChange == 1),
+      .EnableCoverWithhold(EnableCoverCreditWithhold),
+      .EnableAssertAlwaysDecr(!EnableCoverPushCreditStall),
       // Since credit_decr_valid is tied to credit_stall, we disable the final not-valid check
       .EnableAssertFinalNotValid(0)
   ) br_credit_counter (
@@ -233,30 +256,51 @@ module br_credit_receiver #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_IMPL(push_credit_stall_a, push_credit_stall |-> !push_credit_internal)
+  if (EnableCoverPushCreditStall) begin : gen_push_credit_stall_impl_checks
+    `BR_ASSERT_IMPL(push_credit_stall_a, push_credit_stall |-> !push_credit_internal)
+  end
+
   `BR_COVER_IMPL(passthru_credit_c,
                  pop_credit > '0 && push_credit_internal > '0 && credit_count == '0)
-  if (MaxCredit > 1) begin : gen_passthru_credit_nonzero_count
+  // Credits can pass through the counter combinationally with nonzero count
+  // only if push_credit_stall is asserted or credits are withheld.
+  if (MaxCredit > 1 && (EnableCoverPushCreditStall || EnableCoverCreditWithhold))
+  begin : gen_passthru_credit_nonzero_count
     `BR_COVER_IMPL(passthru_credit_nonzero_count_c,
                    pop_credit > '0 && push_credit_internal > '0 && credit_count > '0)
+  end else begin : gen_assert_no_passthru_nonzero_count
+    `BR_ASSERT_IMPL(passthru_only_on_zero_a,
+                    pop_credit > '0 && push_credit_internal > '0 |-> credit_count == '0)
   end
-  `BR_ASSERT_IMPL(over_withhold_a,
-                  credit_withhold > (credit_count + pop_credit) |-> !push_credit_internal)
-  `BR_ASSERT_IMPL(withhold_and_release_a,
-                  credit_count == credit_withhold && push_credit_internal |-> pop_credit)
+  if (EnableCoverCreditWithhold) begin : gen_credit_withhold_impl_checks
+    `BR_ASSERT_IMPL(over_withhold_a,
+                    credit_withhold > (credit_count + pop_credit) |-> !push_credit_internal)
+    `BR_ASSERT_IMPL(withhold_and_release_a,
+                    credit_count == credit_withhold && push_credit_internal |-> pop_credit)
+  end
+
   `BR_ASSERT_IMPL(push_credit_in_range_a, push_credit <= PushCreditMaxChange)
 
   // Reset
   `BR_ASSERT_INCL_RST_IMPL(pop_valid_0_in_reset_a, rst |-> !pop_valid)
-  `BR_ASSERT_IMPL(push_sender_in_reset_no_pop_valid_a, push_sender_in_reset |-> !pop_valid)
+  if (EnableCoverPushSenderInReset) begin : gen_push_sender_in_reset_impl_checks
+    `BR_ASSERT_INCL_RST_IMPL(push_sender_in_reset_no_pop_valid_a,
+                             push_sender_in_reset |-> !pop_valid)
+  end
   if (RegisterPushOutputs) begin : gen_assert_push_reg
     `BR_ASSERT_INCL_RST_IMPL(push_receiver_in_reset_a, rst |=> push_receiver_in_reset)
     `BR_ASSERT_INCL_RST_IMPL(push_credit_0_in_reset_a, rst |=> !push_credit)
-    `BR_ASSERT_IMPL(push_sender_in_reset_no_push_credit_a, push_sender_in_reset |=> !push_credit)
+    if (EnableCoverPushSenderInReset) begin : gen_push_sender_in_reset_no_push_credit
+      `BR_ASSERT_INCL_RST_IMPL(push_sender_in_reset_no_push_credit_a,
+                               push_sender_in_reset |=> !push_credit)
+    end
   end else begin : gen_assert_push_no_reg
     `BR_ASSERT_INCL_RST_IMPL(push_receiver_in_reset_a, rst |-> push_receiver_in_reset)
     `BR_ASSERT_INCL_RST_IMPL(push_credit_0_in_reset_a, rst |-> !push_credit)
-    `BR_ASSERT_IMPL(push_sender_in_reset_no_push_credit_a, push_sender_in_reset |-> !push_credit)
+    if (EnableCoverPushSenderInReset) begin : gen_push_sender_in_reset_no_push_credit
+      `BR_ASSERT_INCL_RST_IMPL(push_sender_in_reset_no_push_credit_a,
+                               push_sender_in_reset |-> !push_credit)
+    end
   end
 
   // Rely on submodule implementation checks

--- a/credit/rtl/br_credit_sender.sv
+++ b/credit/rtl/br_credit_sender.sv
@@ -98,6 +98,12 @@ module br_credit_sender #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that pop_receiver_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPopReceiverInReset = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
 
@@ -160,6 +166,12 @@ module br_credit_sender #(
       .data (push_data)
   );
 
+  if (EnableCoverPopReceiverInReset) begin : gen_cover_pop_receiver_in_reset
+    `BR_COVER_INCL_RST_INTG(pop_receiver_in_reset_a, pop_receiver_in_reset)
+  end else begin : gen_assert_no_pop_receiver_in_reset
+    `BR_ASSERT_INCL_RST_INTG(no_pop_receiver_in_reset_a, !pop_receiver_in_reset)
+  end
+
   // Rely on submodule integration checks
 
   //------------------------------------------
@@ -192,6 +204,7 @@ module br_credit_sender #(
       .EnableCoverZeroIncrement(0),
       .EnableCoverZeroDecrement(NumFlows > 1),
       .EnableCoverDecrementBackpressure(NumFlows == 1 && EnableCoverPushBackpressure),
+      .EnableCoverWithhold(EnableCoverCreditWithhold),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_credit_counter (
       .clk,
@@ -276,23 +289,36 @@ module br_credit_sender #(
   `BR_ASSERT_IMPL(push_pop_unchanged_credit_count_a, $countones(internal_pop_valid)
                                                      == pop_credit |=> credit_count == $past
                                                      (credit_count))
-  `BR_ASSERT_IMPL(withhold_and_spend_a,
-                  credit_count == credit_withhold && (|internal_pop_valid) |-> (pop_credit != '0))
+
+  if (EnableCoverCreditWithhold) begin : gen_credit_withhold_impl_checks
+    `BR_ASSERT_IMPL(withhold_and_spend_a,
+                    credit_count == credit_withhold && (|internal_pop_valid) |-> (pop_credit != '0))
+  end
+
   `BR_COVER_IMPL(pop_valid_and_pop_credit_c, (|pop_valid) && (pop_credit != '0))
   `BR_ASSERT_IMPL(pop_only_avail_credit_a, (credit_available < NumFlows) |-> ($countones
                                            (push_valid & push_ready) <= credit_available))
 
   // Reset
   `BR_ASSERT_INCL_RST_IMPL(push_ready_0_in_reset_a, rst |-> !push_ready)
-  `BR_ASSERT_IMPL(pop_receiver_in_reset_no_push_ready_a, pop_receiver_in_reset |-> !push_ready)
+  if (EnableCoverPopReceiverInReset) begin : gen_pop_receiver_in_reset_impl_checks
+    `BR_ASSERT_INCL_RST_IMPL(pop_receiver_in_reset_no_push_ready_a,
+                             pop_receiver_in_reset |-> !push_ready)
+  end
   if (RegisterPopOutputs) begin : gen_assert_pop_reg
     `BR_ASSERT_INCL_RST_IMPL(pop_sender_in_reset_a, rst |=> pop_sender_in_reset)
     `BR_ASSERT_INCL_RST_IMPL(pop_valid_0_in_reset_a, rst |=> !pop_valid)
-    `BR_ASSERT_IMPL(pop_receiver_in_reset_no_pop_valid_a, pop_receiver_in_reset |=> !pop_valid)
+    if (EnableCoverPopReceiverInReset) begin : gen_pop_receiver_in_reset_no_pop_valid
+      `BR_ASSERT_INCL_RST_IMPL(pop_receiver_in_reset_no_pop_valid_a,
+                               pop_receiver_in_reset |=> !pop_valid)
+    end
   end else begin : gen_assert_pop_no_reg
     `BR_ASSERT_INCL_RST_IMPL(pop_sender_in_reset_a, rst |-> pop_sender_in_reset)
     `BR_ASSERT_INCL_RST_IMPL(pop_valid_0_in_reset_a, rst |-> !pop_valid)
-    `BR_ASSERT_IMPL(pop_receiver_in_reset_no_pop_valid_a, pop_receiver_in_reset |-> !pop_valid)
+    if (EnableCoverPopReceiverInReset) begin : gen_pop_receiver_in_reset_no_pop_valid
+      `BR_ASSERT_INCL_RST_IMPL(pop_receiver_in_reset_no_pop_valid_a,
+                               pop_receiver_in_reset |-> !pop_valid)
+    end
   end
 
   // Rely on submodule implementation checks

--- a/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
+++ b/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
@@ -89,6 +89,15 @@ module br_fifo_ctrl_1r1w_push_credit #(
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     parameter bit EnableAssertFinalNotValid = 1,
     localparam int AddrWidth = br_math::clamped_clog2(RamDepth),
     localparam int CountWidth = $clog2(Depth + 1),
@@ -163,6 +172,9 @@ module br_fifo_ctrl_1r1w_push_credit #(
       .RegisterPushOutputs(RegisterPushOutputs),
       .RamDepth(RamDepth),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
+      .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall(EnableCoverPushCreditStall),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_fifo_push_ctrl_credit (
       .clk,

--- a/fifo/rtl/br_fifo_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_flops_push_credit.sv
@@ -76,6 +76,15 @@ module br_fifo_flops_push_credit #(
     parameter int FlopRamReadDataWidthStages = 0,
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
@@ -158,6 +167,9 @@ module br_fifo_flops_push_credit #(
       .RamReadLatency(RamReadLatency),
       .RamDepth(RamDepth),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
+      .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall(EnableCoverPushCreditStall),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_fifo_ctrl_1r1w_push_credit (
       .clk,

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -27,6 +27,15 @@ module br_fifo_push_ctrl_credit #(
     parameter int RamDepth = Depth,
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
@@ -96,10 +105,13 @@ module br_fifo_push_ctrl_credit #(
   logic [Width-1:0] internal_data;
 
   br_credit_receiver #(
-      .Width                    (Width),
-      .MaxCredit                (MaxCredit),
-      .RegisterPushOutputs      (RegisterPushOutputs),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .Width                       (Width),
+      .MaxCredit                   (MaxCredit),
+      .RegisterPushOutputs         (RegisterPushOutputs),
+      .EnableCoverCreditWithhold   (EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall  (EnableCoverPushCreditStall),
+      .EnableAssertFinalNotValid   (EnableAssertFinalNotValid)
   ) br_credit_receiver (
       .clk,
       // Not using either_rst here so that there is no path from

--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -104,8 +104,13 @@ end
 // Clock: 'clk'
 // Reset: 'rst'
 `ifdef BR_ASSERT_ON
+`ifndef BR_ENABLE_FPV // FPV cannot check properties during reset
 `define BR_ASSERT_INCL_RST(__name__, __expr__) \
 __name__ : assert property (@(posedge clk) disable iff (rst === 1'bx) (__expr__)) else `BR_ASSERT_ERROR(__name__, __expr__);
+`else  // BR_ENABLE_FPV
+`define BR_ASSERT_INCL_RST(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ENABLE_FPV
 `else  // BR_ASSERT_ON
 `define BR_ASSERT_INCL_RST(__name__, __expr__) \
 `BR_NOOP
@@ -113,8 +118,13 @@ __name__ : assert property (@(posedge clk) disable iff (rst === 1'bx) (__expr__)
 
 // More expressive form of BR_ASSERT_INCL_RST that allows the use of a custom clock signal name.
 `ifdef BR_ASSERT_ON
+`ifndef BR_ENABLE_FPV // FPV cannot check properties during reset
 `define BR_ASSERT_INCL_RST_C(__name__, __expr__, __clk__) \
 __name__ : assert property (@(posedge __clk__) disable iff (rst === 1'bx) (__expr__)) else `BR_ASSERT_ERROR(__name__, __expr__);
+`else  // BR_ENABLE_FPV
+`define BR_ASSERT_INCL_RST_C(__name__, __expr__, __clk__) \
+`BR_NOOP
+`endif  // BR_ENABLE_FPV
 `else  // BR_ASSERT_ON
 `define BR_ASSERT_INCL_RST_C(__name__, __expr__, __clk__) \
 `BR_NOOP
@@ -268,6 +278,21 @@ end
 __name__ : cover property (@(posedge clk) disable iff (rst === 1'b1 || rst === 1'bx) (__expr__));
 `else  // BR_ASSERT_ON
 `define BR_COVER(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
+// Clock: 'clk'
+// Reset: 'rst'
+`ifdef BR_ASSERT_ON
+`ifndef BR_ENABLE_FPV // FPV cannot check properties during reset
+`define BR_COVER_INCL_RST(__name__, __expr__) \
+__name__ : cover property (@(posedge clk) disable iff (rst === 1'bx) (__expr__));
+`else // BR_ENABLE_FPV
+`define BR_COVER_INCL_RST(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ENABLE_FPV
+`else  // BR_ASSERT_ON
+`define BR_COVER_INCL_RST(__name__, __expr__) \
 `BR_NOOP
 `endif  // BR_ASSERT_ON
 

--- a/macros/br_asserts_internal.svh
+++ b/macros/br_asserts_internal.svh
@@ -233,6 +233,16 @@
 `BR_NOOP
 `endif  // BR_DISABLE_INTG_CHECKS
 
+// Clock: 'clk'
+// Reset: 'rst'
+`ifndef BR_DISABLE_INTG_CHECKS
+`define BR_COVER_INCL_RST_INTG(__name__, __expr__) \
+`BR_COVER_INCL_RST(__name__, __expr__)
+`else  // BR_DISABLE_INTG_CHECKS
+`define BR_COVER_INCL_RST_INTG(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_DISABLE_INTG_CHECKS
+
 // More expressive form of BR_COVER_INTG that allows the use of custom clock and reset signal names.
 `ifndef BR_DISABLE_INTG_CHECKS
 `define BR_COVER_CR_INTG(__name__, __expr__, __clk__, __rst__) \
@@ -249,6 +259,16 @@
 `BR_COVER(__name__, __expr__)
 `else  // BR_ENABLE_IMPL_CHECKS
 `define BR_COVER_IMPL(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ENABLE_IMPL_CHECKS
+
+// Clock: 'clk'
+// Reset: 'rst'
+`ifdef BR_ENABLE_IMPL_CHECKS
+`define BR_COVER_INCL_RST_IMPL(__name__, __expr__) \
+`BR_COVER_INCL_RST(__name__, __expr__)
+`else  // BR_ENABLE_IMPL_CHECKS
+`define BR_COVER_INCL_RST_IMPL(__name__, __expr__) \
 `BR_NOOP
 `endif  // BR_ENABLE_IMPL_CHECKS
 


### PR DESCRIPTION
The credit withhold, credit stall, and sender/receiver in reset signals
are often tied low when unused. Add parameters allowing related
covers/asserts to be disabled if they would be unreachable.

---

**Stack**:
- #835
- #834 ⬅
- #833


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*