### PR TITLE
Adapt cdc fifo for VCF

### DIFF
--- a/cdc/fpv/BUILD.bazel
+++ b/cdc/fpv/BUILD.bazel
@@ -595,3 +595,22 @@ br_verilog_fpv_test_tools_suite(
     top = "br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor",
     deps = [":br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv_monitor"],
 )
+
+# VCF experiment
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_fifo_flops_test_vcf",
+    params = {
+        "Jasper": [
+            "0",
+        ],
+    },
+    tools = {
+        "vcf": "br_cdc_fifo_flops_fpv.vcf.tcl",
+    },
+    top = "br_cdc_fifo_flops_fpv_monitor",
+    deps = [
+        ":br_cdc_fifo_flops_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+        "//mux/rtl:br_mux_bin_structured_gates_mock",
+    ],
+)

--- a/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
@@ -18,6 +18,7 @@
 `include "br_registers.svh"
 
 module br_cdc_fifo_basic_fpv_monitor #(
+    parameter bit Jasper = 1,  // If 1 use Jasper scoreboard, else use Synopsys FML scoreboard
     parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // Number of synchronization stages to use for the gray counts. Must be >=2.
@@ -179,21 +180,44 @@ module br_cdc_fifo_basic_fpv_monitor #(
   `BR_ASSERT_CR(push_slots_a, fv_push_slots == push_slots, push_clk, push_rst)
 
   // ----------Data integrity Check----------
-  jasper_scoreboard_3 #(
-      .CHUNK_WIDTH(Width),
-      .IN_CHUNKS(1),
-      .OUT_CHUNKS(1),
-      .SINGLE_CLOCK(0),
-      .MAX_PENDING(Depth)
-  ) scoreboard (
-      .incoming_clk(push_clk),
-      .outgoing_clk(pop_clk),
-      .rstN(!rst),
-      .incoming_vld(push_vr),
-      .incoming_data(push_data),
-      .outgoing_vld(pop_vr),
-      .outgoing_data(pop_data)
-  );
+  if (Jasper) begin : gen_jasper
+    jasper_scoreboard_3 #(
+        .CHUNK_WIDTH(Width),
+        .IN_CHUNKS(1),
+        .OUT_CHUNKS(1),
+        .SINGLE_CLOCK(0),
+        .MAX_PENDING(Depth)
+    ) scoreboard (
+        .incoming_clk(push_clk),
+        .outgoing_clk(pop_clk),
+        .rstN(!rst),
+        .incoming_vld(push_vr),
+        .incoming_data(push_data),
+        .outgoing_vld(pop_vr),
+        .outgoing_data(pop_data)
+    );
+  end else begin : gen_snps
+    snps_fml_scoreboard #(
+        .DATA_CHUNK_WIDTH   (Width),
+        .NUM_OF_IN_CHUNKS   (1),
+        .NUM_OF_OUT_CHUNKS   (1),
+        .MAX_OUTSTANDING_CHUNKS  (Depth),
+        .ENABLE_INORDER (1),
+        //       .CHKLT   (0),
+        //       .MAXLT   (0),
+        //       .CHKFL   (0),
+        .ENABLE_DUAL_CLOCKS (1),
+        .SCBMODE (0)
+    ) scoreboard (
+        .Resetn  (!rst),
+        .ClkIn   (push_clk),
+        .ValidIn (push_vr),
+        .DataIn  (push_data),
+        .ClkOut  (pop_clk),
+        .ValidOut(pop_vr),
+        .DataOut (pop_data)
+    );
+  end
 
   // ----------Forward Progress Check----------
   if (EnableAssertPushValidStability) begin : gen_stable

--- a/cdc/fpv/br_cdc_fifo_flops_fpv.vcf.tcl
+++ b/cdc/fpv/br_cdc_fifo_flops_fpv.vcf.tcl
@@ -1,0 +1,36 @@
+# Copyright 2024-2025 The Bedrock-RTL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Need this set up before analyze/elaborate
+# fv_quickstart
+# set_fml_var fml_coi_reduction false
+# set_app_var define_synthesis_macro false
+
+# clock/reset set up
+create_clock clk -period 10
+create_random_clock -clock push_clk -period 10
+create_random_clock -clock pop_clk -period 10
+
+create_reset rst -value high
+create_reset push_rst -value high
+create_reset pop_rst -value high
+
+#set_grid_usage -type lsf=72 -control { bsub -app batch_normal -R "rusage[mem=32G]" }
+
+# push/pop side primary input signals only toggle w.r.t its clock
+set_change_at -internal -clock push_clk -posedge {push_valid push_data}
+set_change_at -internal -clock pop_clk -posedge {pop_ready}
+
+#run properties
+check_fv -block

--- a/cdc/fpv/br_cdc_fifo_flops_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_flops_fpv_monitor.sv
@@ -18,6 +18,7 @@
 `include "br_registers.svh"
 
 module br_cdc_fifo_flops_fpv_monitor #(
+    parameter bit Jasper = 1,  // If 1 use Jasper scoreboard, else use Synopsys FML scoreboard
     parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then ensure pop_valid/pop_data always come directly from a register
@@ -127,6 +128,7 @@ module br_cdc_fifo_flops_fpv_monitor #(
 
   // ----------Instantiate CDC FIFO FV basic checks----------
   br_cdc_fifo_basic_fpv_monitor #(
+      .Jasper(Jasper),
       .Depth(Depth),
       .Width(Width),
       .NumSyncStages(NumSyncStages),


### PR DESCRIPTION
I want to test snps_scoreboard, so adapted cdc fifo basic FV checker to be compatible with both Cadence and Synopsys scoreboard.
Right now, this test has 1 deadlock failure due to push_clk/pop_clk declared by VCF tcl (clock stopped, so there is deadlock).
AE is looking into this.