### PR TITLE
Fix enable_priority_update on RR arbiter in br_amba_axil2apb

### DIFF
--- a/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi2axil_fpv.jg.tcl
@@ -21,16 +21,6 @@ get_design_info
 assume -from_assert <embedded>::br_amba_axi2axil.monitor.axi4.genStableChksRDInf.genRStableChks.slave_r_rdata_stable
 assume -from_assert <embedded>::br_amba_axi2axil.monitor.axi4_lite.genPropChksWRInf.genNoWrDatTblOverflow.genMas.master_w_wr_tbl_no_overflow
 
-# TODO(bgelb): disable RTL unreachable covers
-cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_wrap_impl_check.value_overflow_a:precondition1
-cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_wrap_impl_check.maxvalue_plus_one_a:precondition1
-cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_cover_zero_increment.plus_zero_a:precondition1
-cover -disable *br_amba_axi2axil_core_write.br_counter_incr_req.gen_cover_reinit.gen_cover_reinit_no_incr.reinit_no_incr_a:precondition1
-cover -disable *br_amba_axi2axil_core_write.br_fifo_flops_resp_tracker.br_fifo_ctrl_1r1w.br_fifo_push_ctrl.br_fifo_push_ctrl_core.br_flow_checks_valid_data_intg.gen_flow_checks\[0\].gen_backpressure_checks.gen_valid_stability_checks.gen_valid_data_stability_checks.valid_data_stable_when_backpressured_a:precondition1
-cover -disable *br_amba_axi2axil_core_read.br_counter_incr_req.gen_cover_zero_increment.plus_zero_a:precondition1
-cover -disable *br_amba_axi2axil_core_read.br_counter_incr_req.gen_cover_reinit.gen_cover_reinit_no_incr.reinit_no_incr_a:precondition1
-cover -disable *br_amba_axi2axil_core_read.br_fifo_flops_resp_tracker.br_fifo_ctrl_1r1w.br_fifo_push_ctrl.br_fifo_push_ctrl_core.br_flow_checks_valid_data_intg.gen_flow_checks\[0\].gen_backpressure_checks.gen_valid_stability_checks.gen_valid_data_stability_checks.valid_data_stable_when_backpressured_a:precondition1
-
 # disable ABVIP unreachable covers
 # FV set ABVIP Max_Pending to be RTL_OutstandingReq + 2 to test RTL backpressure
 # Therefore, ABVIP overflow precondition is unreachable

--- a/amba/fpv/br_amba_axi_default_target_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_default_target_fpv.jg.tcl
@@ -19,13 +19,6 @@ get_design_info
 
 array set param_list [get_design_info -list parameter]
 set SingleBeat $param_list(SingleBeat)
-# TODO(bgelb): disable RTL unreachable covers
-if {$SingleBeat eq "1'b0"} {
-  cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_wrap_impl_check.value_overflow_a:precondition1
-  cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_wrap_impl_check.maxvalue_plus_one_a:precondition1
-  cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_cover_zero_increment.plus_zero_a:precondition1
-  cover -disable *br_amba_axi_default_target.gen_multi_beat.br_counter_incr_arlen.gen_cover_reinit.gen_cover_reinit_no_incr.reinit_no_incr_a:precondition1
-}
 
 # disable AXI ABVIP covers
 # ABVIP Max_pending default is 2, if overwritten to 1, those covers are reachable (then bunch of other covers are unreachable).

--- a/amba/fpv/br_amba_axil2apb_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil2apb_fpv.jg.tcl
@@ -17,9 +17,5 @@ clock clk
 reset rst
 get_design_info
 
-# TODO(bgelb): disable RTL unreachable cover
-# This cover is unreachable because enable_priority_update is tired to 0 in RTL
-cover -disable <embedded>::br_amba_axil2apb.br_arb_rr.br_arb_rr_internal.rr_state_internal.grant_onehot_A:precondition1
-
 # prove command
 prove -all

--- a/amba/rtl/br_amba_axi_default_target.sv
+++ b/amba/rtl/br_amba_axi_default_target.sv
@@ -170,7 +170,10 @@ module br_amba_axi_default_target #(
         .MaxValue(2 ** AxiLenWidth - 1),
         .MaxIncrement(1),
         .EnableReinitAndIncr(0),
-        .EnableSaturate(0)
+        .EnableSaturate(0),
+        .EnableWrap(0),
+        .EnableCoverZeroIncrement(0),
+        .EnableCoverReinitNoIncr(0)
     ) br_counter_incr_arlen (
         .clk,
         .rst,

--- a/amba/rtl/br_amba_axil2apb.sv
+++ b/amba/rtl/br_amba_axil2apb.sv
@@ -109,7 +109,7 @@ module br_amba_axil2apb #(
   ) br_arb_rr (
       .clk(clk),
       .rst(rst),
-      .enable_priority_update(1'b0),
+      .enable_priority_update(1'b1),
       .request({arb_write_req, arb_read_req}),
       .grant({arb_write_grant, arb_read_grant})
   );

--- a/amba/rtl/internal/BUILD.bazel
+++ b/amba/rtl/internal/BUILD.bazel
@@ -24,6 +24,8 @@ verilog_library(
         "//amba/rtl:br_amba_pkg",
         "//counter/rtl:br_counter_incr",
         "//fifo/rtl:br_fifo_flops",
+        "//flow/rtl:br_flow_fork",
+        "//flow/rtl:br_flow_join",
         "//flow/rtl:br_flow_reg_both",
         "//macros:br_asserts_internal",
         "//macros:br_registers",


### PR DESCRIPTION
Tying this to 0 makes the RR state never update, meaning that the RR
arbiter will not actually be RR. Assume this is unintentional.

---

**Stack**:
- #855
- #854 ⬅
- #853
- #852


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*