### PR TITLE
Fix unreachable covers in br_amba_axi2axil

### DIFF
--- a/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
@@ -21,16 +21,6 @@ get_design_info
 assume -from_assert <embedded>::br_amba_axi2axil.monitor.axi4.genStableChksRDInf.genRStableChks.slave_r_rdata_stable
 assume -from_assert <embedded>::br_amba_axi2axil.monitor.axi4_lite.genPropChksWRInf.genNoWrDatTblOverflow.genMas.master_w_wr_tbl_no_overflow
 
-# TODO(bgelb): disable RTL unreachable covers
-cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_wrap_impl_check.value_overflow_a:precondition1
-cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_wrap_impl_check.maxvalue_plus_one_a:precondition1
-cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_cover_zero_increment.plus_zero_a:precondition1
-cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_cover_reinit.gen_cover_reinit_no_incr.reinit_no_incr_a:precondition1
-cover -disable *br_amba_axi2axil_core_write.br_fifo_flops_resp_tracker.br_fifo_ctrl_1r1w.br_fifo_push_ctrl.br_fifo_push_ctrl_core.br_flow_checks_valid_data_intg.gen_flow_checks\[0\].gen_backpressure_checks.gen_valid_stability_checks.gen_valid_data_stability_checks.valid_data_stable_when_backpressured_a:precondition1
-cover -disable *br_amba_axi2axil_core_read.br_counter_incr_req.gen_cover_zero_increment.plus_zero_a:precondition1
-cover -disable *br_amba_axi2axil_core_read.br_counter_incr_req.gen_cover_reinit.gen_cover_reinit_no_incr.reinit_no_incr_a:precondition1
-cover -disable *br_amba_axi2axil_core_read.br_fifo_flops_resp_tracker.br_fifo_ctrl_1r1w.br_fifo_push_ctrl.br_fifo_push_ctrl_core.br_flow_checks_valid_data_intg.gen_flow_checks\[0\].gen_backpressure_checks.gen_valid_stability_checks.gen_valid_data_stability_checks.valid_data_stable_when_backpressured_a:precondition1
-
 # disable ABVIP unreachable covers
 # FV set ABVIP Max_Pending to be RTL_OutstandingReq + 2 to test RTL backpressure
 # Therefore, ABVIP overflow precondition is unreachable

--- a/amba/rtl/internal/BUILD.bazel
+++ b/amba/rtl/internal/BUILD.bazel
@@ -24,6 +24,8 @@ verilog_library(
         "//amba/rtl:br_amba_pkg",
         "//counter/rtl:br_counter_incr",
         "//fifo/rtl:br_fifo_flops",
+        "//flow/rtl:br_flow_fork",
+        "//flow/rtl:br_flow_join",
         "//flow/rtl:br_flow_reg_both",
         "//macros:br_asserts_internal",
         "//macros:br_registers",


### PR DESCRIPTION
* Unreachable covers in counter are by design. Just disable them by
parameter.
* Update ready/valid handshake logic to use br_flow_fork/join to
avoid unreachable backpressure cover.

---

**Stack**:
- #855
- #854
- #853
- #852 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*