### PR TITLE
More br_fifo fix

### DIFF
--- a/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
@@ -35,6 +35,15 @@ module br_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
     // The RAM depth may be made larger than the minimum if convenient (e.g. the
     // backing RAM is an SRAM of slightly larger depth than the FIFO depth).
     parameter int RamDepth = Depth,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     localparam int AddrWidth = br_math::clamped_clog2(RamDepth),
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int CreditWidth = $clog2(MaxCredit + 1)
@@ -87,7 +96,10 @@ module br_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
   br_credit_receiver_fpv_monitor #(
       .PStatic(0),
       .MaxCredit(MaxCredit),
-      .NumWritePorts(1)
+      .NumWritePorts(1),
+      .EnableCoverPushCreditStall(EnableCoverPushCreditStall),
+      .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset)
   ) br_credit_receiver_fpv_monitor (
       .clk,
       .rst,
@@ -158,5 +170,8 @@ bind br_fifo_ctrl_1r1w_push_credit br_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
     .RegisterPushOutputs(RegisterPushOutputs),
     .RegisterPopOutputs(RegisterPopOutputs),
     .RamReadLatency(RamReadLatency),
-    .RamDepth(RamDepth)
+    .RamDepth(RamDepth),
+    .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+    .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+    .EnableCoverPushCreditStall(EnableCoverPushCreditStall)
 ) monitor (.*);

--- a/fifo/fpv/br_fifo/br_fifo_flops_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo/br_fifo_flops_push_credit_fpv_monitor.sv
@@ -30,6 +30,15 @@ module br_fifo_flops_push_credit_fpv_monitor #(
     parameter int FlopRamAddressDepthStages = 0,
     parameter int FlopRamReadDataDepthStages = 0,
     parameter int FlopRamReadDataWidthStages = 0,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int CreditWidth = $clog2(MaxCredit + 1)
@@ -73,7 +82,10 @@ module br_fifo_flops_push_credit_fpv_monitor #(
   br_credit_receiver_fpv_monitor #(
       .PStatic(0),
       .MaxCredit(MaxCredit),
-      .NumWritePorts(1)
+      .NumWritePorts(1),
+      .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall(EnableCoverPushCreditStall)
   ) br_credit_receiver_fpv_monitor (
       .clk,
       .rst,
@@ -134,5 +146,8 @@ bind br_fifo_flops_push_credit br_fifo_flops_push_credit_fpv_monitor #(
     .FlopRamWidthTiles(FlopRamWidthTiles),
     .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
     .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages),
-    .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages)
+    .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages),
+    .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+    .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+    .EnableCoverPushCreditStall(EnableCoverPushCreditStall)
 ) monitor (.*);

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor.sv
@@ -40,6 +40,15 @@ module br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor #(
     // driven directly from a flop. This comes at the expense of one additional
     // cycle of credit loop latency.
     parameter bit RegisterPushOutputs = 0,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
     // If 1, place a register on the deallocation path from the pop-side
     // staging buffer to the freelist. This improves timing at the cost of
     // adding a cycle of backpressure latency.
@@ -102,7 +111,10 @@ module br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor #(
   br_credit_receiver_fpv_monitor #(
       .PStatic(0),
       .MaxCredit(Depth),
-      .NumWritePorts(NumWritePorts)
+      .NumWritePorts(NumWritePorts),
+      .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall(EnableCoverPushCreditStall)
   ) fv_credit (
       .clk,
       .rst,
@@ -168,7 +180,7 @@ module br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor #(
       .Width(Width),
       .StagingBufferDepth(StagingBufferDepth),
       .HasStagingBuffer(HasStagingBuffer),
-      .EnableCoverPushBackpressure(1)
+      .EnableCoverPushBackpressure(0)
   ) fv_checker (
       .clk,
       .rst,
@@ -192,6 +204,9 @@ bind br_fifo_shared_dynamic_ctrl_push_credit br_fifo_shared_dynamic_ctrl_push_cr
     .StagingBufferDepth(StagingBufferDepth),
     .RegisterPopOutputs(RegisterPopOutputs),
     .RegisterPushOutputs(RegisterPushOutputs),
+    .EnableCoverPushCreditStall(EnableCoverPushCreditStall),
+    .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+    .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
     .RegisterDeallocation(RegisterDeallocation),
     .DataRamReadLatency(DataRamReadLatency),
     .PointerRamReadLatency(PointerRamReadLatency),

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv_monitor.sv
@@ -40,6 +40,15 @@ module br_fifo_shared_dynamic_flops_push_credit_fpv_monitor #(
     // driven directly from a flop. This comes at the expense of one additional
     // cycle of credit loop latency.
     parameter bit RegisterPushOutputs = 0,
+    // If 1, cover that push_credit_stall can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushCreditStall = 1,
+    // If 1, cover that credit_withhold can be non-zero.
+    // Otherwise, assert that it is always zero.
+    parameter bit EnableCoverCreditWithhold = 1,
+    // If 1, cover that push_sender_in_reset can be asserted
+    // Otherwise, assert that it is never asserted.
+    parameter bit EnableCoverPushSenderInReset = 1,
     // If 1, place a register on the deallocation path from the pop-side
     // staging buffer to the freelist. This improves timing at the cost of
     // adding a cycle of backpressure latency.
@@ -101,7 +110,10 @@ module br_fifo_shared_dynamic_flops_push_credit_fpv_monitor #(
   br_credit_receiver_fpv_monitor #(
       .PStatic(0),
       .MaxCredit(Depth),
-      .NumWritePorts(NumWritePorts)
+      .NumWritePorts(NumWritePorts),
+      .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+      .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
+      .EnableCoverPushCreditStall(EnableCoverPushCreditStall)
   ) fv_credit (
       .clk,
       .rst,
@@ -131,7 +143,7 @@ module br_fifo_shared_dynamic_flops_push_credit_fpv_monitor #(
       .Width(Width),
       .StagingBufferDepth(StagingBufferDepth),
       .HasStagingBuffer(HasStagingBuffer),
-      .EnableCoverPushBackpressure(1)
+      .EnableCoverPushBackpressure(0)
   ) fv_checker (
       .clk,
       .rst,
@@ -156,6 +168,9 @@ bind br_fifo_shared_dynamic_flops_push_credit
     .StagingBufferDepth(StagingBufferDepth),
     .RegisterPopOutputs(RegisterPopOutputs),
     .RegisterPushOutputs(RegisterPushOutputs),
+    .EnableCoverPushCreditStall(EnableCoverPushCreditStall),
+    .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
+    .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
     .RegisterDeallocation(RegisterDeallocation),
     .DataRamDepthTiles(DataRamDepthTiles),
     .DataRamWidthTiles(DataRamWidthTiles),


### PR DESCRIPTION
1. Add new cover parameters, add corresponding cover/assumption
2. for _push_credit variations, disable valid/ready protocol properties in FV checker (because push_ready is tied to 1 for this checker, push back pressure is controlled by push_credit)