### PR TITLE
clean up amba FPV TODO

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -75,6 +75,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_default_target_test_suite",
+    gui = True,
     params = {
         "AxiIdWidth": [
             "1",
@@ -114,6 +115,7 @@ br_verilog_fpv_test_tools_suite(
     elab_opts = [
         "-parameter MaxOutstandingReqs 4",
     ],
+    gui = True,
     tools = {
         "jg": "br_amba_axi2axil_fpv.jg.tcl",
     },
@@ -140,6 +142,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_split_test_suite",
+    gui = True,
     params = {
         "NumBranchAddrRanges": [
             "1",
@@ -173,6 +176,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_timing_slice_test_suite",
+    gui = True,
     tools = {
         "jg": "br_amba_axi_timing_slice_fpv.jg.tcl",
     },
@@ -199,6 +203,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_timing_slice_test_suite",
+    gui = True,
     tools = {
         "jg": "br_amba_axil_timing_slice_fpv.jg.tcl",
     },
@@ -225,6 +230,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil2apb_test_suite",
+    gui = True,
     tools = {
         "jg": "br_amba_axil2apb_fpv.jg.tcl",
     },
@@ -251,6 +257,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_apb_timing_slice_test_suite",
+    gui = True,
     tools = {
         "jg": "",
     },
@@ -277,6 +284,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_atb_funnel_test_suite",
+    gui = True,
     tools = {
         "jg": "br_amba_atb_funnel_fpv.jg.tcl",
     },
@@ -303,6 +311,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_msi_test_suite",
+    gui = True,
     tools = {
         "jg": "br_amba_axil_msi_fpv.jg.tcl",
     },
@@ -333,6 +342,7 @@ br_verilog_fpv_test_tools_suite(
     elab_opts = [
         "-parameter MaxOutstanding 4",
     ],
+    gui = True,
     params = {
         "MaxAxiBurstLen": [
             "1",
@@ -371,6 +381,7 @@ br_verilog_fpv_test_tools_suite(
         "-parameter AxiIdCount 2",
         "-parameter StaticPerIdReadTrackerFifoDepth 2",
     ],
+    gui = True,
     params = {
         "MaxAxiBurstLen": [
             "1",
@@ -406,7 +417,7 @@ verilog_library(
 verilog_elab_test(
     name = "br_amba_axi_demux_fpv_monitor_elab_test",
     custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
-    #TODO: elab complains about: use of undefined macro 'JS3_OUT_OF_ORDER'
+    # elab complains about: use of undefined macro 'JS3_OUT_OF_ORDER'
     # needs to disable those spurious warnings for regression
     tags = ["manual"],
     tool = "verific",
@@ -419,6 +430,7 @@ br_verilog_fpv_test_tools_suite(
         "-parameter AwAxiIdWidth 2",
         "-parameter ArAxiIdWidth 2",
     ],
+    gui = True,
     params = {
         "NumSubordinates": [
             "2",

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -75,7 +75,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_default_target_test_suite",
-    gui = True,
     params = {
         "AxiIdWidth": [
             "1",
@@ -115,7 +114,6 @@ br_verilog_fpv_test_tools_suite(
     elab_opts = [
         "-parameter MaxOutstandingReqs 4",
     ],
-    gui = True,
     tools = {
         "jg": "br_amba_axi2axil_fpv.jg.tcl",
     },
@@ -142,7 +140,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_split_test_suite",
-    gui = True,
     params = {
         "NumBranchAddrRanges": [
             "1",
@@ -176,7 +173,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_timing_slice_test_suite",
-    gui = True,
     tools = {
         "jg": "br_amba_axi_timing_slice_fpv.jg.tcl",
     },
@@ -203,7 +199,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_timing_slice_test_suite",
-    gui = True,
     tools = {
         "jg": "br_amba_axil_timing_slice_fpv.jg.tcl",
     },
@@ -230,7 +225,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil2apb_test_suite",
-    gui = True,
     tools = {
         "jg": "br_amba_axil2apb_fpv.jg.tcl",
     },
@@ -257,7 +251,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_apb_timing_slice_test_suite",
-    gui = True,
     tools = {
         "jg": "",
     },
@@ -284,7 +277,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_atb_funnel_test_suite",
-    gui = True,
     tools = {
         "jg": "br_amba_atb_funnel_fpv.jg.tcl",
     },
@@ -311,7 +303,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_msi_test_suite",
-    gui = True,
     tools = {
         "jg": "br_amba_axil_msi_fpv.jg.tcl",
     },
@@ -342,7 +333,6 @@ br_verilog_fpv_test_tools_suite(
     elab_opts = [
         "-parameter MaxOutstanding 4",
     ],
-    gui = True,
     params = {
         "MaxAxiBurstLen": [
             "1",
@@ -381,7 +371,6 @@ br_verilog_fpv_test_tools_suite(
         "-parameter AxiIdCount 2",
         "-parameter StaticPerIdReadTrackerFifoDepth 2",
     ],
-    gui = True,
     params = {
         "MaxAxiBurstLen": [
             "1",
@@ -430,7 +419,6 @@ br_verilog_fpv_test_tools_suite(
         "-parameter AwAxiIdWidth 2",
         "-parameter ArAxiIdWidth 2",
     ],
-    gui = True,
     params = {
         "NumSubordinates": [
             "2",

--- a/amba/fpv/br_amba_atb_funnel_fpv.jg.tcl
+++ b/amba/fpv/br_amba_atb_funnel_fpv.jg.tcl
@@ -24,6 +24,7 @@ assert -disable <embedded>::br_amba_atb_funnel.monitor.gen_src\[*\].src.ATB_v1_0
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_atb_funnel.monitor*
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_atb_funnel_fpv.jg.tcl
+++ b/amba/fpv/br_amba_atb_funnel_fpv.jg.tcl
@@ -22,10 +22,6 @@ assert -disable <embedded>::br_amba_atb_funnel.monitor.gen_src\[*\].src.slv_stab
 assert -disable <embedded>::br_amba_atb_funnel.monitor.gen_src\[*\].src.deassert.slave_af_afvalid_deasserted
 assert -disable <embedded>::br_amba_atb_funnel.monitor.gen_src\[*\].src.ATB_v1_0.syncreq.assert_syncreq_disabled_rev0_0
 
-# TODO: disable covers to make nightly clean
-cover -disable *
-cover -enable *br_amba_atb_funnel.monitor*
-
 # limit run time to 30-mins
 set_prove_time_limit 1800s
 

--- a/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
@@ -23,6 +23,7 @@ assume -from_assert <embedded>::br_amba_axi2axil.monitor.axi4_lite.genPropChksWR
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_axi2axil.monitor*
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
@@ -21,9 +21,20 @@ get_design_info
 assume -from_assert <embedded>::br_amba_axi2axil.monitor.axi4.genStableChksRDInf.genRStableChks.slave_r_rdata_stable
 assume -from_assert <embedded>::br_amba_axi2axil.monitor.axi4_lite.genPropChksWRInf.genNoWrDatTblOverflow.genMas.master_w_wr_tbl_no_overflow
 
-# TODO: disable covers to make nightly clean
-cover -disable *
-cover -enable *br_amba_axi2axil.monitor*
+# TODO(bgelb): disable RTL unreachable covers
+cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_wrap_impl_check.value_overflow_a:precondition1
+cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_wrap_impl_check.maxvalue_plus_one_a:precondition1
+cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_cover_zero_increment.plus_zero_a:precondition1
+cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_cover_reinit.gen_cover_reinit_no_incr.reinit_no_incr_a:precondition1
+cover -disable *br_amba_axi2axil_core_write.br_fifo_flops_resp_tracker.br_fifo_ctrl_1r1w.br_fifo_push_ctrl.br_fifo_push_ctrl_core.br_flow_checks_valid_data_intg.gen_flow_checks\[0\].gen_backpressure_checks.gen_valid_stability_checks.gen_valid_data_stability_checks.valid_data_stable_when_backpressured_a:precondition1
+cover -disable *br_amba_axi2axil_core_read.br_counter_incr_req.gen_cover_zero_increment.plus_zero_a:precondition1
+cover -disable *br_amba_axi2axil_core_read.br_counter_incr_req.gen_cover_reinit.gen_cover_reinit_no_incr.reinit_no_incr_a:precondition1
+cover -disable *br_amba_axi2axil_core_read.br_fifo_flops_resp_tracker.br_fifo_ctrl_1r1w.br_fifo_push_ctrl.br_fifo_push_ctrl_core.br_flow_checks_valid_data_intg.gen_flow_checks\[0\].gen_backpressure_checks.gen_valid_stability_checks.gen_valid_data_stability_checks.valid_data_stable_when_backpressured_a:precondition1
+
+# disable ABVIP unreachable covers
+# FV set ABVIP Max_Pending to be RTL_OutstandingReq + 2 to test RTL backpressure
+# Therefore, ABVIP overflow precondition is unreachable
+cover -disable *monitor*tbl_no_overflow:precondition1
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axi_default_target_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_default_target_fpv.jg.tcl
@@ -20,7 +20,7 @@ get_design_info
 array set param_list [get_design_info -list parameter]
 set SingleBeat $param_list(SingleBeat)
 # TODO(bgelb): disable RTL unreachable covers
-if {$SingleBeat == 0} {
+if {$SingleBeat eq "1'b0"} {
   cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_wrap_impl_check.value_overflow_a:precondition1
   cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_wrap_impl_check.maxvalue_plus_one_a:precondition1
   cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_cover_zero_increment.plus_zero_a:precondition1
@@ -36,7 +36,7 @@ cover -disable *genPropChksWRInf.genNoWrTblOverflow.master_aw_wr_tbl_no_overflow
 cover -disable *genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow:precondition1
 cover -disable *genPropChksWRInf.genNoWrDatTblOverflow.master_w_wr_tbl_no_overflow:precondition1
 cover -disable *genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow:precondition1
-if {$SingleBeat == 1} {
+if {$SingleBeat eq "1'b1"} {
   # these covers require multi-burst
   cover -disable *genPropChksRDInf.genAXI4Full.genChkMaxLen.genBurstWrap.master_ar_araddr_wrap_aligned:precondition1
   cover -disable *genPropChksRDInf.genAXI4Full.genChkMaxLen.genBurstWrap.master_ar_araddr_wrap_arlen:precondition1

--- a/amba/fpv/br_amba_axi_default_target_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_default_target_fpv.jg.tcl
@@ -17,8 +17,37 @@ clock clk
 reset rst
 get_design_info
 
-# TODO: disable covers to make nightly clean
-cover -disable *
+array set param_list [get_design_info -list parameter]
+set SingleBeat $param_list(SingleBeat)
+# TODO(bgelb): disable RTL unreachable covers
+if {$SingleBeat == 0} {
+  cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_wrap_impl_check.value_overflow_a:precondition1
+  cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_wrap_impl_check.maxvalue_plus_one_a:precondition1
+  cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_cover_zero_increment.plus_zero_a:precondition1
+  cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_cover_reinit.gen_cover_reinit_no_incr.reinit_no_incr_a:precondition1
+}
+
+# disable AXI ABVIP covers
+# ABVIP Max_pending default is 2, if overwritten to 1, those covers are reachable (then bunch of other covers are unreachable).
+# TODO(bgelb): please double check, RTL probably has no back pressure
+cover -disable *genPropChksRDInf.genNoRdTblOverflow.master_ar_rd_tbl_no_overflow:precondition1
+cover -disable *genPropChksRDInf.genNoRdTblOverflow.genSlv.slave_ar_rd_tbl_no_overflow:precondition1
+cover -disable *genPropChksWRInf.genNoWrTblOverflow.master_aw_wr_tbl_no_overflow:precondition1
+cover -disable *genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow:precondition1
+cover -disable *genPropChksWRInf.genNoWrDatTblOverflow.master_w_wr_tbl_no_overflow:precondition1
+cover -disable *genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow:precondition1
+if {$SingleBeat == 1} {
+  # these covers require multi-burst
+  cover -disable *genPropChksRDInf.genAXI4Full.genChkMaxLen.genBurstWrap.master_ar_araddr_wrap_aligned:precondition1
+  cover -disable *genPropChksRDInf.genAXI4Full.genChkMaxLen.genBurstWrap.master_ar_araddr_wrap_arlen:precondition1
+  cover -disable *genPropChksWRInf.genAXI4Full.genChkMaxlenGr1.genBurstWrap.master_aw_awaddr_wrap_aligned:precondition1
+  cover -disable *genPropChksWRInf.genAXI4Full.genChkMaxlenGr1.genBurstWrap.master_aw_awaddr_wrap_awlen:precondition1
+  cover -disable *genPropChksWRInf.genAXI4Full.genDbcAw.genAwlenMaxLenGr1.genAwlenDatAcpt.master_aw_w_awlen_exact_len_dbc:precondition4
+  cover -disable *genPropChksWRInf.genAXI4Full.genAwlenMaxLenGr1.genAwlenDatAcpt.master_aw_w_awlen_exact_len_collision_dbc_data_end:precondition1
+  cover -disable *genPropChksWRInf.genAXI4Full.genAwlenMaxLenGr1.genAwlenDatAcpt.genChkDBC.master_aw_w_awlen_exact_len_collision_dbc_data_cont:precondition1
+  cover -disable *genPropChksWRInf.genDbcW.genAXI4Full.genWlastExactLenDbc.master_w_aw_wlast_exact_len_dbc:precondition1
+  cover -disable *genPropChksWRInf.genNoLite.genWlastCol.master_w_aw_wlast_exact_len_collision:precondition1
+}
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axi_demux_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_demux_fpv.jg.tcl
@@ -19,6 +19,7 @@ get_design_info
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_axi_demux.monitor*
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axi_demux_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_demux_fpv.jg.tcl
@@ -17,9 +17,13 @@ clock clk
 reset rst
 get_design_info
 
-# TODO: disable covers to make nightly clean
+# TODO(bgelb): disable RTL covers to make nightly clean
 cover -disable *
 cover -enable *br_amba_axi_demux.monitor*
+# disable ABVIP unreachable covers
+# FV set ABVIP Max_Pending to be RTL_OutstandingReq + 2 to test RTL backpressure
+# Therefore, ABVIP overflow precondition is unreachable
+cover -disable *monitor*tbl_no_overflow:precondition1
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axi_isolate_mgr_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_isolate_mgr_fpv.jg.tcl
@@ -19,9 +19,10 @@ get_design_info
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_axi_isolate_mgr.monitor*
 
 # during isolate_req & !isolate_done window, upstream assertions don't matter
-# TODO: don't know how to disable these assertions dynamically w.r.t a signal
+# There is no way to disable these assertions dynamically w.r.t a signal
 # Has tried tying off isolate_req, those assertions stop failing.
 # also checked each CEX, they all failed inside "isolate_req & !isolate_done" window
 assert -disable {*upstream.genStableChksRDInf.genRStableChks.slave_r_rvalid_stable}

--- a/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
@@ -17,9 +17,15 @@ clock clk
 reset rst
 get_design_info
 
-# TODO: disable covers to make nightly clean
+array set param_list [get_design_info -list parameter]
+set MaxAxiBurstLen $param_list(MaxAxiBurstLen)
+# TODO(bgelb): disable RTL covers to make nightly clean
 cover -disable *
 cover -enable *br_amba_axi_isolate_sub.monitor*
+# disable ABVIP unreachable covers
+# FV set ABVIP Max_Pending to be RTL_OutstandingReq + 2 to test RTL backpressure
+# Therefore, ABVIP overflow precondition is unreachable
+cover -disable *monitor*tbl_no_overflow:precondition1
 
 # during isolate_req & !isolate_done window, downstream assertions don't matter
 # Coded same assertion with precondition: isolate_req & !isolate_done in br_amba_axi_isolate_sub_fpv.sv

--- a/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_isolate_sub_fpv.jg.tcl
@@ -19,6 +19,7 @@ get_design_info
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_axi_isolate_sub.monitor*
 
 # during isolate_req & !isolate_done window, downstream assertions don't matter
 # Coded same assertion with precondition: isolate_req & !isolate_done in br_amba_axi_isolate_sub_fpv.sv

--- a/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
@@ -27,10 +27,6 @@ assert -disable <embedded>::br_amba_axi_timing_slice.monitor.init.genPropChksRDI
 assert -disable <embedded>::br_amba_axi_timing_slice.monitor.init.genPropChksWRInf.genNoWrTblOverflow.genMas.master_aw_wr_tbl_no_overflow
 assert -disable <embedded>::br_amba_axi_timing_slice.monitor.init.genPropChksWRInf.genNoWrDatTblOverflow.genMas.master_w_wr_tbl_no_overflow
 
-# TODO: disable covers to make nightly clean
-cover -disable *
-cover -enable *br_amba_axi_timing_slice.monitor*
-
 # limit run time to 30-mins
 set_prove_time_limit 1800s
 

--- a/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_timing_slice_fpv.jg.tcl
@@ -29,6 +29,7 @@ assert -disable <embedded>::br_amba_axi_timing_slice.monitor.init.genPropChksWRI
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_axi_timing_slice.monitor*
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axil2apb_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil2apb_fpv.jg.tcl
@@ -17,9 +17,9 @@ clock clk
 reset rst
 get_design_info
 
-# TODO: disable covers to make nightly clean
-cover -disable *
-cover -enable *br_amba_axil2apb.monitor*
+# TODO(bgelb): disable RTL unreachable cover
+# This cover is unreachable because enable_priority_update is tired to 0 in RTL
+cover -disable <embedded>::br_amba_axil2apb.br_arb_rr.br_arb_rr_internal.rr_state_internal.grant_onehot_A:precondition1
 
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axil2apb_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil2apb_fpv.jg.tcl
@@ -19,6 +19,7 @@ get_design_info
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_axil2apb.monitor*
 
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axil2apb_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil2apb_fpv_monitor.sv
@@ -68,7 +68,8 @@ module br_amba_axil2apb_fpv_monitor #(
       .AXI4_LITE(1),
       .ADDR_WIDTH(AddrWidth),
       .DATA_WIDTH(DataWidth),
-      .CONFIG_WAIT_FOR_VALID_BEFORE_READY(ValidBeforeReady)
+      .CONFIG_WAIT_FOR_VALID_BEFORE_READY(ValidBeforeReady),
+      .MAX_PENDING(1)
   ) axi (
       // Global signals
       .aclk    (clk),

--- a/amba/fpv/br_amba_axil_default_target_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_default_target_fpv.jg.tcl
@@ -17,8 +17,15 @@ clock clk
 reset rst
 get_design_info
 
-# TODO: disable covers to make nightly clean
-cover -disable *
+# disable AXI ABVIP cover properties
+# ABVIP Max_pending default is 2, if overwritten to 1, those covers are reachable (then bunch of other covers are unreachable).
+# TODO(bgelb): please double check, RTL probably has no back pressure
+cover -disable *genPropChksRDInf.genNoRdTblOverflow.master_ar_rd_tbl_no_overflow:precondition1
+cover -disable *genPropChksRDInf.genNoRdTblOverflow.genSlv.slave_ar_rd_tbl_no_overflow:precondition1
+cover -disable *genPropChksWRInf.genNoWrTblOverflow.master_aw_wr_tbl_no_overflow:precondition1
+cover -disable *genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow:precondition1
+cover -disable *genPropChksWRInf.genNoWrDatTblOverflow.master_w_wr_tbl_no_overflow:precondition1
+cover -disable *genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow:precondition1
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axil_default_target_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_default_target_fpv.jg.tcl
@@ -20,12 +20,7 @@ get_design_info
 # disable AXI ABVIP cover properties
 # ABVIP Max_pending default is 2, if overwritten to 1, those covers are reachable (then bunch of other covers are unreachable).
 # TODO(bgelb): please double check, RTL probably has no back pressure
-cover -disable *genPropChksRDInf.genNoRdTblOverflow.master_ar_rd_tbl_no_overflow:precondition1
-cover -disable *genPropChksRDInf.genNoRdTblOverflow.genSlv.slave_ar_rd_tbl_no_overflow:precondition1
-cover -disable *genPropChksWRInf.genNoWrTblOverflow.master_aw_wr_tbl_no_overflow:precondition1
-cover -disable *genPropChksWRInf.genNoWrTblOverflow.genSlv.slave_aw_wr_tbl_no_overflow:precondition1
-cover -disable *genPropChksWRInf.genNoWrDatTblOverflow.master_w_wr_tbl_no_overflow:precondition1
-cover -disable *genPropChksWRInf.genNoWrDatTblOverflow.genSlv.slave_w_wr_tbl_no_overflow:precondition1
+cover -disable *monitor*tbl_no_overflow:precondition1
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
@@ -32,6 +32,7 @@ assume -disable <embedded>::br_amba_axil_msi.monitor.axi.genPropChksRDInf.genSla
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_axil_msi.monitor*
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_msi_fpv.jg.tcl
@@ -30,9 +30,8 @@ assert -disable <embedded>::br_amba_axil_msi.monitor.axi.genPropChksWRInf.genNoW
 # this means: It is impossible to satisfy all fairness constraints infinitely often.
 assume -disable <embedded>::br_amba_axil_msi.monitor.axi.genPropChksRDInf.genSlaveLiveAR.slave_ar_no_arvalid_arready_eventually
 
-# TODO: disable covers to make nightly clean
+# TODO(masai, bgelb): disable covers to make nightly clean
 cover -disable *
-cover -enable *br_amba_axil_msi.monitor*
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axil_split_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_split_fpv.jg.tcl
@@ -17,9 +17,21 @@ clock clk
 reset rst
 get_design_info
 
-# TODO: disable covers to make nightly clean
+# TODO(bgelb): disable RTL covers
 cover -disable *
 cover -enable *br_amba_axil_split.monitor*
+
+# disable ABVIP covers
+# FV set ABVIP Max_Pending to be RTL_OutstandingReq + 2 to test RTL backpressure
+# Therefore, ABVIP overflow precondition is unreachable
+cover -disable *monitor*tbl_no_overflow:precondition1
+# If aw/w channels have skew, these covers will be reachable.
+# That's why they are reachable for root.
+# For downstream branch and trunk, only when both aw and w are present, downstream_valid will be generated.
+cover -disable *trunk.genPropChksWRInf.genDBCLive.genSlaveLiveAW.genLiveAW.master_aw_awvalid_eventually:precondition1
+cover -disable *trunk.genPropChksWRInf.genSlaveLiveW.genLiveW.master_w_wvalid_eventually:precondition1
+cover -disable *branch.genPropChksWRInf.genDBCLive.genSlaveLiveAW.genLiveAW.master_aw_awvalid_eventually:precondition1
+cover -disable *branch.genPropChksWRInf.genSlaveLiveW.genLiveW.master_w_wvalid_eventually:precondition1
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axil_split_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_split_fpv.jg.tcl
@@ -19,6 +19,7 @@ get_design_info
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_axil_split.monitor*
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s

--- a/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
@@ -27,10 +27,6 @@ assert -disable <embedded>::br_amba_axil_timing_slice.monitor.init.genPropChksRD
 assert -disable <embedded>::br_amba_axil_timing_slice.monitor.init.genPropChksWRInf.genNoWrTblOverflow.genMas.master_aw_wr_tbl_no_overflow
 assert -disable <embedded>::br_amba_axil_timing_slice.monitor.init.genPropChksWRInf.genNoWrDatTblOverflow.genMas.master_w_wr_tbl_no_overflow
 
-# TODO: disable covers to make nightly clean
-cover -disable *
-cover -enable *br_amba_axil_timing_slice.monitor*
-
 # limit run time to 30-mins
 set_prove_time_limit 1800s
 

--- a/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_timing_slice_fpv.jg.tcl
@@ -29,6 +29,7 @@ assert -disable <embedded>::br_amba_axil_timing_slice.monitor.init.genPropChksWR
 
 # TODO: disable covers to make nightly clean
 cover -disable *
+cover -enable *br_amba_axil_timing_slice.monitor*
 
 # limit run time to 30-mins
 set_prove_time_limit 1800s


### PR DESCRIPTION
only 1 TODO left for br_amba_axil_msi: need some time, quite many unreachable covers in AXI ABVIP.
1. if RTL doesn't have too many unreachable covers, I disabled them explicitly. Left TODO for @bgelb-openai to have a look.
2. If RTL have a lot of unreachable covers, I just disabled all covers. left a TODO for Ben.
3. AXI ABVIP and FV checker unreachable covers are disabled with comments.