### PR TITLE
Make br_flow_demux_select* and br_flow_mux_select* select stability default to 1

### DIFF
--- a/flow/rtl/br_flow_demux_select.sv
+++ b/flow/rtl/br_flow_demux_select.sv
@@ -43,7 +43,7 @@ module br_flow_demux_select #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, assert that select is stable when backpressured.
     // If 0, cover that select can be unstable.
-    parameter bit EnableAssertSelectStability = 0,
+    parameter bit EnableAssertSelectStability = 1,
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.

--- a/flow/rtl/br_flow_demux_select_unstable.sv
+++ b/flow/rtl/br_flow_demux_select_unstable.sv
@@ -49,7 +49,7 @@ module br_flow_demux_select_unstable #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, assert that select is stable when push is backpressured.
     // If 0, cover that select can be unstable.
-    parameter bit EnableAssertSelectStability = 0,
+    parameter bit EnableAssertSelectStability = EnableAssertPushValidStability,
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
@@ -105,7 +105,7 @@ module br_flow_demux_select_unstable #(
       .data (push_data)
   );
 
-  if (EnableCoverPushBackpressure) begin : gen_push_backpressure_intg_checks
+  if (EnableCoverPushBackpressure && EnableAssertValidStability) begin : gen_select_checks
     if (EnableAssertSelectStability) begin : gen_select_stability_check
       `BR_ASSERT_INTG(select_stable_a,
                       (!push_ready && push_valid) |=> push_valid && $stable(select))

--- a/flow/rtl/br_flow_mux_select.sv
+++ b/flow/rtl/br_flow_mux_select.sv
@@ -43,7 +43,7 @@ module br_flow_mux_select #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, assert that select will not change when the selected push flow is backpressured.
     // Otherwise, cover that select can be unstable.
-    parameter bit EnableAssertSelectStability = 0,
+    parameter bit EnableAssertSelectStability = EnableAssertPushValidStability,
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.

--- a/flow/rtl/br_flow_mux_select_unstable.sv
+++ b/flow/rtl/br_flow_mux_select_unstable.sv
@@ -50,7 +50,7 @@ module br_flow_mux_select_unstable #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, assert that select will not change when the selected push flow is backpressured.
     // Otherwise, cover that select can be unstable.
-    parameter bit EnableAssertSelectStability = 0,
+    parameter bit EnableAssertSelectStability = EnableAssertPushValidStability,
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
@@ -104,7 +104,7 @@ module br_flow_mux_select_unstable #(
       .data (push_data)
   );
 
-  if (EnableCoverPushBackpressure) begin : gen_backpressure_select_checks
+  if (EnableCoverPushBackpressure && EnableAssertValidStability) begin : gen_select_checks
     if (EnableAssertSelectStability) begin : gen_stable_select
       `BR_ASSERT_INTG(select_stable_a,
                       push_valid[select] && !push_ready[select] |=> $stable(select))


### PR DESCRIPTION
Also, remove assertions and covers if push valid is not stable