### PR TITLE
qualify br_ram_flops data output, add missing asserts for StructuredGates mode

### DIFF
--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -183,15 +183,14 @@ br_verilog_elab_and_lint_test_suite(
         "Width": ["8"],
         "FlopRamAddressDepthStages": [
             "0",
+            "1",
         ],
-        "FlopRamReadDataDepthStages": [
-            "0",
-        ],
-        "RegisterPopOutputs": [
+        "EnableStructuredGatesDataQualification": [
             "0",
             "1",
         ],
-        "FlopRamWidthTiles": [
+        "RegisterPopOutputs": [
+            "0",
             "1",
         ],
     },
@@ -222,15 +221,14 @@ br_verilog_elab_and_lint_test_suite(
         "Width": ["8"],
         "FlopRamAddressDepthStages": [
             "0",
+            "1",
         ],
-        "FlopRamReadDataDepthStages": [
-            "0",
-        ],
-        "RegisterPopOutputs": [
+        "EnableStructuredGatesDataQualification": [
             "0",
             "1",
         ],
-        "FlopRamWidthTiles": [
+        "RegisterPopOutputs": [
+            "0",
             "1",
         ],
     },

--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -183,11 +183,9 @@ br_verilog_elab_and_lint_test_suite(
         "Width": ["8"],
         "FlopRamAddressDepthStages": [
             "0",
-            "1",
         ],
         "FlopRamReadDataDepthStages": [
             "0",
-            "1",
         ],
         "RegisterPopOutputs": [
             "0",
@@ -195,7 +193,6 @@ br_verilog_elab_and_lint_test_suite(
         ],
         "FlopRamWidthTiles": [
             "1",
-            "2",
         ],
     },
     top = "br_cdc_fifo_flops",
@@ -225,11 +222,9 @@ br_verilog_elab_and_lint_test_suite(
         "Width": ["8"],
         "FlopRamAddressDepthStages": [
             "0",
-            "1",
         ],
         "FlopRamReadDataDepthStages": [
             "0",
-            "1",
         ],
         "RegisterPopOutputs": [
             "0",
@@ -237,7 +232,6 @@ br_verilog_elab_and_lint_test_suite(
         ],
         "FlopRamWidthTiles": [
             "1",
-            "2",
         ],
     },
     top = "br_cdc_fifo_flops_push_credit",

--- a/cdc/rtl/br_cdc_fifo_flops.sv
+++ b/cdc/rtl/br_cdc_fifo_flops.sv
@@ -72,6 +72,10 @@ module br_cdc_fifo_flops #(
     // Number of pipeline register stages inserted along the read data path in the width dimension.
     // Must be at least 0.
     parameter int FlopRamReadDataWidthStages = 0,
+    // If 1 then the read data is qualified with the rd_data_valid signal, 0 when not valid. Should
+    // generally always be 1, unless gating logic is managed externally (including netlist-level
+    // concerns!).
+    parameter bit EnableStructuredGatesDataQualification = 1,
     // If 1, cover that the push side experiences backpressure.
     // If 0, assert that there is never backpressure.
     parameter bit EnableCoverPushBackpressure = 1,
@@ -186,6 +190,7 @@ module br_cdc_fifo_flops #(
       // Since there is an asynchronous path on the read,
       // we need to use structured gates for the read mux.
       .UseStructuredGates(1),
+      .EnableStructuredGatesDataQualification(EnableStructuredGatesDataQualification),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_ram_flops (
       .wr_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME

--- a/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
@@ -79,9 +79,9 @@ module br_cdc_fifo_flops_push_credit #(
     // Number of pipeline register stages inserted along the read data path in the width dimension.
     // Must be at least 0.
     parameter int FlopRamReadDataWidthStages = 0,
-    // If 1 and UseStructuredGates is 1, then the read data is qualified with the
-    // rd_data_valid signal, 0 when not valid. Should generally always be 1 for CDC
-    // use cases.
+    // If 1 then the read data is qualified with the rd_data_valid signal, 0 when not valid. Should
+    // generally always be 1, unless gating logic is managed externally (including netlist-level
+    // concerns!).
     parameter bit EnableStructuredGatesDataQualification = 1,
     // If 1, cover that credit_withhold can be non-zero.
     // Otherwise, assert that it is always zero.

--- a/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
@@ -79,6 +79,10 @@ module br_cdc_fifo_flops_push_credit #(
     // Number of pipeline register stages inserted along the read data path in the width dimension.
     // Must be at least 0.
     parameter int FlopRamReadDataWidthStages = 0,
+    // If 1 and UseStructuredGates is 1, then the read data is qualified with the
+    // rd_data_valid signal, 0 when not valid. Should generally always be 1 for CDC
+    // use cases.
+    parameter bit EnableStructuredGatesDataQualification = 1,
     // If 1, cover that credit_withhold can be non-zero.
     // Otherwise, assert that it is always zero.
     parameter bit EnableCoverCreditWithhold = 1,
@@ -217,6 +221,7 @@ module br_cdc_fifo_flops_push_credit #(
       // Since there is an asynchronous path on the read,
       // we need to use structured gates for the read mux.
       .UseStructuredGates(1),
+      .EnableStructuredGatesDataQualification(EnableStructuredGatesDataQualification),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_ram_flops (
       .wr_clk(push_clk),  // ri lint_check_waive SAME_CLOCK_NAME

--- a/cdc/sim/BUILD.bazel
+++ b/cdc/sim/BUILD.bazel
@@ -63,7 +63,6 @@ verilog_elab_test(
             ],
             "FlopRamReadDataDepthStages": [
                 "0",
-                "1",
             ],
             "NumSyncStages": [
                 "2",
@@ -130,7 +129,6 @@ verilog_elab_test(
             ],
             "FlopRamReadDataDepthStages": [
                 "0",
-                "1",
             ],
             "NumSyncStages": [
                 "2",

--- a/cdc/sim/BUILD.bazel
+++ b/cdc/sim/BUILD.bazel
@@ -61,8 +61,9 @@ verilog_elab_test(
                 "0",
                 "1",
             ],
-            "FlopRamReadDataDepthStages": [
+            "EnableStructuredGatesDataQualification": [
                 "0",
+                "1",
             ],
             "NumSyncStages": [
                 "2",
@@ -127,8 +128,9 @@ verilog_elab_test(
                 "0",
                 "1",
             ],
-            "FlopRamReadDataDepthStages": [
+            "EnableStructuredGatesDataQualification": [
                 "0",
+                "1",
             ],
             "NumSyncStages": [
                 "2",

--- a/ram/rtl/BUILD.bazel
+++ b/ram/rtl/BUILD.bazel
@@ -155,6 +155,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_ram_flops_tile",
     deps = [
         ":br_ram_flops_tile",
+        "//gate/rtl:br_gate_mock",
         "//mux/rtl:br_mux_bin_structured_gates_mock",
     ],
 )
@@ -551,6 +552,7 @@ br_verilog_elab_and_lint_test_suite(
     top = "br_ram_flops",
     deps = [
         ":br_ram_flops",
+        "//gate/rtl:br_gate_mock",
         "//mux/rtl:br_mux_bin_structured_gates_mock",
     ],
 )

--- a/ram/rtl/br_ram_flops.sv
+++ b/ram/rtl/br_ram_flops.sv
@@ -122,6 +122,17 @@ module br_ram_flops #(
   `BR_ASSERT_STATIC(width_tiles_gte1_a, WidthTiles >= 1)
   `BR_ASSERT_STATIC(width_tiles_evenly_divides_width_a, (WidthTiles * TileWidth) == Width)
 
+  // Structured gates checks (CDC use cases)
+  // Multi-tile configurations are not supported with structured gates.
+  `BR_ASSERT_STATIC(no_depth_tiles_if_structured_gates_a, (DepthTiles == 1) || !UseStructuredGates)
+  `BR_ASSERT_STATIC(no_width_tiles_if_structured_gates_a, (WidthTiles == 1) || !UseStructuredGates)
+  // Multi-stage read data pipelines are not supported with structured gates, data must be
+  // qualified before destination flop (which is not supported).
+  `BR_ASSERT_STATIC(no_read_depth_stages_if_structured_gates_a,
+                    (ReadDataDepthStages == 0) || !UseStructuredGates)
+  `BR_ASSERT_STATIC(no_read_width_stages_if_structured_gates_a,
+                    (ReadDataWidthStages == 0) || !UseStructuredGates)
+
   // Address stages checks
   `BR_ASSERT_STATIC(address_depth_stages_gte0_a, AddressDepthStages >= 0)
 

--- a/ram/rtl/br_ram_flops.sv
+++ b/ram/rtl/br_ram_flops.sv
@@ -29,8 +29,10 @@ module br_ram_flops #(
     parameter int Depth = 2,  // Number of entries in the RAM. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the RAM. Must be at least 1.
     // Number of tiles along the depth (address) dimension. Must be at least 1 and evenly divide Depth.
+    // Must be 1 if UseStructuredGates is 1.
     parameter int DepthTiles = 1,
     // Number of tiles along the width (data) dimension. Must be at least 1 and evenly divide Width.
+    // Must be 1 if UseStructuredGates is 1.
     parameter int WidthTiles = 1,
     // If 1, allow partial writes to the memory using the wr_word_en signal.
     // If 0, only full writes are allowed and wr_word_en is ignored.
@@ -45,10 +47,10 @@ module br_ram_flops #(
     // in the depth dimension. Must be at least 0.
     parameter int AddressDepthStages = 0,
     // Number of pipeline register stages inserted along the read data path in the depth dimension.
-    // Must be at least 0.
+    // Must be at least 0. Must be 0 if UseStructuredGates is 1.
     parameter int ReadDataDepthStages = 0,
     // Number of pipeline register stages inserted along the read data path in the width dimension.
-    // Must be at least 0.
+    // Must be at least 0. Must be 0 if UseStructuredGates is 1.
     parameter int ReadDataWidthStages = 0,
     // If 1, then each memory tile has a read-after-write hazard latency of 0 cycles, i.e.,
     // if the tile read and write address are valid and equal on the same cycle then the tile
@@ -64,6 +66,10 @@ module br_ram_flops #(
     // If 1, use structured mux2 gates for the read mux instead of relying on synthesis.
     // This is required if write and read clocks are different.
     parameter bit UseStructuredGates = 0,
+    // If 1 and UseStructuredGates is 1, then the read data is qualified with the
+    // rd_data_valid signal, 0 when not valid. Should generally always be 1 for CDC
+    // use cases.
+    parameter bit EnableStructuredGatesDataQualification = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     localparam int AddressWidth = br_math::clamped_clog2(Depth),
@@ -290,6 +296,7 @@ module br_ram_flops #(
           .EnableBypass(TileEnableBypass),
           .EnableReset(EnableMemReset),
           .UseStructuredGates(UseStructuredGates),
+          .EnableStructuredGatesDataQualification(EnableStructuredGatesDataQualification),
           .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
       ) br_ram_flops_tile (
           .wr_clk,

--- a/ram/rtl/br_ram_flops_tile.sv
+++ b/ram/rtl/br_ram_flops_tile.sv
@@ -357,7 +357,7 @@ module br_ram_flops_tile #(
 
       if (UseStructuredGates) begin : gen_structured_read
         logic [Depth-1:0][Width-1:0] mem_packed;
-        logic [NumWords-1:0][WordWidth-1:0] rd_data_mem_unqual;
+        logic [NumWords-1:0][WordWidth-1:0] _BR_CDC_PRESERVE_NET__rd_data_mem_unqual;
 
 
         for (genvar i = 0; i < Depth; i++) begin : gen_mem_packed
@@ -370,7 +370,7 @@ module br_ram_flops_tile #(
         ) br_mux_bin_structured_gates_inst (
             .select(rd_addr[rport]),
             .in(mem_packed),
-            .out(rd_data_mem_unqual),
+            .out(_BR_CDC_PRESERVE_NET__rd_data_mem_unqual),
             .out_valid()
         );
 
@@ -378,14 +378,14 @@ module br_ram_flops_tile #(
           for (genvar j = 0; j < NumWords; j++) begin : gen_data_qualification_word
             for (genvar k = 0; k < WordWidth; k++) begin : gen_data_qualification_word_bit
               br_gate_and2 br_gate_and2_inst (
-                  .in0(rd_data_mem_unqual[j][k]),
+                  .in0(_BR_CDC_PRESERVE_NET__rd_data_mem_unqual[j][k]),
                   .in1(rd_data_valid[rport]),
                   .out(rd_data_mem[j][k])
               );
             end
           end
         end else begin : gen_no_data_qualification
-          assign rd_data_mem = rd_data_mem_unqual;
+          assign rd_data_mem = _BR_CDC_PRESERVE_NET__rd_data_mem_unqual;
         end
       end else begin : gen_behavioral_read
         // This coding style is more friendly for emulation than using br_mux_bin.

--- a/ram/rtl/br_ram_flops_tile.sv
+++ b/ram/rtl/br_ram_flops_tile.sv
@@ -353,7 +353,7 @@ module br_ram_flops_tile #(
     assign rd_data_valid = rd_addr_valid;
 
     for (genvar rport = 0; rport < NumReadPorts; rport++) begin : gen_read_port
-      logic [NumWords-1:0][WordWidth-1:0] rd_data_mem;
+      logic [NumWords-1:0][WordWidth-1:0] rd_data_mem, rd_data_mem_unqual;
 
       if (UseStructuredGates) begin : gen_structured_read
         logic [Depth-1:0][Width-1:0] mem_packed;
@@ -373,11 +373,11 @@ module br_ram_flops_tile #(
         );
 
         if (EnableStructuredGatesDataQualification) begin : gen_data_qualification
-          for (genvar i = 0; i < Width; i++) begin : gen_data_qualification_word
+          for (genvar j = 0; j < Width; j++) begin : gen_data_qualification_word
             br_gate_and2 br_gate_and2_inst (
-                .in0(rd_data_mem_unqual[i]),
-                .in1(rd_data_valid),
-                .out(rd_data_mem[i])
+                .in0(rd_data_mem_unqual[j]),
+                .in1(rd_data_valid[rport]),
+                .out(rd_data_mem[j])
             );
           end
         end else begin : gen_no_data_qualification

--- a/ram/rtl/br_ram_flops_tile.sv
+++ b/ram/rtl/br_ram_flops_tile.sv
@@ -353,10 +353,12 @@ module br_ram_flops_tile #(
     assign rd_data_valid = rd_addr_valid;
 
     for (genvar rport = 0; rport < NumReadPorts; rport++) begin : gen_read_port
-      logic [NumWords-1:0][WordWidth-1:0] rd_data_mem, rd_data_mem_unqual;
+      logic [NumWords-1:0][WordWidth-1:0] rd_data_mem;
 
       if (UseStructuredGates) begin : gen_structured_read
         logic [Depth-1:0][Width-1:0] mem_packed;
+        logic [NumWords-1:0][WordWidth-1:0] rd_data_mem_unqual;
+
 
         for (genvar i = 0; i < Depth; i++) begin : gen_mem_packed
           assign mem_packed[i] = mem[i];
@@ -373,12 +375,14 @@ module br_ram_flops_tile #(
         );
 
         if (EnableStructuredGatesDataQualification) begin : gen_data_qualification
-          for (genvar j = 0; j < Width; j++) begin : gen_data_qualification_word
-            br_gate_and2 br_gate_and2_inst (
-                .in0(rd_data_mem_unqual[j]),
-                .in1(rd_data_valid[rport]),
-                .out(rd_data_mem[j])
-            );
+          for (genvar j = 0; j < NumWords; j++) begin : gen_data_qualification_word
+            for (genvar k = 0; k < WordWidth; k++) begin : gen_data_qualification_word_bit
+              br_gate_and2 br_gate_and2_inst (
+                  .in0(rd_data_mem_unqual[j][k]),
+                  .in1(rd_data_valid[rport]),
+                  .out(rd_data_mem[j][k])
+              );
+            end
           end
         end else begin : gen_no_data_qualification
           assign rd_data_mem = rd_data_mem_unqual;

--- a/ram/rtl/br_ram_flops_tile.sv
+++ b/ram/rtl/br_ram_flops_tile.sv
@@ -357,6 +357,7 @@ module br_ram_flops_tile #(
 
       if (UseStructuredGates) begin : gen_structured_read
         logic [Depth-1:0][Width-1:0] mem_packed;
+        // ri lint_check_waive VAR_NAME
         logic [NumWords-1:0][WordWidth-1:0] _BR_CDC_PRESERVE_NET__rd_data_mem_unqual;
 
 


### PR DESCRIPTION
added a br_gate_and2 array on data output in flops ram when used with StructuredGates. This ensures that the output data is qualified on the rd_data_valid before hitting any downstream combo logic (i.e. external to BR component) before the destination flop (which might be external). 

also added asserts to make sure that there's no tiling or read pipelining in the br_ram_flops when used with StructuredGates (tile muxing is not structured!)