### PR TITLE
Add random clock generation for CDC

### DIFF
--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+proc create_random_clock {clk main_clk} {
+  set clk_en ${clk}_en
+  virtual_net $clk_en
+  replace_driver $clk -expression "$main_clk && $clk_en" -env
+  assume -reset $clk_en
+  assume "s_eventually $clk_en"
+}
+
 # clock/reset set up
 clock clk
-clock push_clk -from 1 -to 10 -both_edges
-clock pop_clk -from 1 -to 10 -both_edges
+create_random_clock push_clk clk
+create_random_clock pop_clk clk
 reset rst push_rst pop_rst
 
 # push/pop side primary input signals only toggle w.r.t its clock
@@ -46,11 +54,7 @@ pop_rst |-> pop_valid == 'd0}
 assert -name fv_rst_check_pop_ram_rd_addr_valid {@(posedge pop_clk) \
 pop_rst |-> pop_ram_rd_addr_valid == 'd0}
 
-# If assertion bound - pre-condition reachable cycle >= 2:
-# it's marked as "bounded_proven (auto) instead of "undetermined"
-# this only affects the status report, not the proof
-set_prove_inferred_target_bound on
 # limit run time to 10-mins
-set_prove_time_limit 600s
+set_prove_time_limit 10m
 
 prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+proc create_random_clock {clk main_clk} {
+  set clk_en ${clk}_en
+  virtual_net $clk_en
+  replace_driver $clk -expression "$main_clk && $clk_en" -env
+  assume -reset $clk_en
+  assume "s_eventually $clk_en"
+}
+
 # clock/reset set up
 clock clk
-clock push_clk -from 1 -to 10 -both_edges
-clock pop_clk -from 1 -to 10 -both_edges
+create_random_clock push_clk clk
+create_random_clock pop_clk clk
 
 reset -none
 assume -reset -name set_rst_during_reset {rst}
@@ -67,11 +75,7 @@ pop_rst |-> pop_ram_rd_addr_valid == 'd0}
 # no push_ready signal in push credit interface
 assert -disable *fv_checker.no_ready_when_full_a*
 
-# If assertion bound - pre-condition reachable cycle >= 2:
-# it's marked as "bounded_proven (auto) instead of "undetermined"
-# this only affects the status report, not the proof
-set_prove_inferred_target_bound on
 # limit run time to 10-mins
-set_prove_time_limit 600s
+set_prove_time_limit 10m
 
 prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv.jg.tcl
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+proc create_random_clock {clk main_clk} {
+  set clk_en ${clk}_en
+  virtual_net $clk_en
+  replace_driver $clk -expression "$main_clk && $clk_en" -env
+  assume -reset $clk_en
+  assume "s_eventually $clk_en"
+}
+
 # clock/reset set up
 clock clk
-clock push_clk -from 1 -to 10 -both_edges
-clock pop_clk -from 1 -to 10 -both_edges
+create_random_clock push_clk clk
+create_random_clock pop_clk clk
 
 reset -none
 assume -reset -name set_rst_during_reset {rst}
@@ -52,12 +60,8 @@ pop_rst |-> pop_valid == 'd0}
 assert -name fv_rst_check_pop_ram_rd_addr_valid {@(posedge pop_clk) \
 pop_rst |-> pop_ram_rd_addr_valid == 'd0}
 
-# If assertion bound - pre-condition reachable cycle >= 2:
-# it's marked as "bounded_proven (auto) instead of "undetermined"
-# this only affects the status report, not the proof
-set_prove_inferred_target_bound on
 # limit run time to 10-mins
-set_prove_time_limit 600s
+set_prove_time_limit 10m
 
 # prove command
 prove -all

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+proc create_random_clock {clk main_clk} {
+  set clk_en ${clk}_en
+  virtual_net $clk_en
+  replace_driver $clk -expression "$main_clk && $clk_en" -env
+  assume -reset $clk_en
+  assume "s_eventually $clk_en"
+}
+
 # clock/reset set up
 clock clk
-clock push_clk -from 1 -to 10 -both_edges
-clock pop_clk -from 1 -to 10 -both_edges
+create_random_clock push_clk clk
+create_random_clock pop_clk clk
 
 reset -none
 assume -reset -name set_rst_during_reset {rst}
@@ -67,11 +75,7 @@ pop_rst |-> pop_ram_rd_addr_valid == 'd0}
 # no push_ready signal in push credit interface
 assert -disable *fv_checker.no_ready_when_full_a*
 
-# If assertion bound - pre-condition reachable cycle >= 2:
-# it's marked as "bounded_proven (auto) instead of "undetermined"
-# this only affects the status report, not the proof
-set_prove_inferred_target_bound on
 # limit run time to 10-mins
-set_prove_time_limit 600s
+set_prove_time_limit 10m
 
 prove -all

--- a/cdc/fpv/br_cdc_fifo_flops_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_flops_fpv.jg.tcl
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+proc create_random_clock {clk main_clk} {
+  set clk_en ${clk}_en
+  virtual_net $clk_en
+  replace_driver $clk -expression "$main_clk && $clk_en" -env
+  assume -reset $clk_en
+  assume "s_eventually $clk_en"
+}
+
 # clock/reset set up
 clock clk
-clock push_clk -from 1 -to 10 -both_edges
-clock pop_clk -from 1 -to 10 -both_edges
+create_random_clock push_clk clk
+create_random_clock pop_clk clk
 reset rst push_rst pop_rst
 
 # push/pop side primary input signals only toggle w.r.t its clock
@@ -32,11 +40,7 @@ push_rst |-> push_valid == 'd0}
 assert -name fv_rst_check_pop_valid {@(posedge pop_clk) \
 pop_rst |-> pop_valid == 'd0}
 
-# If assertion bound - pre-condition reachable cycle >= 2:
-# it's marked as "bounded_proven (auto) instead of "undetermined"
-# this only affects the status report, not the proof
-set_prove_inferred_target_bound on
 # limit run time to 10-mins
-set_prove_time_limit 600s
+set_prove_time_limit 10m
 
 prove -all


### PR DESCRIPTION
1. Replace pseudo-random clock ratio between push_clk and pop_clk to real random clock generation tcl (this also has better performance).
2. Remove "set_prove_inferred_target_bound on", this is in global flow.