### PR TITLE
remove reset simulation from VCF tcl

### DIFF
--- a/arb/fpv/br_arb_fixed_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_fixed_fpv.vcf.tcl
@@ -22,9 +22,5 @@ report_fv_complexity
 # This is RTL intention
 fvdisable {*no_deadlock_a*}
 
-#reset simulation
-sim_run -stable
-sim_save_reset
-
 #run properties
 check_fv -block

--- a/arb/fpv/br_arb_lru_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_lru_fpv.vcf.tcl
@@ -18,10 +18,6 @@ create_reset rst -high
 #design infomation
 report_fv_complexity
 
-#reset simulation
-sim_run -stable
-sim_save_reset
-
 # standard use case: request will hold until grant
 fvtask -create standard -copy FPV
 

--- a/arb/fpv/br_arb_multi_rr_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_multi_rr_fpv.vcf.tcl
@@ -18,10 +18,6 @@ create_reset rst -high
 #design infomation
 report_fv_complexity
 
-#reset simulation
-sim_run -stable
-sim_save_reset
-
 # standard use case: request will hold until grant
 fvtask -create standard -copy FPV
 

--- a/arb/fpv/br_arb_pri_rr_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_pri_rr_fpv.vcf.tcl
@@ -18,10 +18,6 @@ create_reset rst -high
 #design infomation
 report_fv_complexity
 
-#reset simulation
-sim_run -stable
-sim_save_reset
-
 # standard use case: request will hold until grant
 fvtask -create standard -copy FPV
 

--- a/arb/fpv/br_arb_rr_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_rr_fpv.vcf.tcl
@@ -18,10 +18,6 @@ create_reset rst -high
 #design infomation
 report_fv_complexity
 
-#reset simulation
-sim_run -stable
-sim_save_reset
-
 # standard use case: request will hold until grant
 fvtask -create standard -copy FPV
 

--- a/arb/fpv/br_arb_weighted_rr_fpv.vcf.tcl
+++ b/arb/fpv/br_arb_weighted_rr_fpv.vcf.tcl
@@ -18,10 +18,6 @@ create_reset rst -high
 #design infomation
 report_fv_complexity
 
-#reset simulation
-sim_run -stable
-sim_save_reset
-
 # disable unreachable RTL inline covers
 fvdisable br_arb_weighted_rr.gen_accumulated_weight\[*\].br_counter.increment_min_c
 fvdisable br_arb_weighted_rr.gen_accumulated_weight\[*\].br_counter.decrement_min_c

--- a/ram/fpv/br_ram_flops_tile_1clk_fpv.vcf.tcl
+++ b/ram/fpv/br_ram_flops_tile_1clk_fpv.vcf.tcl
@@ -22,10 +22,6 @@ create_reset rd_rst -high
 #design infomation
 report_fv_complexity
 
-#reset simulation
-sim_run -stable
-sim_save_reset
-
 #run properties
 check_fv -block
 report_fv -list


### PR DESCRIPTION
For whatever reason, reset simulation makes VCF run 3x slower in our env.