### PR TITLE
Fix covers in AXI-Lite splitter

### DIFF
--- a/amba/fpv/br_amba_axil_split_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_split_fpv.jg.tcl
@@ -17,9 +17,8 @@ clock clk
 reset rst
 get_design_info
 
-# TODO(bgelb): disable RTL covers
-cover -disable *
-cover -enable *br_amba_axil_split.monitor*
+# Unreachable RTL implementation covers
+cover -disable *br_flow_reg_both_write_*.br_flow_reg_rev.br_flow_checks_valid_data_impl.gen_backpressure_checks.gen_valid_stability_checks.gen_valid_data_stability_checks.gen_valid_data_stability_per_flow*.valid_data_stable_when_backpressured_a:precondition1
 
 # disable ABVIP covers
 # FV set ABVIP Max_Pending to be RTL_OutstandingReq + 2 to test RTL backpressure

--- a/flow/rtl/br_flow_reg_both.sv
+++ b/flow/rtl/br_flow_reg_both.sv
@@ -45,7 +45,10 @@ module br_flow_reg_both #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, cover that the interface between the rev and fwd stages experiences
+    // backpressure. Otherwise, assert that there is never backpressure.
+    parameter bit EnableCoverIntermediateBackpressure = 1
 ) (
     input logic clk,
     input logic rst,  // Synchronous active-high
@@ -101,9 +104,9 @@ module br_flow_reg_both #(
       // The fwd stage can still backpressure the rev stage without
       // backpressuring the input. The rev stage will shield the fwd stage from
       // instability on the push interface.
-      .EnableCoverPushBackpressure(1),
-      .EnableAssertPushValidStability(1),
-      .EnableAssertPushDataStability(1),
+      .EnableCoverPushBackpressure(EnableCoverIntermediateBackpressure),
+      .EnableAssertPushValidStability(EnableCoverIntermediateBackpressure),
+      .EnableAssertPushDataStability(EnableCoverIntermediateBackpressure),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_flow_reg_fwd (


### PR DESCRIPTION
* Added new parameter to br_counter to allow simultaneous incr/decr cover
to be disabled.
* Added new parameters to flow-reg to disable backpressure checks
on pop and intermediate interfaces.
* Refactor ready/valid handshaking for aw/w and buffers to avoid
backpressure coverage failure.