### PR TITLE
Turn coverpoints in br_flow_checks to any-flow covers

### DIFF
--- a/flow/rtl/internal/BUILD.bazel
+++ b/flow/rtl/internal/BUILD.bazel
@@ -59,6 +59,7 @@ verilog_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//macros:br_asserts_internal",
+        "//macros:br_registers",
         "//macros:br_unused",
     ],
 )
@@ -71,6 +72,7 @@ verilog_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//macros:br_asserts_internal",
+        "//macros:br_registers",
         "//macros:br_unused",
     ],
 )

--- a/flow/rtl/internal/br_flow_checks_valid_data_impl.sv
+++ b/flow/rtl/internal/br_flow_checks_valid_data_impl.sv
@@ -21,6 +21,7 @@
 
 `include "br_asserts_internal.svh"
 `include "br_unused.svh"
+`include "br_registers.svh"
 
 // ri lint_check_off NO_OUTPUT
 module br_flow_checks_valid_data_impl #(
@@ -63,35 +64,49 @@ module br_flow_checks_valid_data_impl #(
 
 `ifdef BR_ASSERT_ON
 `ifdef BR_ENABLE_IMPL_CHECKS
-  for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks  // ri lint_check_waive IFDEF_CODE
-    if (EnableCoverBackpressure) begin : gen_backpressure_checks
-      if (EnableAssertValidStability) begin : gen_valid_stability_checks
+  if (EnableCoverBackpressure) begin : gen_backpressure_checks
+    if (EnableAssertValidStability) begin : gen_valid_stability_checks
+      if (EnableAssertDataStability) begin : gen_valid_data_stability_checks
         // Assert that under backpressure conditions, the upstream properly
         // maintains the stability guarantee of the ready-valid protocol. That is,
         // on any given cycle, if valid is 1 and ready is 0, then assert that on
         // the following cycle valid is still 1 and data has not changed.
-        if (EnableAssertDataStability) begin : gen_valid_data_stability_checks
+        for (genvar i = 0; i < NumFlows; i++) begin : gen_valid_data_stability_per_flow
           `BR_ASSERT_IMPL(valid_data_stable_when_backpressured_a,
                           !ready[i] && valid[i] |=> valid[i] && $stable(data[i]))
