### PR TITLE
Disallow dynamic FIFO configurations with more read ports than entries

### DIFF
--- a/fifo/fpv/br_fifo_shared_dynamic/BUILD.bazel
+++ b/fifo/fpv/br_fifo_shared_dynamic/BUILD.bazel
@@ -310,6 +310,13 @@ br_verilog_fpv_test_tools_suite(
             ("3", "3"),
             ("5", "3"),
         ],
+        # Depth >= NumReadPorts
+        (
+            "Depth",
+            "NumReadPorts",
+        ): [
+            ("3", "4"),
+        ],
     },
     params = {
         "Depth": [

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
@@ -150,7 +150,7 @@ module br_fifo_shared_dynamic_ctrl #(
   `BR_ASSERT_STATIC(legal_num_read_ports_a, NumReadPorts >= 1 && br_math::is_power_of_2(
                     NumReadPorts))
   `BR_ASSERT_STATIC(num_fifos_in_range_a, NumFifos >= 2)
-  `BR_ASSERT_STATIC(depth_in_range_a, Depth > 2 * NumWritePorts)
+  `BR_ASSERT_STATIC(depth_in_range_a, Depth > 2 * NumWritePorts && Depth >= NumReadPorts)
   `BR_ASSERT_STATIC(width_in_range_a, Width >= 1)
   `BR_ASSERT_STATIC(staging_buffer_depth_in_range_a, StagingBufferDepth >= 1)
   `BR_ASSERT_STATIC(pointer_ram_read_latency_in_range_a, PointerRamReadLatency >= 0)

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_ext_arbiter.sv
@@ -162,7 +162,7 @@ module br_fifo_shared_dynamic_ctrl_ext_arbiter #(
   `BR_ASSERT_STATIC(legal_num_read_ports_a, NumReadPorts >= 1 && br_math::is_power_of_2(
                     NumReadPorts))
   `BR_ASSERT_STATIC(num_fifos_in_range_a, NumFifos >= 2)
-  `BR_ASSERT_STATIC(depth_in_range_a, Depth > 2 * NumWritePorts)
+  `BR_ASSERT_STATIC(depth_in_range_a, Depth > 2 * NumWritePorts && Depth >= NumReadPorts)
   `BR_ASSERT_STATIC(width_in_range_a, Width >= 1)
   `BR_ASSERT_STATIC(staging_buffer_depth_in_range_a, StagingBufferDepth >= 1)
   `BR_ASSERT_STATIC(pointer_ram_read_latency_in_range_a, PointerRamReadLatency >= 0)

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
@@ -163,7 +163,7 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
   `BR_ASSERT_STATIC(legal_num_read_ports_a, NumReadPorts >= 1 && br_math::is_power_of_2(
                     NumReadPorts))
   `BR_ASSERT_STATIC(num_fifos_in_range_a, NumFifos >= 2)
-  `BR_ASSERT_STATIC(depth_in_range_a, Depth > 2 * NumWritePorts)
+  `BR_ASSERT_STATIC(depth_in_range_a, Depth > 2 * NumWritePorts && Depth >= NumReadPorts)
   `BR_ASSERT_STATIC(width_in_range_a, Width >= 1)
   `BR_ASSERT_STATIC(staging_buffer_depth_in_range_a, StagingBufferDepth >= 1)
   `BR_ASSERT_STATIC(pointer_ram_read_latency_in_range_a, PointerRamReadLatency >= 0)

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter.sv
@@ -167,7 +167,7 @@ module br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter #(
   `BR_ASSERT_STATIC(legal_num_read_ports_a, NumReadPorts >= 1 && br_math::is_power_of_2(
                     NumReadPorts))
   `BR_ASSERT_STATIC(num_fifos_in_range_a, NumFifos >= 2)
-  `BR_ASSERT_STATIC(depth_in_range_a, Depth > 2 * NumWritePorts)
+  `BR_ASSERT_STATIC(depth_in_range_a, Depth > 2 * NumWritePorts && Depth >= NumReadPorts)
   `BR_ASSERT_STATIC(width_in_range_a, Width >= 1)
   `BR_ASSERT_STATIC(staging_buffer_depth_in_range_a, StagingBufferDepth >= 1)
   `BR_ASSERT_STATIC(pointer_ram_read_latency_in_range_a, PointerRamReadLatency >= 0)


### PR DESCRIPTION
These configurations don't make any sense since it's impossible to read
more entries simultaneously than actually exist in the queue.