### PR TITLE
axi2axil: fix error response aggregation

### DIFF
--- a/amba/rtl/br_amba_pkg.sv
+++ b/amba/rtl/br_amba_pkg.sv
@@ -27,6 +27,11 @@ package br_amba;
     AxiRespDecerr = 2'b11   // Decode error
   } axi_resp_t;
 
+  // According to AXI spec, we need to pick the worst error response (i.e., DECERR > SLVERR > OKAY).
+  function automatic logic [1:0] get_worst_error_response(logic [1:0] resp1, logic [1:0] resp2);
+    return (resp1 > resp2) ? resp1 : resp2;  // ri lint_check_waive ENUM_RHS
+  endfunction
+
   // AXI Burst types
   typedef enum logic [1:0] {
     AxiBurstFixed    = 2'b00,  // Fixed burst

--- a/amba/rtl/internal/br_amba_axi2axil_core.sv
+++ b/amba/rtl/internal/br_amba_axi2axil_core.sv
@@ -363,8 +363,9 @@ module br_amba_axi2axil_core #(
   // For write responses, we need to aggregate the responses from each beat. We need to
   // reset it after each response.
   assign resp_next = (axi_resp_handshake) ? br_amba::AxiRespOkay :  // ri lint_check_waive ENUM_RHS
-      (axil_resp_resp != br_amba::AxiRespOkay) ?  // ri lint_check_waive ENUM_COMPARE
-      axil_resp_resp : resp;
+      br_amba::get_worst_error_response(
+          axil_resp_resp, resp
+      );
 
   logic axi_resp_valid_unqual;
   logic axi_resp_ready_unqual;


### PR DESCRIPTION
AXI spec says to pick the highest error response if a request generates multiple requests.