### PR TITLE
[fv] Add shrink checkers for br_amba_axi_shrinker

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -431,6 +431,7 @@ verilog_library(
     srcs = ["br_amba_axi_shrinker_fpv_monitor.sv"],
     deps = [
         "//amba/rtl:br_amba_axi_shrinker",
+        "//fpv/lib:fv_fifo",
     ],
 )
 

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -448,6 +448,7 @@ br_verilog_fpv_test_tools_suite(
         "-parameter MaxOutstandingReqs 8",
         "-parameter IdWidth 3",
     ],
+    gui = True,
     tools = {
         "jg": "br_amba_axi_shrinker_fpv.jg.tcl",
     },

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -458,12 +458,13 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_shrinker_test_suite",
     elab_opts = [
-        "-parameter WideDataWidth 64",
+        "-parameter WideDataWidth 128",
         "-parameter MaxOutstandingReqs 4",
         "-parameter IdWidth 3",
     ],
     params = {
         "NarrowDataWidth": [
+            "32",
             "16",
             "8",
         ],

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -396,6 +396,7 @@ verilog_elab_test(
     custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
     # elab complains about: use of undefined macro 'JS3_OUT_OF_ORDER'
     # needs to disable those spurious warnings for regression
+    tags = ["manual"],
     tool = "verific",
     deps = [":br_amba_axi_demux_fpv_monitor"],
 )

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -37,6 +37,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_default_target_test_suite",
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil_default_target_fpv.jg.tcl",
     },
@@ -73,6 +74,7 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_default_target_fpv.jg.tcl",
     },
@@ -102,6 +104,7 @@ br_verilog_fpv_test_tools_suite(
     elab_opts = [
         "-parameter MaxOutstandingReqs 4",
     ],
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi2axil_fpv.jg.tcl",
     },
@@ -135,6 +138,7 @@ br_verilog_fpv_test_tools_suite(
             "3",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil_split_fpv.jg.tcl",
     },
@@ -161,6 +165,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_timing_slice_test_suite",
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_timing_slice_fpv.jg.tcl",
     },
@@ -187,6 +192,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_timing_slice_test_suite",
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil_timing_slice_fpv.jg.tcl",
     },
@@ -213,6 +219,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil2apb_test_suite",
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil2apb_fpv.jg.tcl",
     },
@@ -239,6 +246,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_apb_timing_slice_test_suite",
+    tags = ["manual"],
     tools = {
         "jg": "",
     },
@@ -265,6 +273,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_atb_funnel_test_suite",
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_atb_funnel_fpv.jg.tcl",
     },
@@ -291,6 +300,7 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_msi_test_suite",
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil_msi_fpv.jg.tcl",
     },
@@ -327,6 +337,7 @@ br_verilog_fpv_test_tools_suite(
             "256",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_isolate_mgr_fpv.jg.tcl",
     },
@@ -373,6 +384,7 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_isolate_sub_fpv.jg.tcl",
     },
@@ -417,6 +429,7 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
     },
+    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_demux_fpv.jg.tcl",
     },
@@ -445,11 +458,16 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_shrinker_test_suite",
     elab_opts = [
-        "-parameter WideDataWidth 16",
-        "-parameter MaxOutstandingReqs 8",
+        "-parameter WideDataWidth 32",
+        "-parameter MaxOutstandingReqs 4",
         "-parameter IdWidth 3",
     ],
-    gui = True,
+    params = {
+        "NarrowDataWidth": [
+            "16",
+            "8",
+        ],
+    },
     tools = {
         "jg": "br_amba_axi_shrinker_fpv.jg.tcl",
     },

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -37,7 +37,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_default_target_test_suite",
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil_default_target_fpv.jg.tcl",
     },
@@ -74,7 +73,6 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_default_target_fpv.jg.tcl",
     },
@@ -104,7 +102,6 @@ br_verilog_fpv_test_tools_suite(
     elab_opts = [
         "-parameter MaxOutstandingReqs 4",
     ],
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi2axil_fpv.jg.tcl",
     },
@@ -138,7 +135,6 @@ br_verilog_fpv_test_tools_suite(
             "3",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil_split_fpv.jg.tcl",
     },
@@ -165,7 +161,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_timing_slice_test_suite",
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_timing_slice_fpv.jg.tcl",
     },
@@ -192,7 +187,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_timing_slice_test_suite",
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil_timing_slice_fpv.jg.tcl",
     },
@@ -219,7 +213,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil2apb_test_suite",
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil2apb_fpv.jg.tcl",
     },
@@ -246,7 +239,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_apb_timing_slice_test_suite",
-    tags = ["manual"],
     tools = {
         "jg": "",
     },
@@ -273,7 +265,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_atb_funnel_test_suite",
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_atb_funnel_fpv.jg.tcl",
     },
@@ -300,7 +291,6 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axil_msi_test_suite",
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axil_msi_fpv.jg.tcl",
     },
@@ -337,7 +327,6 @@ br_verilog_fpv_test_tools_suite(
             "256",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_isolate_mgr_fpv.jg.tcl",
     },
@@ -384,7 +373,6 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_isolate_sub_fpv.jg.tcl",
     },
@@ -408,7 +396,6 @@ verilog_elab_test(
     custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
     # elab complains about: use of undefined macro 'JS3_OUT_OF_ORDER'
     # needs to disable those spurious warnings for regression
-    tags = ["manual"],
     tool = "verific",
     deps = [":br_amba_axi_demux_fpv_monitor"],
 )
@@ -429,7 +416,6 @@ br_verilog_fpv_test_tools_suite(
             "1",
         ],
     },
-    tags = ["manual"],
     tools = {
         "jg": "br_amba_axi_demux_fpv.jg.tcl",
     },

--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -458,7 +458,7 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_shrinker_test_suite",
     elab_opts = [
-        "-parameter WideDataWidth 32",
+        "-parameter WideDataWidth 64",
         "-parameter MaxOutstandingReqs 4",
         "-parameter IdWidth 3",
     ],

--- a/amba/fpv/br_amba_axi_shrinker_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_shrinker_fpv.jg.tcl
@@ -7,7 +7,7 @@ reset rst
 get_design_info
 
 # limit run time to 30-mins
-set_prove_time_limit 30m
+set_prove_time_limit 2h
 
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axi_shrinker_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_shrinker_fpv.jg.tcl
@@ -7,7 +7,7 @@ reset rst
 get_design_info
 
 # limit run time to 30-mins
-set_prove_time_limit 2h
+set_prove_time_limit 30m
 
 # fv_fifo is a bit oversized
 cover -disable *monitor.w_fifo.gen_Bypass_ast.no_push_full_a:precondition1

--- a/amba/fpv/br_amba_axi_shrinker_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axi_shrinker_fpv.jg.tcl
@@ -9,5 +9,8 @@ get_design_info
 # limit run time to 30-mins
 set_prove_time_limit 2h
 
+# fv_fifo is a bit oversized
+cover -disable *monitor.w_fifo.gen_Bypass_ast.no_push_full_a:precondition1
+
 # prove command
 prove -all

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -105,9 +105,12 @@ module br_amba_axi_shrinker_fpv_monitor #(
 
   localparam int WideSizeLog2 = $clog2(WideStrobeWidth);
   localparam int NarrowSizeLog2 = $clog2(NarrowStrobeWidth);
+  localparam int LanesPerWide = WideDataWidth / NarrowDataWidth;
+  localparam int LaneIdxWidth = br_math::clamped_clog2(LanesPerWide);
   localparam int ArPayloadWidth = AddrWidth + IdWidth + br_amba::AxiBurstLenWidth +
                                   br_amba::AxiBurstSizeWidth + br_amba::AxiBurstTypeWidth +
                                   br_amba::AxiProtWidth + ARUserWidth;
+  localparam int RPayloadWidth = IdWidth + WideDataWidth + RUserWidth + br_amba::AxiRespWidth + 1;
 
   // ABVIP should send more than DUT to test backpressure.
   localparam int MaxPending = MaxOutstandingReqs + WriteFifoDepth + 2;
@@ -117,6 +120,15 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic [ArPayloadWidth-1:0] fv_narrow_ar_payload;
   int unsigned ar_shift;
   logic [br_amba::AxiBurstLenWidth:0] fv_narrow_arlen_ext;
+  logic fv_narrow_r_hs;
+  logic fv_wide_rdata_vld;
+  logic [IdWidth-1:0] fv_rid_idx;
+  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_lane;
+  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_lane_next;
+  logic [MaxOutstandingReqs-1:0][WideDataWidth-1:0] fv_wide_rdata_saved;
+  logic [MaxOutstandingReqs-1:0][WideDataWidth-1:0] fv_wide_rdata_next;
+  logic [MaxOutstandingReqs-1:0][WideDataWidth-1:0] fv_wide_rdata_saved_next;
+  logic [RPayloadWidth-1:0] fv_wide_r_payload;
 
   always_comb begin
     ar_shift = 0;
@@ -166,6 +178,56 @@ module br_amba_axi_shrinker_fpv_monitor #(
         narrow_arprot,
         narrow_aruser
       })
