### PR TITLE
[csr:axil_widget] Add CSR AXI-Lite widget

### DIFF
--- a/csr/rtl/BUILD.bazel
+++ b/csr/rtl/BUILD.bazel
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_elab_and_lint_test_suite")
+
+package(default_visibility = ["//visibility:public"])
+
+verilog_library(
+    name = "br_csr_axil_widget",
+    srcs = ["br_csr_axil_widget.sv"],
+    deps = [
+        "//amba/rtl:br_amba_pkg",
+        "//flow/rtl:br_flow_demux_select_unstable",
+        "//flow/rtl:br_flow_join",
+        "//flow/rtl:br_flow_mux_rr_stable",
+        "//flow/rtl:br_flow_reg_fwd",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+        "//macros:br_tieoff",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_csr_axil_widget_test_suite",
+    params = {
+        "AddrWidth": ["16"],
+        "DataWidth": [
+            "32",
+            "64",
+        ],
+        "MaxTimeoutCycles": [
+            "100",
+            "63",
+        ],
+        "RegisterResponseOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_csr_axil_widget"],
+)

--- a/csr/rtl/br_csr_axil_widget.sv
+++ b/csr/rtl/br_csr_axil_widget.sv
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL AXI4-Lite to SCB Widget
+//
+// Converts an AXI4-Lite interface to the Superintelligent CSR Bus (SCB) interface.
+//
+// The SCB interface is a simple request/response interface that allows only a single
+// outstanding request at a time. The conversion of each field from AXI4-Lite is straightforward:
+//
+// For write requests:
+// - csr_req_write <- 1
+// - csr_req_addr <- axil_awaddr
+// - csr_req_wdata <- axil_wdata
+// - csr_req_wstrb <- axil_wstrb
+// - csr_req_secure <- !axil_awprot[1]
+// - csr_req_privileged <- axil_awprot[0]
+// - csr_req_abort <- (special handling, see below)
+//
+// For read requests:
+// - csr_req_write <- 0
+// - csr_req_addr <- axil_araddr
+// - csr_req_wdata <- 0
+// - csr_req_wstrb <- 0
+// - csr_req_secure <- !axil_arprot[1]
+// - csr_req_privileged <- axil_arprot[0]
+//
+// The response from the SCB is then converted to the B or R channel
+// depending on whether the request was a write or read.
+//
+// For the R channel:
+// - axil_rresp <- 11 if csr_resp_decerr=1, 10 if csr_resp_slverr=1, 00 if neither are set
+// - axil_rdata <- csr_resp_rdata
+// It is assumed that csr_resp_decerr and csr_resp_slverr cannot both be set for a single response.
+//
+// For the B channel:
+// - axil_bresp <- 11 if csr_resp_decerr=1, 10 if csr_resp_slverr=1, 00 if neither are set
+//
+// The RegisterResponseOutputs parameter controls whether the response outputs are registered.
+//
+// The SCB protocol provides a mechanism for the requester to abort an in-progress request after
+// a timeout. Compliant SCB peripherals must either guarantee that they will always respond to requests
+// in a bounded timeframe or respect the abort signal. The abort mechanism works as follows:
+//
+// When the SCB request is sent out, a watchdog timer starts counting with a configurable timeout period
+// set by the timeout_cycles input.
+// When the internal count is greater than or equal to `timeout_cycles`, the watchdog timer will expire.
+// When this occurs, the abort signal will be asserted for a single cycle.
+// The timer will then reset and count for another timeout period. If no response is received before the
+// second period expires, a response with code SLVERR is sent on the appropriate AXI-Lite channel,
+// and the timeout_expired signal is asserted for a single cycle.
+// Changing `timeout_cycles` while a request is active is permitted. If it's changed to a value below the
+// current count, the timer will expire immediately.
+// Setting `timeout_cycles` to 0 disables the watchdog timer.
+//
+// SCB leaf nodes that always respond in a bounded timeframe are allowed to
+// simply ignore the abort signal. Otherwise, they must handle the abort signal
+// properly.  If the inflight request is in a state where completion is not
+// guaranteed, the request must be dropped when the abort signal is asserted. It
+// must be guaranteed that no response will be sent from then on.
+
+`include "br_asserts_internal.svh"
+`include "br_unused.svh"
+`include "br_registers.svh"
+`include "br_tieoff.svh"
+
+module br_csr_axil_widget #(
+    parameter int AddrWidth = 1,  // Must be at least 1
+    parameter int DataWidth = 32,  // Must be 32 or 64
+    parameter bit RegisterResponseOutputs = 0,
+    parameter int MaxTimeoutCycles = 1000,  // Must be at least 1
+
+    localparam int StrobeWidth = DataWidth / 8,
+    localparam int TimerWidth  = br_math::clamped_clog2(MaxTimeoutCycles + 1)
+) (
+    input logic clk,
+    input logic rst,  // Synchronous, active-high reset
+
+    // AXI4-Lite target interface
+    input  logic                             axil_awvalid,
+    output logic                             axil_awready,
+    input  logic [            AddrWidth-1:0] axil_awaddr,
+    input  logic [br_amba::AxiProtWidth-1:0] axil_awprot,
+    input  logic                             axil_wvalid,
+    output logic                             axil_wready,
+    input  logic [            DataWidth-1:0] axil_wdata,
+    input  logic [          StrobeWidth-1:0] axil_wstrb,
+    output logic                             axil_bvalid,
+    input  logic                             axil_bready,
+    output logic [br_amba::AxiRespWidth-1:0] axil_bresp,
+    input  logic                             axil_arvalid,
+    output logic                             axil_arready,
+    input  logic [            AddrWidth-1:0] axil_araddr,
+    input  logic [br_amba::AxiProtWidth-1:0] axil_arprot,
+    output logic                             axil_rvalid,
+    input  logic                             axil_rready,
+    output logic [            DataWidth-1:0] axil_rdata,
+    output logic [br_amba::AxiRespWidth-1:0] axil_rresp,
+
+    output logic                   csr_req_valid,
+    // 1 indicates a write request, 0 indicates a read request
+    output logic                   csr_req_write,
+    output logic [  AddrWidth-1:0] csr_req_addr,
+    output logic [  DataWidth-1:0] csr_req_wdata,
+    output logic [StrobeWidth-1:0] csr_req_wstrb,
+    output logic                   csr_req_secure,
+    output logic                   csr_req_privileged,
+    output logic                   csr_req_abort,
+
+    input logic                 csr_resp_valid,
+    input logic [DataWidth-1:0] csr_resp_rdata,
+    input logic                 csr_resp_slverr,
+    input logic                 csr_resp_decerr,
+
+    input  logic [TimerWidth-1:0] timeout_cycles,
+    output logic                  timeout_expired
+);
+
+  //----------------------------------------------------------------------------
+  // Integration checks
+  //----------------------------------------------------------------------------
+  `BR_ASSERT_STATIC(legal_addr_width_a, AddrWidth >= 1)
+  `BR_ASSERT_STATIC(legal_data_width_a, DataWidth == 32 || DataWidth == 64)
+  `BR_ASSERT_STATIC(legal_max_timeout_cycles_a, MaxTimeoutCycles >= 1)
+
+  `BR_ASSERT_INTG(legal_timeout_cycles_a, timeout_cycles <= MaxTimeoutCycles)
+  `BR_ASSERT_INTG(legal_csr_resp_a, csr_resp_valid |-> !(csr_resp_decerr && csr_resp_slverr))
+
+  //----------------------------------------------------------------------------
+  // Implementation
+  //----------------------------------------------------------------------------
+
+  logic csr_write_valid;
+  logic csr_write_ready;
+
+  br_flow_join #(
+      .NumFlows(2)
+  ) br_flow_join_csr_write (
+      .clk,
+      .rst,
+      .push_ready({axil_awready, axil_wready}),
+      .push_valid({axil_awvalid, axil_wvalid}),
+      .pop_ready (csr_write_ready),
+      .pop_valid (csr_write_valid)
+  );
+
+  typedef struct packed {
+    logic [AddrWidth-1:0] addr;
+    logic [DataWidth-1:0] wdata;
+    logic [StrobeWidth-1:0] wstrb;
+    logic write;
+    logic secure;
+    logic privileged;
+  } csr_req_t;
+
+  csr_req_t csr_write_req;
+  csr_req_t csr_read_req;
+  csr_req_t csr_req;
+  logic csr_unqual_req_valid;
+  logic csr_unqual_req_ready;
+
+  assign csr_write_req = '{
+          addr: axil_awaddr,
+          wdata: axil_wdata,
+          wstrb: axil_wstrb,
+          write: 1'b1,
+          secure: !axil_awprot[1],
+          privileged: axil_awprot[0]
+      };
+  assign csr_read_req = '{
+          addr: axil_araddr,
+          wdata: {DataWidth{1'b0}},
+          wstrb: {StrobeWidth{1'b0}},
+          write: 1'b0,
+          secure: !axil_arprot[1],
+          privileged: axil_arprot[0]
+      };
+
+  // SCB protocol doesn't distinguish between data and instruction access
+  `BR_UNUSED_NAMED(axil_axprot_instr, {axil_awprot[2], axil_arprot[2]})
+
+  br_flow_mux_rr_stable #(
+      .NumFlows(2),
+      .Width($bits(csr_req_t))
+  ) br_flow_mux_rr_stable_csr_req (
+      .clk,
+      .rst,
+      .push_ready({csr_write_ready, axil_arready}),
+      .push_valid({csr_write_valid, axil_arvalid}),
+      .push_data ({csr_write_req, csr_read_req}),
+      .pop_ready (csr_unqual_req_ready),
+      .pop_valid (csr_unqual_req_valid),
+      .pop_data  (csr_req)
+  );
+
+  assign csr_req_valid = csr_unqual_req_valid && csr_unqual_req_ready;
+  assign csr_req_addr = csr_req.addr;
+  assign csr_req_wdata = csr_req.wdata;
+  assign csr_req_wstrb = csr_req.wstrb;
+  assign csr_req_write = csr_req.write;
+  assign csr_req_secure = csr_req.secure;
+  assign csr_req_privileged = csr_req.privileged;
+
+  // TODO(zhemao): Implement the watchdog timer and abort mechanism.
+  `BR_TIEOFF_ZERO_TODO(timeout_output, {csr_req_abort, timeout_expired})
+  `BR_UNUSED_TODO(timeout_input, timeout_cycles)
+
+  // Only allow one outstanding CSR request at a time
+  typedef struct packed {
+    br_amba::axi_resp_t   resp;
+    logic [DataWidth-1:0] data;
+  } resp_t;
+
+  logic inflight, inflight_next;
+  logic inflight_write;
+  logic buf_resp_valid, buf_resp_valid_next;
+  logic buf_resp_ready;
+  logic [DataWidth-1:0] buf_resp_rdata;
+  logic buf_resp_slverr;
+  logic buf_resp_decerr;
+  resp_t buf_resp;
+
+  // Set inflight when request is sent out
+  // Clear it when the response is accepted
+  assign inflight_next = (inflight || csr_req_valid) && !(buf_resp_valid && buf_resp_ready);
+  // Set buf_resp_valid when response is received from downstream
+  // Clear it when the response is accepted
+  assign buf_resp_valid_next = (buf_resp_valid && !buf_resp_ready) || csr_resp_valid;
+
+  `BR_REG(inflight, inflight_next)
+  `BR_REGL(inflight_write, csr_req_write, csr_req_valid)
+  `BR_REG(buf_resp_valid, buf_resp_valid_next)
+  `BR_REGLN(buf_resp_rdata, csr_resp_rdata, csr_resp_valid)
+  `BR_REGLN(buf_resp_slverr, csr_resp_slverr, csr_resp_valid)
+  `BR_REGLN(buf_resp_decerr, csr_resp_decerr, csr_resp_valid)
+
+  assign csr_unqual_req_ready = !inflight;
+  assign buf_resp.data = buf_resp_rdata;
+  assign buf_resp.resp =
+      buf_resp_decerr ? br_amba::AxiRespDecerr :
+      buf_resp_slverr ? br_amba::AxiRespSlverr :
+      br_amba::AxiRespOkay;
+
+  logic  axil_bvalid_int;
+  logic  axil_bready_int;
+  resp_t axil_b_int;
+
+  logic  axil_rvalid_int;
+  logic  axil_rready_int;
+  resp_t axil_r_int;
+
+
+  br_flow_demux_select_unstable #(
+      .NumFlows(2),
+      .Width(br_amba::AxiRespWidth + DataWidth)
+  ) br_flow_demux_select_unstable_resp (
+      .clk,
+      .rst,
+      .select(inflight_write),
+      .push_ready(buf_resp_ready),
+      .push_valid(buf_resp_valid),
+      .push_data(buf_resp),
+      .pop_ready({axil_bready_int, axil_rready_int}),
+      .pop_valid_unstable({axil_bvalid_int, axil_rvalid_int}),
+      .pop_data_unstable({axil_b_int, axil_r_int})
+  );
+
+  `BR_UNUSED_NAMED(axil_b_int_data, axil_b_int.data)
+
+  if (RegisterResponseOutputs) begin : gen_reg_resp_out
+    br_flow_reg_fwd #(
+        .Width(br_amba::AxiRespWidth)
+    ) br_flow_reg_fwd_b (
+        .clk,
+        .rst,
+        .push_ready(axil_bready_int),
+        .push_valid(axil_bvalid_int),
+        .push_data ({axil_b_int.resp}),
+        .pop_ready (axil_bready),
+        .pop_valid (axil_bvalid),
+        .pop_data  (axil_bresp)
+    );
+
+    br_flow_reg_fwd #(
+        .Width(DataWidth + br_amba::AxiRespWidth)
+    ) br_flow_reg_fwd_r (
+        .clk,
+        .rst,
+        .push_ready(axil_rready_int),
+        .push_valid(axil_rvalid_int),
+        .push_data ({axil_r_int.data, axil_r_int.resp}),
+        .pop_ready (axil_rready),
+        .pop_valid (axil_rvalid),
+        .pop_data  ({axil_rdata, axil_rresp})
+    );
+  end else begin : gen_no_reg_resp_out
+    assign axil_bvalid = axil_bvalid_int;
+    assign axil_bready_int = axil_bready;
+    assign axil_bresp = {axil_b_int.resp};
+    assign axil_rvalid = axil_rvalid_int;
+    assign axil_rready_int = axil_rready;
+    assign axil_rresp = {axil_r_int.resp};
+    assign axil_rdata = axil_r_int.data;
+  end
+
+  // Implementation assertions
+  `BR_ASSERT_IMPL(only_single_request_inflight_a, inflight |-> !csr_req_valid)
+  `BR_ASSERT_IMPL(no_spurious_resp_a, csr_resp_valid |-> inflight && !buf_resp_valid)
+
+endmodule

--- a/csr/sim/BUILD.bazel
+++ b/csr/sim/BUILD.bazel
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:private"])
+
+verilog_library(
+    name = "br_csr_axil_widget_tb",
+    srcs = ["br_csr_axil_widget_tb.sv"],
+    deps = [
+        "//csr/rtl:br_csr_axil_widget",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_csr_axil_widget_tb_elab_test",
+    tool = "verific",
+    deps = [":br_csr_axil_widget_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_csr_axil_widget_sim_test_tools_suite",
+    params = {
+        "AddrWidth": ["16"],
+        "DataWidth": ["32"],
+        "RegisterResponseOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    tools = ["vcs"],
+    deps = [":br_csr_axil_widget_tb"],
+)

--- a/csr/sim/br_csr_axil_widget_tb.sv
+++ b/csr/sim/br_csr_axil_widget_tb.sv
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Basic unit test for br_csr_axil_widget.
+
+module br_csr_axil_widget_tb;
+
+  parameter int MaxTimeoutCycles = 100;
+  parameter int TimeoutCycles = MaxTimeoutCycles;
+  parameter int AddrWidth = 16;
+  parameter int DataWidth = 32;
+  parameter bit RegisterResponseOutputs = 0;
+  localparam int StrobeWidth = DataWidth / 8;
+  localparam int TimerWidth = br_math::clamped_clog2(MaxTimeoutCycles + 1);
+
+  logic clk;
+  logic rst;
+
+  logic axil_awvalid;
+  logic axil_awready;
+  logic [AddrWidth-1:0] axil_awaddr;
+  logic [br_amba::AxiProtWidth-1:0] axil_awprot;
+  logic axil_wvalid;
+  logic axil_wready;
+  logic [DataWidth-1:0] axil_wdata;
+  logic [StrobeWidth-1:0] axil_wstrb;
+  logic axil_bvalid;
+  logic axil_bready;
+  logic [br_amba::AxiRespWidth-1:0] axil_bresp;
+  logic axil_arvalid;
+  logic axil_arready;
+  logic [AddrWidth-1:0] axil_araddr;
+  logic [br_amba::AxiProtWidth-1:0] axil_arprot;
+  logic axil_rvalid;
+  logic axil_rready;
+  logic [DataWidth-1:0] axil_rdata;
+  logic [br_amba::AxiRespWidth-1:0] axil_rresp;
+
+  logic csr_req_valid;
+  logic csr_req_write;
+  logic [AddrWidth-1:0] csr_req_addr;
+  logic [DataWidth-1:0] csr_req_wdata;
+  logic [StrobeWidth-1:0] csr_req_wstrb;
+  logic csr_req_secure;
+  logic csr_req_privileged;
+  logic csr_req_abort;
+
+  logic csr_resp_valid;
+  logic [DataWidth-1:0] csr_resp_rdata;
+  logic csr_resp_slverr;
+  logic csr_resp_decerr;
+
+  logic [TimerWidth-1:0] timeout_cycles;
+  logic timeout_expired;
+
+  br_csr_axil_widget #(
+      .AddrWidth(AddrWidth),
+      .DataWidth(DataWidth),
+      .RegisterResponseOutputs(RegisterResponseOutputs),
+      .MaxTimeoutCycles(MaxTimeoutCycles)
+  ) dut (
+      .clk,
+      .rst,
+      .axil_awvalid,
+      .axil_awready,
+      .axil_awaddr,
+      .axil_awprot,
+      .axil_wvalid,
+      .axil_wready,
+      .axil_wdata,
+      .axil_wstrb,
+      .axil_bvalid,
+      .axil_bready,
+      .axil_bresp,
+      .axil_arvalid,
+      .axil_arready,
+      .axil_araddr,
+      .axil_arprot,
+      .axil_rvalid,
+      .axil_rready,
+      .axil_rdata,
+      .axil_rresp,
+      .csr_req_valid,
+      .csr_req_write,
+      .csr_req_addr,
+      .csr_req_wdata,
+      .csr_req_wstrb,
+      .csr_req_secure,
+      .csr_req_privileged,
+      .csr_req_abort,
+      .csr_resp_valid,
+      .csr_resp_rdata,
+      .csr_resp_slverr,
+      .csr_resp_decerr,
+      .timeout_cycles,
+      .timeout_expired
+  );
+
+  br_test_driver #(
+      .ResetCycles(5)
+  ) td (
+      .clk,
+      .rst
+  );
+
+  task automatic send_axil_write(
+      input logic [AddrWidth-1:0] addr, input logic [br_amba::AxiProtWidth-1:0] prot,
+      input logic [DataWidth-1:0] wdata, input logic [StrobeWidth-1:0] strb);
+    axil_awvalid = 1;
+    axil_awaddr  = addr;
+    axil_awprot  = prot;
+    axil_wvalid  = 1;
+    axil_wdata   = wdata;
+    axil_wstrb   = strb;
+
+    fork
+      begin
+        int timeout = 0;
+        @(posedge clk);
+        while (!axil_awready && timeout < TimeoutCycles) begin
+          @(posedge clk);
+          timeout++;
+        end
+        td.check(timeout < TimeoutCycles, "Timeout waiting for AXI-Lite write address ready");
+        @(negedge clk);
+        axil_awvalid = 0;
+      end
+      begin
+        int timeout = 0;
+        @(posedge clk);
+        while (!axil_wready && timeout < TimeoutCycles) begin
+          @(posedge clk);
+          timeout++;
+        end
+        td.check(timeout < TimeoutCycles, "Timeout waiting for AXI-Lite write data ready");
+        @(negedge clk);
+        axil_wvalid = 0;
+      end
+    join
+
+    @(negedge clk);
+  endtask
+
+  task automatic send_axil_read(input logic [AddrWidth-1:0] addr,
+                                input logic [br_amba::AxiProtWidth-1:0] prot);
+    int timeout = 0;
+
+    axil_arvalid = 1;
+    axil_araddr  = addr;
+    axil_arprot  = prot;
+
+    @(posedge clk);
+    while (!axil_arready && timeout < TimeoutCycles) begin
+      @(posedge clk);
+      timeout++;
+    end
+    td.check(timeout < TimeoutCycles, "Timeout waiting for AXI-Lite read address ready");
+    @(negedge clk);
+    axil_arvalid = 0;
+  endtask
+
+  task automatic wait_csr_read(input logic [AddrWidth-1:0] expected_addr,
+                               input logic expected_privileged, input logic expected_secure);
+    int timeout = 0;
+
+    @(posedge clk);
+    while (!csr_req_valid && timeout < TimeoutCycles) begin
+      @(posedge clk);
+      timeout++;
+    end
+
+    td.check(timeout < TimeoutCycles, "Timeout waiting for CSR read request");
+    td.check(!csr_req_write, "Expected read, not write");
+    td.check_integer(csr_req_addr, expected_addr, "CSR request address mismatch");
+    td.check_integer(csr_req_privileged, expected_privileged, "CSR request privileged mismatch");
+    td.check_integer(csr_req_secure, expected_secure, "CSR request secure mismatch");
+    @(negedge clk);
+  endtask
+
+  task automatic wait_csr_write(input logic [AddrWidth-1:0] expected_addr,
+                                input logic [DataWidth-1:0] expected_wdata,
+                                input logic [StrobeWidth-1:0] expected_wstrb,
+                                input logic expected_privileged, input logic expected_secure);
+    int timeout = 0;
+    @(posedge clk);
+    while (!csr_req_valid && timeout < TimeoutCycles) begin
+      @(posedge clk);
+      timeout++;
+    end
+
+    td.check(timeout < TimeoutCycles, "Timeout waiting for CSR write request");
+    td.check(csr_req_write, "Expected write, not read");
+    td.check_integer(csr_req_addr, expected_addr, "CSR request address mismatch");
+    td.check_integer(csr_req_wdata, expected_wdata, "CSR request wdata mismatch");
+    td.check_integer(csr_req_wstrb, expected_wstrb, "CSR request wstrb mismatch");
+    td.check_integer(csr_req_privileged, expected_privileged, "CSR request privileged mismatch");
+    td.check_integer(csr_req_secure, expected_secure, "CSR request secure mismatch");
+
+    @(negedge clk);
+  endtask
+
+  task automatic send_csr_response(input logic [DataWidth-1:0] rdata, input logic slverr,
+                                   input logic decerr);
+    csr_resp_valid  = 1;
+    csr_resp_rdata  = rdata;
+    csr_resp_slverr = slverr;
+    csr_resp_decerr = decerr;
+
+    @(negedge clk);
+    csr_resp_valid  = 0;
+    csr_resp_rdata  = 0;
+    csr_resp_slverr = 0;
+    csr_resp_decerr = 0;
+  endtask
+
+  task automatic wait_axil_read_response(input logic [br_amba::AxiRespWidth-1:0] expected_rresp,
+                                         input logic [DataWidth-1:0] expected_rdata);
+    axil_rready = 1;
+
+    @(posedge clk);
+    while (!axil_rvalid) @(posedge clk);
+
+    td.check_integer(axil_rresp, expected_rresp, "AXI-Lite rresp mismatch");
+    td.check_integer(axil_rdata, expected_rdata, "AXI-Lite rdata mismatch");
+
+    @(negedge clk);
+    axil_rready = 0;
+  endtask
+
+  task automatic wait_axil_write_response(input logic [br_amba::AxiRespWidth-1:0] expected_bresp);
+    int timeout = 0;
+    axil_bready = 1;
+
+    @(posedge clk);
+    while (!axil_bvalid && timeout < TimeoutCycles) begin
+      @(posedge clk);
+      timeout++;
+    end
+
+    td.check(timeout < TimeoutCycles, "Timeout waiting for AXI-Lite write response");
+    td.check_integer(axil_bresp, expected_bresp, "AXI-Lite bresp mismatch");
+
+    @(negedge clk);
+    axil_bready = 0;
+  endtask
+
+  initial begin
+    axil_awvalid = 0;
+    axil_awaddr = 0;
+    axil_awprot = 0;
+    axil_wvalid = 0;
+    axil_wdata = 0;
+    axil_wstrb = 0;
+    axil_bready = 0;
+    axil_arvalid = 0;
+    axil_araddr = 0;
+    axil_arprot = 0;
+    axil_rready = 0;
+    csr_resp_valid = 0;
+    csr_resp_rdata = 0;
+    csr_resp_slverr = 0;
+    csr_resp_decerr = 0;
+    timeout_cycles = TimeoutCycles;
+
+    td.reset_dut();
+    td.wait_cycles(2);
+
+    // Send a write request and check that it's successfully converted
+    $display("Checking normal AXI-Lite to CSR write conversion");
+    fork
+      send_axil_write(16'h0000, 3'b000, 32'h12345678, 4'b1101);
+      wait_csr_write(16'h0000, 32'h12345678, 4'b1101, 1'b0, 1'b1);
+    join
+    fork
+      send_csr_response({DataWidth{1'b0}}, 1'b0, 1'b0);
+      wait_axil_write_response(br_amba::AxiRespOkay);
+    join
+
+    // Send a read request and check that it's successfully converted
+    $display("Checking normal AXI-Lite to CSR read conversion");
+    fork
+      send_axil_read(16'h0010, 3'b000);
+      wait_csr_read(16'h0010, 1'b0, 1'b1);
+    join
+    fork
+      send_csr_response(32'hDEADBEEF, 1'b0, 1'b0);
+      wait_axil_read_response(br_amba::AxiRespOkay, 32'hDEADBEEF);
+    join
+
+    // Send a slverr response for a write request
+    $display("Checking AXI-Lite to CSR write conversion with slverr response");
+    fork
+      send_axil_write(16'h0020, 3'b000, 32'hFFFFFFFF, 4'b0000);
+      wait_csr_write(16'h0020, 32'hFFFFFFFF, 4'b0000, 1'b0, 1'b1);
+    join
+    fork
+      send_csr_response(32'hFFFFFFFF, 1'b1, 1'b0);
+      wait_axil_write_response(br_amba::AxiRespSlverr);
+    join
+
+    // Send a decerr response for a read request
+    $display("Checking AXI-Lite to CSR read conversion with decerr response");
+    fork
+      send_axil_read(16'hFFFF, 3'b000);
+      wait_csr_read(16'hFFFF, 1'b0, 1'b1);
+    join
+    fork
+      send_csr_response(32'hFFFFFFFF, 1'b0, 1'b1);
+      wait_axil_read_response(br_amba::AxiRespDecerr, 32'hFFFFFFFF);
+    join
+
+    // Send read and write requests simultaneously and check the sequencing.
+    // Since last request sent was a read, the write should get priority.
+    $display("Checking simultaneous read and write requests.");
+    fork
+      begin
+        send_axil_write(16'h0030, 3'b000, 32'hABCD0123, 4'b1111);
+        wait_axil_write_response(br_amba::AxiRespOkay);
+      end
+      begin
+        send_axil_read(16'h0040, 3'b000);
+        wait_axil_read_response(br_amba::AxiRespOkay, 32'hDEADBEEF);
+      end
+      begin
+        wait_csr_write(16'h0030, 32'hABCD0123, 4'b1111, 1'b0, 1'b1);
+        send_csr_response(32'h00000000, 1'b0, 1'b0);
+        wait_csr_read(16'h0040, 1'b0, 1'b1);
+        send_csr_response(32'hDEADBEEF, 1'b0, 1'b0);
+      end
+    join
+
+    td.wait_cycles(2);
+    td.finish();
+  end
+endmodule


### PR DESCRIPTION
This commit adds an adapter from the AXI4-Lite protocol to the Simple
CSR Bus (SCB) protocol. This is a lightweight protocol for low-bandwidth
register access allowing a single outstanding request at a time and a
configurable timeout and abort mechanism.

---

**Stack**:
- #945
- #944
- #939 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*