### PR TITLE
Remove redundant and not waivable stability assert

### DIFF
--- a/flow/rtl/br_flow_join.sv
+++ b/flow/rtl/br_flow_join.sv
@@ -103,6 +103,4 @@ module br_flow_join #(
       .data (1'b0)
   );
 
-  `BR_ASSERT_IMPL(pop_backpressure_a, !pop_ready && pop_valid |=> pop_valid)
-
 endmodule : br_flow_join


### PR DESCRIPTION
If EnableAssertPushValidStability is 0, and push_valid is unstable, pop_valid will also be unstable, causing this assertion to fail. It should really be dependent on the EnableAssertPushValidStability parameter, however, this assertion is redundant with the valid stability assertion within br_flow_checks_valid_data_impl, so it can just be removed.