+  );
+
+  // Reconstructs the wide read data from accepted narrow R beats.
+  // Stitch state is kept per tracked RID slot, and earlier beats fill lower
+  // byte lanes first within that slot.
+  assign fv_narrow_r_hs = narrow_rvalid && narrow_rready;
+  assign fv_wide_rdata_vld = fv_narrow_r_hs && narrow_rlast;
+  assign fv_rid_idx = narrow_rid;
+
+  always_comb begin
+    fv_r_lane_next = fv_r_lane;
+    fv_wide_rdata_next = fv_wide_rdata_saved;
+    fv_wide_rdata_saved_next = fv_wide_rdata_saved;
+
+    if (fv_narrow_r_hs) begin
+      fv_wide_rdata_next[fv_rid_idx]
+          [fv_r_lane[fv_rid_idx]*NarrowDataWidth +: NarrowDataWidth] = narrow_rdata;
+      fv_wide_rdata_saved_next = fv_wide_rdata_next;
+
+      if (narrow_rlast) begin
+        fv_r_lane_next[fv_rid_idx] = '0;
+        fv_wide_rdata_saved_next[fv_rid_idx] = '0;
+      end else begin
+        fv_r_lane_next[fv_rid_idx] = fv_r_lane[fv_rid_idx] + 1'b1;
+      end
+    end
+  end
+
+  `BR_REGLI(fv_r_lane, fv_r_lane_next, fv_narrow_r_hs, '0)
+  `BR_REGLI(fv_wide_rdata_saved, fv_wide_rdata_saved_next, fv_narrow_r_hs, '0)
+
+  assign fv_wide_r_payload = {
+    narrow_rid, fv_wide_rdata_next[fv_rid_idx], narrow_ruser, narrow_rresp, narrow_rlast
+  };
+
+  // Checks that the reconstructed wide R payload from the narrow interface
+  // matches the RTL wide R channel.
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(RPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxPending)
+  ) r_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(fv_wide_rdata_vld),
+      .incoming_data(fv_wide_r_payload),
+      .outgoing_vld(wide_rvalid && wide_rready),
+      .outgoing_data({wide_rid, wide_rdata, wide_ruser, wide_rresp, wide_rlast})
   );
 
   `BR_ASSUME(

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -107,6 +107,9 @@ module br_amba_axi_shrinker_fpv_monitor #(
   localparam int NarrowSizeLog2 = $clog2(NarrowStrobeWidth);
   localparam int LanesPerWide = WideDataWidth / NarrowDataWidth;
   localparam int LaneIdxWidth = br_math::clamped_clog2(LanesPerWide);
+  localparam int ByteOffsetWidth = br_math::clamped_clog2(WideStrobeWidth);
+  localparam int InternalIdWidth = br_math::clamped_clog2(MaxOutstandingReqs);
+  localparam int BeatOffsetIncrWidth = $clog2(NarrowStrobeWidth + 1);
   localparam int ArPayloadWidth = AddrWidth + IdWidth + br_amba::AxiBurstLenWidth +
                                   br_amba::AxiBurstSizeWidth + br_amba::AxiBurstTypeWidth +
                                   br_amba::AxiProtWidth + ARUserWidth;
@@ -120,16 +123,95 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic [ArPayloadWidth-1:0] fv_narrow_ar_payload;
   int unsigned ar_shift;
   logic [br_amba::AxiBurstLenWidth:0] fv_narrow_arlen_ext;
+  logic fv_wide_ar_hs;
   logic fv_narrow_r_hs;
   logic fv_wide_rdata_vld;
-  logic [IdWidth-1:0] fv_rid_idx;
-  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_lane;
-  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_lane_next;
+  logic [InternalIdWidth-1:0] fv_wide_ar_idx;
+  logic [InternalIdWidth-1:0] fv_rid_idx;
+  logic [ByteOffsetWidth-1:0] fv_wide_ar_offset;
+  logic [BeatOffsetIncrWidth-1:0] fv_r_offset_incr_cfg;
+  logic [LaneIdxWidth:0] fv_r_beats_per_wide_ext;
+  logic [LaneIdxWidth:0] fv_r_beats_per_wide_m1_ext;
+  logic [LaneIdxWidth-1:0] fv_r_beats_per_wide_m1_cfg;
+  logic [LaneIdxWidth-1:0] fv_r_lane_cur;
+  logic [LaneIdxWidth-1:0] fv_r_beat_id_cur;
+  logic [BeatOffsetIncrWidth-1:0] fv_r_offset_incr_cur;
+  logic [ByteOffsetWidth-1:0] fv_r_offset_after_beat;
+  logic [br_amba::AxiRespWidth-1:0] fv_wide_rresp_cur;
+  logic fv_r_beat_last;
+  logic [MaxOutstandingReqs-1:0] fv_r_is_fixed;
+  logic [MaxOutstandingReqs-1:0] fv_r_is_fixed_next;
+  logic [MaxOutstandingReqs-1:0][ByteOffsetWidth-1:0] fv_r_offset;
+  logic [MaxOutstandingReqs-1:0][ByteOffsetWidth-1:0] fv_r_offset_next;
+  logic [MaxOutstandingReqs-1:0][BeatOffsetIncrWidth-1:0] fv_r_offset_incr;
+  logic [MaxOutstandingReqs-1:0][BeatOffsetIncrWidth-1:0] fv_r_offset_incr_next;
+  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_beats_per_wide_m1;
+  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_beats_per_wide_m1_next;
+  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_beat_id;
+  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_beat_id_next;
   logic [MaxOutstandingReqs-1:0][WideDataWidth-1:0] fv_wide_rdata_saved;
-  logic [MaxOutstandingReqs-1:0][WideDataWidth-1:0] fv_wide_rdata_next;
   logic [MaxOutstandingReqs-1:0][WideDataWidth-1:0] fv_wide_rdata_saved_next;
+  logic [WideDataWidth-1:0] fv_wide_rdata_cur;
+  logic [MaxOutstandingReqs-1:0][br_amba::AxiRespWidth-1:0] fv_wide_rresp_saved;
+  logic [MaxOutstandingReqs-1:0][br_amba::AxiRespWidth-1:0] fv_wide_rresp_saved_next;
   logic [RPayloadWidth-1:0] fv_wide_r_payload;
 
+  function automatic logic [br_amba::AxiRespWidth-1:0] fv_combine_rresp(
+      input logic [br_amba::AxiRespWidth-1:0] saved_resp,
+      input logic [br_amba::AxiRespWidth-1:0] narrow_resp);
+    begin
+      unique case (br_amba::axi_resp_t'(narrow_resp))
+        br_amba::AxiRespOkay: fv_combine_rresp = saved_resp;
+        br_amba::AxiRespExOkay:
+        if (saved_resp == br_amba::AxiRespOkay) begin
+          fv_combine_rresp = br_amba::AxiRespExOkay;
+        end else begin
+          fv_combine_rresp = saved_resp;
+        end
+        br_amba::AxiRespSlverr:
+        if (saved_resp == br_amba::AxiRespDecerr) begin
+          fv_combine_rresp = br_amba::AxiRespDecerr;
+        end else begin
+          fv_combine_rresp = br_amba::AxiRespSlverr;
+        end
+        br_amba::AxiRespDecerr: fv_combine_rresp = br_amba::AxiRespDecerr;
+        default: fv_combine_rresp = 'x;
+      endcase
+    end
+  endfunction
+
+  // ----------FV assumptions----------
+  `BR_ASSUME(
+      shrinking_awburst_incr_a,
+      (wide_awvalid && wide_awsize > NarrowSizeLog2) |-> wide_awburst == br_amba::AxiBurstIncr)
+  `BR_ASSUME(
+      shrinking_arburst_incr_a,
+      (wide_arvalid && wide_arsize > NarrowSizeLog2) |-> wide_arburst == br_amba::AxiBurstIncr)
+
+  // Make sure wide len and size won't result in narrow len overflowing
+  localparam int ExtBurstLenWidth = br_amba::AxiBurstLenWidth + WideSizeLog2 - NarrowSizeLog2;
+  localparam int MaxBurstLen = 2 ** br_amba::AxiBurstLenWidth - 1;
+
+  logic [ExtBurstLenWidth-1:0] ext_wide_awlen;
+  logic [ExtBurstLenWidth-1:0] ext_wide_arlen;
+  logic [ExtBurstLenWidth-1:0] ext_narrow_awlen;
+  logic [ExtBurstLenWidth-1:0] ext_narrow_arlen;
+
+  assign ext_wide_awlen = ExtBurstLenWidth'(wide_awlen);
+  assign ext_wide_arlen = ExtBurstLenWidth'(wide_arlen);
+
+  assign ext_narrow_awlen =
+      (wide_awsize > NarrowSizeLog2) ?
+      ((ext_wide_awlen + 1'b1) << (wide_awsize - NarrowSizeLog2)) - 1'b1 : ext_wide_awlen;
+  assign ext_narrow_arlen =
+      (wide_arsize > NarrowSizeLog2) ?
+      ((ext_wide_arlen + 1'b1) << (wide_arsize - NarrowSizeLog2)) - 1'b1 : ext_wide_arlen;
+
+  `BR_ASSUME(narrow_awlen_no_overflow_a, wide_awvalid |-> ext_narrow_awlen <= MaxBurstLen)
+  `BR_ASSUME(narrow_arlen_no_overflow_a, wide_arvalid |-> ext_narrow_arlen <= MaxBurstLen)
+
+  // ----------Shrink checks----------
+  // ----------AR channel----------
   always_comb begin
     ar_shift = 0;
     fv_narrow_arsize = wide_arsize;
@@ -180,37 +262,79 @@ module br_amba_axi_shrinker_fpv_monitor #(
       })
   );
 
+  // ----------R channel----------
   // Reconstructs the wide read data from accepted narrow R beats.
-  // Stitch state is kept per tracked RID slot, and earlier beats fill lower
-  // byte lanes first within that slot.
+  // Stitch state is kept per tracked RID slot using the original wide AR
+  // address and size so the monitor emits one reconstructed wide beat whenever
+  // the shrink ratio says that wide beat is complete.
+  assign fv_wide_ar_hs = wide_arvalid && wide_arready;
   assign fv_narrow_r_hs = narrow_rvalid && narrow_rready;
-  assign fv_wide_rdata_vld = fv_narrow_r_hs && narrow_rlast;
-  assign fv_rid_idx = narrow_rid;
+  assign fv_wide_ar_idx = wide_arid[InternalIdWidth-1:0];
+  assign fv_rid_idx = narrow_rid[InternalIdWidth-1:0];
+  assign fv_wide_ar_offset = wide_araddr[ByteOffsetWidth-1:0];
+  assign fv_r_offset_incr_cfg = BeatOffsetIncrWidth'(1'b1) << fv_narrow_arsize;
+  assign fv_r_beats_per_wide_ext = {{LaneIdxWidth{1'b0}}, 1'b1} << ar_shift;
+  assign fv_r_beats_per_wide_m1_ext = fv_r_beats_per_wide_ext - 1'b1;
+  assign fv_r_beats_per_wide_m1_cfg = fv_r_beats_per_wide_m1_ext[LaneIdxWidth-1:0];
+  assign fv_r_lane_cur = LaneIdxWidth'(fv_r_offset[fv_rid_idx] >> NarrowSizeLog2);
+  assign fv_r_beat_id_cur = fv_r_beat_id[fv_rid_idx];
+  assign fv_r_offset_incr_cur = fv_r_offset_incr[fv_rid_idx];
+  assign fv_r_offset_after_beat = fv_r_is_fixed[fv_rid_idx] ? fv_r_offset[fv_rid_idx]
+                                                            : fv_r_offset[fv_rid_idx] +
+                                                              fv_r_offset_incr_cur;
+  assign fv_r_beat_last = fv_r_beat_id_cur == fv_r_beats_per_wide_m1[fv_rid_idx];
+  assign fv_wide_rdata_vld = fv_narrow_r_hs && fv_r_beat_last;
 
   always_comb begin
-    fv_r_lane_next = fv_r_lane;
-    fv_wide_rdata_next = fv_wide_rdata_saved;
+    fv_r_is_fixed_next = fv_r_is_fixed;
+    fv_r_offset_next = fv_r_offset;
+    fv_r_offset_incr_next = fv_r_offset_incr;
+    fv_r_beats_per_wide_m1_next = fv_r_beats_per_wide_m1;
+    fv_r_beat_id_next = fv_r_beat_id;
+    fv_wide_rdata_cur = fv_wide_rdata_saved[fv_rid_idx];
     fv_wide_rdata_saved_next = fv_wide_rdata_saved;
+    fv_wide_rresp_cur = fv_wide_rresp_saved[fv_rid_idx];
+    fv_wide_rresp_saved_next = fv_wide_rresp_saved;
+
+    if (fv_wide_ar_hs) begin
+      fv_r_is_fixed_next[fv_wide_ar_idx] = wide_arburst == br_amba::AxiBurstFixed;
+      fv_r_offset_next[fv_wide_ar_idx] = fv_wide_ar_offset;
+      fv_r_offset_incr_next[fv_wide_ar_idx] = fv_r_offset_incr_cfg;
+      fv_r_beats_per_wide_m1_next[fv_wide_ar_idx] = fv_r_beats_per_wide_m1_cfg;
+      fv_r_beat_id_next[fv_wide_ar_idx] = '0;
+      fv_wide_rdata_saved_next[fv_wide_ar_idx] = '0;
+      fv_wide_rresp_saved_next[fv_wide_ar_idx] = br_amba::AxiRespOkay;
+    end
 
     if (fv_narrow_r_hs) begin
-      fv_wide_rdata_next[fv_rid_idx]
-          [fv_r_lane[fv_rid_idx]*NarrowDataWidth +: NarrowDataWidth] = narrow_rdata;
-      fv_wide_rdata_saved_next = fv_wide_rdata_next;
+      fv_wide_rdata_cur[fv_r_lane_cur*NarrowDataWidth+:NarrowDataWidth] = narrow_rdata;
+      fv_wide_rresp_cur = fv_combine_rresp(fv_wide_rresp_saved[fv_rid_idx], narrow_rresp);
+      fv_r_offset_next[fv_rid_idx] = fv_r_offset_after_beat;
 
-      if (narrow_rlast) begin
-        fv_r_lane_next[fv_rid_idx] = '0;
+      if (fv_r_beat_last) begin
+        fv_r_beat_id_next[fv_rid_idx] = '0;
         fv_wide_rdata_saved_next[fv_rid_idx] = '0;
+        fv_wide_rresp_saved_next[fv_rid_idx] = br_amba::AxiRespOkay;
       end else begin
-        fv_r_lane_next[fv_rid_idx] = fv_r_lane[fv_rid_idx] + 1'b1;
+        fv_r_beat_id_next[fv_rid_idx] = fv_r_beat_id_cur + 1'b1;
+        fv_wide_rdata_saved_next[fv_rid_idx] = fv_wide_rdata_cur;
+        fv_wide_rresp_saved_next[fv_rid_idx] = fv_wide_rresp_cur;
       end
     end
   end
 
-  `BR_REGLI(fv_r_lane, fv_r_lane_next, fv_narrow_r_hs, '0)
-  `BR_REGLI(fv_wide_rdata_saved, fv_wide_rdata_saved_next, fv_narrow_r_hs, '0)
+  `BR_REGLI(fv_r_is_fixed, fv_r_is_fixed_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
+  `BR_REGLI(fv_r_offset, fv_r_offset_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
+  `BR_REGLI(fv_r_offset_incr, fv_r_offset_incr_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
+  `BR_REGLI(fv_r_beats_per_wide_m1, fv_r_beats_per_wide_m1_next, fv_wide_ar_hs || fv_narrow_r_hs,
+            '0)
+  `BR_REGLI(fv_r_beat_id, fv_r_beat_id_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
+  `BR_REGLI(fv_wide_rdata_saved, fv_wide_rdata_saved_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
+  `BR_REGLI(fv_wide_rresp_saved, fv_wide_rresp_saved_next, fv_wide_ar_hs || fv_narrow_r_hs,
+            {MaxOutstandingReqs{br_amba::AxiRespOkay}})
 
   assign fv_wide_r_payload = {
-    narrow_rid, fv_wide_rdata_next[fv_rid_idx], narrow_ruser, narrow_rresp, narrow_rlast
+    narrow_rid, fv_wide_rdata_cur, narrow_ruser, fv_wide_rresp_cur, narrow_rlast
   };
 
   // Checks that the reconstructed wide R payload from the narrow interface
@@ -230,35 +354,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .outgoing_data({wide_rid, wide_rdata, wide_ruser, wide_rresp, wide_rlast})
   );
 
-  `BR_ASSUME(
-      shrinking_awburst_incr_a,
-      (wide_awvalid && wide_awsize > NarrowSizeLog2) |-> wide_awburst == br_amba::AxiBurstIncr)
-  `BR_ASSUME(
-      shrinking_arburst_incr_a,
-      (wide_arvalid && wide_arsize > NarrowSizeLog2) |-> wide_arburst == br_amba::AxiBurstIncr)
-
-  // Make sure wide len and size won't result in narrow len overflowing
-  localparam int ExtBurstLenWidth = br_amba::AxiBurstLenWidth + WideSizeLog2 - NarrowSizeLog2;
-  localparam int MaxBurstLen = 2 ** br_amba::AxiBurstLenWidth - 1;
-
-  logic [ExtBurstLenWidth-1:0] ext_wide_awlen;
-  logic [ExtBurstLenWidth-1:0] ext_wide_arlen;
-  logic [ExtBurstLenWidth-1:0] ext_narrow_awlen;
-  logic [ExtBurstLenWidth-1:0] ext_narrow_arlen;
-
-  assign ext_wide_awlen = ExtBurstLenWidth'(wide_awlen);
-  assign ext_wide_arlen = ExtBurstLenWidth'(wide_arlen);
-
-  assign ext_narrow_awlen =
-      (wide_awsize > NarrowSizeLog2) ?
-      ((ext_wide_awlen + 1'b1) << (wide_awsize - NarrowSizeLog2)) - 1'b1 : ext_wide_awlen;
-  assign ext_narrow_arlen =
-      (wide_arsize > NarrowSizeLog2) ?
-      ((ext_wide_arlen + 1'b1) << (wide_arsize - NarrowSizeLog2)) - 1'b1 : ext_wide_arlen;
-
-  `BR_ASSUME(narrow_awlen_no_overflow_a, wide_awvalid |-> ext_narrow_awlen <= MaxBurstLen)
-  `BR_ASSUME(narrow_arlen_no_overflow_a, wide_arvalid |-> ext_narrow_arlen <= MaxBurstLen)
-
+  // ----------AXI protocols----------
   axi4_master #(
       .ADDR_WIDTH(AddrWidth),
       .DATA_WIDTH(WideDataWidth),

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -110,6 +110,8 @@ module br_amba_axi_shrinker_fpv_monitor #(
   localparam int ByteOffsetWidth = br_math::clamped_clog2(WideStrobeWidth);
   localparam int InternalIdWidth = br_math::clamped_clog2(MaxOutstandingReqs);
   localparam int BeatOffsetIncrWidth = $clog2(NarrowStrobeWidth + 1);
+  localparam int BeatsPerWideWidth = br_math::clamped_clog2(LanesPerWide + 1);
+  localparam int RespRankWidth = 2;
   localparam int ArPayloadWidth = AddrWidth + IdWidth + br_amba::AxiBurstLenWidth +
                                   br_amba::AxiBurstSizeWidth + br_amba::AxiBurstTypeWidth +
                                   br_amba::AxiProtWidth + ARUserWidth;
@@ -126,56 +128,57 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic fv_wide_ar_hs;
   logic fv_narrow_r_hs;
   logic fv_wide_rdata_vld;
-  logic [InternalIdWidth-1:0] fv_wide_ar_idx;
   logic [InternalIdWidth-1:0] fv_rid_idx;
   logic [ByteOffsetWidth-1:0] fv_wide_ar_offset;
   logic [BeatOffsetIncrWidth-1:0] fv_r_offset_incr_cfg;
-  logic [LaneIdxWidth:0] fv_r_beats_per_wide_ext;
-  logic [LaneIdxWidth:0] fv_r_beats_per_wide_m1_ext;
-  logic [LaneIdxWidth-1:0] fv_r_beats_per_wide_m1_cfg;
   logic [LaneIdxWidth-1:0] fv_r_lane_cur;
-  logic [LaneIdxWidth-1:0] fv_r_beat_id_cur;
-  logic [BeatOffsetIncrWidth-1:0] fv_r_offset_incr_cur;
   logic [ByteOffsetWidth-1:0] fv_r_offset_after_beat;
+  logic [BeatsPerWideWidth-1:0] fv_r_beats_per_wide_cfg;
   logic [br_amba::AxiRespWidth-1:0] fv_wide_rresp_cur;
-  logic fv_r_beat_last;
+  logic [RespRankWidth-1:0] fv_wide_rresp_rank_cur;
+  // Per-slot state for the abstract wide-R reconstruction model.
   logic [MaxOutstandingReqs-1:0] fv_r_is_fixed;
   logic [MaxOutstandingReqs-1:0] fv_r_is_fixed_next;
   logic [MaxOutstandingReqs-1:0][ByteOffsetWidth-1:0] fv_r_offset;
   logic [MaxOutstandingReqs-1:0][ByteOffsetWidth-1:0] fv_r_offset_next;
   logic [MaxOutstandingReqs-1:0][BeatOffsetIncrWidth-1:0] fv_r_offset_incr;
   logic [MaxOutstandingReqs-1:0][BeatOffsetIncrWidth-1:0] fv_r_offset_incr_next;
-  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_beats_per_wide_m1;
-  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_beats_per_wide_m1_next;
-  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_beat_id;
-  logic [MaxOutstandingReqs-1:0][LaneIdxWidth-1:0] fv_r_beat_id_next;
+  logic [MaxOutstandingReqs-1:0][BeatsPerWideWidth-1:0] fv_r_beats_per_wide;
+  logic [MaxOutstandingReqs-1:0][BeatsPerWideWidth-1:0] fv_r_beats_per_wide_next;
+  logic [MaxOutstandingReqs-1:0][BeatsPerWideWidth-1:0] fv_r_beats_remaining;
+  logic [MaxOutstandingReqs-1:0][BeatsPerWideWidth-1:0] fv_r_beats_remaining_next;
   logic [MaxOutstandingReqs-1:0][WideDataWidth-1:0] fv_wide_rdata_saved;
   logic [MaxOutstandingReqs-1:0][WideDataWidth-1:0] fv_wide_rdata_saved_next;
   logic [WideDataWidth-1:0] fv_wide_rdata_cur;
-  logic [MaxOutstandingReqs-1:0][br_amba::AxiRespWidth-1:0] fv_wide_rresp_saved;
-  logic [MaxOutstandingReqs-1:0][br_amba::AxiRespWidth-1:0] fv_wide_rresp_saved_next;
+  logic [MaxOutstandingReqs-1:0][RespRankWidth-1:0] fv_wide_rresp_rank_saved;
+  logic [MaxOutstandingReqs-1:0][RespRankWidth-1:0] fv_wide_rresp_rank_saved_next;
   logic [RPayloadWidth-1:0] fv_wide_r_payload;
 
-  function automatic logic [br_amba::AxiRespWidth-1:0] fv_combine_rresp(
-      input logic [br_amba::AxiRespWidth-1:0] saved_resp,
-      input logic [br_amba::AxiRespWidth-1:0] narrow_resp);
+  // Rank narrow responses by architectural severity while building a wide beat.
+  function automatic logic [RespRankWidth-1:0] fv_resp_rank(
+      input logic [br_amba::AxiRespWidth-1:0] resp);
     begin
-      unique case (br_amba::axi_resp_t'(narrow_resp))
-        br_amba::AxiRespOkay: fv_combine_rresp = saved_resp;
-        br_amba::AxiRespExOkay:
-        if (saved_resp == br_amba::AxiRespOkay) begin
-          fv_combine_rresp = br_amba::AxiRespExOkay;
-        end else begin
-          fv_combine_rresp = saved_resp;
-        end
-        br_amba::AxiRespSlverr:
-        if (saved_resp == br_amba::AxiRespDecerr) begin
-          fv_combine_rresp = br_amba::AxiRespDecerr;
-        end else begin
-          fv_combine_rresp = br_amba::AxiRespSlverr;
-        end
-        br_amba::AxiRespDecerr: fv_combine_rresp = br_amba::AxiRespDecerr;
-        default: fv_combine_rresp = 'x;
+      unique case (br_amba::axi_resp_t'(resp))
+        br_amba::AxiRespOkay: fv_resp_rank = 2'd0;
+        br_amba::AxiRespExOkay: fv_resp_rank = 2'd1;
+        br_amba::AxiRespSlverr: fv_resp_rank = 2'd2;
+        br_amba::AxiRespDecerr: fv_resp_rank = 2'd3;
+        default: fv_resp_rank = 'x;
+      endcase
+    end
+  endfunction
+
+  // Convert the saved worst-severity rank back into the AXI response encoding
+  // expected on the reconstructed wide R channel.
+  function automatic logic [br_amba::AxiRespWidth-1:0] fv_rank_resp(
+      input logic [RespRankWidth-1:0] rank);
+    begin
+      unique case (rank)
+        2'd0: fv_rank_resp = br_amba::AxiRespOkay;
+        2'd1: fv_rank_resp = br_amba::AxiRespExOkay;
+        2'd2: fv_rank_resp = br_amba::AxiRespSlverr;
+        2'd3: fv_rank_resp = br_amba::AxiRespDecerr;
+        default: fv_rank_resp = 'x;
       endcase
     end
   endfunction
@@ -263,75 +266,83 @@ module br_amba_axi_shrinker_fpv_monitor #(
   );
 
   // ----------R channel----------
-  // Reconstructs the wide read data from accepted narrow R beats.
-  // Stitch state is kept per tracked RID slot using the original wide AR
-  // address and size so the monitor emits one reconstructed wide beat whenever
-  // the shrink ratio says that wide beat is complete.
+  // Abstract reconstruction model for wide R beats. Each accepted AR seeds the
+  // slot's byte offset, narrow-beat stride, and the number of narrow beats that
+  // must be seen before the next wide beat is expected on the output.
   assign fv_wide_ar_hs = wide_arvalid && wide_arready;
   assign fv_narrow_r_hs = narrow_rvalid && narrow_rready;
-  assign fv_wide_ar_idx = wide_arid[InternalIdWidth-1:0];
   assign fv_rid_idx = narrow_rid[InternalIdWidth-1:0];
   assign fv_wide_ar_offset = wide_araddr[ByteOffsetWidth-1:0];
+  // A wide beat is formed from 2**(wide_arsize - narrow_arsize) narrow beats.
   assign fv_r_offset_incr_cfg = BeatOffsetIncrWidth'(1'b1) << fv_narrow_arsize;
-  assign fv_r_beats_per_wide_ext = {{LaneIdxWidth{1'b0}}, 1'b1} << ar_shift;
-  assign fv_r_beats_per_wide_m1_ext = fv_r_beats_per_wide_ext - 1'b1;
-  assign fv_r_beats_per_wide_m1_cfg = fv_r_beats_per_wide_m1_ext[LaneIdxWidth-1:0];
+  assign fv_r_beats_per_wide_cfg = BeatsPerWideWidth'(1'b1) << ar_shift;
+  // The current byte offset determines which narrow lane is being filled next.
   assign fv_r_lane_cur = LaneIdxWidth'(fv_r_offset[fv_rid_idx] >> NarrowSizeLog2);
-  assign fv_r_beat_id_cur = fv_r_beat_id[fv_rid_idx];
-  assign fv_r_offset_incr_cur = fv_r_offset_incr[fv_rid_idx];
   assign fv_r_offset_after_beat = fv_r_is_fixed[fv_rid_idx] ? fv_r_offset[fv_rid_idx]
                                                             : fv_r_offset[fv_rid_idx] +
-                                                              fv_r_offset_incr_cur;
-  assign fv_r_beat_last = fv_r_beat_id_cur == fv_r_beats_per_wide_m1[fv_rid_idx];
-  assign fv_wide_rdata_vld = fv_narrow_r_hs && fv_r_beat_last;
+                                                              fv_r_offset_incr[fv_rid_idx];
+  assign fv_wide_rdata_vld = fv_narrow_r_hs &&
+                             (fv_r_beats_remaining[fv_rid_idx] == BeatsPerWideWidth'(1));
 
   always_comb begin
     fv_r_is_fixed_next = fv_r_is_fixed;
     fv_r_offset_next = fv_r_offset;
     fv_r_offset_incr_next = fv_r_offset_incr;
-    fv_r_beats_per_wide_m1_next = fv_r_beats_per_wide_m1;
-    fv_r_beat_id_next = fv_r_beat_id;
+    fv_r_beats_per_wide_next = fv_r_beats_per_wide;
+    fv_r_beats_remaining_next = fv_r_beats_remaining;
     fv_wide_rdata_cur = fv_wide_rdata_saved[fv_rid_idx];
     fv_wide_rdata_saved_next = fv_wide_rdata_saved;
-    fv_wide_rresp_cur = fv_wide_rresp_saved[fv_rid_idx];
-    fv_wide_rresp_saved_next = fv_wide_rresp_saved;
+    fv_wide_rresp_rank_cur = fv_wide_rresp_rank_saved[fv_rid_idx];
+    fv_wide_rresp_rank_saved_next = fv_wide_rresp_rank_saved;
 
     if (fv_wide_ar_hs) begin
-      fv_r_is_fixed_next[fv_wide_ar_idx] = wide_arburst == br_amba::AxiBurstFixed;
-      fv_r_offset_next[fv_wide_ar_idx] = fv_wide_ar_offset;
-      fv_r_offset_incr_next[fv_wide_ar_idx] = fv_r_offset_incr_cfg;
-      fv_r_beats_per_wide_m1_next[fv_wide_ar_idx] = fv_r_beats_per_wide_m1_cfg;
-      fv_r_beat_id_next[fv_wide_ar_idx] = '0;
-      fv_wide_rdata_saved_next[fv_wide_ar_idx] = '0;
-      fv_wide_rresp_saved_next[fv_wide_ar_idx] = br_amba::AxiRespOkay;
+      // A new accepted AR seeds the slot's reconstruction parameters and
+      // clears any partial wide beat state for that internal request slot.
+      fv_r_is_fixed_next[wide_arid[InternalIdWidth-1:0]] = wide_arburst == br_amba::AxiBurstFixed;
+      fv_r_offset_next[wide_arid[InternalIdWidth-1:0]] = fv_wide_ar_offset;
+      fv_r_offset_incr_next[wide_arid[InternalIdWidth-1:0]] = fv_r_offset_incr_cfg;
+      fv_r_beats_per_wide_next[wide_arid[InternalIdWidth-1:0]] = fv_r_beats_per_wide_cfg;
+      fv_r_beats_remaining_next[wide_arid[InternalIdWidth-1:0]] = fv_r_beats_per_wide_cfg;
+      fv_wide_rdata_saved_next[wide_arid[InternalIdWidth-1:0]] = '0;
+      fv_wide_rresp_rank_saved_next[wide_arid[InternalIdWidth-1:0]] = '0;
     end
 
     if (fv_narrow_r_hs) begin
+      // Merge the current narrow beat into the slot's partial wide beat and
+      // update the saved response severity if this beat is worse.
       fv_wide_rdata_cur[fv_r_lane_cur*NarrowDataWidth+:NarrowDataWidth] = narrow_rdata;
-      fv_wide_rresp_cur = fv_combine_rresp(fv_wide_rresp_saved[fv_rid_idx], narrow_rresp);
+      if (fv_wide_rresp_rank_saved[fv_rid_idx] >= fv_resp_rank(narrow_rresp)) begin
+        fv_wide_rresp_rank_cur = fv_wide_rresp_rank_saved[fv_rid_idx];
+      end else begin
+        fv_wide_rresp_rank_cur = fv_resp_rank(narrow_rresp);
+      end
       fv_r_offset_next[fv_rid_idx] = fv_r_offset_after_beat;
 
-      if (fv_r_beat_last) begin
-        fv_r_beat_id_next[fv_rid_idx] = '0;
+      if (fv_r_beats_remaining[fv_rid_idx] == BeatsPerWideWidth'(1)) begin
+        // This beat completes the reconstructed wide beat, so reset the
+        // partial data and reload the beat counter for the next wide beat.
+        fv_r_beats_remaining_next[fv_rid_idx] = fv_r_beats_per_wide[fv_rid_idx];
         fv_wide_rdata_saved_next[fv_rid_idx] = '0;
-        fv_wide_rresp_saved_next[fv_rid_idx] = br_amba::AxiRespOkay;
+        fv_wide_rresp_rank_saved_next[fv_rid_idx] = '0;
       end else begin
-        fv_r_beat_id_next[fv_rid_idx] = fv_r_beat_id_cur + 1'b1;
+        // Otherwise keep accumulating until the remaining-beat counter reaches 1.
+        fv_r_beats_remaining_next[fv_rid_idx] =
+            fv_r_beats_remaining[fv_rid_idx] - BeatsPerWideWidth'(1);
         fv_wide_rdata_saved_next[fv_rid_idx] = fv_wide_rdata_cur;
-        fv_wide_rresp_saved_next[fv_rid_idx] = fv_wide_rresp_cur;
+        fv_wide_rresp_rank_saved_next[fv_rid_idx] = fv_wide_rresp_rank_cur;
       end
     end
   end
 
-  `BR_REGLI(fv_r_is_fixed, fv_r_is_fixed_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
-  `BR_REGLI(fv_r_offset, fv_r_offset_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
-  `BR_REGLI(fv_r_offset_incr, fv_r_offset_incr_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
-  `BR_REGLI(fv_r_beats_per_wide_m1, fv_r_beats_per_wide_m1_next, fv_wide_ar_hs || fv_narrow_r_hs,
-            '0)
-  `BR_REGLI(fv_r_beat_id, fv_r_beat_id_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
-  `BR_REGLI(fv_wide_rdata_saved, fv_wide_rdata_saved_next, fv_wide_ar_hs || fv_narrow_r_hs, '0)
-  `BR_REGLI(fv_wide_rresp_saved, fv_wide_rresp_saved_next, fv_wide_ar_hs || fv_narrow_r_hs,
-            {MaxOutstandingReqs{br_amba::AxiRespOkay}})
+  `BR_REGL(fv_r_is_fixed, fv_r_is_fixed_next, fv_wide_ar_hs)
+  `BR_REGL(fv_r_offset, fv_r_offset_next, fv_wide_ar_hs || fv_narrow_r_hs)
+  `BR_REGL(fv_r_offset_incr, fv_r_offset_incr_next, fv_wide_ar_hs)
+  `BR_REGL(fv_r_beats_per_wide, fv_r_beats_per_wide_next, fv_wide_ar_hs)
+  `BR_REGL(fv_r_beats_remaining, fv_r_beats_remaining_next, fv_wide_ar_hs || fv_narrow_r_hs)
+  `BR_REGL(fv_wide_rdata_saved, fv_wide_rdata_saved_next, fv_wide_ar_hs || fv_narrow_r_hs)
+  `BR_REGL(fv_wide_rresp_rank_saved, fv_wide_rresp_rank_saved_next, fv_wide_ar_hs || fv_narrow_r_hs)
+
+  assign fv_wide_rresp_cur = fv_rank_resp(fv_wide_rresp_rank_cur);
 
   assign fv_wide_r_payload = {
     narrow_rid, fv_wide_rdata_cur, narrow_ruser, fv_wide_rresp_cur, narrow_rlast

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -118,6 +118,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
   localparam int ArPayloadWidth = AddrWidth + IdWidth + br_amba::AxiBurstLenWidth +
                                   br_amba::AxiBurstSizeWidth + br_amba::AxiBurstTypeWidth +
                                   br_amba::AxiProtWidth + ARUserWidth;
+  localparam int BPayloadWidth = IdWidth + BUserWidth + br_amba::AxiRespWidth;
   localparam int RPayloadWidth = IdWidth + WideDataWidth + RUserWidth + br_amba::AxiRespWidth + 1;
 
   // ABVIP should send more than DUT to test backpressure.
@@ -422,6 +423,23 @@ module br_amba_axi_shrinker_fpv_monitor #(
         narrow_awprot,
         narrow_awuser
       })
+  );
+
+  // ----------B channel----------
+  // Checks that the wide B channel matches the narrow B channel response payload.
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(BPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxPending)
+  ) b_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(narrow_bvalid && narrow_bready),
+      .incoming_data({narrow_bid, narrow_buser, narrow_bresp}),
+      .outgoing_vld(wide_bvalid && wide_bready),
+      .outgoing_data({wide_bid, wide_buser, wide_bresp})
   );
 
   // ----------AXI protocols----------

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -121,12 +121,10 @@ module br_amba_axi_shrinker_fpv_monitor #(
   localparam int BPayloadWidth = IdWidth + BUserWidth + br_amba::AxiRespWidth;
   localparam int WPayloadWidth = NarrowDataWidth + NarrowStrobeWidth + WUserWidth + 1;
   localparam int RPayloadWidth = IdWidth + WideDataWidth + RUserWidth + br_amba::AxiRespWidth + 1;
+  localparam int WFifoPayloadWidth = 1 + ByteOffsetWidth + BeatOffsetIncrWidth + BeatsPerWideWidth;
 
   // ABVIP should send more than DUT to test backpressure.
   localparam int MaxPending = MaxOutstandingReqs + WriteFifoDepth + 2;
-  localparam int WriteMaxPending = MaxOutstandingReqs + WriteFifoDepth;
-  localparam int WCfgPtrWidth = br_math::clamped_clog2(WriteMaxPending);
-  localparam int WCfgCountWidth = br_math::clamped_clog2(WriteMaxPending + 1);
 
   logic [br_amba::AxiBurstSizeWidth-1:0] fv_narrow_arsize;
   logic [br_amba::AxiBurstLenWidth-1:0] fv_narrow_arlen;
@@ -139,51 +137,35 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic [br_amba::AxiBurstLenWidth:0] fv_narrow_awlen_ext;
   logic [br_amba::AxiBurstLenWidth:0] fv_narrow_arlen_ext;
   logic fv_narrow_w_hs;
-  logic fv_narrow_w_model_valid;
-  logic fv_narrow_w_model_ready;
-  logic fv_narrow_w_model_hs;
   logic fv_wide_ar_hs;
   logic fv_narrow_r_hs;
   logic fv_wide_rdata_vld;
   logic fv_wide_w_hs;
-  logic fv_w_cfg_push;
-  logic fv_w_cfg_pop;
-  logic fv_w_cfg_available;
-  logic fv_w_cfg_bypass;
-  logic [WCfgPtrWidth-1:0] fv_w_cfg_head;
-  logic [WCfgPtrWidth-1:0] fv_w_cfg_head_inc;
-  logic [WCfgPtrWidth-1:0] fv_w_cfg_tail;
-  logic [WCfgPtrWidth-1:0] fv_w_cfg_tail_inc;
-  logic [WCfgCountWidth-1:0] fv_w_cfg_count;
-  logic [WCfgPtrWidth-1:0] fv_w_cfg_idx;
-  logic fv_w_pipe_full;
+  logic fv_w_fifo_push;
+  logic fv_w_fifo_empty;
+  logic [WFifoPayloadWidth-1:0] fv_w_fifo_push_data;
+  logic [WFifoPayloadWidth-1:0] fv_w_fifo_pop_data;
+  logic fv_w_active_load;
+  logic fv_w_active_valid;
+  logic fv_w_active_done;
+  logic fv_w_ctx_valid;
   logic [BeatOffsetIncrWidth-1:0] fv_w_offset_incr_cfg;
   logic [BeatsPerWideWidth-1:0] fv_w_beats_per_wide_cfg;
-  logic [WriteMaxPending-1:0] fv_w_is_fixed;
-  logic [WriteMaxPending-1:0] fv_w_is_fixed_next;
-  logic [WriteMaxPending-1:0][ByteOffsetWidth-1:0] fv_w_offset;
-  logic [WriteMaxPending-1:0][ByteOffsetWidth-1:0] fv_w_offset_next;
-  logic [WriteMaxPending-1:0][BeatOffsetIncrWidth-1:0] fv_w_offset_incr;
-  logic [WriteMaxPending-1:0][BeatOffsetIncrWidth-1:0] fv_w_offset_incr_next;
-  logic [WriteMaxPending-1:0][BeatsPerWideWidth-1:0] fv_w_beats_per_wide;
-  logic [WriteMaxPending-1:0][BeatsPerWideWidth-1:0] fv_w_beats_per_wide_next;
-  logic [WriteMaxPending-1:0][BeatsPerWideWidth-1:0] fv_w_beats_remaining;
-  logic [WriteMaxPending-1:0][BeatsPerWideWidth-1:0] fv_w_beats_remaining_next;
+  logic fv_w_fifo_pop_is_fixed;
+  logic [ByteOffsetWidth-1:0] fv_w_fifo_pop_offset;
+  logic [BeatOffsetIncrWidth-1:0] fv_w_fifo_pop_offset_incr;
+  logic [BeatsPerWideWidth-1:0] fv_w_fifo_pop_beats_per_wide;
+  logic fv_w_active_is_fixed;
+  logic [ByteOffsetWidth-1:0] fv_w_active_offset;
+  logic [ByteOffsetWidth-1:0] fv_w_active_offset_next;
+  logic [BeatOffsetIncrWidth-1:0] fv_w_active_offset_incr;
+  logic [BeatsPerWideWidth-1:0] fv_w_active_beats_per_wide;
+  logic fv_w_ctx_is_fixed;
+  logic [ByteOffsetWidth-1:0] fv_w_ctx_offset;
+  logic [BeatOffsetIncrWidth-1:0] fv_w_ctx_offset_incr;
+  logic [BeatsPerWideWidth-1:0] fv_w_ctx_beats_per_wide;
   logic fv_w_beat_start;
-  logic [ByteOffsetWidth-1:0] fv_w_offset_after_beat;
-  logic fv_w_beat_last;
-  logic [WideDataWidth-1:0] fv_wide_wdata_cur;
-  logic [WideDataWidth-1:0] fv_wide_wdata_saved;
-  logic [WideDataWidth-1:0] fv_wide_wdata_saved_next;
-  logic [WideStrobeWidth-1:0] fv_wide_wstrb_cur;
-  logic [WideStrobeWidth-1:0] fv_wide_wstrb_saved;
-  logic [WideStrobeWidth-1:0] fv_wide_wstrb_saved_next;
-  logic [WUserWidth-1:0] fv_wide_wuser_cur;
-  logic [WUserWidth-1:0] fv_wide_wuser_saved;
-  logic [WUserWidth-1:0] fv_wide_wuser_saved_next;
-  logic fv_wide_wlast_cur;
-  logic fv_wide_wlast_saved;
-  logic fv_wide_wlast_saved_next;
+  logic [ByteOffsetWidth-1:0] fv_w_offset_after_wide_beat;
   logic [LanesPerWide-1:0][ByteOffsetWidth-1:0] fv_w_chunk_offset;
   logic [LanesPerWide-1:0][LaneIdxWidth-1:0] fv_w_chunk_lane;
   logic [LanesPerWide-1:0] fv_w_chunk_last;
@@ -459,7 +441,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(1),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(WriteMaxPending)
+      .MAX_PENDING(WriteFifoDepth)
   ) aw_sb (
       .clk(clk),
       .rstN(!rst),
@@ -484,7 +466,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(1),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(WriteMaxPending)
+      .MAX_PENDING(WriteFifoDepth)
   ) b_sb (
       .clk(clk),
       .rstN(!rst),
@@ -495,42 +477,48 @@ module br_amba_axi_shrinker_fpv_monitor #(
   );
 
   // ----------W channel----------
-  // Queue accepted AW-derived write contexts, then use the head entry to
-  // predict how each wide W beat serializes onto the narrow W channel.
+  // Queue accepted AW-derived write contexts in a FIFO. The head context stays
+  // active across wide-W beats until its final wide_wlast handshake.
   assign fv_narrow_w_hs = narrow_wvalid && narrow_wready;
   assign fv_wide_w_hs = wide_wvalid && wide_wready;
-  assign fv_w_cfg_push = wide_awvalid && wide_awready;
+  assign fv_w_fifo_push = wide_awvalid && wide_awready;
   assign fv_w_offset_incr_cfg = BeatOffsetIncrWidth'(1'b1) << fv_narrow_awsize;
   assign fv_w_beats_per_wide_cfg = BeatsPerWideWidth'(1'b1) << aw_shift;
-  assign fv_w_cfg_available = fv_w_cfg_count != '0;
-  assign fv_w_cfg_bypass = !fv_w_cfg_available && fv_w_cfg_push;
-  assign fv_w_cfg_idx = fv_w_cfg_available ? fv_w_cfg_head : fv_w_cfg_tail;
-  assign fv_w_offset_after_beat = (fv_w_cfg_available ? fv_w_is_fixed[fv_w_cfg_head]
-                                                      : (wide_awburst == br_amba::AxiBurstFixed)) ?
-                                  (fv_w_cfg_available ? fv_w_offset[fv_w_cfg_head]
-                                                      : wide_awaddr[ByteOffsetWidth-1:0]) :
-                                  (fv_w_cfg_available ? fv_w_offset[fv_w_cfg_head] +
-                                                       fv_w_offset_incr[fv_w_cfg_head]
-                                                      : wide_awaddr[ByteOffsetWidth-1:0] +
-                                                        fv_w_offset_incr_cfg);
-  // The wide side only accepts one W beat when the DUT has finished
-  // serializing that beat internally, so the monitor should enqueue the full
-  // predicted narrow-beat set on wide-W acceptance.
-  assign fv_w_beat_last = 1'b1;
-  assign fv_narrow_w_model_valid = (fv_w_cfg_available || fv_w_cfg_push) && wide_wvalid;
-  assign fv_narrow_w_model_ready = RegisterNarrowOutputs ? (!fv_w_pipe_full || narrow_wready)
-                                                         : narrow_wready;
-  assign fv_narrow_w_model_hs = fv_narrow_w_model_valid && fv_narrow_w_model_ready;
-  assign fv_wide_wdata_cur = wide_wdata;
-  assign fv_wide_wstrb_cur = wide_wstrb;
-  assign fv_wide_wuser_cur = wide_wuser;
-  assign fv_wide_wlast_cur = wide_wlast;
+  assign fv_w_fifo_push_data = {
+    wide_awburst == br_amba::AxiBurstFixed,
+    wide_awaddr[ByteOffsetWidth-1:0],
+    fv_w_offset_incr_cfg,
+    fv_w_beats_per_wide_cfg
+  };
+  assign {fv_w_fifo_pop_is_fixed, fv_w_fifo_pop_offset, fv_w_fifo_pop_offset_incr,
+          fv_w_fifo_pop_beats_per_wide} = fv_w_fifo_pop_data;
+  assign fv_w_active_load = !fv_w_active_valid && (!fv_w_fifo_empty || fv_w_fifo_push);
+  assign fv_w_ctx_valid = fv_w_active_valid || fv_w_active_load;
+  assign fv_w_ctx_is_fixed = fv_w_active_valid ? fv_w_active_is_fixed : fv_w_fifo_pop_is_fixed;
+  assign fv_w_ctx_offset = fv_w_active_valid ? fv_w_active_offset : fv_w_fifo_pop_offset;
+  assign fv_w_ctx_offset_incr = fv_w_active_valid ? fv_w_active_offset_incr
+                                                  : fv_w_fifo_pop_offset_incr;
+  assign fv_w_ctx_beats_per_wide = fv_w_active_valid ? fv_w_active_beats_per_wide
+                                                      : fv_w_fifo_pop_beats_per_wide;
+  assign fv_w_offset_after_wide_beat = fv_w_ctx_is_fixed ? fv_w_ctx_offset :
+      ByteOffsetWidth'(fv_w_ctx_offset + (fv_w_ctx_beats_per_wide * fv_w_ctx_offset_incr));
   assign fv_w_beat_start = fv_wide_w_hs;
-  assign fv_w_cfg_pop = fv_wide_w_hs && wide_wlast;
-  assign fv_w_cfg_head_inc =
-      (fv_w_cfg_head == WCfgPtrWidth'(WriteMaxPending - 1)) ? '0 : fv_w_cfg_head + 'd1;
-  assign fv_w_cfg_tail_inc =
-      (fv_w_cfg_tail == WCfgPtrWidth'(WriteMaxPending - 1)) ? '0 : fv_w_cfg_tail + 'd1;
+  assign fv_w_active_done = fv_wide_w_hs && wide_wlast;
+
+  fv_fifo #(
+      .Depth(WriteFifoDepth + 1),
+      .DataWidth(WFifoPayloadWidth),
+      .Bypass(1)
+  ) w_fifo (
+      .clk(clk),
+      .rst(rst),
+      .push(fv_w_fifo_push),
+      .push_data(fv_w_fifo_push_data),
+      .pop(fv_w_active_load),
+      .pop_data(fv_w_fifo_pop_data),
+      .empty(fv_w_fifo_empty),
+      .full()
+  );
 
   always_comb begin
     fv_narrow_w_pred_vld = '0;
@@ -539,9 +527,8 @@ module br_amba_axi_shrinker_fpv_monitor #(
     fv_w_chunk_lane = '0;
     fv_w_chunk_last = '0;
 
-    if (fv_w_cfg_available || fv_w_cfg_push) begin
-      fv_w_chunk_offset[0] = fv_w_cfg_available ? fv_w_offset[fv_w_cfg_head]
-                                                : wide_awaddr[ByteOffsetWidth-1:0];
+    if (fv_w_ctx_valid) begin
+      fv_w_chunk_offset[0] = fv_w_ctx_offset;
 
       for (int i = 0; i < LanesPerWide; i++) begin
         // Multi-input scoreboard mode lets one wide W beat enqueue every
@@ -550,30 +537,21 @@ module br_amba_axi_shrinker_fpv_monitor #(
         // 2:1 example: chunk 0 is the first narrow beat sent, chunk 1 is the
         // second. For aligned INCR bursts that is low lane first, then high.
         fv_w_chunk_lane[i] = LaneIdxWidth'(fv_w_chunk_offset[i] >> NarrowSizeLog2);
-        fv_w_chunk_last[i] = fv_wide_wlast_cur &&
-                             (BeatsPerWideWidth'(i + 1) ==
-                              (fv_w_cfg_available ? fv_w_beats_per_wide[fv_w_cfg_head]
-                                                  : fv_w_beats_per_wide_cfg));
+        fv_w_chunk_last[i] = wide_wlast && (BeatsPerWideWidth'(i + 1) == fv_w_ctx_beats_per_wide);
 
-        if (fv_w_beat_start &&
-            (BeatsPerWideWidth'(i) <
-             (fv_w_cfg_available ? fv_w_beats_per_wide[fv_w_cfg_head]
-                                 : fv_w_beats_per_wide_cfg))) begin
+        if (fv_w_beat_start && (BeatsPerWideWidth'(i) < fv_w_ctx_beats_per_wide)) begin
           fv_narrow_w_pred_vld[i] = 1'b1;
           fv_narrow_w_pred_payloads[i] = {
-            fv_wide_wdata_cur[fv_w_chunk_lane[i]*NarrowDataWidth+:NarrowDataWidth],
-            fv_wide_wstrb_cur[fv_w_chunk_lane[i]*NarrowStrobeWidth+:NarrowStrobeWidth],
-            fv_wide_wuser_cur,
+            wide_wdata[fv_w_chunk_lane[i]*NarrowDataWidth+:NarrowDataWidth],
+            wide_wstrb[fv_w_chunk_lane[i]*NarrowStrobeWidth+:NarrowStrobeWidth],
+            wide_wuser,
             fv_w_chunk_last[i]
           };
         end
 
         if ((i + 1) < LanesPerWide) begin
-          if (fv_w_cfg_available ? !fv_w_is_fixed[fv_w_cfg_head]
-                                 : wide_awburst != br_amba::AxiBurstFixed) begin
-            fv_w_chunk_offset[i+1] = fv_w_chunk_offset[i] +
-                                     (fv_w_cfg_available ? fv_w_offset_incr[fv_w_cfg_head]
-                                                         : fv_w_offset_incr_cfg);
+          if (!fv_w_ctx_is_fixed) begin
+            fv_w_chunk_offset[i+1] = fv_w_chunk_offset[i] + fv_w_ctx_offset_incr;
           end else begin
             fv_w_chunk_offset[i+1] = fv_w_chunk_offset[i];
           end
@@ -583,53 +561,22 @@ module br_amba_axi_shrinker_fpv_monitor #(
   end
 
   always_comb begin
-    fv_w_is_fixed_next = fv_w_is_fixed;
-    fv_w_offset_next = fv_w_offset;
-    fv_w_offset_incr_next = fv_w_offset_incr;
-    fv_w_beats_per_wide_next = fv_w_beats_per_wide;
-    fv_w_beats_remaining_next = fv_w_beats_remaining;
-    if (fv_w_cfg_push) begin
-      fv_w_is_fixed_next[fv_w_cfg_tail] = wide_awburst == br_amba::AxiBurstFixed;
-      fv_w_offset_next[fv_w_cfg_tail] = wide_awaddr[ByteOffsetWidth-1:0];
-      fv_w_offset_incr_next[fv_w_cfg_tail] = fv_w_offset_incr_cfg;
-      fv_w_beats_per_wide_next[fv_w_cfg_tail] = fv_w_beats_per_wide_cfg;
-      fv_w_beats_remaining_next[fv_w_cfg_tail] = fv_w_beats_per_wide_cfg;
+    fv_w_active_offset_next = fv_w_active_offset;
+
+    if (fv_w_active_load) begin
+      fv_w_active_offset_next = fv_w_fifo_pop_offset;
     end
 
-    if (fv_wide_w_hs && !fv_w_cfg_pop) begin
-      // One accepted wide W beat consumes the entire predicted narrow-beat
-      // set for that beat, so advance directly to the next wide-beat starting
-      // offset within this transaction.
-      if (fv_w_cfg_available ? !fv_w_is_fixed[fv_w_cfg_head]
-                             : wide_awburst != br_amba::AxiBurstFixed) begin
-        fv_w_offset_next[fv_w_cfg_idx] =
-            ByteOffsetWidth'((fv_w_cfg_available ? fv_w_offset[fv_w_cfg_head]
-                                                 : wide_awaddr[ByteOffsetWidth-1:0]) +
-                             ((fv_w_cfg_available ? fv_w_beats_per_wide[fv_w_cfg_head]
-                                                  : fv_w_beats_per_wide_cfg) *
-                              (fv_w_cfg_available ? fv_w_offset_incr[fv_w_cfg_head]
-                                                  : fv_w_offset_incr_cfg)));
-      end
-      fv_w_beats_remaining_next[fv_w_cfg_idx] = fv_w_cfg_available
-                                                ? fv_w_beats_per_wide[fv_w_cfg_head]
-                                                : fv_w_beats_per_wide_cfg;
+    if (fv_wide_w_hs && !fv_w_active_done) begin
+      fv_w_active_offset_next = fv_w_offset_after_wide_beat;
     end
   end
 
-  if (RegisterNarrowOutputs) begin : gen_w_pipe_state
-    `BR_REGL(fv_w_pipe_full, fv_narrow_w_model_hs, fv_narrow_w_model_hs ^ fv_narrow_w_hs)
-  end else begin : gen_no_w_pipe_state
-    assign fv_w_pipe_full = 1'b0;
-  end
-
-  `BR_REG(fv_w_cfg_count, fv_w_cfg_count + fv_w_cfg_push - fv_w_cfg_pop)
-  `BR_REGL(fv_w_cfg_head, fv_w_cfg_head_inc, fv_w_cfg_pop && !(fv_w_cfg_bypass && fv_w_cfg_push))
-  `BR_REGL(fv_w_cfg_tail, fv_w_cfg_tail_inc, fv_w_cfg_push && !(fv_w_cfg_bypass && fv_w_cfg_pop))
-  `BR_REG(fv_w_is_fixed, fv_w_is_fixed_next)
-  `BR_REG(fv_w_offset, fv_w_offset_next)
-  `BR_REG(fv_w_offset_incr, fv_w_offset_incr_next)
-  `BR_REG(fv_w_beats_per_wide, fv_w_beats_per_wide_next)
-  `BR_REG(fv_w_beats_remaining, fv_w_beats_remaining_next)
+  `BR_REG(fv_w_active_valid, fv_w_ctx_valid && !fv_w_active_done)
+  `BR_REGL(fv_w_active_is_fixed, fv_w_fifo_pop_is_fixed, fv_w_active_load)
+  `BR_REGL(fv_w_active_offset, fv_w_active_offset_next, fv_w_active_load || fv_wide_w_hs)
+  `BR_REGL(fv_w_active_offset_incr, fv_w_fifo_pop_offset_incr, fv_w_active_load)
+  `BR_REGL(fv_w_active_beats_per_wide, fv_w_fifo_pop_beats_per_wide, fv_w_active_load)
 
   // Enqueue every narrow beat for one wide W beat at serializer start. The
   // scoreboard then drains them one per actual narrow-W handshake, absorbing
@@ -643,7 +590,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(LanesPerWide),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(WriteMaxPending)
+      .MAX_PENDING(WriteFifoDepth)
   ) w_sb (
       .clk(clk),
       .rstN(!rst),

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -112,6 +112,9 @@ module br_amba_axi_shrinker_fpv_monitor #(
   localparam int BeatOffsetIncrWidth = $clog2(NarrowStrobeWidth + 1);
   localparam int BeatsPerWideWidth = br_math::clamped_clog2(LanesPerWide + 1);
   localparam int RespRankWidth = 2;
+  localparam int AwPayloadWidth = AddrWidth + IdWidth + br_amba::AxiBurstLenWidth +
+                                  br_amba::AxiBurstSizeWidth + br_amba::AxiBurstTypeWidth +
+                                  br_amba::AxiProtWidth + AWUserWidth;
   localparam int ArPayloadWidth = AddrWidth + IdWidth + br_amba::AxiBurstLenWidth +
                                   br_amba::AxiBurstSizeWidth + br_amba::AxiBurstTypeWidth +
                                   br_amba::AxiProtWidth + ARUserWidth;
@@ -123,7 +126,12 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic [br_amba::AxiBurstSizeWidth-1:0] fv_narrow_arsize;
   logic [br_amba::AxiBurstLenWidth-1:0] fv_narrow_arlen;
   logic [ArPayloadWidth-1:0] fv_narrow_ar_payload;
+  logic [br_amba::AxiBurstSizeWidth-1:0] fv_narrow_awsize;
+  logic [br_amba::AxiBurstLenWidth-1:0] fv_narrow_awlen;
+  logic [AwPayloadWidth-1:0] fv_narrow_aw_payload;
+  int unsigned aw_shift;
   int unsigned ar_shift;
+  logic [br_amba::AxiBurstLenWidth:0] fv_narrow_awlen_ext;
   logic [br_amba::AxiBurstLenWidth:0] fv_narrow_arlen_ext;
   logic fv_wide_ar_hs;
   logic fv_narrow_r_hs;
@@ -363,6 +371,57 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .incoming_data(fv_wide_r_payload),
       .outgoing_vld(wide_rvalid && wide_rready),
       .outgoing_data({wide_rid, wide_rdata, wide_ruser, wide_rresp, wide_rlast})
+  );
+
+  // ----------AW channel----------
+  always_comb begin
+    aw_shift = 0;
+    fv_narrow_awsize = wide_awsize;
+
+    if (wide_awsize > NarrowSizeLog2) begin
+      fv_narrow_awsize = NarrowSizeLog2;
+      aw_shift = wide_awsize - NarrowSizeLog2;
+    end
+
+    // AXI len encodes beats - 1, so after scaling the beat count by the width ratio
+    // we subtract 1 to convert back to the AXI burst-length encoding.
+    fv_narrow_awlen_ext = (({1'b0, wide_awlen} + 1'b1) << aw_shift) - 1'b1;
+    fv_narrow_awlen = fv_narrow_awlen_ext[br_amba::AxiBurstLenWidth-1:0];
+  end
+
+  assign fv_narrow_aw_payload = {
+    wide_awaddr,
+    wide_awid,
+    fv_narrow_awlen,
+    fv_narrow_awsize,
+    wide_awburst,
+    wide_awprot,
+    wide_awuser
+  };
+
+  // Checks that the RTL narrow AW channel matches the monitor prediction for
+  // narrow awlen/awsize derived from each accepted wide AW request.
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(AwPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxPending)
+  ) aw_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(wide_awvalid && wide_awready),
+      .incoming_data(fv_narrow_aw_payload),
+      .outgoing_vld(narrow_awvalid && narrow_awready),
+      .outgoing_data({
+        narrow_awaddr,
+        narrow_awid,
+        narrow_awlen,
+        narrow_awsize,
+        narrow_awburst,
+        narrow_awprot,
+        narrow_awuser
+      })
   );
 
   // ----------AXI protocols----------

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -112,6 +112,12 @@ module br_amba_axi_shrinker_fpv_monitor #(
   localparam int BeatOffsetIncrWidth = $clog2(NarrowStrobeWidth + 1);
   localparam int BeatsPerWideWidth = br_math::clamped_clog2(LanesPerWide + 1);
   localparam int RespRankWidth = 2;
+  typedef struct packed {
+    logic is_fixed;
+    logic [ByteOffsetWidth-1:0] offset;
+    logic [BeatOffsetIncrWidth-1:0] offset_incr;
+    logic [BeatsPerWideWidth-1:0] beats_per_wide;
+  } fv_w_ctx_t;
   localparam int AwPayloadWidth = AddrWidth + IdWidth + br_amba::AxiBurstLenWidth +
                                   br_amba::AxiBurstSizeWidth + br_amba::AxiBurstTypeWidth +
                                   br_amba::AxiProtWidth + AWUserWidth;
@@ -121,10 +127,11 @@ module br_amba_axi_shrinker_fpv_monitor #(
   localparam int BPayloadWidth = IdWidth + BUserWidth + br_amba::AxiRespWidth;
   localparam int WPayloadWidth = NarrowDataWidth + NarrowStrobeWidth + WUserWidth + 1;
   localparam int RPayloadWidth = IdWidth + WideDataWidth + RUserWidth + br_amba::AxiRespWidth + 1;
-  localparam int WFifoPayloadWidth = 1 + ByteOffsetWidth + BeatOffsetIncrWidth + BeatsPerWideWidth;
+  localparam int WFifoPayloadWidth = $bits(fv_w_ctx_t);
 
   // ABVIP should send more than DUT to test backpressure.
   localparam int MaxPending = MaxOutstandingReqs + WriteFifoDepth + 2;
+  localparam int WriteMaxPending = MaxOutstandingReqs + WriteFifoDepth;
 
   logic [br_amba::AxiBurstSizeWidth-1:0] fv_narrow_arsize;
   logic [br_amba::AxiBurstLenWidth-1:0] fv_narrow_arlen;
@@ -143,7 +150,9 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic fv_wide_w_hs;
   logic fv_w_fifo_push;
   logic fv_w_fifo_empty;
+  fv_w_ctx_t fv_w_fifo_push_ctx;
   logic [WFifoPayloadWidth-1:0] fv_w_fifo_push_data;
+  fv_w_ctx_t fv_w_fifo_pop_ctx;
   logic [WFifoPayloadWidth-1:0] fv_w_fifo_pop_data;
   logic fv_w_active_load;
   logic fv_w_active_valid;
@@ -151,24 +160,11 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic fv_w_ctx_valid;
   logic [BeatOffsetIncrWidth-1:0] fv_w_offset_incr_cfg;
   logic [BeatsPerWideWidth-1:0] fv_w_beats_per_wide_cfg;
-  logic fv_w_fifo_pop_is_fixed;
-  logic [ByteOffsetWidth-1:0] fv_w_fifo_pop_offset;
-  logic [BeatOffsetIncrWidth-1:0] fv_w_fifo_pop_offset_incr;
-  logic [BeatsPerWideWidth-1:0] fv_w_fifo_pop_beats_per_wide;
-  logic fv_w_active_is_fixed;
-  logic [ByteOffsetWidth-1:0] fv_w_active_offset;
+  fv_w_ctx_t fv_w_active_ctx;
   logic [ByteOffsetWidth-1:0] fv_w_active_offset_next;
-  logic [BeatOffsetIncrWidth-1:0] fv_w_active_offset_incr;
-  logic [BeatsPerWideWidth-1:0] fv_w_active_beats_per_wide;
-  logic fv_w_ctx_is_fixed;
-  logic [ByteOffsetWidth-1:0] fv_w_ctx_offset;
-  logic [BeatOffsetIncrWidth-1:0] fv_w_ctx_offset_incr;
-  logic [BeatsPerWideWidth-1:0] fv_w_ctx_beats_per_wide;
+  fv_w_ctx_t fv_w_ctx;
   logic fv_w_beat_start;
   logic [ByteOffsetWidth-1:0] fv_w_offset_after_wide_beat;
-  logic [LanesPerWide-1:0][ByteOffsetWidth-1:0] fv_w_chunk_offset;
-  logic [LanesPerWide-1:0][LaneIdxWidth-1:0] fv_w_chunk_lane;
-  logic [LanesPerWide-1:0] fv_w_chunk_last;
   logic [LanesPerWide-1:0] fv_narrow_w_pred_vld;
   logic [LanesPerWide-1:0][WPayloadWidth-1:0] fv_narrow_w_pred_payloads;
   logic [InternalIdWidth-1:0] fv_rid_idx;
@@ -177,8 +173,10 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic [LaneIdxWidth-1:0] fv_r_lane_cur;
   logic [ByteOffsetWidth-1:0] fv_r_offset_after_beat;
   logic [BeatsPerWideWidth-1:0] fv_r_beats_per_wide_cfg;
+  logic fv_r_beat_done;
   logic [br_amba::AxiRespWidth-1:0] fv_wide_rresp_cur;
   logic [RespRankWidth-1:0] fv_wide_rresp_rank_cur;
+  logic [RespRankWidth-1:0] fv_r_resp_rank_next;
   // Per-slot state for the abstract wide-R reconstruction model.
   logic [MaxOutstandingReqs-1:0] fv_r_is_fixed;
   logic [MaxOutstandingReqs-1:0] fv_r_is_fixed_next;
@@ -324,8 +322,13 @@ module br_amba_axi_shrinker_fpv_monitor #(
   assign fv_r_offset_after_beat = fv_r_is_fixed[fv_rid_idx] ? fv_r_offset[fv_rid_idx]
                                                             : fv_r_offset[fv_rid_idx] +
                                                               fv_r_offset_incr[fv_rid_idx];
-  assign fv_wide_rdata_vld = fv_narrow_r_hs &&
-                             (fv_r_beats_remaining[fv_rid_idx] == BeatsPerWideWidth'(1));
+  assign fv_r_beat_done = fv_r_beats_remaining[fv_rid_idx] == BeatsPerWideWidth'(1);
+  assign fv_wide_rdata_vld = fv_narrow_r_hs && fv_r_beat_done;
+  assign fv_r_resp_rank_next = (fv_wide_rresp_rank_saved[fv_rid_idx] >= fv_resp_rank(
+      narrow_rresp
+  )) ? fv_wide_rresp_rank_saved[fv_rid_idx] : fv_resp_rank(
+      narrow_rresp
+  );
 
   always_comb begin
     fv_r_is_fixed_next = fv_r_is_fixed;
@@ -354,14 +357,10 @@ module br_amba_axi_shrinker_fpv_monitor #(
       // Merge the current narrow beat into the slot's partial wide beat and
       // update the saved response severity if this beat is worse.
       fv_wide_rdata_cur[fv_r_lane_cur*NarrowDataWidth+:NarrowDataWidth] = narrow_rdata;
-      if (fv_wide_rresp_rank_saved[fv_rid_idx] >= fv_resp_rank(narrow_rresp)) begin
-        fv_wide_rresp_rank_cur = fv_wide_rresp_rank_saved[fv_rid_idx];
-      end else begin
-        fv_wide_rresp_rank_cur = fv_resp_rank(narrow_rresp);
-      end
+      fv_wide_rresp_rank_cur = fv_r_resp_rank_next;
       fv_r_offset_next[fv_rid_idx] = fv_r_offset_after_beat;
 
-      if (fv_r_beats_remaining[fv_rid_idx] == BeatsPerWideWidth'(1)) begin
+      if (fv_r_beat_done) begin
         // This beat completes the reconstructed wide beat, so reset the
         // partial data and reload the beat counter for the next wide beat.
         fv_r_beats_remaining_next[fv_rid_idx] = fv_r_beats_per_wide[fv_rid_idx];
@@ -441,7 +440,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(1),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(WriteFifoDepth)
+      .MAX_PENDING(WriteMaxPending)
   ) aw_sb (
       .clk(clk),
       .rstN(!rst),
@@ -466,7 +465,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(1),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(WriteFifoDepth)
+      .MAX_PENDING(WriteMaxPending)
   ) b_sb (
       .clk(clk),
       .rstN(!rst),
@@ -484,29 +483,24 @@ module br_amba_axi_shrinker_fpv_monitor #(
   assign fv_w_fifo_push = wide_awvalid && wide_awready;
   assign fv_w_offset_incr_cfg = BeatOffsetIncrWidth'(1'b1) << fv_narrow_awsize;
   assign fv_w_beats_per_wide_cfg = BeatsPerWideWidth'(1'b1) << aw_shift;
-  assign fv_w_fifo_push_data = {
-    wide_awburst == br_amba::AxiBurstFixed,
-    wide_awaddr[ByteOffsetWidth-1:0],
-    fv_w_offset_incr_cfg,
-    fv_w_beats_per_wide_cfg
-  };
-  assign {fv_w_fifo_pop_is_fixed, fv_w_fifo_pop_offset, fv_w_fifo_pop_offset_incr,
-          fv_w_fifo_pop_beats_per_wide} = fv_w_fifo_pop_data;
+  assign fv_w_fifo_push_ctx = '{
+          is_fixed: wide_awburst == br_amba::AxiBurstFixed,
+          offset: wide_awaddr[ByteOffsetWidth-1:0],
+          offset_incr: fv_w_offset_incr_cfg,
+          beats_per_wide: fv_w_beats_per_wide_cfg
+      };
+  assign fv_w_fifo_push_data = fv_w_fifo_push_ctx;
+  assign fv_w_fifo_pop_ctx = fv_w_fifo_pop_data;
   assign fv_w_active_load = !fv_w_active_valid && (!fv_w_fifo_empty || fv_w_fifo_push);
   assign fv_w_ctx_valid = fv_w_active_valid || fv_w_active_load;
-  assign fv_w_ctx_is_fixed = fv_w_active_valid ? fv_w_active_is_fixed : fv_w_fifo_pop_is_fixed;
-  assign fv_w_ctx_offset = fv_w_active_valid ? fv_w_active_offset : fv_w_fifo_pop_offset;
-  assign fv_w_ctx_offset_incr = fv_w_active_valid ? fv_w_active_offset_incr
-                                                  : fv_w_fifo_pop_offset_incr;
-  assign fv_w_ctx_beats_per_wide = fv_w_active_valid ? fv_w_active_beats_per_wide
-                                                      : fv_w_fifo_pop_beats_per_wide;
-  assign fv_w_offset_after_wide_beat = fv_w_ctx_is_fixed ? fv_w_ctx_offset :
-      ByteOffsetWidth'(fv_w_ctx_offset + (fv_w_ctx_beats_per_wide * fv_w_ctx_offset_incr));
+  assign fv_w_ctx = fv_w_active_valid ? fv_w_active_ctx : fv_w_fifo_pop_ctx;
+  assign fv_w_offset_after_wide_beat = fv_w_ctx.is_fixed ? fv_w_ctx.offset :
+      ByteOffsetWidth'(fv_w_ctx.offset + (fv_w_ctx.beats_per_wide * fv_w_ctx.offset_incr));
   assign fv_w_beat_start = fv_wide_w_hs;
   assign fv_w_active_done = fv_wide_w_hs && wide_wlast;
 
   fv_fifo #(
-      .Depth(WriteFifoDepth + 1),
+      .Depth(WriteMaxPending),
       .DataWidth(WFifoPayloadWidth),
       .Bypass(1)
   ) w_fifo (
@@ -521,14 +515,16 @@ module br_amba_axi_shrinker_fpv_monitor #(
   );
 
   always_comb begin
+    logic [ByteOffsetWidth-1:0] chunk_offset;
+    logic [LaneIdxWidth-1:0] chunk_lane;
+
     fv_narrow_w_pred_vld = '0;
     fv_narrow_w_pred_payloads = '0;
-    fv_w_chunk_offset = '0;
-    fv_w_chunk_lane = '0;
-    fv_w_chunk_last = '0;
+    chunk_offset = '0;
+    chunk_lane = '0;
 
     if (fv_w_ctx_valid) begin
-      fv_w_chunk_offset[0] = fv_w_ctx_offset;
+      chunk_offset = fv_w_ctx.offset;
 
       for (int i = 0; i < LanesPerWide; i++) begin
         // Multi-input scoreboard mode lets one wide W beat enqueue every
@@ -536,24 +532,21 @@ module br_amba_axi_shrinker_fpv_monitor #(
         // order, not lane order:
         // 2:1 example: chunk 0 is the first narrow beat sent, chunk 1 is the
         // second. For aligned INCR bursts that is low lane first, then high.
-        fv_w_chunk_lane[i] = LaneIdxWidth'(fv_w_chunk_offset[i] >> NarrowSizeLog2);
-        fv_w_chunk_last[i] = wide_wlast && (BeatsPerWideWidth'(i + 1) == fv_w_ctx_beats_per_wide);
+        chunk_lane = LaneIdxWidth'(chunk_offset >> NarrowSizeLog2);
 
-        if (fv_w_beat_start && (BeatsPerWideWidth'(i) < fv_w_ctx_beats_per_wide)) begin
+        if (fv_w_beat_start && (BeatsPerWideWidth'(i) < fv_w_ctx.beats_per_wide)) begin
           fv_narrow_w_pred_vld[i] = 1'b1;
           fv_narrow_w_pred_payloads[i] = {
-            wide_wdata[fv_w_chunk_lane[i]*NarrowDataWidth+:NarrowDataWidth],
-            wide_wstrb[fv_w_chunk_lane[i]*NarrowStrobeWidth+:NarrowStrobeWidth],
+            wide_wdata[chunk_lane*NarrowDataWidth+:NarrowDataWidth],
+            wide_wstrb[chunk_lane*NarrowStrobeWidth+:NarrowStrobeWidth],
             wide_wuser,
-            fv_w_chunk_last[i]
+            wide_wlast && (BeatsPerWideWidth'(i + 1) == fv_w_ctx.beats_per_wide)
           };
         end
 
         if ((i + 1) < LanesPerWide) begin
-          if (!fv_w_ctx_is_fixed) begin
-            fv_w_chunk_offset[i+1] = fv_w_chunk_offset[i] + fv_w_ctx_offset_incr;
-          end else begin
-            fv_w_chunk_offset[i+1] = fv_w_chunk_offset[i];
+          if (!fv_w_ctx.is_fixed) begin
+            chunk_offset = chunk_offset + fv_w_ctx.offset_incr;
           end
         end
       end
@@ -561,10 +554,10 @@ module br_amba_axi_shrinker_fpv_monitor #(
   end
 
   always_comb begin
-    fv_w_active_offset_next = fv_w_active_offset;
+    fv_w_active_offset_next = fv_w_active_ctx.offset;
 
     if (fv_w_active_load) begin
-      fv_w_active_offset_next = fv_w_fifo_pop_offset;
+      fv_w_active_offset_next = fv_w_fifo_pop_ctx.offset;
     end
 
     if (fv_wide_w_hs && !fv_w_active_done) begin
@@ -573,10 +566,10 @@ module br_amba_axi_shrinker_fpv_monitor #(
   end
 
   `BR_REG(fv_w_active_valid, fv_w_ctx_valid && !fv_w_active_done)
-  `BR_REGL(fv_w_active_is_fixed, fv_w_fifo_pop_is_fixed, fv_w_active_load)
-  `BR_REGL(fv_w_active_offset, fv_w_active_offset_next, fv_w_active_load || fv_wide_w_hs)
-  `BR_REGL(fv_w_active_offset_incr, fv_w_fifo_pop_offset_incr, fv_w_active_load)
-  `BR_REGL(fv_w_active_beats_per_wide, fv_w_fifo_pop_beats_per_wide, fv_w_active_load)
+  `BR_REGL(fv_w_active_ctx.is_fixed, fv_w_fifo_pop_ctx.is_fixed, fv_w_active_load)
+  `BR_REGL(fv_w_active_ctx.offset, fv_w_active_offset_next, fv_w_active_load || fv_wide_w_hs)
+  `BR_REGL(fv_w_active_ctx.offset_incr, fv_w_fifo_pop_ctx.offset_incr, fv_w_active_load)
+  `BR_REGL(fv_w_active_ctx.beats_per_wide, fv_w_fifo_pop_ctx.beats_per_wide, fv_w_active_load)
 
   // Enqueue every narrow beat for one wide W beat at serializer start. The
   // scoreboard then drains them one per actual narrow-W handshake, absorbing
@@ -590,7 +583,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(LanesPerWide),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(WriteFifoDepth)
+      .MAX_PENDING(WriteMaxPending)
   ) w_sb (
       .clk(clk),
       .rstN(!rst),

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -105,9 +105,68 @@ module br_amba_axi_shrinker_fpv_monitor #(
 
   localparam int WideSizeLog2 = $clog2(WideStrobeWidth);
   localparam int NarrowSizeLog2 = $clog2(NarrowStrobeWidth);
+  localparam int ArPayloadWidth = AddrWidth + IdWidth + br_amba::AxiBurstLenWidth +
+                                  br_amba::AxiBurstSizeWidth + br_amba::AxiBurstTypeWidth +
+                                  br_amba::AxiProtWidth + ARUserWidth;
 
   // ABVIP should send more than DUT to test backpressure.
   localparam int MaxPending = MaxOutstandingReqs + WriteFifoDepth + 2;
+
+  logic [br_amba::AxiBurstSizeWidth-1:0] fv_narrow_arsize;
+  logic [br_amba::AxiBurstLenWidth-1:0] fv_narrow_arlen;
+  logic [ArPayloadWidth-1:0] fv_narrow_ar_payload;
+  int unsigned ar_shift;
+  logic [br_amba::AxiBurstLenWidth:0] fv_narrow_arlen_ext;
+
+  always_comb begin
+    ar_shift = 0;
+    fv_narrow_arsize = wide_arsize;
+
+    if (wide_arsize > NarrowSizeLog2) begin
+      fv_narrow_arsize = NarrowSizeLog2;
+      ar_shift = wide_arsize - NarrowSizeLog2;
+    end
+
+    // AXI len encodes beats - 1, so after scaling the beat count by the width ratio
+    // we subtract 1 to convert back to the AXI burst-length encoding.
+    fv_narrow_arlen_ext = (({1'b0, wide_arlen} + 1'b1) << ar_shift) - 1'b1;
+    fv_narrow_arlen = fv_narrow_arlen_ext[br_amba::AxiBurstLenWidth-1:0];
+  end
+
+  assign fv_narrow_ar_payload = {
+    wide_araddr,
+    wide_arid,
+    fv_narrow_arlen,
+    fv_narrow_arsize,
+    wide_arburst,
+    wide_arprot,
+    wide_aruser
+  };
+
+  // Checks that the RTL narrow AR channel matches the monitor prediction for
+  // narrow arlen/arsize derived from each accepted wide AR request.
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(ArPayloadWidth),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxPending)
+  ) ar_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(wide_arvalid && wide_arready),
+      .incoming_data(fv_narrow_ar_payload),
+      .outgoing_vld(narrow_arvalid && narrow_arready),
+      .outgoing_data({
+        narrow_araddr,
+        narrow_arid,
+        narrow_arlen,
+        narrow_arsize,
+        narrow_arburst,
+        narrow_arprot,
+        narrow_aruser
+      })
+  );
 
   `BR_ASSUME(
       shrinking_awburst_incr_a,

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -132,6 +132,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
   // ABVIP should send more than DUT to test backpressure.
   localparam int MaxPending = MaxOutstandingReqs + WriteFifoDepth + 2;
   localparam int WriteMaxPending = MaxOutstandingReqs + WriteFifoDepth;
+  localparam int WriteWMaxPending = WriteMaxPending * LanesPerWide;
 
   logic [br_amba::AxiBurstSizeWidth-1:0] fv_narrow_arsize;
   logic [br_amba::AxiBurstLenWidth-1:0] fv_narrow_arlen;
@@ -163,6 +164,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
   fv_w_ctx_t fv_w_active_ctx;
   logic [ByteOffsetWidth-1:0] fv_w_active_offset_next;
   fv_w_ctx_t fv_w_ctx;
+  logic fv_w_beat_inflight;
   logic fv_w_beat_start;
   logic [ByteOffsetWidth-1:0] fv_w_offset_after_wide_beat;
   logic [LanesPerWide-1:0] fv_narrow_w_pred_vld;
@@ -496,7 +498,11 @@ module br_amba_axi_shrinker_fpv_monitor #(
   assign fv_w_ctx = fv_w_active_valid ? fv_w_active_ctx : fv_w_fifo_pop_ctx;
   assign fv_w_offset_after_wide_beat = fv_w_ctx.is_fixed ? fv_w_ctx.offset :
       ByteOffsetWidth'(fv_w_ctx.offset + (fv_w_ctx.beats_per_wide * fv_w_ctx.offset_incr));
-  assign fv_w_beat_start = fv_wide_w_hs;
+  // The RTL starts serializing a wide W beat as soon as an active write context
+  // exists and wide_wvalid is asserted; wide_wready is only raised on the final
+  // serialized narrow beat. Track whether the current wide beat has already
+  // been enqueued so prediction starts on the first send cycle, not on wide_w_hs.
+  assign fv_w_beat_start = fv_w_ctx_valid && wide_wvalid && !fv_w_beat_inflight;
   assign fv_w_active_done = fv_wide_w_hs && wide_wlast;
 
   fv_fifo #(
@@ -566,6 +572,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
   end
 
   `BR_REG(fv_w_active_valid, fv_w_ctx_valid && !fv_w_active_done)
+  `BR_REG(fv_w_beat_inflight, (fv_w_beat_inflight || fv_w_beat_start) && !fv_wide_w_hs)
   `BR_REGL(fv_w_active_ctx.is_fixed, fv_w_fifo_pop_ctx.is_fixed, fv_w_active_load)
   `BR_REGL(fv_w_active_ctx.offset, fv_w_active_offset_next, fv_w_active_load || fv_wide_w_hs)
   `BR_REGL(fv_w_active_ctx.offset_incr, fv_w_fifo_pop_ctx.offset_incr, fv_w_active_load)
@@ -583,7 +590,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(LanesPerWide),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(WriteMaxPending)
+      .MAX_PENDING(WriteWMaxPending)
   ) w_sb (
       .clk(clk),
       .rstN(!rst),

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -145,6 +145,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic fv_wide_ar_hs;
   logic fv_narrow_r_hs;
   logic fv_wide_rdata_vld;
+  logic fv_wide_w_hs;
   logic fv_w_cfg_push;
   logic fv_w_cfg_pop;
   logic fv_w_cfg_available;
@@ -171,6 +172,18 @@ module br_amba_axi_shrinker_fpv_monitor #(
   logic fv_w_beat_start;
   logic [ByteOffsetWidth-1:0] fv_w_offset_after_beat;
   logic fv_w_beat_last;
+  logic [WideDataWidth-1:0] fv_wide_wdata_cur;
+  logic [WideDataWidth-1:0] fv_wide_wdata_saved;
+  logic [WideDataWidth-1:0] fv_wide_wdata_saved_next;
+  logic [WideStrobeWidth-1:0] fv_wide_wstrb_cur;
+  logic [WideStrobeWidth-1:0] fv_wide_wstrb_saved;
+  logic [WideStrobeWidth-1:0] fv_wide_wstrb_saved_next;
+  logic [WUserWidth-1:0] fv_wide_wuser_cur;
+  logic [WUserWidth-1:0] fv_wide_wuser_saved;
+  logic [WUserWidth-1:0] fv_wide_wuser_saved_next;
+  logic fv_wide_wlast_cur;
+  logic fv_wide_wlast_saved;
+  logic fv_wide_wlast_saved_next;
   logic [LanesPerWide-1:0][ByteOffsetWidth-1:0] fv_w_chunk_offset;
   logic [LanesPerWide-1:0][LaneIdxWidth-1:0] fv_w_chunk_lane;
   logic [LanesPerWide-1:0] fv_w_chunk_last;
@@ -485,6 +498,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
   // Queue accepted AW-derived write contexts, then use the head entry to
   // predict how each wide W beat serializes onto the narrow W channel.
   assign fv_narrow_w_hs = narrow_wvalid && narrow_wready;
+  assign fv_wide_w_hs = wide_wvalid && wide_wready;
   assign fv_w_cfg_push = wide_awvalid && wide_awready;
   assign fv_w_offset_incr_cfg = BeatOffsetIncrWidth'(1'b1) << fv_narrow_awsize;
   assign fv_w_beats_per_wide_cfg = BeatsPerWideWidth'(1'b1) << aw_shift;
@@ -499,22 +513,20 @@ module br_amba_axi_shrinker_fpv_monitor #(
                                                        fv_w_offset_incr[fv_w_cfg_head]
                                                       : wide_awaddr[ByteOffsetWidth-1:0] +
                                                         fv_w_offset_incr_cfg);
-  // This is the final narrow beat for the current wide W beat, not
-  // necessarily the final beat of the whole AXI burst.
-  assign fv_w_beat_last = (fv_w_cfg_available ? fv_w_beats_remaining[fv_w_cfg_head]
-                                              : fv_w_beats_per_wide_cfg) == BeatsPerWideWidth'(1);
+  // The wide side only accepts one W beat when the DUT has finished
+  // serializing that beat internally, so the monitor should enqueue the full
+  // predicted narrow-beat set on wide-W acceptance.
+  assign fv_w_beat_last = 1'b1;
   assign fv_narrow_w_model_valid = (fv_w_cfg_available || fv_w_cfg_push) && wide_wvalid;
   assign fv_narrow_w_model_ready = RegisterNarrowOutputs ? (!fv_w_pipe_full || narrow_wready)
                                                          : narrow_wready;
   assign fv_narrow_w_model_hs = fv_narrow_w_model_valid && fv_narrow_w_model_ready;
-  // Serializer start for one wide W beat. This is when the checker enqueues
-  // every narrow beat that should later appear on the narrow W channel.
-  assign fv_w_beat_start = fv_narrow_w_model_hs &&
-                           ((fv_w_cfg_available ? fv_w_beats_remaining[fv_w_cfg_head]
-                                                : fv_w_beats_per_wide_cfg) ==
-                            (fv_w_cfg_available ? fv_w_beats_per_wide[fv_w_cfg_head]
-                                                : fv_w_beats_per_wide_cfg));
-  assign fv_w_cfg_pop = fv_narrow_w_model_hs && fv_w_beat_last && wide_wlast;
+  assign fv_wide_wdata_cur = wide_wdata;
+  assign fv_wide_wstrb_cur = wide_wstrb;
+  assign fv_wide_wuser_cur = wide_wuser;
+  assign fv_wide_wlast_cur = wide_wlast;
+  assign fv_w_beat_start = fv_wide_w_hs;
+  assign fv_w_cfg_pop = fv_wide_w_hs && wide_wlast;
   assign fv_w_cfg_head_inc =
       (fv_w_cfg_head == WCfgPtrWidth'(WriteMaxPending - 1)) ? '0 : fv_w_cfg_head + 'd1;
   assign fv_w_cfg_tail_inc =
@@ -538,7 +550,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
         // 2:1 example: chunk 0 is the first narrow beat sent, chunk 1 is the
         // second. For aligned INCR bursts that is low lane first, then high.
         fv_w_chunk_lane[i] = LaneIdxWidth'(fv_w_chunk_offset[i] >> NarrowSizeLog2);
-        fv_w_chunk_last[i] = wide_wlast &&
+        fv_w_chunk_last[i] = fv_wide_wlast_cur &&
                              (BeatsPerWideWidth'(i + 1) ==
                               (fv_w_cfg_available ? fv_w_beats_per_wide[fv_w_cfg_head]
                                                   : fv_w_beats_per_wide_cfg));
@@ -549,9 +561,9 @@ module br_amba_axi_shrinker_fpv_monitor #(
                                  : fv_w_beats_per_wide_cfg))) begin
           fv_narrow_w_pred_vld[i] = 1'b1;
           fv_narrow_w_pred_payloads[i] = {
-            wide_wdata[fv_w_chunk_lane[i]*NarrowDataWidth+:NarrowDataWidth],
-            wide_wstrb[fv_w_chunk_lane[i]*NarrowStrobeWidth+:NarrowStrobeWidth],
-            wide_wuser,
+            fv_wide_wdata_cur[fv_w_chunk_lane[i]*NarrowDataWidth+:NarrowDataWidth],
+            fv_wide_wstrb_cur[fv_w_chunk_lane[i]*NarrowStrobeWidth+:NarrowStrobeWidth],
+            fv_wide_wuser_cur,
             fv_w_chunk_last[i]
           };
         end
@@ -576,7 +588,6 @@ module br_amba_axi_shrinker_fpv_monitor #(
     fv_w_offset_incr_next = fv_w_offset_incr;
     fv_w_beats_per_wide_next = fv_w_beats_per_wide;
     fv_w_beats_remaining_next = fv_w_beats_remaining;
-
     if (fv_w_cfg_push) begin
       fv_w_is_fixed_next[fv_w_cfg_tail] = wide_awburst == br_amba::AxiBurstFixed;
       fv_w_offset_next[fv_w_cfg_tail] = wide_awaddr[ByteOffsetWidth-1:0];
@@ -585,20 +596,23 @@ module br_amba_axi_shrinker_fpv_monitor #(
       fv_w_beats_remaining_next[fv_w_cfg_tail] = fv_w_beats_per_wide_cfg;
     end
 
-    if (fv_narrow_w_model_hs && !fv_w_cfg_pop) begin
-      // After one predicted narrow beat is consumed, either reload the
-      // per-wide-beat countdown or advance to the next serializer position.
-      fv_w_offset_next[fv_w_cfg_idx] = fv_w_offset_after_beat;
-
-      if (fv_w_beat_last) begin
-        fv_w_beats_remaining_next[fv_w_cfg_idx] = fv_w_cfg_available
-                                                  ? fv_w_beats_per_wide[fv_w_cfg_head]
-                                                  : fv_w_beats_per_wide_cfg;
-      end else begin
-        fv_w_beats_remaining_next[fv_w_cfg_idx] =
-            (fv_w_cfg_available ? fv_w_beats_remaining[fv_w_cfg_head]
-                                : fv_w_beats_per_wide_cfg) - BeatsPerWideWidth'(1);
+    if (fv_wide_w_hs && !fv_w_cfg_pop) begin
+      // One accepted wide W beat consumes the entire predicted narrow-beat
+      // set for that beat, so advance directly to the next wide-beat starting
+      // offset within this transaction.
+      if (fv_w_cfg_available ? !fv_w_is_fixed[fv_w_cfg_head]
+                             : wide_awburst != br_amba::AxiBurstFixed) begin
+        fv_w_offset_next[fv_w_cfg_idx] =
+            ByteOffsetWidth'((fv_w_cfg_available ? fv_w_offset[fv_w_cfg_head]
+                                                 : wide_awaddr[ByteOffsetWidth-1:0]) +
+                             ((fv_w_cfg_available ? fv_w_beats_per_wide[fv_w_cfg_head]
+                                                  : fv_w_beats_per_wide_cfg) *
+                              (fv_w_cfg_available ? fv_w_offset_incr[fv_w_cfg_head]
+                                                  : fv_w_offset_incr_cfg)));
       end
+      fv_w_beats_remaining_next[fv_w_cfg_idx] = fv_w_cfg_available
+                                                ? fv_w_beats_per_wide[fv_w_cfg_head]
+                                                : fv_w_beats_per_wide_cfg;
     end
   end
 

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -119,10 +119,14 @@ module br_amba_axi_shrinker_fpv_monitor #(
                                   br_amba::AxiBurstSizeWidth + br_amba::AxiBurstTypeWidth +
                                   br_amba::AxiProtWidth + ARUserWidth;
   localparam int BPayloadWidth = IdWidth + BUserWidth + br_amba::AxiRespWidth;
+  localparam int WPayloadWidth = NarrowDataWidth + NarrowStrobeWidth + WUserWidth + 1;
   localparam int RPayloadWidth = IdWidth + WideDataWidth + RUserWidth + br_amba::AxiRespWidth + 1;
 
   // ABVIP should send more than DUT to test backpressure.
   localparam int MaxPending = MaxOutstandingReqs + WriteFifoDepth + 2;
+  localparam int WriteMaxPending = MaxOutstandingReqs + WriteFifoDepth;
+  localparam int WCfgPtrWidth = br_math::clamped_clog2(WriteMaxPending);
+  localparam int WCfgCountWidth = br_math::clamped_clog2(WriteMaxPending + 1);
 
   logic [br_amba::AxiBurstSizeWidth-1:0] fv_narrow_arsize;
   logic [br_amba::AxiBurstLenWidth-1:0] fv_narrow_arlen;
@@ -134,9 +138,44 @@ module br_amba_axi_shrinker_fpv_monitor #(
   int unsigned ar_shift;
   logic [br_amba::AxiBurstLenWidth:0] fv_narrow_awlen_ext;
   logic [br_amba::AxiBurstLenWidth:0] fv_narrow_arlen_ext;
+  logic fv_narrow_w_hs;
+  logic fv_narrow_w_model_valid;
+  logic fv_narrow_w_model_ready;
+  logic fv_narrow_w_model_hs;
   logic fv_wide_ar_hs;
   logic fv_narrow_r_hs;
   logic fv_wide_rdata_vld;
+  logic fv_w_cfg_push;
+  logic fv_w_cfg_pop;
+  logic fv_w_cfg_available;
+  logic fv_w_cfg_bypass;
+  logic [WCfgPtrWidth-1:0] fv_w_cfg_head;
+  logic [WCfgPtrWidth-1:0] fv_w_cfg_head_inc;
+  logic [WCfgPtrWidth-1:0] fv_w_cfg_tail;
+  logic [WCfgPtrWidth-1:0] fv_w_cfg_tail_inc;
+  logic [WCfgCountWidth-1:0] fv_w_cfg_count;
+  logic [WCfgPtrWidth-1:0] fv_w_cfg_idx;
+  logic fv_w_pipe_full;
+  logic [BeatOffsetIncrWidth-1:0] fv_w_offset_incr_cfg;
+  logic [BeatsPerWideWidth-1:0] fv_w_beats_per_wide_cfg;
+  logic [WriteMaxPending-1:0] fv_w_is_fixed;
+  logic [WriteMaxPending-1:0] fv_w_is_fixed_next;
+  logic [WriteMaxPending-1:0][ByteOffsetWidth-1:0] fv_w_offset;
+  logic [WriteMaxPending-1:0][ByteOffsetWidth-1:0] fv_w_offset_next;
+  logic [WriteMaxPending-1:0][BeatOffsetIncrWidth-1:0] fv_w_offset_incr;
+  logic [WriteMaxPending-1:0][BeatOffsetIncrWidth-1:0] fv_w_offset_incr_next;
+  logic [WriteMaxPending-1:0][BeatsPerWideWidth-1:0] fv_w_beats_per_wide;
+  logic [WriteMaxPending-1:0][BeatsPerWideWidth-1:0] fv_w_beats_per_wide_next;
+  logic [WriteMaxPending-1:0][BeatsPerWideWidth-1:0] fv_w_beats_remaining;
+  logic [WriteMaxPending-1:0][BeatsPerWideWidth-1:0] fv_w_beats_remaining_next;
+  logic fv_w_beat_start;
+  logic [ByteOffsetWidth-1:0] fv_w_offset_after_beat;
+  logic fv_w_beat_last;
+  logic [LanesPerWide-1:0][ByteOffsetWidth-1:0] fv_w_chunk_offset;
+  logic [LanesPerWide-1:0][LaneIdxWidth-1:0] fv_w_chunk_lane;
+  logic [LanesPerWide-1:0] fv_w_chunk_last;
+  logic [LanesPerWide-1:0] fv_narrow_w_pred_vld;
+  logic [LanesPerWide-1:0][WPayloadWidth-1:0] fv_narrow_w_pred_payloads;
   logic [InternalIdWidth-1:0] fv_rid_idx;
   logic [ByteOffsetWidth-1:0] fv_wide_ar_offset;
   logic [BeatOffsetIncrWidth-1:0] fv_r_offset_incr_cfg;
@@ -256,7 +295,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(1),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(MaxPending)
+      .MAX_PENDING(MaxOutstandingReqs)
   ) ar_sb (
       .clk(clk),
       .rstN(!rst),
@@ -364,7 +403,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(1),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(MaxPending)
+      .MAX_PENDING(MaxOutstandingReqs)
   ) r_sb (
       .clk(clk),
       .rstN(!rst),
@@ -407,7 +446,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(1),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(MaxPending)
+      .MAX_PENDING(WriteMaxPending)
   ) aw_sb (
       .clk(clk),
       .rstN(!rst),
@@ -432,7 +471,7 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .IN_CHUNKS(1),
       .OUT_CHUNKS(1),
       .SINGLE_CLOCK(1),
-      .MAX_PENDING(MaxPending)
+      .MAX_PENDING(WriteMaxPending)
   ) b_sb (
       .clk(clk),
       .rstN(!rst),
@@ -440,6 +479,164 @@ module br_amba_axi_shrinker_fpv_monitor #(
       .incoming_data({narrow_bid, narrow_buser, narrow_bresp}),
       .outgoing_vld(wide_bvalid && wide_bready),
       .outgoing_data({wide_bid, wide_buser, wide_bresp})
+  );
+
+  // ----------W channel----------
+  // Queue accepted AW-derived write contexts, then use the head entry to
+  // predict how each wide W beat serializes onto the narrow W channel.
+  assign fv_narrow_w_hs = narrow_wvalid && narrow_wready;
+  assign fv_w_cfg_push = wide_awvalid && wide_awready;
+  assign fv_w_offset_incr_cfg = BeatOffsetIncrWidth'(1'b1) << fv_narrow_awsize;
+  assign fv_w_beats_per_wide_cfg = BeatsPerWideWidth'(1'b1) << aw_shift;
+  assign fv_w_cfg_available = fv_w_cfg_count != '0;
+  assign fv_w_cfg_bypass = !fv_w_cfg_available && fv_w_cfg_push;
+  assign fv_w_cfg_idx = fv_w_cfg_available ? fv_w_cfg_head : fv_w_cfg_tail;
+  assign fv_w_offset_after_beat = (fv_w_cfg_available ? fv_w_is_fixed[fv_w_cfg_head]
+                                                      : (wide_awburst == br_amba::AxiBurstFixed)) ?
+                                  (fv_w_cfg_available ? fv_w_offset[fv_w_cfg_head]
+                                                      : wide_awaddr[ByteOffsetWidth-1:0]) :
+                                  (fv_w_cfg_available ? fv_w_offset[fv_w_cfg_head] +
+                                                       fv_w_offset_incr[fv_w_cfg_head]
+                                                      : wide_awaddr[ByteOffsetWidth-1:0] +
+                                                        fv_w_offset_incr_cfg);
+  // This is the final narrow beat for the current wide W beat, not
+  // necessarily the final beat of the whole AXI burst.
+  assign fv_w_beat_last = (fv_w_cfg_available ? fv_w_beats_remaining[fv_w_cfg_head]
+                                              : fv_w_beats_per_wide_cfg) == BeatsPerWideWidth'(1);
+  assign fv_narrow_w_model_valid = (fv_w_cfg_available || fv_w_cfg_push) && wide_wvalid;
+  assign fv_narrow_w_model_ready = RegisterNarrowOutputs ? (!fv_w_pipe_full || narrow_wready)
+                                                         : narrow_wready;
+  assign fv_narrow_w_model_hs = fv_narrow_w_model_valid && fv_narrow_w_model_ready;
+  // Serializer start for one wide W beat. This is when the checker enqueues
+  // every narrow beat that should later appear on the narrow W channel.
+  assign fv_w_beat_start = fv_narrow_w_model_hs &&
+                           ((fv_w_cfg_available ? fv_w_beats_remaining[fv_w_cfg_head]
+                                                : fv_w_beats_per_wide_cfg) ==
+                            (fv_w_cfg_available ? fv_w_beats_per_wide[fv_w_cfg_head]
+                                                : fv_w_beats_per_wide_cfg));
+  assign fv_w_cfg_pop = fv_narrow_w_model_hs && fv_w_beat_last && wide_wlast;
+  assign fv_w_cfg_head_inc =
+      (fv_w_cfg_head == WCfgPtrWidth'(WriteMaxPending - 1)) ? '0 : fv_w_cfg_head + 'd1;
+  assign fv_w_cfg_tail_inc =
+      (fv_w_cfg_tail == WCfgPtrWidth'(WriteMaxPending - 1)) ? '0 : fv_w_cfg_tail + 'd1;
+
+  always_comb begin
+    fv_narrow_w_pred_vld = '0;
+    fv_narrow_w_pred_payloads = '0;
+    fv_w_chunk_offset = '0;
+    fv_w_chunk_lane = '0;
+    fv_w_chunk_last = '0;
+
+    if (fv_w_cfg_available || fv_w_cfg_push) begin
+      fv_w_chunk_offset[0] = fv_w_cfg_available ? fv_w_offset[fv_w_cfg_head]
+                                                : wide_awaddr[ByteOffsetWidth-1:0];
+
+      for (int i = 0; i < LanesPerWide; i++) begin
+        // Multi-input scoreboard mode lets one wide W beat enqueue every
+        // narrow beat it will serialize into. Keep the chunks in serializer
+        // order, not lane order:
+        // 2:1 example: chunk 0 is the first narrow beat sent, chunk 1 is the
+        // second. For aligned INCR bursts that is low lane first, then high.
+        fv_w_chunk_lane[i] = LaneIdxWidth'(fv_w_chunk_offset[i] >> NarrowSizeLog2);
+        fv_w_chunk_last[i] = wide_wlast &&
+                             (BeatsPerWideWidth'(i + 1) ==
+                              (fv_w_cfg_available ? fv_w_beats_per_wide[fv_w_cfg_head]
+                                                  : fv_w_beats_per_wide_cfg));
+
+        if (fv_w_beat_start &&
+            (BeatsPerWideWidth'(i) <
+             (fv_w_cfg_available ? fv_w_beats_per_wide[fv_w_cfg_head]
+                                 : fv_w_beats_per_wide_cfg))) begin
+          fv_narrow_w_pred_vld[i] = 1'b1;
+          fv_narrow_w_pred_payloads[i] = {
+            wide_wdata[fv_w_chunk_lane[i]*NarrowDataWidth+:NarrowDataWidth],
+            wide_wstrb[fv_w_chunk_lane[i]*NarrowStrobeWidth+:NarrowStrobeWidth],
+            wide_wuser,
+            fv_w_chunk_last[i]
+          };
+        end
+
+        if ((i + 1) < LanesPerWide) begin
+          if (fv_w_cfg_available ? !fv_w_is_fixed[fv_w_cfg_head]
+                                 : wide_awburst != br_amba::AxiBurstFixed) begin
+            fv_w_chunk_offset[i+1] = fv_w_chunk_offset[i] +
+                                     (fv_w_cfg_available ? fv_w_offset_incr[fv_w_cfg_head]
+                                                         : fv_w_offset_incr_cfg);
+          end else begin
+            fv_w_chunk_offset[i+1] = fv_w_chunk_offset[i];
+          end
+        end
+      end
+    end
+  end
+
+  always_comb begin
+    fv_w_is_fixed_next = fv_w_is_fixed;
+    fv_w_offset_next = fv_w_offset;
+    fv_w_offset_incr_next = fv_w_offset_incr;
+    fv_w_beats_per_wide_next = fv_w_beats_per_wide;
+    fv_w_beats_remaining_next = fv_w_beats_remaining;
+
+    if (fv_w_cfg_push) begin
+      fv_w_is_fixed_next[fv_w_cfg_tail] = wide_awburst == br_amba::AxiBurstFixed;
+      fv_w_offset_next[fv_w_cfg_tail] = wide_awaddr[ByteOffsetWidth-1:0];
+      fv_w_offset_incr_next[fv_w_cfg_tail] = fv_w_offset_incr_cfg;
+      fv_w_beats_per_wide_next[fv_w_cfg_tail] = fv_w_beats_per_wide_cfg;
+      fv_w_beats_remaining_next[fv_w_cfg_tail] = fv_w_beats_per_wide_cfg;
+    end
+
+    if (fv_narrow_w_model_hs && !fv_w_cfg_pop) begin
+      // After one predicted narrow beat is consumed, either reload the
+      // per-wide-beat countdown or advance to the next serializer position.
+      fv_w_offset_next[fv_w_cfg_idx] = fv_w_offset_after_beat;
+
+      if (fv_w_beat_last) begin
+        fv_w_beats_remaining_next[fv_w_cfg_idx] = fv_w_cfg_available
+                                                  ? fv_w_beats_per_wide[fv_w_cfg_head]
+                                                  : fv_w_beats_per_wide_cfg;
+      end else begin
+        fv_w_beats_remaining_next[fv_w_cfg_idx] =
+            (fv_w_cfg_available ? fv_w_beats_remaining[fv_w_cfg_head]
+                                : fv_w_beats_per_wide_cfg) - BeatsPerWideWidth'(1);
+      end
+    end
+  end
+
+  if (RegisterNarrowOutputs) begin : gen_w_pipe_state
+    `BR_REGL(fv_w_pipe_full, fv_narrow_w_model_hs, fv_narrow_w_model_hs ^ fv_narrow_w_hs)
+  end else begin : gen_no_w_pipe_state
+    assign fv_w_pipe_full = 1'b0;
+  end
+
+  `BR_REG(fv_w_cfg_count, fv_w_cfg_count + fv_w_cfg_push - fv_w_cfg_pop)
+  `BR_REGL(fv_w_cfg_head, fv_w_cfg_head_inc, fv_w_cfg_pop && !(fv_w_cfg_bypass && fv_w_cfg_push))
+  `BR_REGL(fv_w_cfg_tail, fv_w_cfg_tail_inc, fv_w_cfg_push && !(fv_w_cfg_bypass && fv_w_cfg_pop))
+  `BR_REG(fv_w_is_fixed, fv_w_is_fixed_next)
+  `BR_REG(fv_w_offset, fv_w_offset_next)
+  `BR_REG(fv_w_offset_incr, fv_w_offset_incr_next)
+  `BR_REG(fv_w_beats_per_wide, fv_w_beats_per_wide_next)
+  `BR_REG(fv_w_beats_remaining, fv_w_beats_remaining_next)
+
+  // Enqueue every narrow beat for one wide W beat at serializer start. The
+  // scoreboard then drains them one per actual narrow-W handshake, absorbing
+  // any latency added by RegisterNarrowOutputs.
+  // Example, 2:1 shrink:
+  // one wide W beat enqueues two predicted narrow chunks on fv_w_beat_start.
+  // chunk 0 is the first serialized narrow beat; chunk 1 is the second.
+  // For aligned INCR traffic that is lower lane first, then higher lane.
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(WPayloadWidth),
+      .IN_CHUNKS(LanesPerWide),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(WriteMaxPending)
+  ) w_sb (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(fv_narrow_w_pred_vld),
+      .incoming_data(fv_narrow_w_pred_payloads),
+      .outgoing_vld(narrow_wvalid && narrow_wready),
+      .outgoing_data({narrow_wdata, narrow_wstrb, narrow_wuser, narrow_wlast})
   );
 
   // ----------AXI protocols----------


### PR DESCRIPTION
**The monitor now covers:**

AR: predicts the transformed narrow read request from each accepted wide AR and checks the narrow side matches the expected addr/id/len/size/burst/prot/user
R: reconstructs wide read beats from the returning narrow R stream and checks the wide side matches the reconstructed id/data/user/resp/last
AW: predicts the transformed narrow write request from each accepted wide AW and checks the narrow side matches the expected addr/id/len/size/burst/prot/user
W: predicts how each accepted wide write beat is serialized into narrow W beats and checks the narrow side stream matches the expected data/strb/user/last
B: checks the wide write response matches the narrow write response payload

**High-level intent for R**

each accepted wide AR seeds per-request reconstruction state
that state records the byte offset, narrow-beat stride, and how many narrow beats are needed to complete one wide beat
as narrow R beats return, the monitor places each narrow payload into the correct wide lane, accumulates the worst response seen for that reconstructed wide beat, and emits one expected wide R item once the required number of narrow beats has been observed.

**High-level intent for W**

each accepted wide AW pushes write-context metadata into a monitor-side queue
that metadata tells the monitor where the write starts, whether the burst is fixed or incrementing, and how many narrow beats each wide beat should produce
when a wide W beat is presented, the monitor predicts the full ordered sequence of narrow W beats that should come out of the shrinker, including lane selection, strobe slicing, and which narrow beat should carry last.