### PR TITLE
Disable br_counter_incr unreachable reinit property 

### DIFF
--- a/counter/rtl/br_counter.sv
+++ b/counter/rtl/br_counter.sv
@@ -119,9 +119,7 @@ module br_counter #(
 
   `BR_ASSERT_INTG(incr_in_range_a, incr_valid |-> incr <= MaxIncrement)
   `BR_ASSERT_INTG(decr_in_range_a, decr_valid |-> decr <= MaxDecrement)
-  if (EnableCoverReinit) begin : gen_reinit
-    `BR_ASSERT_INTG(initial_value_in_range_a, reinit |-> initial_value <= MaxValue)
-  end
+  `BR_ASSERT_INTG(initial_value_in_range_a, initial_value <= MaxValue)
 
   // Assertion-only helper logic for overflow/underflow detection
 `ifdef BR_ASSERT_ON

--- a/counter/rtl/br_counter.sv
+++ b/counter/rtl/br_counter.sv
@@ -119,7 +119,9 @@ module br_counter #(
 
   `BR_ASSERT_INTG(incr_in_range_a, incr_valid |-> incr <= MaxIncrement)
   `BR_ASSERT_INTG(decr_in_range_a, decr_valid |-> decr <= MaxDecrement)
-  `BR_ASSERT_INTG(initial_value_in_range_a, initial_value <= MaxValue)
+  if (EnableCoverReinit) begin : gen_reinit
+    `BR_ASSERT_INTG(initial_value_in_range_a, reinit |-> initial_value <= MaxValue)
+  end
 
   // Assertion-only helper logic for overflow/underflow detection
 `ifdef BR_ASSERT_ON

--- a/counter/rtl/br_counter_incr.sv
+++ b/counter/rtl/br_counter_incr.sv
@@ -99,7 +99,9 @@ module br_counter_incr #(
   `BR_ASSERT_STATIC(max_increment_lte_max_value_a, MaxIncrement <= MaxValue)
 
   `BR_ASSERT_INTG(incr_in_range_a, incr_valid |-> incr <= MaxIncrement)
-  `BR_ASSERT_INTG(initial_value_in_range_a, reinit |-> initial_value <= MaxValue)
+  if (EnableCoverReinit) begin : gen_reinit
+    `BR_ASSERT_INTG(initial_value_in_range_a, reinit |-> initial_value <= MaxValue)
+  end
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_incr_valid_a, !incr_valid)

--- a/counter/rtl/br_counter_incr.sv
+++ b/counter/rtl/br_counter_incr.sv
@@ -99,7 +99,9 @@ module br_counter_incr #(
   `BR_ASSERT_STATIC(max_increment_lte_max_value_a, MaxIncrement <= MaxValue)
 
   `BR_ASSERT_INTG(incr_in_range_a, incr_valid |-> incr <= MaxIncrement)
-  `BR_ASSERT_INTG(initial_value_in_range_a, initial_value <= MaxValue)
+  if (EnableCoverReinit) begin : gen_reinit
+    `BR_ASSERT_INTG(initial_value_in_range_a, reinit |-> initial_value <= MaxValue)
+  end
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_incr_valid_a, !incr_valid)

--- a/counter/rtl/br_counter_incr.sv
+++ b/counter/rtl/br_counter_incr.sv
@@ -99,9 +99,7 @@ module br_counter_incr #(
   `BR_ASSERT_STATIC(max_increment_lte_max_value_a, MaxIncrement <= MaxValue)
 
   `BR_ASSERT_INTG(incr_in_range_a, incr_valid |-> incr <= MaxIncrement)
-  if (EnableCoverReinit) begin : gen_reinit
-    `BR_ASSERT_INTG(initial_value_in_range_a, reinit |-> initial_value <= MaxValue)
-  end
+  `BR_ASSERT_INTG(initial_value_in_range_a, initial_value <= MaxValue)
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_incr_valid_a, !incr_valid)


### PR DESCRIPTION
When reinit is tied to 0 in instantiation, initial_value_in_range_a will trigger unreachable cover.