### PR TITLE
Disable final value assert for br_arb_weighted_rr

### DIFF
--- a/arb/rtl/br_arb_weighted_rr.sv
+++ b/arb/rtl/br_arb_weighted_rr.sv
@@ -124,7 +124,8 @@ module br_arb_weighted_rr #(
         .EnableSaturate(1),
         .EnableWrap(0),
         .EnableCoverZeroChange(0),
-        .EnableCoverReinit(0)
+        .EnableCoverReinit(0),
+        .EnableAssertFinalInitialValue(0)
     ) br_counter (
         .clk,
         .rst,


### PR DESCRIPTION
Seems like this is not expected to return to the initial value (it depends on which requests get grants)