### PR TITLE
fix narrow access wstrb

### DIFF
--- a/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axil_msi_fpv_monitor.sv
@@ -105,10 +105,10 @@ module br_amba_axil_msi_fpv_monitor #(
         fv_init_wstrb[i] = {{StrobeWidthPadding{1'b0}}, {EventIdStrobeWidth{1'b1}}};
       end
       for (int j = 0; j < StrobeWidth; j++) begin : gen_asm
-        // if index is not address[StrobeBitWidth-1:0], wstrb must be 0
+        // if index < address[StrobeBitWidth-1:0], wstrb must be 0
         // e.g. if StrobeWidth=8, then StrobeBitWidth=3
-        // if awaddr[2:0] == 3'b010, then only wstrb[2] can be 1, others must be 0
-        if (j != fv_init_awaddr[i][StrobeBitWidth-1:0]) begin
+        // if awaddr[2:0] == 3'b010, then wstrb[7:2] can be 1, lower bits must be 0
+        if (j < fv_init_awaddr[i][StrobeBitWidth-1:0]) begin
           `BR_ASSUME(legal_narrow_access_a, fv_init_wstrb[i][j] == 1'b0)
         end
       end


### PR DESCRIPTION
Thanks to @seanclark-oai , fixing wrong constraints of narrow access wstrb.

index = awaddrs[StrobeBitWidth-1:0]
This is axi-lite interface, therefore, I only need to make sure wstrb[< index] must be 0.
There is no awsize in axi-lite, so I don't need to add further constraints on wstrb based on size.
