### PR TITLE
Remove illegal UseStructuredGates sweep

### DIFF
--- a/ram/fpv/BUILD.bazel
+++ b/ram/fpv/BUILD.bazel
@@ -481,6 +481,22 @@ br_verilog_fpv_test_tools_suite(
         ): [
             ("1", "1"),
         ],
+        # when UseStructuredGates = 1,
+        # DepthTiles and WidthTiles must be 1
+        (
+            "DepthTiles",
+            "UseStructuredGates",
+        ): [
+            ("2", "1"),
+            ("3", "1"),
+        ],
+        (
+            "WidthTiles",
+            "UseStructuredGates",
+        ): [
+            ("2", "1"),
+            ("3", "1"),
+        ],
     },
     params = {
         "Depth": [
@@ -536,14 +552,6 @@ br_verilog_fpv_test_tools_suite(
         # write on all ports without address conflicts
         "-parameter Depth 6",
     ],
-    illegal_param_combinations = {
-        (
-            "TileEnableBypass",
-            "UseStructuredGates",
-        ): [
-            ("1", "1"),
-        ],
-    },
     params = {
         "TileEnableBypass": [
             "0",
@@ -567,10 +575,6 @@ br_verilog_fpv_test_tools_suite(
             "4",
             "6",
         ],
-        "UseStructuredGates": [
-            "0",
-            "1",
-        ],
     },
     tools = {
         "jg": "br_ram_flops_tile_1clk_fpv.jg.tcl",
@@ -585,6 +589,20 @@ br_verilog_fpv_test_tools_suite(
     illegal_param_combinations = {
         (
             "TileEnableBypass",
+            "UseStructuredGates",
+        ): [
+            ("1", "1"),
+        ],
+        # when UseStructuredGates = 1,
+        # ReadDataDepthStages and ReadDataWidthStages must be 0
+        (
+            "ReadDataDepthStages",
+            "UseStructuredGates",
+        ): [
+            ("1", "1"),
+        ],
+        (
+            "ReadDataWidthStages",
             "UseStructuredGates",
         ): [
             ("1", "1"),
@@ -633,7 +651,7 @@ br_verilog_fpv_test_tools_suite(
     name = "br_ram_flops_2clk_test_tile",
     elab_opts = [
         "-parameter TileEnableBypass 0",
-        "-parameter UseStructuredGates 1",
+        "-parameter UseStructuredGates 0",
     ],
     illegal_param_combinations = {
         # DepthTiles must be at least 1 and evenly divide Depth
@@ -763,8 +781,23 @@ br_verilog_fpv_test_tools_suite(
     name = "br_ram_flops_2clk_test_delay",
     elab_opts = [
         "-parameter TileEnableBypass 0",
-        "-parameter UseStructuredGates 1",
     ],
+    illegal_param_combinations = {
+        # when UseStructuredGates = 1,
+        # ReadDataDepthStages and ReadDataWidthStages must be 0
+        (
+            "ReadDataDepthStages",
+            "UseStructuredGates",
+        ): [
+            ("1", "1"),
+        ],
+        (
+            "ReadDataWidthStages",
+            "UseStructuredGates",
+        ): [
+            ("1", "1"),
+        ],
+    },
     params = {
         "TileEnableBypass": [
             "0",


### PR DESCRIPTION
1. UseStructuredGates = 1, DepthTiles must be 1
2. UseStructuredGates = 1, WidthTiles must be 1
3. UseStructuredGates = 1, ReadDataDepthStages must be 0
4. UseStructuredGates = 1, ReadDataWidthStages must be 0

When test is not testing delay (parameter sweep on tiles, ports, etc), use default UseStructuredGates value, which is 0.
Then we don't have to exclude extra illegal_param_combinations.

BR Ram tot should be clean now.