-        end else begin : gen_valid_only_stability_checks
+        end
+      end else begin : gen_valid_only_stability_checks
+        for (genvar i = 0; i < NumFlows; i++) begin : gen_valid_only_stability_per_flow
           // In some cases, the data may be expected to be unstable when
           // backpressured. For instance, at the output of a br_flow_mux_*
           // module. In this case, we still want to check that the valid
           // is stable when backpressured.
           `BR_ASSERT_IMPL(valid_stable_when_backpressured_a, !ready[i] && valid[i] |=> valid[i])
-          `BR_COVER_IMPL(data_unstable_c, (!ready[i] && valid[i]) ##1 !$stable(data[i]))
-          // Assert that if valid is 1, then data must be known (not X).
-          // This is not strictly a required integration check, because most modules
-          // should still function correctly even if data is unknown (X).
-          // However, under the ready-valid protocol convention where data is stable while
-          // backpressured, unknown values are by definition not stable and therefore violate the
-          // protocol requirement.
-          `BR_ASSERT_IMPL(data_known_a, valid[i] |-> !$isunknown(data[i]))
         end
-      end else begin : gen_no_valid_stability_checks
-        // Cover that valid can be unstable when backpressured.
-        `BR_COVER_IMPL(valid_unstable_c, (!ready[i] && valid[i]) ##1 !valid[i])
+        logic [NumFlows-1:0] valid_not_ready;
+        logic [NumFlows-1:0][Width-1:0] data_d;
+        logic [NumFlows-1:0] data_unstable;
+
+        assign valid_not_ready = valid & ~ready;
+        `BR_REG(data_d, data)
+
+        for (genvar i = 0; i < NumFlows; i++) begin : gen_data_unstable
+          assign data_unstable[i] = data[i] != data_d[i];
+        end
+
+        `BR_COVER_IMPL(data_unstable_c, ##1 |($past(valid_not_ready) & data_unstable))
       end
+    end else begin : gen_no_valid_stability_checks
+      logic [NumFlows-1:0] valid_not_ready;
+
+      assign valid_not_ready = valid & ~ready;
+
+      // Cover that valid can be unstable when backpressured.
+      `BR_COVER_IMPL(valid_unstable_c, ##1 |($past(valid_not_ready) & ~valid))
+    end
+  end else begin : gen_no_backpressure_checks
+    for (genvar i = 0; i < NumFlows; i++) begin : gen_no_backpressure_per_flow
+      `BR_ASSERT_IMPL(no_backpressure_a, valid[i] |-> ready[i])
     end
   end
 `endif  // BR_ENABLE_IMPL_CHECKS

--- a/flow/rtl/internal/br_flow_checks_valid_data_intg.sv
+++ b/flow/rtl/internal/br_flow_checks_valid_data_intg.sv
@@ -21,6 +21,7 @@
 
 `include "br_asserts_internal.svh"
 `include "br_unused.svh"
+`include "br_registers.svh"
 
 // ri lint_check_off NO_OUTPUT
 module br_flow_checks_valid_data_intg #(
@@ -68,34 +69,54 @@ module br_flow_checks_valid_data_intg #(
 
 `ifdef BR_ASSERT_ON
 `ifndef BR_DISABLE_INTG_CHECKS
-  for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks  // ri lint_check_waive IFDEF_CODE
-    if (EnableCoverBackpressure) begin : gen_backpressure_checks
-      if (EnableAssertValidStability) begin : gen_valid_stability_checks
+  if (EnableCoverBackpressure) begin : gen_backpressure_checks
+    if (EnableAssertValidStability) begin : gen_valid_stability_checks
+      if (EnableAssertDataStability) begin : gen_valid_data_stability_checks
         // Assert that under backpressure conditions, the upstream properly
         // maintains the stability guarantee of the ready-valid protocol. That is,
         // on any given cycle, if valid is 1 and ready is 0, then assert that on
         // the following cycle valid is still 1 and data has not changed.
-        if (EnableAssertDataStability) begin : gen_valid_data_stability_checks
+        for (genvar i = 0; i < NumFlows; i++) begin : gen_valid_data_stability_per_flow
           `BR_ASSERT_INTG(valid_data_stable_when_backpressured_a,
                           !ready[i] && valid[i] |=> valid[i] && $stable(data[i]))
-        end else begin : gen_valid_only_stability_checks
+        end
+      end else begin : gen_valid_only_stability_checks
+        for (genvar i = 0; i < NumFlows; i++) begin : gen_valid_only_stability_per_flow
           // In some cases, the data may be expected to be unstable when
           // backpressured. For instance, at the output of a br_flow_mux_*
           // module. In this case, we still want to check that the valid
           // is stable when backpressured.
           `BR_ASSERT_INTG(valid_stable_when_backpressured_a, !ready[i] && valid[i] |=> valid[i])
-          `BR_COVER_INTG(data_unstable_c, (!ready[i] && valid[i]) ##1 !$stable(data[i]))
         end
-      end else begin : gen_no_valid_stability_checks
-        // Cover that valid can be unstable when backpressured.
-        `BR_COVER_INTG(valid_unstable_c, (!ready[i] && valid[i]) ##1 !valid[i])
+        logic [NumFlows-1:0] valid_not_ready;
+        logic [NumFlows-1:0][Width-1:0] data_d;
+        logic [NumFlows-1:0] data_unstable;
+
+        assign valid_not_ready = valid & ~ready;
+        `BR_REG(data_d, data)
+
+        for (genvar i = 0; i < NumFlows; i++) begin : gen_data_unstable
+          assign data_unstable[i] = data[i] != data_d[i];
+        end
+
+        `BR_COVER_INTG(data_unstable_c, ##1 |($past(valid_not_ready) & data_unstable))
       end
-    end else begin : gen_no_backpressure_checks
-      // Assert that backpressure never occurs.
+    end else begin : gen_no_valid_stability_checks
+      logic [NumFlows-1:0] valid_not_ready;
+
+      assign valid_not_ready = valid & ~ready;
+
+      // Cover that valid can be unstable when backpressured.
+      `BR_COVER_INTG(valid_unstable_c, ##1 |($past(valid_not_ready) & ~valid))
+    end
+  end else begin : gen_no_backpressure_checks
+    for (genvar i = 0; i < NumFlows; i++) begin : gen_no_backpressure_per_flow
       `BR_ASSERT_INTG(no_backpressure_a, valid[i] |-> ready[i])
     end
-    // Always assert that if valid is asserted, data is known (not X), if enabled.
-    if (EnableAssertDataKnown) begin : gen_data_known_checks
+  end
+  // Always assert that if valid is asserted, data is known (not X), if enabled.
+  if (EnableAssertDataKnown) begin : gen_data_known_checks
+    for (genvar i = 0; i < NumFlows; i++) begin : gen_data_known_per_flow
       `BR_ASSERT_INTG(data_known_a, valid[i] |-> !$isunknown(data[i]))
     end
   end


### PR DESCRIPTION
Generally for parameter in br_flow_checks_valid_data_intg/impl, we
either assert a condition is held or cover that it is not.
However, we were doing this on a per-flow basis, which means covers
could be met for one flow but not for another. To simplify coverage
closure, turn the cover points into any-flow cover, so that any flow
satisfying the condition will meet the cover.

---

**Stack**:
- #845
- #838
- #837 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*