### PR TITLE
[tracker:reorder] Allow reorder buffers to have single entry

### DIFF
--- a/tracker/rtl/BUILD.bazel
+++ b/tracker/rtl/BUILD.bazel
@@ -108,6 +108,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_tracker_reorder_test_suite",
     params = {
         "NumEntries": [
+            "1",
             "2",
             "3",
             "4",
@@ -136,6 +137,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_tracker_reorder_buffer_ctrl_1r1w_test_suite",
     params = {
         "NumEntries": [
+            "1",
             "2",
             "3",
             "4",
@@ -165,6 +167,7 @@ br_verilog_elab_and_lint_test_suite(
     name = "br_tracker_reorder_buffer_flops_test_suite",
     params = {
         "NumEntries": [
+            "1",
             "2",
             "3",
             "4",

--- a/tracker/rtl/br_tracker_reorder_buffer_ctrl_1r1w.sv
+++ b/tracker/rtl/br_tracker_reorder_buffer_ctrl_1r1w.sv
@@ -35,7 +35,7 @@ module br_tracker_reorder_buffer_ctrl_1r1w #(
     parameter bit RegisterPopOutputs = 0,
     // If 1, then assert unordered_resp_push_valid is low at the end of the test.
     parameter bit EnableAssertFinalNotDeallocValid = 1,
-    localparam int MinEntryIdWidth = $clog2(NumEntries),
+    localparam int MinEntryIdWidth = br_math::clamped_clog2(NumEntries),
     localparam int EntryCountWidth = $clog2(NumEntries + 1)
 ) (
     input logic clk,

--- a/tracker/rtl/br_tracker_reorder_buffer_flops.sv
+++ b/tracker/rtl/br_tracker_reorder_buffer_flops.sv
@@ -40,7 +40,7 @@ module br_tracker_reorder_buffer_flops #(
     // Count Information
     output logic resp_pending
 );
-  localparam int MinEntryIdWidth = $clog2(NumEntries);
+  localparam int MinEntryIdWidth = br_math::clamped_clog2(NumEntries);
 
   logic [MinEntryIdWidth-1:0] ram_wr_addr;
   logic ram_wr_valid;


### PR DESCRIPTION
**Stack**:
- #939
- #938 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*