### PR TITLE
Disable unreachable covers in cdc_fifo

### DIFF
--- a/cdc/rtl/internal/br_cdc_fifo_pop_flag_mgr.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_pop_flag_mgr.sv
@@ -54,7 +54,9 @@ module br_cdc_fifo_pop_flag_mgr #(
 
   br_counter_incr #(
       .MaxValue(MaxCount),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableCoverZeroIncrement(0),
+      .EnableCoverReinit(0)
   ) br_counter_incr_pop_count (
       .clk,
       .rst,

--- a/cdc/rtl/internal/br_cdc_fifo_push_flag_mgr.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_flag_mgr.sv
@@ -57,7 +57,9 @@ module br_cdc_fifo_push_flag_mgr #(
 
   br_counter_incr #(
       .MaxValue(MaxCount),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableCoverZeroIncrement(0),
+      .EnableCoverReinit(0)
   ) br_counter_incr_push_count (
       .clk,
       .rst,


### PR DESCRIPTION
reinit is tied to 0.
incr is tied to 1.