### PR TITLE
Disable unreachable covers in br_fifo_shared_dynamic_push_ctrl

### DIFF
--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
@@ -149,6 +149,7 @@ module br_fifo_shared_dynamic_push_ctrl #(
         .NumSymbols(NumWritePorts),
         .NumFlows(NumWritePorts),
         .SymbolWidth(AddrWidth),
+        .EnableCoverMorePopReadyThanSendable(EnableCoverPushBackpressure),
         // TODO(zhemao): check this is right
         .EnableAssertFinalNotSendable(0)
     ) br_multi_xfer_distributor_rr_inst (

--- a/multi_xfer/rtl/br_multi_xfer_distributor_rr.sv
+++ b/multi_xfer/rtl/br_multi_xfer_distributor_rr.sv
@@ -36,6 +36,11 @@ module br_multi_xfer_distributor_rr #(
     // If 1, cover that push_sendable can be greater than push_receivable.
     // If 0, assert that push_sendable is always less than or equal to push_receivable.
     parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, cover that there are more pop flows ready to accept than
+    // sendable symbols.
+    // Otherwise, assert that there are never more pop flows ready to accept
+    // than sendable symbols.
+    parameter bit EnableCoverMorePopReadyThanSendable = 1,
     // If 1, assert that push_data is stable when push_sendable > push_receivable.
     // If 0, cover that push_data is unstable when push_sendable > push_receivable.
     parameter bit EnableAssertPushDataStability = 1,
@@ -69,6 +74,7 @@ module br_multi_xfer_distributor_rr #(
       .NumFlows(NumFlows),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableCoverMorePopReadyThanSendable(EnableCoverMorePopReadyThanSendable),
       .EnableAssertFinalNotSendable(EnableAssertFinalNotSendable)
   ) br_multi_xfer_distributor_core_inst (
       .clk,
@@ -90,7 +96,8 @@ module br_multi_xfer_distributor_rr #(
   br_arb_multi_rr #(
       .NumRequesters(NumFlows),
       .MaxGrantPerCycle(NumSymbols),
-      .EnableCoverBlockPriorityUpdate(0)
+      .EnableCoverBlockPriorityUpdate(0),
+      .EnableCoverMoreRequestThanAllowed(EnableCoverMorePopReadyThanSendable)
   ) br_arb_multi_rr_inst (
       .clk,
       .rst,

--- a/multi_xfer/rtl/internal/br_multi_xfer_distributor_core.sv
+++ b/multi_xfer/rtl/internal/br_multi_xfer_distributor_core.sv
@@ -27,6 +27,7 @@ module br_multi_xfer_distributor_core #(
     parameter int NumFlows = 2,
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushDataStability = 1,
+    parameter bit EnableCoverMorePopReadyThanSendable = 1,
     parameter bit EnableAssertFinalNotSendable = 1,
 
     localparam int CountWidth = $clog2(NumSymbols + 1)
@@ -77,6 +78,12 @@ module br_multi_xfer_distributor_core #(
       .receivable(push_receivable),
       .data(push_data)
   );
+
+  if (EnableCoverMorePopReadyThanSendable) begin : gen_more_pop_ready_than_sendable_cover
+    `BR_COVER_INTG(more_pop_ready_than_sendable_c, $countones(pop_ready) > push_sendable)
+  end else begin : gen_no_more_pop_ready_than_sendable_assert
+    `BR_ASSERT_INTG(no_more_pop_ready_than_sendable_a, $countones(pop_ready) <= push_sendable)
+  end
 
   // Internal integration checks
   `BR_ASSERT_IMPL(grant_count_lt_allowed_a, grant_count <= grant_allowed)


### PR DESCRIPTION
When there is no push backpressure (e.g. in the push_credit FIFO), there
can never be more entries requested than there are available. As a
result, some covers in the multi-xfer distributor won't be hit. Allow
these to be disabled by parameter.