### PR TITLE
Remove confusing implementation cover in br_flow_fork

### DIFF
--- a/flow/rtl/br_flow_fork.sv
+++ b/flow/rtl/br_flow_fork.sv
@@ -107,8 +107,4 @@ module br_flow_fork #(
       .data ({NumFlows{1'b0}})
   );
 
-  for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks
-    `BR_COVER_IMPL(pop_valid_unstable_c, $stable(push_valid) && $fell(pop_valid_unstable[i]))
-  end
-
 endmodule : br_flow_fork


### PR DESCRIPTION
This cover is named to check pop_valid stability, but only depends on
pop_valid and push_valid but not pop_ready. Just rely on the standard
implementation check module for this.

---

**Stack**:
- #845
- #847
- #846 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*