### PR TITLE
Enable select stability on read crossbar demux within dynamic fifo

### DIFF
--- a/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
+++ b/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
@@ -77,7 +77,8 @@ module br_fifo_shared_read_xbar #(
       br_flow_demux_select_unstable #(
           .NumFlows(NumReadPorts),
           .Width(AddrWidth),
-          .EnableAssertPushValidStability(EnableAssertPushValidStability)
+          .EnableAssertPushValidStability(EnableAssertPushValidStability),
+          .EnableAssertSelectStability(1)
       ) br_flow_demux_select_unstable_inst (
           .clk,
           .rst,

--- a/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
+++ b/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
@@ -78,7 +78,7 @@ module br_fifo_shared_read_xbar #(
           .NumFlows(NumReadPorts),
           .Width(AddrWidth),
           .EnableAssertPushValidStability(EnableAssertPushValidStability),
-          .EnableAssertSelectStability(1)
+          .EnableAssertSelectStability(EnableAssertPushValidStability)
       ) br_flow_demux_select_unstable_inst (
           .clk,
           .rst,


### PR DESCRIPTION
This prevents an unreachable cover