### PR TITLE
Clarify StagingBufferDepth documentation

### DIFF
--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_basic_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_basic_fpv_monitor.sv
@@ -22,8 +22,8 @@ module br_fifo_shared_dynamic_basic_fpv_monitor #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
-    // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (DataRamAddressDepthStages
+    // + DataRamReadDataDepthStages + DataRamReadDataWidthStages + 1)`.
     parameter int StagingBufferDepth = 1,
     parameter bit HasStagingBuffer = 1,
     parameter bit EnableCoverPushBackpressure = 1,

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv_monitor.sv
@@ -20,7 +20,7 @@ module br_fifo_shared_dynamic_ctrl_fpv_monitor #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (DataRamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor.sv
@@ -20,7 +20,7 @@ module br_fifo_shared_dynamic_ctrl_push_credit_fpv_monitor #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (DataRamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv_monitor.sv
@@ -20,8 +20,8 @@ module br_fifo_shared_dynamic_flops_fpv_monitor #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
-    // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (DataRamAddressDepthStages
+    // + DataRamReadDataDepthStages + DataRamReadDataWidthStages + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv_monitor.sv
@@ -20,7 +20,8 @@ module br_fifo_shared_dynamic_flops_push_credit_fpv_monitor #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (DataRamAddressDepthStages
+    // + DataRamReadDataDepthStages + DataRamReadDataWidthStages + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_ctrl_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_ctrl_fpv_monitor.sv
@@ -16,7 +16,7 @@ module br_fifo_shared_pstatic_ctrl_fpv_monitor #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (RamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_fpv_monitor.sv
@@ -16,8 +16,8 @@ module br_fifo_shared_pstatic_flops_fpv_monitor #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
-    // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (RamAddressDepthStages
+    // + RamReadDataDepthStages + RamReadDataWidthStages + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_push_credit_fpv_monitor.sv
@@ -19,7 +19,7 @@ module br_fifo_shared_pstatic_flops_push_credit_fpv_monitor #(
     parameter bit RegisterPushOutputs = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (RamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/rtl/br_fifo_shared_pop_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl.sv
@@ -33,8 +33,7 @@ module br_fifo_shared_pop_ctrl #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
-    // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (RamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/rtl/br_fifo_shared_pop_ctrl_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl_ext_arbiter.sv
@@ -37,8 +37,7 @@ module br_fifo_shared_pop_ctrl_ext_arbiter #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
-    // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (RamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/rtl/br_fifo_shared_pstatic_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_pstatic_ctrl.sv
@@ -48,7 +48,7 @@ module br_fifo_shared_pstatic_ctrl #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (RamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/rtl/br_fifo_shared_pstatic_ctrl_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_pstatic_ctrl_push_credit.sv
@@ -54,7 +54,7 @@ module br_fifo_shared_pstatic_ctrl_push_credit #(
     parameter bit RegisterPushOutputs = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (RamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/rtl/br_fifo_shared_pstatic_flops.sv
+++ b/fifo/rtl/br_fifo_shared_pstatic_flops.sv
@@ -49,8 +49,8 @@ module br_fifo_shared_pstatic_flops #(
     parameter int Width = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamAddressDepthStages
-    // + PointerRamReadDataDepthStages + PointerRamReadDataWidthStages + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (RamAddressDepthStages
+    // + RamReadDataDepthStages + RamReadDataWidthStages + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.

--- a/fifo/rtl/br_fifo_shared_pstatic_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_pstatic_flops_push_credit.sv
@@ -54,7 +54,7 @@ module br_fifo_shared_pstatic_flops_push_credit #(
     parameter bit RegisterPushOutputs = 1,
     // The depth of the pop-side staging buffer.
     // This affects the pop bandwidth of each logical FIFO.
-    // The bandwidth will be `StagingBufferDepth / (PointerRamReadLatency + 1)`.
+    // The bandwidth will be `StagingBufferDepth / (RamReadLatency + 1)`.
     parameter int StagingBufferDepth = 1,
     // If 1, make sure pop_valid/pop_data are registered at the output
     // of the staging buffer. This adds a cycle of cut-through latency.


### PR DESCRIPTION
## Summary
- update the pseudo-static FIFO RTL modules and pop controllers so the StagingBufferDepth parameter is described in terms of RAM read latency rather than pointer RAM terminology
- align the dynamic and pseudo-static FPV monitor comments with the same data-RAM-based bandwidth formulas so the documentation matches the implementation

Fixes #711

------
https://chatgpt.com/codex/tasks/task_i_690ba75619248332a1040c076d3a9607