### PR TITLE
[WIP] push/pop reset happens twice for cdc fifos

### DIFF
--- a/cdc/fpv/BUILD.bazel
+++ b/cdc/fpv/BUILD.bazel
@@ -263,7 +263,6 @@ br_verilog_fpv_test_tools_suite(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_cdc_fifo_ctrl_1r1w_test_suite",
-    gui = True,
     illegal_param_combinations = {
         (
             "Depth",

--- a/cdc/fpv/BUILD.bazel
+++ b/cdc/fpv/BUILD.bazel
@@ -263,6 +263,7 @@ br_verilog_fpv_test_tools_suite(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_cdc_fifo_ctrl_1r1w_test_suite",
+    gui = True,
     illegal_param_combinations = {
         (
             "Depth",

--- a/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
@@ -212,10 +212,11 @@ module br_cdc_fifo_basic_fpv_monitor #(
   `BR_COVER_CR(fifo_full_c, push_full, push_clk, push_rst)
 
   // ----------assert reset again----------
+  /*
   localparam int ResetLen = NumSyncStages + 2;
   logic [1:0] push_rst_cnt, pop_rst_cnt;
-  logic push_rst_flg, pop_rst_flg;
   logic push_rst_d, pop_rst_d;
+  logic push_rst_flg, pop_rst_flg;
 
   `BR_REGNX(push_rst_d, push_rst, push_clk);
   `BR_REGNX(pop_rst_d, pop_rst, pop_clk);
@@ -228,11 +229,18 @@ module br_cdc_fifo_basic_fpv_monitor #(
   `BR_ASSUME_CR(pop_rst_twice_a, pop_rst_cnt <= 2, pop_clk, rst)
   `BR_ASSUME_CR(push_rst_rise_once_a, push_rst_flg |-> !$rose(push_rst), push_clk, rst)
   `BR_ASSUME_CR(pop_rst_rise_once_a, pop_rst_flg |-> !$rose(pop_rst), pop_clk, rst)
+  `BR_COVER_CR(push_rst_twice_c, push_rst_cnt == 2, push_clk, rst)
+  `BR_COVER_CR(pop_rst_twice_c, pop_rst_cnt == 2, pop_clk, rst)
+  // push and pop reset must overlap
+  `BR_ASSUME_CR(no_push_rst_rise_a, (pop_rst_cnt != 'd1) |-> !$rose(push_rst), push_clk, rst)
+  `BR_ASSUME_CR(no_pop_rst_rise_a, (push_rst_cnt != 'd1) |-> !$rose(pop_rst), pop_clk, rst)
+  `BR_ASSUME_CR(push_rst_rise_a, $rose(push_rst) |-> push_rst until_with pop_rst, push_clk, rst)
+  `BR_ASSUME_CR(pop_rst_rise_a, $rose(pop_rst) |-> pop_rst until_with push_rst, pop_clk, rst)
   // Don't assert reset until NumSyncStages + 2 cycles after the other side's reset is deasserted
-  `BR_ASSUME_CR(no_push_rst_a, !pop_rst |-> !$rose(push_rst) [* ResetLen], push_clk, rst)
-  `BR_ASSUME_CR(no_pop_rst_a, !push_rst |-> !$rose(pop_rst) [* ResetLen], pop_clk, rst)
+  `BR_ASSUME_CR(no_push_rst_a, $fell(pop_rst) |-> !$rose(push_rst) [* ResetLen], push_clk, rst)
+  `BR_ASSUME_CR(no_pop_rst_a, $fell(push_rst) |-> !$rose(pop_rst) [* ResetLen], pop_clk, rst)
   // Don't deassert reset until NumSyncStages + 2 cycles after the other side's reset is asserted
-  `BR_ASSUME_CR(hold_push_rst_a, pop_rst |-> !$fell(push_rst) [* ResetLen], push_clk, rst)
-  `BR_ASSUME_CR(hold_pop_rst_a, push_rst |-> !$fell(pop_rst) [* ResetLen], pop_clk, rst)
-
+  `BR_ASSUME_CR(hold_push_rst_a, $rose(pop_rst) |-> !$fell(push_rst) [* ResetLen], push_clk, rst)
+  `BR_ASSUME_CR(hold_pop_rst_a, $rose(push_rst) |-> !$fell(pop_rst) [* ResetLen], pop_clk, rst)
+  */
 endmodule : br_cdc_fifo_basic_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
@@ -212,7 +212,6 @@ module br_cdc_fifo_basic_fpv_monitor #(
   `BR_COVER_CR(fifo_full_c, push_full, push_clk, push_rst)
 
   // ----------assert reset again----------
-  /*
   localparam int ResetLen = NumSyncStages + 2;
   logic [1:0] push_rst_cnt, pop_rst_cnt;
   logic push_rst_d, pop_rst_d;
@@ -242,5 +241,5 @@ module br_cdc_fifo_basic_fpv_monitor #(
   // Don't deassert reset until NumSyncStages + 2 cycles after the other side's reset is asserted
   `BR_ASSUME_CR(hold_push_rst_a, $rose(pop_rst) |-> !$fell(push_rst) [* ResetLen], push_clk, rst)
   `BR_ASSUME_CR(hold_pop_rst_a, $rose(push_rst) |-> !$fell(pop_rst) [* ResetLen], pop_clk, rst)
-  */
+
 endmodule : br_cdc_fifo_basic_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
@@ -211,4 +211,28 @@ module br_cdc_fifo_basic_fpv_monitor #(
   // ----------Critical Covers----------
   `BR_COVER_CR(fifo_full_c, push_full, push_clk, push_rst)
 
+  // ----------assert reset again----------
+  localparam int ResetLen = NumSyncStages + 2;
+  logic [1:0] push_rst_cnt, pop_rst_cnt;
+  logic push_rst_flg, pop_rst_flg;
+  logic push_rst_d, pop_rst_d;
+
+  `BR_REGNX(push_rst_d, push_rst, push_clk);
+  `BR_REGNX(pop_rst_d, pop_rst, pop_clk);
+  `BR_REGLX(push_rst_cnt, push_rst_cnt + 1, !push_rst && push_rst_d, push_clk, rst)
+  `BR_REGLX(pop_rst_cnt, pop_rst_cnt + 1, !pop_rst && pop_rst_d, pop_clk, rst)
+  `BR_REGLX(push_rst_flg, 1, push_rst && !push_rst_d, push_clk, rst)
+  `BR_REGLX(pop_rst_flg, 1, pop_rst && !pop_rst_d, pop_clk, rst)
+
+  `BR_ASSUME_CR(push_rst_twice_a, push_rst_cnt <= 2, push_clk, rst)
+  `BR_ASSUME_CR(pop_rst_twice_a, pop_rst_cnt <= 2, pop_clk, rst)
+  `BR_ASSUME_CR(push_rst_rise_once_a, push_rst_flg |-> !$rose(push_rst), push_clk, rst)
+  `BR_ASSUME_CR(pop_rst_rise_once_a, pop_rst_flg |-> !$rose(pop_rst), pop_clk, rst)
+  // Don't assert reset until NumSyncStages + 2 cycles after the other side's reset is deasserted
+  `BR_ASSUME_CR(no_push_rst_a, !pop_rst |-> !$rose(push_rst) [* ResetLen], push_clk, rst)
+  `BR_ASSUME_CR(no_pop_rst_a, !push_rst |-> !$rose(pop_rst) [* ResetLen], pop_clk, rst)
+  // Don't deassert reset until NumSyncStages + 2 cycles after the other side's reset is asserted
+  `BR_ASSUME_CR(hold_push_rst_a, pop_rst |-> !$fell(push_rst) [* ResetLen], push_clk, rst)
+  `BR_ASSUME_CR(hold_pop_rst_a, push_rst |-> !$fell(pop_rst) [* ResetLen], pop_clk, rst)
+
 endmodule : br_cdc_fifo_basic_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
@@ -14,8 +14,8 @@ assume -name deassert_rst {##1 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
-assume -env {!push_rst |=> !push_rst}
-assume -env {!pop_rst |=> !pop_rst}
+#assume -env {!push_rst |=> !push_rst}
+#assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}
 assume -env {s_eventually !pop_rst}
 
@@ -41,14 +41,6 @@ pop_rst |-> pop_ram_rd_data_valid == 'd0}
 # add assumption to force it to zero during first system_clock cycle.
 assume -bound 1 {dut.br_cdc_fifo_ctrl_push_1r1w.br_cdc_fifo_push_ctrl.br_cdc_fifo_push_flag_mgr.br_cdc_fifo_reset_overlap_checks.overlap_cycles == 'd0}
 assume -bound 1 {dut.br_cdc_fifo_ctrl_pop_1r1w_inst.br_cdc_fifo_pop_ctrl.br_cdc_fifo_pop_flag_mgr.br_cdc_fifo_reset_overlap_checks.overlap_cycles == 'd0}
-
-# push_count_gray is not initialized, so it becomes a random value in FV.
-# It needs RamWriteLatency of push_clk cycles to be initialized to zero.
-# Since push_clk : pop_clk ratio can be 10:1 in current set up, instead of waiting for 10xRamWriteLatency cycles,
-# we just directly assume it to be zero at beginning.
-assume -bound 1 {dut.br_cdc_fifo_ctrl_push_1r1w.br_cdc_fifo_push_ctrl.br_cdc_fifo_push_flag_mgr.br_delay_nr_push_count_gray.stages[1] == 'd0}
-assume -bound 1 {dut.br_cdc_fifo_ctrl_push_1r1w.br_cdc_fifo_push_ctrl.br_cdc_fifo_push_flag_mgr.br_delay_nr_push_count_gray.stages[2] == 'd0}
-assume -bound 1 {dut.br_cdc_fifo_ctrl_push_1r1w.br_cdc_fifo_push_ctrl.br_cdc_fifo_push_flag_mgr.br_delay_nr_push_count_gray.stages[3] == 'd0}
 
 # primary output control signal should be legal during reset
 #assert -name fv_rst_check_push_ram_write_valid {@(posedge push_clk) \

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
@@ -9,13 +9,13 @@ clock pop_clk -from 1 -to 10 -both_edges
 # declare always_in system clock
 reset -none
 assume -reset -name set_rst_during_reset {rst}
-assume -bound 30 -name delay_rst {rst}
-assume -name deassert_rst {##30 !rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
-#assume -env {!push_rst |=> !push_rst}
-#assume -env {!pop_rst |=> !pop_rst}
+assume -env {!push_rst |=> !push_rst}
+assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}
 assume -env {s_eventually !pop_rst}
 
@@ -41,6 +41,14 @@ pop_rst |-> pop_ram_rd_data_valid == 'd0}
 # add assumption to force it to zero during first system_clock cycle.
 assume -bound 1 {dut.br_cdc_fifo_ctrl_push_1r1w.br_cdc_fifo_push_ctrl.br_cdc_fifo_push_flag_mgr.br_cdc_fifo_reset_overlap_checks.overlap_cycles == 'd0}
 assume -bound 1 {dut.br_cdc_fifo_ctrl_pop_1r1w_inst.br_cdc_fifo_pop_ctrl.br_cdc_fifo_pop_flag_mgr.br_cdc_fifo_reset_overlap_checks.overlap_cycles == 'd0}
+
+# push_count_gray is not initialized, so it becomes a random value in FV.
+# It needs RamWriteLatency of push_clk cycles to be initialized to zero.
+# Since push_clk : pop_clk ratio can be 10:1 in current set up, instead of waiting for 10xRamWriteLatency cycles,
+# we just directly assume it to be zero at beginning.
+assume -bound 1 {dut.br_cdc_fifo_ctrl_push_1r1w.br_cdc_fifo_push_ctrl.br_cdc_fifo_push_flag_mgr.br_delay_nr_push_count_gray.stages[1] == 'd0}
+assume -bound 1 {dut.br_cdc_fifo_ctrl_push_1r1w.br_cdc_fifo_push_ctrl.br_cdc_fifo_push_flag_mgr.br_delay_nr_push_count_gray.stages[2] == 'd0}
+assume -bound 1 {dut.br_cdc_fifo_ctrl_push_1r1w.br_cdc_fifo_push_ctrl.br_cdc_fifo_push_flag_mgr.br_delay_nr_push_count_gray.stages[3] == 'd0}
 
 # primary output control signal should be legal during reset
 #assert -name fv_rst_check_push_ram_write_valid {@(posedge push_clk) \

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
@@ -14,8 +14,8 @@ assume -name deassert_rst {##1 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
-assume -env {!push_rst |=> !push_rst}
-assume -env {!pop_rst |=> !pop_rst}
+#assume -env {!push_rst |=> !push_rst}
+#assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}
 assume -env {s_eventually !pop_rst}
 

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
@@ -9,13 +9,11 @@ clock pop_clk -from 1 -to 10 -both_edges
 # declare always_in system clock
 reset -none
 assume -reset -name set_rst_during_reset {rst}
-assume -bound 1 -name delay_rst {rst}
-assume -name deassert_rst {##1 !rst}
+assume -bound 30 -name delay_rst {rst}
+assume -name deassert_rst {##30 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
-assume -env {$fell(rst) |-> $fell(push_rst)}
-assume -env {$fell(rst) |-> $fell(pop_rst)}
 #assume -env {!push_rst |=> !push_rst}
 #assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv.jg.tcl
@@ -14,6 +14,8 @@ assume -name deassert_rst {##1 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
+assume -env {$fell(rst) |-> $fell(push_rst)}
+assume -env {$fell(rst) |-> $fell(pop_rst)}
 #assume -env {!push_rst |=> !push_rst}
 #assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
@@ -142,6 +142,7 @@ module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
   );
 
   // ----------assert reset again----------
+  localparam int ResetLen = NumSyncStages + 1;
   logic [1:0] push_rst_cnt, pop_rst_cnt;
   logic push_rst_flg, pop_rst_flg;
   logic push_rst_d, pop_rst_d;
@@ -157,5 +158,9 @@ module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
   `BR_ASSUME_CR(pop_rst_twice_a, pop_rst_cnt <= 2, pop_clk, rst)
   `BR_ASSUME_CR(push_rst_rise_once_a, push_rst_flg |-> !$rose(push_rst), push_clk, rst)
   `BR_ASSUME_CR(pop_rst_rise_once_a, pop_rst_flg |-> !$rose(pop_rst), pop_clk, rst)
+  `BR_ASSUME_CR(push_rst_propagate_a, $rose(push_rst) |-> push_rst [* ResetLen], push_clk, rst)
+  `BR_ASSUME_CR(pop_rst_propagate_a, $rose(pop_rst) |-> pop_rst [* ResetLen], pop_clk, rst)
+  `BR_ASSUME_CR(hold_push_rst_a, $rose(push_rst) |-> push_rst s_until pop_rst [* ResetLen],
+                push_clk, rst)
 
 endmodule : br_cdc_fifo_ctrl_1r1w_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
@@ -141,26 +141,4 @@ module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
       .pop_items
   );
 
-  // ----------assert reset again----------
-  localparam int ResetLen = NumSyncStages + 1;
-  logic [1:0] push_rst_cnt, pop_rst_cnt;
-  logic push_rst_flg, pop_rst_flg;
-  logic push_rst_d, pop_rst_d;
-
-  `BR_REGNX(push_rst_d, push_rst, push_clk);
-  `BR_REGNX(pop_rst_d, pop_rst, pop_clk);
-  `BR_REGLX(push_rst_cnt, push_rst_cnt + 1, !push_rst && push_rst_d, push_clk, rst)
-  `BR_REGLX(pop_rst_cnt, pop_rst_cnt + 1, !pop_rst && pop_rst_d, pop_clk, rst)
-  `BR_REGLX(push_rst_flg, 1, push_rst && !push_rst_d, push_clk, rst)
-  `BR_REGLX(pop_rst_flg, 1, pop_rst && !pop_rst_d, pop_clk, rst)
-
-  `BR_ASSUME_CR(push_rst_twice_a, push_rst_cnt <= 2, push_clk, rst)
-  `BR_ASSUME_CR(pop_rst_twice_a, pop_rst_cnt <= 2, pop_clk, rst)
-  `BR_ASSUME_CR(push_rst_rise_once_a, push_rst_flg |-> !$rose(push_rst), push_clk, rst)
-  `BR_ASSUME_CR(pop_rst_rise_once_a, pop_rst_flg |-> !$rose(pop_rst), pop_clk, rst)
-  `BR_ASSUME_CR(push_rst_propagate_a, $rose(push_rst) |-> push_rst [* ResetLen], push_clk, rst)
-  `BR_ASSUME_CR(pop_rst_propagate_a, $rose(pop_rst) |-> pop_rst [* ResetLen], pop_clk, rst)
-  `BR_ASSUME_CR(hold_push_rst_a, $rose(push_rst) |-> push_rst s_until pop_rst [* ResetLen],
-                push_clk, rst)
-
 endmodule : br_cdc_fifo_ctrl_1r1w_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
@@ -141,4 +141,21 @@ module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
       .pop_items
   );
 
+  // ----------assert reset again----------
+  logic [1:0] push_rst_cnt, pop_rst_cnt;
+  logic push_rst_flg, pop_rst_flg;
+  logic push_rst_d, pop_rst_d;
+
+  `BR_REGNX(push_rst_d, push_rst, push_clk);
+  `BR_REGNX(pop_rst_d, pop_rst, pop_clk);
+  `BR_REGLX(push_rst_cnt, push_rst_cnt + 1, !push_rst && push_rst_d, push_clk, rst)
+  `BR_REGLX(pop_rst_cnt, pop_rst_cnt + 1, !pop_rst && pop_rst_d, pop_clk, rst)
+  `BR_REGLX(push_rst_flg, 1, push_rst && !push_rst_d, push_clk, rst)
+  `BR_REGLX(pop_rst_flg, 1, pop_rst && !pop_rst_d, pop_clk, rst)
+
+  `BR_ASSUME_CR(push_rst_twice_a, push_rst_cnt <= 2, push_clk, rst)
+  `BR_ASSUME_CR(pop_rst_twice_a, pop_rst_cnt <= 2, pop_clk, rst)
+  `BR_ASSUME_CR(push_rst_rise_once_a, push_rst_flg |-> !$rose(push_rst), push_clk, rst)
+  `BR_ASSUME_CR(pop_rst_rise_once_a, pop_rst_flg |-> !$rose(pop_rst), pop_clk, rst)
+
 endmodule : br_cdc_fifo_ctrl_1r1w_fpv_monitor

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
@@ -9,13 +9,13 @@ clock pop_clk -from 1 -to 10 -both_edges
 # declare always_in system clock
 reset -none
 assume -reset -name set_rst_during_reset {rst}
-assume -bound 1 -name delay_rst {rst}
-assume -name deassert_rst {##1 !rst}
+assume -bound 30 -name delay_rst {rst}
+assume -name deassert_rst {##30 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
-assume -env {!push_rst |=> !push_rst}
-assume -env {!pop_rst |=> !pop_rst}
+#assume -env {!push_rst |=> !push_rst}
+#assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}
 assume -env {s_eventually !pop_rst}
 

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv.jg.tcl
@@ -9,13 +9,13 @@ clock pop_clk -from 1 -to 10 -both_edges
 # declare always_in system clock
 reset -none
 assume -reset -name set_rst_during_reset {rst}
-assume -bound 1 -name delay_rst {rst}
-assume -name deassert_rst {##1 !rst}
+assume -bound 30 -name delay_rst {rst}
+assume -name deassert_rst {##30 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
-assume -env {!push_rst |=> !push_rst}
-assume -env {!pop_rst |=> !pop_rst}
+#assume -env {!push_rst |=> !push_rst}
+#assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}
 assume -env {s_eventually !pop_rst}
 

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl
@@ -9,13 +9,13 @@ clock pop_clk -from 1 -to 10 -both_edges
 # declare always_in system clock
 reset -none
 assume -reset -name set_rst_during_reset {rst}
-assume -bound 1 -name delay_rst {rst}
-assume -name deassert_rst {##1 !rst}
+assume -bound 30 -name delay_rst {rst}
+assume -name deassert_rst {##30 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
-assume -env {!push_rst |=> !push_rst}
-assume -env {!pop_rst |=> !pop_rst}
+#assume -env {!push_rst |=> !push_rst}
+#assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}
 assume -env {s_eventually !pop_rst}
 

--- a/cdc/fpv/br_cdc_fifo_flops_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_flops_fpv.jg.tcl
@@ -9,13 +9,13 @@ clock pop_clk -from 1 -to 10 -both_edges
 # declare always_in system clock
 reset -none
 assume -reset -name set_rst_during_reset {rst}
-assume -bound 1 -name delay_rst {rst}
-assume -name deassert_rst {##1 !rst}
+assume -bound 30 -name delay_rst {rst}
+assume -name deassert_rst {##30 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
-assume -env {!push_rst |=> !push_rst}
-assume -env {!pop_rst |=> !pop_rst}
+#assume -env {!push_rst |=> !push_rst}
+#assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}
 assume -env {s_eventually !pop_rst}
 

--- a/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv.jg.tcl
@@ -9,13 +9,13 @@ clock pop_clk -from 1 -to 10 -both_edges
 # declare always_in system clock
 reset -none
 assume -reset -name set_rst_during_reset {rst}
-assume -bound 1 -name delay_rst {rst}
-assume -name deassert_rst {##1 !rst}
+assume -bound 30 -name delay_rst {rst}
+assume -name deassert_rst {##30 !rst}
 # reset are ready at different times
 assume -env {rst |-> push_rst}
 assume -env {rst |-> pop_rst}
-assume -env {!push_rst |=> !push_rst}
-assume -env {!pop_rst |=> !pop_rst}
+#assume -env {!push_rst |=> !push_rst}
+#assume -env {!pop_rst |=> !pop_rst}
 assume -env {s_eventually !push_rst}
 assume -env {s_eventually !pop_rst}
 


### PR DESCRIPTION
Once FPV test is out of reset, FV usually doesn't go into reset again.
However, due to RTL bug https://github.com/xlsynth/bedrock-rtl/issues/948, adding this change so push_rst and pop_rst would reset twice. 

bazel test //cdc/fpv:br_cdc_fifo_ctrl_1r1w_test_suite_jg_d2_nss3_rrl0_rwl3_rpo0_w1_fpv_test --test_env=DISPLAY=$DISPLAY --test_timeout=18000

assertion to debug:
<embedded>::br_cdc_fifo_ctrl_1r1w_fpv_monitor.dut.br_cdc_fifo_ctrl_push_1r1w.br_cdc_fifo_push_ctrl.slots_in_range_a