### PR TITLE
Disable backpressure coverage in shared FIFO read crossbar corner case

### DIFF
--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv.jg.tcl
@@ -36,6 +36,16 @@ set_prove_time_limit 600s
 # ready to hold until valid is asserted.
 # TODO(zhemao): Find a way to disable in RTL
 cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
+# There are certain cases where the backpressure precondition on these checks are unreachable.
+# Annoying to disable in RTL because only certain output ports are affected.
+# These are redundant with the push integration checks on the muxes, so just disable them all
+# TODO(masai): Figure out a more fine-grained waiver
+array set param_list [get_design_info -list parameter]
+set NumReadPorts $param_list(NumReadPorts)
+set Depth $param_list(Depth)
+if {$Depth < 2 * $NumReadPorts} {
+  cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
+}
 
 # prove command
 prove -all

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl
@@ -43,6 +43,16 @@ set_prove_time_limit 600s
 # ready to hold until valid is asserted.
 # TODO(zhemao): Find a way to disable in RTL
 cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
+# There are certain cases where the backpressure precondition on these checks are unreachable.
+# Annoying to disable in RTL because only certain output ports are affected.
+# These are redundant with the push integration checks on the muxes, so just disable them all
+# TODO(masai): Figure out a more fine-grained waiver
+array set param_list [get_design_info -list parameter]
+set NumReadPorts $param_list(NumReadPorts)
+set Depth $param_list(Depth)
+if {$Depth < 2 * $NumReadPorts} {
+  cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
+}
 
 # prove command
 prove -all

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv.jg.tcl
@@ -24,6 +24,16 @@ set_prove_time_limit 600s
 # ready to hold until valid is asserted.
 # TODO(zhemao): Find a way to disable in RTL
 cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
+# There are certain cases where the backpressure precondition on these checks are unreachable.
+# Annoying to disable in RTL because only certain output ports are affected.
+# These are redundant with the push integration checks on the muxes, so just disable them all
+# TODO(masai): Figure out a more fine-grained waiver
+array set param_list [get_design_info -list parameter]
+set NumReadPorts $param_list(NumReadPorts)
+set Depth $param_list(Depth)
+if {$Depth < 2 * $NumReadPorts} {
+  cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
+}
 
 # prove command
 prove -all

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl
@@ -37,6 +37,16 @@ set_prove_time_limit 600s
 # ready to hold until valid is asserted.
 # TODO(zhemao): Find a way to disable in RTL
 cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
+# There are certain cases where the backpressure precondition on these checks are unreachable.
+# Annoying to disable in RTL because only certain output ports are affected.
+# These are redundant with the push integration checks on the muxes, so just disable them all
+# TODO(masai): Figure out a more fine-grained waiver
+array set param_list [get_design_info -list parameter]
+set NumReadPorts $param_list(NumReadPorts)
+set Depth $param_list(Depth)
+if {$Depth < 2 * $NumReadPorts} {
+  cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
+}
 
 # prove command
 prove -all

--- a/fifo/rtl/br_fifo_shared_pop_ctrl_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl_ext_arbiter.sv
@@ -211,7 +211,7 @@ module br_fifo_shared_pop_ctrl_ext_arbiter #(
   br_fifo_shared_read_xbar #(
       .NumFifos(NumFifos),
       .NumReadPorts(NumReadPorts),
-      .AddrWidth(AddrWidth),
+      .Depth(Depth),
       .Width(Width),
       .RamReadLatency(RamReadLatency),
       .EnableAssertPushValidStability(1),

--- a/fifo/rtl/internal/BUILD.bazel
+++ b/fifo/rtl/internal/BUILD.bazel
@@ -252,7 +252,10 @@ br_verilog_elab_and_lint_test_suite(
             "1",
             "2",
         ],
-        "AddrWidth": ["2"],
+        "Depth": [
+            "3",
+            "4",
+        ],
     },
     deps = [":br_fifo_shared_read_xbar"],
 )

--- a/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
+++ b/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
@@ -20,10 +20,11 @@ module br_fifo_shared_read_xbar #(
     parameter int NumFifos = 2,
     parameter int NumReadPorts = 1,
     parameter int RamReadLatency = 0,
-    parameter int AddrWidth = 1,
+    parameter int Depth = 2,
     parameter int Width = 1,
     parameter bit EnableAssertPushValidStability = 0,
-    parameter bit ArbiterAlwaysGrants = 1
+    parameter bit ArbiterAlwaysGrants = 1,
+    localparam int AddrWidth = $clog2(Depth)
 ) (
     // ri lint_check_waive HIER_NET_NOT_READ INPUT_NOT_READ
     input logic clk,
@@ -54,7 +55,7 @@ module br_fifo_shared_read_xbar #(
   // TODO(zhemao): Remove this restriction once we have efficient modulo block.
   `BR_ASSERT_STATIC(legal_num_read_ports_a, NumReadPorts >= 1 && br_math::is_power_of_2(
                     NumReadPorts))
-  `BR_ASSERT_STATIC(legal_addr_width_a, AddrWidth >= $clog2(NumReadPorts))
+  `BR_ASSERT_STATIC(legal_depth_a, Depth >= NumReadPorts)
 
   // Read Address Demux per FIFO
 
@@ -106,6 +107,16 @@ module br_fifo_shared_read_xbar #(
   logic [NumReadPorts-1:0] pop_rd_data_fifo_id_valid;
 
   for (genvar i = 0; i < NumReadPorts; i++) begin : gen_read_port_mux
+    // The number of entries mapped to this read port
+    localparam int ReadPortEntries =
+        ((Depth & NumReadPorts) == 0) ? (Depth / NumReadPorts) :
+        (i < Depth % NumReadPorts) ? (Depth / NumReadPorts + 1) : (Depth / NumReadPorts);
+    // If there is only one entry mapped to a port, it's impossible for more than one
+    // FIFO to request to that port
+    localparam bit EnableCoverMuxPushBackpressure = ReadPortEntries > 1;
+    localparam bit EnableAssertMuxPushValidStability =
+        EnableAssertPushValidStability && EnableCoverMuxPushBackpressure;
+
     logic [NumFifos-1:0] mux_push_ready;
     logic [NumFifos-1:0] mux_push_valid;
     logic [NumFifos-1:0][TotalMuxWidth-1:0] mux_push_data;
@@ -121,8 +132,9 @@ module br_fifo_shared_read_xbar #(
     br_flow_mux_core #(
         .NumFlows(NumFifos),
         .Width(TotalMuxWidth),
-        .EnableAssertPushValidStability(EnableAssertPushValidStability),
-        .EnableAssertPushDataStability(EnableAssertPushValidStability),
+        .EnableCoverPushBackpressure(EnableCoverMuxPushBackpressure),
+        .EnableAssertPushValidStability(EnableAssertMuxPushValidStability),
+        .EnableAssertPushDataStability(EnableAssertMuxPushValidStability),
         .EnableCoverPopBackpressure(0),
         .ArbiterAlwaysGrants(ArbiterAlwaysGrants)
     ) br_flow_mux_core_inst (


### PR DESCRIPTION
The backpressure cover point between demux and mux is unreachable if
there happens to be only one entry mapped to the read port. Need to
disable the integration cover in the mux. The implementation cover in
the demux is a bit trickier, since it should be covered on one output
interface but not the other.