### PR TITLE
allow independent config of read vs write

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -355,15 +355,21 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_isolate_sub_test_suite",
     elab_opts = [
-        "-parameter MaxOutstanding 4",
-        "-parameter AxiIdCount 2",
+        "-parameter AwMaxOutstanding 4",
+        "-parameter ArMaxOutstanding 4",
+        "-parameter AwAxiIdCount 2",
+        "-parameter ArAxiIdCount 2",
     ],
     params = {
         "MaxAxiBurstLen": [
             "1",
             "256",
         ],
-        "IdWidth": [
+        "AwAxiIdWidth": [
+            "1",
+            "2",
+        ],
+        "ArAxiIdWidth": [
             "1",
             "2",
         ],

--- a/amba/fpv/br_amba_axi_isolate_mgr_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_isolate_mgr_fpv_monitor.sv
@@ -128,13 +128,15 @@ module br_amba_axi_isolate_mgr_fpv_monitor #(
       .ReadInterleaveOn(1),
       .AddrWidth(AddrWidth),
       .DataWidth(DataWidth),
-      .IdWidth(IdWidth),
+      .AwAxiIdWidth(IdWidth),
+      .ArAxiIdWidth(IdWidth),
       .AWUserWidth(AWUserWidth),
       .WUserWidth(WUserWidth),
       .ARUserWidth(ARUserWidth),
       .BUserWidth(BUserWidth),
       .RUserWidth(RUserWidth),
-      .MaxOutstanding(MaxOutstanding),
+      .MaxOutstandingReads(MaxOutstanding),
+      .MaxOutstandingWrites(MaxOutstanding),
       .MaxAxiBurstLen(MaxAxiBurstLen)
   ) fv_axi_check (
       .clk,

--- a/amba/fpv/br_amba_axi_isolate_sub_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_isolate_sub_fpv_monitor.sv
@@ -9,14 +9,17 @@
 module br_amba_axi_isolate_sub_fpv_monitor #(
     parameter int AddrWidth = 12,
     parameter int DataWidth = 32,
-    parameter int IdWidth = 1,
+    parameter int AwAxiIdWidth = 1,
+    parameter int ArAxiIdWidth = 1,
     parameter int AWUserWidth = 1,
     parameter int WUserWidth = 1,
     parameter int ARUserWidth = 1,
     parameter int BUserWidth = 1,
     parameter int RUserWidth = 1,
-    parameter int MaxOutstanding = 128,
-    parameter int AxiIdCount = 2 ** IdWidth,
+    parameter int AwMaxOutstanding = 128,
+    parameter int ArMaxOutstanding = 128,
+    parameter int AwAxiIdCount = 2 ** AwAxiIdWidth,
+    parameter int ArAxiIdCount = 2 ** ArAxiIdWidth,
     parameter int MaxTransactionSkew = 2,
     parameter int MaxAxiBurstLen = 2 ** br_amba::AxiBurstLenWidth,
     parameter br_amba::axi_resp_t IsolateResp = br_amba::AxiRespSlverr,
@@ -24,7 +27,7 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     parameter bit [RUserWidth-1:0] IsolateRUser = '0,
     parameter bit [DataWidth-1:0] IsolateRData = '0,
     parameter bit UseDynamicFifoForReadTracker = 1,
-    parameter int StaticPerIdReadTrackerFifoDepth = MaxOutstanding,
+    parameter int StaticPerIdReadTrackerFifoDepth = ArMaxOutstanding,
     localparam int AxiBurstLenWidth = br_math::clamped_clog2(MaxAxiBurstLen),
     localparam int StrobeWidth = DataWidth / 8
 ) (
@@ -35,7 +38,7 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     input logic                                  isolate_done,
     //
     input logic [                 AddrWidth-1:0] upstream_awaddr,
-    input logic [                   IdWidth-1:0] upstream_awid,
+    input logic [              AwAxiIdWidth-1:0] upstream_awid,
     input logic [          AxiBurstLenWidth-1:0] upstream_awlen,
     input logic [br_amba::AxiBurstSizeWidth-1:0] upstream_awsize,
     input logic [br_amba::AxiBurstTypeWidth-1:0] upstream_awburst,
@@ -50,13 +53,13 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     input logic                                  upstream_wlast,
     input logic                                  upstream_wvalid,
     input logic                                  upstream_wready,
-    input logic [                   IdWidth-1:0] upstream_bid,
+    input logic [              AwAxiIdWidth-1:0] upstream_bid,
     input logic [                BUserWidth-1:0] upstream_buser,
     input logic [     br_amba::AxiRespWidth-1:0] upstream_bresp,
     input logic                                  upstream_bvalid,
     input logic                                  upstream_bready,
     input logic [                 AddrWidth-1:0] upstream_araddr,
-    input logic [                   IdWidth-1:0] upstream_arid,
+    input logic [              ArAxiIdWidth-1:0] upstream_arid,
     input logic [          AxiBurstLenWidth-1:0] upstream_arlen,
     input logic [br_amba::AxiBurstSizeWidth-1:0] upstream_arsize,
     input logic [br_amba::AxiBurstTypeWidth-1:0] upstream_arburst,
@@ -65,7 +68,7 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     input logic [               ARUserWidth-1:0] upstream_aruser,
     input logic                                  upstream_arvalid,
     input logic                                  upstream_arready,
-    input logic [                   IdWidth-1:0] upstream_rid,
+    input logic [              ArAxiIdWidth-1:0] upstream_rid,
     input logic [                 DataWidth-1:0] upstream_rdata,
     input logic [                RUserWidth-1:0] upstream_ruser,
     input logic [     br_amba::AxiRespWidth-1:0] upstream_rresp,
@@ -74,7 +77,7 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     input logic                                  upstream_rready,
     //
     input logic [                 AddrWidth-1:0] downstream_awaddr,
-    input logic [                   IdWidth-1:0] downstream_awid,
+    input logic [              AwAxiIdWidth-1:0] downstream_awid,
     input logic [          AxiBurstLenWidth-1:0] downstream_awlen,
     input logic [br_amba::AxiBurstSizeWidth-1:0] downstream_awsize,
     input logic [br_amba::AxiBurstTypeWidth-1:0] downstream_awburst,
@@ -89,13 +92,13 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     input logic                                  downstream_wlast,
     input logic                                  downstream_wvalid,
     input logic                                  downstream_wready,
-    input logic [                   IdWidth-1:0] downstream_bid,
+    input logic [              AwAxiIdWidth-1:0] downstream_bid,
     input logic [                BUserWidth-1:0] downstream_buser,
     input logic [     br_amba::AxiRespWidth-1:0] downstream_bresp,
     input logic                                  downstream_bvalid,
     input logic                                  downstream_bready,
     input logic [                 AddrWidth-1:0] downstream_araddr,
-    input logic [                   IdWidth-1:0] downstream_arid,
+    input logic [              ArAxiIdWidth-1:0] downstream_arid,
     input logic [          AxiBurstLenWidth-1:0] downstream_arlen,
     input logic [br_amba::AxiBurstSizeWidth-1:0] downstream_arsize,
     input logic [br_amba::AxiBurstTypeWidth-1:0] downstream_arburst,
@@ -104,7 +107,7 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     input logic [               ARUserWidth-1:0] downstream_aruser,
     input logic                                  downstream_arvalid,
     input logic                                  downstream_arready,
-    input logic [                   IdWidth-1:0] downstream_rid,
+    input logic [              ArAxiIdWidth-1:0] downstream_rid,
     input logic [                 DataWidth-1:0] downstream_rdata,
     input logic [                RUserWidth-1:0] downstream_ruser,
     input logic [     br_amba::AxiRespWidth-1:0] downstream_rresp,
@@ -113,32 +116,32 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
     input logic                                  downstream_rready
 );
 
-  localparam int MaxPendingRd = AxiIdCount * StaticPerIdReadTrackerFifoDepth;
-  localparam int RdCntrWidth = $clog2(MaxPendingRd);
-  localparam int MaxPendingWr = AxiIdCount * MaxOutstanding;
-  localparam int WrCntrWidth = $clog2(MaxPendingWr);
+  localparam int MaxPendingRd = ArAxiIdCount * StaticPerIdReadTrackerFifoDepth;
+  localparam int RdCntrWidth = br_math::clamped_clog2(MaxPendingRd + 1);
+  localparam int MaxPendingWr = AwAxiIdCount * AwMaxOutstanding;
+  localparam int WrCntrWidth = br_math::clamped_clog2(MaxPendingWr + 1);
 
-  // if AxiIdCount < 2 ** IdWidth
-  `BR_ASSUME(legal_awid_a, upstream_awvalid |-> upstream_awid < AxiIdCount)
-  `BR_ASSUME(legal_bid_a, downstream_bvalid |-> downstream_bid < AxiIdCount)
-  `BR_ASSUME(legal_arid_a, upstream_arvalid |-> upstream_arid < AxiIdCount)
-  `BR_ASSUME(legal_rid_a, downstream_rvalid |-> downstream_rid < AxiIdCount)
+  // if *AxiIdCount < 2 ** *AxiIdWidth
+  `BR_ASSUME(legal_awid_a, upstream_awvalid |-> upstream_awid < AwAxiIdCount)
+  `BR_ASSUME(legal_bid_a, downstream_bvalid |-> downstream_bid < AwAxiIdCount)
+  `BR_ASSUME(legal_arid_a, upstream_arvalid |-> upstream_arid < ArAxiIdCount)
+  `BR_ASSUME(legal_rid_a, downstream_rvalid |-> downstream_rid < ArAxiIdCount)
 
-  // for each write Id, the number of outstanding transactions should be <= MaxOutstanding
+  // for each write Id, the number of outstanding transactions should be <= AwMaxOutstanding
   // for each read Id, the number of outstanding transactions should be <= StaticPerIdReadTrackerFifoDepth
-  logic [AxiIdCount-1:0][WrCntrWidth-1:0] aw_cntr;
-  logic [AxiIdCount-1:0][RdCntrWidth-1:0] ar_cntr;
+  logic [AwAxiIdCount-1:0][WrCntrWidth-1:0] aw_cntr;
+  logic [ArAxiIdCount-1:0][RdCntrWidth-1:0] ar_cntr;
 
-  for (genvar i = 0; i < AxiIdCount; i++) begin : gen_aw
+  for (genvar i = 0; i < AwAxiIdCount; i++) begin : gen_aw
     `BR_REG(aw_cntr[i],
             aw_cntr[i] +
             (upstream_awvalid && upstream_awready && (upstream_awid == i)) -
             (upstream_bvalid && upstream_bready && (upstream_bid == i)))
-    `BR_ASSUME(max_aw_perId_a, aw_cntr[i] <= MaxOutstanding)
+    `BR_ASSUME(max_aw_perId_a, aw_cntr[i] <= AwMaxOutstanding)
   end
 
   if (UseDynamicFifoForReadTracker == 0) begin : gen_perID
-    for (genvar i = 0; i < AxiIdCount; i++) begin : gen_ar
+    for (genvar i = 0; i < ArAxiIdCount; i++) begin : gen_ar
       `BR_REG(ar_cntr[i],
               ar_cntr[i] +
               (upstream_arvalid && upstream_arready && (upstream_arid == i)) -
@@ -171,13 +174,15 @@ module br_amba_axi_isolate_sub_fpv_monitor #(
       .ReadInterleaveOn(0),
       .AddrWidth(AddrWidth),
       .DataWidth(DataWidth),
-      .IdWidth(IdWidth),
+      .AwAxiIdWidth(AwAxiIdWidth),
+      .ArAxiIdWidth(ArAxiIdWidth),
       .AWUserWidth(AWUserWidth),
       .WUserWidth(WUserWidth),
       .ARUserWidth(ARUserWidth),
       .BUserWidth(BUserWidth),
       .RUserWidth(RUserWidth),
-      .MaxOutstanding(MaxPendingWr + MaxTransactionSkew),
+      .MaxOutstandingReads(MaxPendingRd),
+      .MaxOutstandingWrites(MaxPendingWr + MaxTransactionSkew),
       .MaxAxiBurstLen(MaxAxiBurstLen)
   ) fv_axi_check (
       .clk,
@@ -269,14 +274,17 @@ endmodule : br_amba_axi_isolate_sub_fpv_monitor
 bind br_amba_axi_isolate_sub br_amba_axi_isolate_sub_fpv_monitor #(
     .AddrWidth(AddrWidth),
     .DataWidth(DataWidth),
-    .IdWidth(IdWidth),
+    .AwAxiIdWidth(AwAxiIdWidth),
+    .ArAxiIdWidth(ArAxiIdWidth),
     .AWUserWidth(AWUserWidth),
     .WUserWidth(WUserWidth),
     .ARUserWidth(ARUserWidth),
     .BUserWidth(BUserWidth),
     .RUserWidth(RUserWidth),
-    .MaxOutstanding(MaxOutstanding),
-    .AxiIdCount(AxiIdCount),
+    .AwMaxOutstanding(AwMaxOutstanding),
+    .ArMaxOutstanding(ArMaxOutstanding),
+    .AwAxiIdCount(AwAxiIdCount),
+    .ArAxiIdCount(ArAxiIdCount),
     .MaxTransactionSkew(MaxTransactionSkew),
     .MaxAxiBurstLen(MaxAxiBurstLen),
     .IsolateResp(IsolateResp),

--- a/amba/fpv/isolate_axi_protocol_fv_check.sv
+++ b/amba/fpv/isolate_axi_protocol_fv_check.sv
@@ -9,13 +9,15 @@ module isolate_axi_protocol_fv_check #(
     parameter bit ValidBeforeReady = 1,
     parameter int AddrWidth = 12,
     parameter int DataWidth = 32,
-    parameter int IdWidth = 1,
+    parameter int AwAxiIdWidth = 1,
+    parameter int ArAxiIdWidth = 1,
     parameter int AWUserWidth = 1,
     parameter int WUserWidth = 1,
     parameter int ARUserWidth = 1,
     parameter int BUserWidth = 1,
     parameter int RUserWidth = 1,
-    parameter int MaxOutstanding = 128,
+    parameter int MaxOutstandingReads = 128,
+    parameter int MaxOutstandingWrites = 128,
     parameter int MaxAxiBurstLen = 2 ** br_amba::AxiBurstLenWidth,
     localparam int AxiBurstLenWidth = br_math::clamped_clog2(MaxAxiBurstLen),
     localparam int StrobeWidth = DataWidth / 8
@@ -29,7 +31,7 @@ module isolate_axi_protocol_fv_check #(
     input logic                                  isolate_done,
     //
     input logic [                 AddrWidth-1:0] upstream_awaddr,
-    input logic [                   IdWidth-1:0] upstream_awid,
+    input logic [              AwAxiIdWidth-1:0] upstream_awid,
     input logic [          AxiBurstLenWidth-1:0] upstream_awlen,
     input logic [br_amba::AxiBurstSizeWidth-1:0] upstream_awsize,
     input logic [br_amba::AxiBurstTypeWidth-1:0] upstream_awburst,
@@ -44,13 +46,13 @@ module isolate_axi_protocol_fv_check #(
     input logic                                  upstream_wlast,
     input logic                                  upstream_wvalid,
     input logic                                  upstream_wready,
-    input logic [                   IdWidth-1:0] upstream_bid,
+    input logic [              AwAxiIdWidth-1:0] upstream_bid,
     input logic [                BUserWidth-1:0] upstream_buser,
     input logic [     br_amba::AxiRespWidth-1:0] upstream_bresp,
     input logic                                  upstream_bvalid,
     input logic                                  upstream_bready,
     input logic [                 AddrWidth-1:0] upstream_araddr,
-    input logic [                   IdWidth-1:0] upstream_arid,
+    input logic [              ArAxiIdWidth-1:0] upstream_arid,
     input logic [          AxiBurstLenWidth-1:0] upstream_arlen,
     input logic [br_amba::AxiBurstSizeWidth-1:0] upstream_arsize,
     input logic [br_amba::AxiBurstTypeWidth-1:0] upstream_arburst,
@@ -59,7 +61,7 @@ module isolate_axi_protocol_fv_check #(
     input logic [               ARUserWidth-1:0] upstream_aruser,
     input logic                                  upstream_arvalid,
     input logic                                  upstream_arready,
-    input logic [                   IdWidth-1:0] upstream_rid,
+    input logic [              ArAxiIdWidth-1:0] upstream_rid,
     input logic [                 DataWidth-1:0] upstream_rdata,
     input logic [                RUserWidth-1:0] upstream_ruser,
     input logic [     br_amba::AxiRespWidth-1:0] upstream_rresp,
@@ -68,7 +70,7 @@ module isolate_axi_protocol_fv_check #(
     input logic                                  upstream_rready,
     //
     input logic [                 AddrWidth-1:0] downstream_awaddr,
-    input logic [                   IdWidth-1:0] downstream_awid,
+    input logic [              AwAxiIdWidth-1:0] downstream_awid,
     input logic [          AxiBurstLenWidth-1:0] downstream_awlen,
     input logic [br_amba::AxiBurstSizeWidth-1:0] downstream_awsize,
     input logic [br_amba::AxiBurstTypeWidth-1:0] downstream_awburst,
@@ -83,13 +85,13 @@ module isolate_axi_protocol_fv_check #(
     input logic                                  downstream_wlast,
     input logic                                  downstream_wvalid,
     input logic                                  downstream_wready,
-    input logic [                   IdWidth-1:0] downstream_bid,
+    input logic [              AwAxiIdWidth-1:0] downstream_bid,
     input logic [                BUserWidth-1:0] downstream_buser,
     input logic [     br_amba::AxiRespWidth-1:0] downstream_bresp,
     input logic                                  downstream_bvalid,
     input logic                                  downstream_bready,
     input logic [                 AddrWidth-1:0] downstream_araddr,
-    input logic [                   IdWidth-1:0] downstream_arid,
+    input logic [              ArAxiIdWidth-1:0] downstream_arid,
     input logic [          AxiBurstLenWidth-1:0] downstream_arlen,
     input logic [br_amba::AxiBurstSizeWidth-1:0] downstream_arsize,
     input logic [br_amba::AxiBurstTypeWidth-1:0] downstream_arburst,
@@ -98,7 +100,7 @@ module isolate_axi_protocol_fv_check #(
     input logic [               ARUserWidth-1:0] downstream_aruser,
     input logic                                  downstream_arvalid,
     input logic                                  downstream_arready,
-    input logic [                   IdWidth-1:0] downstream_rid,
+    input logic [              ArAxiIdWidth-1:0] downstream_rid,
     input logic [                 DataWidth-1:0] downstream_rdata,
     input logic [                RUserWidth-1:0] downstream_ruser,
     input logic [     br_amba::AxiRespWidth-1:0] downstream_rresp,
@@ -108,7 +110,8 @@ module isolate_axi_protocol_fv_check #(
 );
 
   // ABVIP should send more than DUT to test backpressure
-  localparam int MaxPending = MaxOutstanding + 2;
+  localparam int MaxPendingRd = MaxOutstandingReads + 2;
+  localparam int MaxPendingWr = MaxOutstandingWrites + 2;
 
   // FV 4-phase handshake modeling
   fv_4phase_handshake #(
@@ -122,7 +125,8 @@ module isolate_axi_protocol_fv_check #(
 
   // upstream
   axi4_master #(
-      .ID_WIDTH(IdWidth),
+      .ID_WIDTH_W(AwAxiIdWidth),
+      .ID_WIDTH_R(ArAxiIdWidth),
       .ADDR_WIDTH(AddrWidth),
       .LEN_WIDTH(AxiBurstLenWidth),
       .SIZE_WIDTH(br_amba::AxiBurstSizeWidth),
@@ -136,7 +140,8 @@ module isolate_axi_protocol_fv_check #(
       .BUSER_WIDTH(BUserWidth),
       .RUSER_WIDTH(RUserWidth),
       .BRESP_WIDTH(br_amba::AxiRespWidth),
-      .MAX_PENDING(MaxPending),
+      .MAX_PENDING_RD(MaxPendingRd),
+      .MAX_PENDING_WR(MaxPendingWr),
       .AXI4_LITE(MaxAxiBurstLen == 1),
       .READ_INTERLEAVE_ON(ReadInterleaveOn),
       // when there is no valid, ready doesn't have to be high eventually
@@ -205,7 +210,8 @@ module isolate_axi_protocol_fv_check #(
 
   // downstream
   axi4_slave #(
-      .ID_WIDTH(IdWidth),
+      .ID_WIDTH_W(AwAxiIdWidth),
+      .ID_WIDTH_R(ArAxiIdWidth),
       .ADDR_WIDTH(AddrWidth),
       .LEN_WIDTH(AxiBurstLenWidth),
       .SIZE_WIDTH(br_amba::AxiBurstSizeWidth),
@@ -219,7 +225,8 @@ module isolate_axi_protocol_fv_check #(
       .BUSER_WIDTH(BUserWidth),
       .RUSER_WIDTH(RUserWidth),
       .BRESP_WIDTH(br_amba::AxiRespWidth),
-      .MAX_PENDING(MaxPending),
+      .MAX_PENDING_RD(MaxPendingRd),
+      .MAX_PENDING_WR(MaxPendingWr),
       .AXI4_LITE(MaxAxiBurstLen == 1),
       .READ_INTERLEAVE_ON(ReadInterleaveOn),  // not supported by br_amba_axi_isolate_sub
       // when there is no valid, ready doesn't have to be high eventually

--- a/amba/rtl/BUILD.bazel
+++ b/amba/rtl/BUILD.bazel
@@ -362,12 +362,18 @@ br_verilog_elab_and_lint_test_suite(
     params = {
         "AddrWidth": ["64"],
         "DataWidth": ["128"],
-        "IdWidth": ["8"],
-        "AxiIdCount": [
+        "AwAxiIdWidth": ["3"],
+        "AwAxiIdCount": [
             "1",
-            "128",
+            "6",
         ],
-        "MaxOutstanding": ["128"],
+        "ArAxiIdWidth": ["2"],
+        "ArAxiIdCount": [
+            "1",
+            "3",
+        ],
+        "AwMaxOutstanding": ["128"],
+        "ArMaxOutstanding": ["64"],
         "MaxAxiBurstLen": [
             "1",
             "256",
@@ -381,9 +387,12 @@ br_verilog_elab_and_lint_test_suite(
     params = {
         "AddrWidth": ["40"],
         "DataWidth": ["64"],
-        "IdWidth": ["1"],
-        "AxiIdCount": ["1"],
-        "MaxOutstanding": ["16"],
+        "AwAxiIdWidth": ["1"],
+        "AwAxiIdCount": ["1"],
+        "ArAxiIdWidth": ["1"],
+        "ArAxiIdCount": ["1"],
+        "AwMaxOutstanding": ["16"],
+        "ArMaxOutstanding": ["16"],
         "MaxAxiBurstLen": ["1"],
     },
     deps = [":br_amba_axi_isolate_sub"],

--- a/amba/rtl/br_amba_axi_isolate_sub.sv
+++ b/amba/rtl/br_amba_axi_isolate_sub.sv
@@ -40,8 +40,10 @@ module br_amba_axi_isolate_sub #(
     parameter int AddrWidth = 12,
     // Width of the AXI data field.
     parameter int DataWidth = 32,
-    // Width of the AXI ID field.
-    parameter int IdWidth = 1,
+    // Width of the AXI ID field for the write path.
+    parameter int AwAxiIdWidth = 1,
+    // Width of the AXI ID field for the read path.
+    parameter int ArAxiIdWidth = 1,
     // Width of the AXI AWUSER field.
     parameter int AWUserWidth = 1,
     // Width of the AXI WUSER field.
@@ -52,12 +54,18 @@ module br_amba_axi_isolate_sub #(
     parameter int BUserWidth = 1,
     // Width of the AXI RUSER field.
     parameter int RUserWidth = 1,
-    // Maximum number of outstanding requests that can be tracked
+    // Maximum number of outstanding write requests that can be tracked
     // without backpressuring the upstream request ports. Must be at least 2.
-    parameter int MaxOutstanding = 128,
-    // Number of unique AXI IDs that can be tracked. Must be less
-    // than or equal to 2^IdWidth. Valid ids are 0 to AxiIdCount-1.
-    parameter int AxiIdCount = 2 ** IdWidth,
+    parameter int AwMaxOutstanding = 128,
+    // Maximum number of outstanding read requests that can be tracked
+    // without backpressuring the upstream request ports. Must be at least 2.
+    parameter int ArMaxOutstanding = 128,
+    // Number of unique AXI write IDs that can be tracked. Must be less than
+    // or equal to 2^AwAxiIdWidth. Valid IDs are 0 to AwAxiIdCount-1.
+    parameter int AwAxiIdCount = 2 ** AwAxiIdWidth,
+    // Number of unique AXI read IDs that can be tracked. Must be less than
+    // or equal to 2^ArAxiIdWidth. Valid IDs are 0 to ArAxiIdCount-1.
+    parameter int ArAxiIdCount = 2 ** ArAxiIdWidth,
     // Maximum allowed skew (measured in max-length transactions)
     // that can be tracked between AW and W channels without causing
     // backpressure on the upstream ports.
@@ -78,39 +86,39 @@ module br_amba_axi_isolate_sub #(
     // list.
     parameter bit UseDynamicFifoForReadTracker = 1,
     // When UseDynamicFifoForReadTracker=0, this parameter controls the depth
-    // of the Per-ID tracking FIFO. This defaults to MaxOutstanding, but may
+    // of the Per-ID tracking FIFO. This defaults to ArMaxOutstanding, but may
     // need to be set to a smaller value as the storage will be replicated for
     // each ID.
-    parameter int StaticPerIdReadTrackerFifoDepth = MaxOutstanding,
+    parameter int StaticPerIdReadTrackerFifoDepth = ArMaxOutstanding,
     // Number of pipeline stages to use for the pointer RAM read data in the
-    // response tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // response tracker FIFO. Has no effect if ArAxiIdCount == 1 or
     // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoPointerRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the data RAM read data in the
-    // response tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // response tracker FIFO. Has no effect if ArAxiIdCount == 1 or
     // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoDataRamReadDataDepthStages = 0,
     // Number of pipeline stages to use for the pointer RAM address in the
-    // response tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // response tracker FIFO. Has no effect if ArAxiIdCount == 1 or
     // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoPointerRamAddressDepthStages = 1,
     // Number of pipeline stages to use for the data RAM address in the
-    // response tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // response tracker FIFO. Has no effect if ArAxiIdCount == 1 or
     // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoDataRamAddressDepthStages = 1,
     // Number of linked lists per FIFO in the response tracker FIFO. Has no
-    // effect if AxiIdCount == 1 or UseDynamicFifoForReadTracker == 0.
+    // effect if ArAxiIdCount == 1 or UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoNumLinkedListsPerFifo = 2,
     // Number of pipeline stages to use for the staging buffer in the response
-    // tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // tracker FIFO. Has no effect if ArAxiIdCount == 1 or
     // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoStagingBufferDepth = 2,
     // Number of pipeline stages to use for the pop outputs in the response
-    // tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // tracker FIFO. Has no effect if ArAxiIdCount == 1 or
     // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoRegisterPopOutputs = 1,
     // Number of pipeline stages to use for the deallocation in the response
-    // tracker FIFO. Has no effect if AxiIdCount == 1 or
+    // tracker FIFO. Has no effect if ArAxiIdCount == 1 or
     // UseDynamicFifoForReadTracker == 0.
     parameter int DynamicFifoRegisterDeallocation = 1,
     //
@@ -124,7 +132,7 @@ module br_amba_axi_isolate_sub #(
     output logic                                  isolate_done,
     //
     input  logic [                 AddrWidth-1:0] upstream_awaddr,
-    input  logic [                   IdWidth-1:0] upstream_awid,
+    input  logic [              AwAxiIdWidth-1:0] upstream_awid,
     input  logic [          AxiBurstLenWidth-1:0] upstream_awlen,
     input  logic [br_amba::AxiBurstSizeWidth-1:0] upstream_awsize,
     input  logic [br_amba::AxiBurstTypeWidth-1:0] upstream_awburst,
@@ -139,13 +147,13 @@ module br_amba_axi_isolate_sub #(
     input  logic                                  upstream_wlast,
     input  logic                                  upstream_wvalid,
     output logic                                  upstream_wready,
-    output logic [                   IdWidth-1:0] upstream_bid,
+    output logic [              AwAxiIdWidth-1:0] upstream_bid,
     output logic [                BUserWidth-1:0] upstream_buser,
     output logic [     br_amba::AxiRespWidth-1:0] upstream_bresp,
     output logic                                  upstream_bvalid,
     input  logic                                  upstream_bready,
     input  logic [                 AddrWidth-1:0] upstream_araddr,
-    input  logic [                   IdWidth-1:0] upstream_arid,
+    input  logic [              ArAxiIdWidth-1:0] upstream_arid,
     input  logic [          AxiBurstLenWidth-1:0] upstream_arlen,
     input  logic [br_amba::AxiBurstSizeWidth-1:0] upstream_arsize,
     input  logic [br_amba::AxiBurstTypeWidth-1:0] upstream_arburst,
@@ -154,7 +162,7 @@ module br_amba_axi_isolate_sub #(
     input  logic [               ARUserWidth-1:0] upstream_aruser,
     input  logic                                  upstream_arvalid,
     output logic                                  upstream_arready,
-    output logic [                   IdWidth-1:0] upstream_rid,
+    output logic [              ArAxiIdWidth-1:0] upstream_rid,
     output logic [                 DataWidth-1:0] upstream_rdata,
     output logic [                RUserWidth-1:0] upstream_ruser,
     output logic [     br_amba::AxiRespWidth-1:0] upstream_rresp,
@@ -163,7 +171,7 @@ module br_amba_axi_isolate_sub #(
     input  logic                                  upstream_rready,
     //
     output logic [                 AddrWidth-1:0] downstream_awaddr,
-    output logic [                   IdWidth-1:0] downstream_awid,
+    output logic [              AwAxiIdWidth-1:0] downstream_awid,
     output logic [          AxiBurstLenWidth-1:0] downstream_awlen,
     output logic [br_amba::AxiBurstSizeWidth-1:0] downstream_awsize,
     output logic [br_amba::AxiBurstTypeWidth-1:0] downstream_awburst,
@@ -178,13 +186,13 @@ module br_amba_axi_isolate_sub #(
     output logic                                  downstream_wlast,
     output logic                                  downstream_wvalid,
     input  logic                                  downstream_wready,
-    input  logic [                   IdWidth-1:0] downstream_bid,
+    input  logic [              AwAxiIdWidth-1:0] downstream_bid,
     input  logic [                BUserWidth-1:0] downstream_buser,
     input  logic [     br_amba::AxiRespWidth-1:0] downstream_bresp,
     input  logic                                  downstream_bvalid,
     output logic                                  downstream_bready,
     output logic [                 AddrWidth-1:0] downstream_araddr,
-    output logic [                   IdWidth-1:0] downstream_arid,
+    output logic [              ArAxiIdWidth-1:0] downstream_arid,
     output logic [          AxiBurstLenWidth-1:0] downstream_arlen,
     output logic [br_amba::AxiBurstSizeWidth-1:0] downstream_arsize,
     output logic [br_amba::AxiBurstTypeWidth-1:0] downstream_arburst,
@@ -193,7 +201,7 @@ module br_amba_axi_isolate_sub #(
     output logic [               ARUserWidth-1:0] downstream_aruser,
     output logic                                  downstream_arvalid,
     input  logic                                  downstream_arready,
-    input  logic [                   IdWidth-1:0] downstream_rid,
+    input  logic [              ArAxiIdWidth-1:0] downstream_rid,
     input  logic [                 DataWidth-1:0] downstream_rdata,
     input  logic [                RUserWidth-1:0] downstream_ruser,
     input  logic [     br_amba::AxiRespWidth-1:0] downstream_rresp,
@@ -206,21 +214,36 @@ module br_amba_axi_isolate_sub #(
   // Integration Checks
   //
 
-  localparam int MinIdWidth = br_math::clamped_clog2(AxiIdCount);
+  localparam int AwMinIdWidth = br_math::clamped_clog2(AwAxiIdCount);
+  localparam int ArMinIdWidth = br_math::clamped_clog2(ArAxiIdCount);
 
-  `BR_ASSERT_STATIC(max_outstanding_gt_1_a, MaxOutstanding > 1)
-  `BR_ASSERT_STATIC(have_enough_ids_a, AxiIdCount <= 2 ** IdWidth)
+  `BR_ASSERT_STATIC(aw_axi_id_width_gte_1_a, AwAxiIdWidth >= 1)
+  `BR_ASSERT_STATIC(ar_axi_id_width_gte_1_a, ArAxiIdWidth >= 1)
+  `BR_ASSERT_STATIC(aw_max_outstanding_gt_1_a, AwMaxOutstanding > 1)
+  `BR_ASSERT_STATIC(ar_max_outstanding_gt_1_a, ArMaxOutstanding > 1)
+  `BR_ASSERT_STATIC(aw_axi_id_count_gte_1_a, AwAxiIdCount >= 1)
+  `BR_ASSERT_STATIC(ar_axi_id_count_gte_1_a, ArAxiIdCount >= 1)
+  `BR_ASSERT_STATIC(have_enough_aw_ids_a, AwAxiIdCount <= 2 ** AwAxiIdWidth)
+  `BR_ASSERT_STATIC(have_enough_ar_ids_a, ArAxiIdCount <= 2 ** ArAxiIdWidth)
   `BR_ASSERT_STATIC(burst_len_legal_a,
                     MaxAxiBurstLen == 1 || MaxAxiBurstLen == 2 ** br_amba::AxiBurstLenWidth)
   // Check that the isolate request can only rise when isolate_done is false.
   `BR_ASSERT_INTG(legal_request_rise_a, $rose(isolate_req) |-> !isolate_done)
   // Check that the isolate request can only fall when isolate_done is true.
   `BR_ASSERT_INTG(legal_request_fall_a, $fell(isolate_req) |-> isolate_done)
-  if (MinIdWidth < IdWidth) begin : gen_id_width_lt_len_width
-    `BR_ASSERT_INTG(unused_upper_awid_zero_a,
-                    upstream_awvalid |-> upstream_awid[IdWidth-1:MinIdWidth] == '0)
-    `BR_ASSERT_INTG(unused_upper_arid_zero_a,
-                    upstream_arvalid |-> upstream_arid[IdWidth-1:MinIdWidth] == '0)
+  `BR_ASSERT_INTG(legal_awid_a, upstream_awvalid |-> upstream_awid < AwAxiIdCount)
+  `BR_ASSERT_INTG(legal_bid_a, downstream_bvalid |-> downstream_bid < AwAxiIdCount)
+  `BR_ASSERT_INTG(legal_arid_a, upstream_arvalid |-> upstream_arid < ArAxiIdCount)
+  `BR_ASSERT_INTG(legal_rid_a, downstream_rvalid |-> downstream_rid < ArAxiIdCount)
+
+  if (AwMinIdWidth < AwAxiIdWidth) begin : gen_aw_id_width_lt_min_width
+    `BR_UNUSED_NAMED(upstream_awid_unused, upstream_awid[AwAxiIdWidth-1:AwMinIdWidth])
+    `BR_UNUSED_NAMED(downstream_bid_unused, downstream_bid[AwAxiIdWidth-1:AwMinIdWidth])
+  end
+
+  if (ArMinIdWidth < ArAxiIdWidth) begin : gen_ar_id_width_lt_min_width
+    `BR_UNUSED_NAMED(upstream_arid_unused, upstream_arid[ArAxiIdWidth-1:ArMinIdWidth])
+    `BR_UNUSED_NAMED(downstream_rid_unused, downstream_rid[ArAxiIdWidth-1:ArMinIdWidth])
   end
 
   //
@@ -231,15 +254,42 @@ module br_amba_axi_isolate_sub #(
   logic upstream_bvalid_int;
   logic [br_amba::AxiRespWidth-1:0] upstream_bresp_int;
   logic [BUserWidth-1:0] upstream_buser_int;
-  logic [IdWidth-1:0] upstream_bid_int;
+  logic [AwMinIdWidth-1:0] upstream_awid_min;
+  logic [AwMinIdWidth-1:0] downstream_bid_min;
+  logic [AwMinIdWidth-1:0] downstream_awid_min;
+  logic [AwMinIdWidth-1:0] upstream_bid_min_int;
+  logic [AwMinIdWidth-1:0] upstream_bid_min;
   //
   logic upstream_rready_int;
   logic upstream_rvalid_int;
   logic upstream_rlast_int;
   logic [br_amba::AxiRespWidth-1:0] upstream_rresp_int;
   logic [RUserWidth-1:0] upstream_ruser_int;
-  logic [IdWidth-1:0] upstream_rid_int;
+  logic [ArMinIdWidth-1:0] upstream_arid_min;
+  logic [ArMinIdWidth-1:0] downstream_rid_min;
+  logic [ArMinIdWidth-1:0] downstream_arid_min;
+  logic [ArMinIdWidth-1:0] upstream_rid_min_int;
+  logic [ArMinIdWidth-1:0] upstream_rid_min;
   logic [DataWidth-1:0] upstream_rdata_int;
+
+  assign upstream_awid_min = upstream_awid[AwMinIdWidth-1:0];
+  assign downstream_bid_min = downstream_bid[AwMinIdWidth-1:0];
+  assign upstream_arid_min = upstream_arid[ArMinIdWidth-1:0];
+  assign downstream_rid_min = downstream_rid[ArMinIdWidth-1:0];
+
+  assign downstream_awid[AwMinIdWidth-1:0] = downstream_awid_min;
+  assign upstream_bid[AwMinIdWidth-1:0] = upstream_bid_min;
+  if (AwMinIdWidth < AwAxiIdWidth) begin : gen_aw_id_upper_tieoff
+    assign downstream_awid[AwAxiIdWidth-1:AwMinIdWidth] = '0;
+    assign upstream_bid[AwAxiIdWidth-1:AwMinIdWidth] = '0;
+  end
+
+  assign downstream_arid[ArMinIdWidth-1:0] = downstream_arid_min;
+  assign upstream_rid[ArMinIdWidth-1:0] = upstream_rid_min;
+  if (ArMinIdWidth < ArAxiIdWidth) begin : gen_ar_id_upper_tieoff
+    assign downstream_arid[ArAxiIdWidth-1:ArMinIdWidth] = '0;
+    assign upstream_rid[ArAxiIdWidth-1:ArMinIdWidth] = '0;
+  end
 
   //
   // Write Path
@@ -302,9 +352,9 @@ module br_amba_axi_isolate_sub #(
   );
 
   br_amba_iso_resp_tracker #(
-      .MaxOutstanding(MaxOutstanding),
-      .AxiIdCount(AxiIdCount),
-      .AxiIdWidth(IdWidth),
+      .MaxOutstanding(AwMaxOutstanding),
+      .AxiIdCount(AwAxiIdCount),
+      .AxiIdWidth(AwMinIdWidth),
       .DataWidth(BUserWidth),
       .DynamicFifoPointerRamReadDataDepthStages(DynamicFifoPointerRamReadDataDepthStages),
       .DynamicFifoPointerRamAddressDepthStages(DynamicFifoPointerRamAddressDepthStages),
@@ -325,7 +375,7 @@ module br_amba_axi_isolate_sub #(
       // than a dynamic FIFO. So no external option is provided to select a
       // dynamic FIFO.
       .UseDynamicFifo(0),
-      .PerIdFifoDepth(MaxOutstanding)
+      .PerIdFifoDepth(AwMaxOutstanding)
   ) br_amba_iso_resp_tracker_w (
       .clk,
       .rst,
@@ -335,13 +385,13 @@ module br_amba_axi_isolate_sub #(
       //
       .upstream_axready(upstream_awready_holdoff),
       .upstream_axvalid(upstream_awvalid_holdoff),
-      .upstream_axid(upstream_awid),
+      .upstream_axid(upstream_awid_min),
       // write responses only have a single beat
       .upstream_axlen(1'b0),
       //
       .upstream_xready(upstream_bready_int),
       .upstream_xvalid(upstream_bvalid_int),
-      .upstream_xid(upstream_bid_int),
+      .upstream_xid(upstream_bid_min_int),
       .upstream_xresp({upstream_bresp_int}),  // ri lint_check_waive ENUM_RHS
       .upstream_xlast(),
       .upstream_xdata(upstream_buser_int),
@@ -352,7 +402,7 @@ module br_amba_axi_isolate_sub #(
       //
       .downstream_axready(downstream_awready_iso),
       .downstream_axvalid(downstream_awvalid_iso),
-      .downstream_axid(downstream_awid),
+      .downstream_axid(downstream_awid_min),
       .downstream_axlen(),
       //
       .downstream_wready(downstream_wready_iso),
@@ -361,7 +411,7 @@ module br_amba_axi_isolate_sub #(
       //
       .downstream_xready(downstream_bready),
       .downstream_xvalid(downstream_bvalid),
-      .downstream_xid(downstream_bid),
+      .downstream_xid(downstream_bid_min),
       .downstream_xresp(br_amba::axi_resp_t'(downstream_bresp)),
       .downstream_xlast(downstream_bvalid),
       .downstream_xdata(downstream_buser)
@@ -423,9 +473,9 @@ module br_amba_axi_isolate_sub #(
   assign align_and_hold_done_r = align_and_hold_req_r;
 
   br_amba_iso_resp_tracker #(
-      .MaxOutstanding(MaxOutstanding),
-      .AxiIdCount(AxiIdCount),
-      .AxiIdWidth(IdWidth),
+      .MaxOutstanding(ArMaxOutstanding),
+      .AxiIdCount(ArAxiIdCount),
+      .AxiIdWidth(ArMinIdWidth),
       .DataWidth(RUserWidth + DataWidth),
       .DynamicFifoPointerRamReadDataDepthStages(DynamicFifoPointerRamReadDataDepthStages),
       .DynamicFifoPointerRamAddressDepthStages(DynamicFifoPointerRamAddressDepthStages),
@@ -451,7 +501,7 @@ module br_amba_axi_isolate_sub #(
       //
       .upstream_axready(upstream_arready_holdoff),
       .upstream_axvalid(upstream_arvalid_holdoff),
-      .upstream_axid(upstream_arid),
+      .upstream_axid(upstream_arid_min),
       .upstream_axlen(upstream_arlen),
       //
       .upstream_wready(),
@@ -460,14 +510,14 @@ module br_amba_axi_isolate_sub #(
       //
       .upstream_xready(upstream_rready_int),
       .upstream_xvalid(upstream_rvalid_int),
-      .upstream_xid(upstream_rid_int),
+      .upstream_xid(upstream_rid_min_int),
       .upstream_xresp({upstream_rresp_int}),  // ri lint_check_waive ENUM_RHS
       .upstream_xlast(upstream_rlast_int),
       .upstream_xdata({upstream_ruser_int, upstream_rdata_int}),
       //
       .downstream_axready(downstream_arready_iso),
       .downstream_axvalid(downstream_arvalid_iso),
-      .downstream_axid(downstream_arid),
+      .downstream_axid(downstream_arid_min),
       .downstream_axlen(downstream_arlen),
       //
       .downstream_wready(1'b1),
@@ -476,7 +526,7 @@ module br_amba_axi_isolate_sub #(
       //
       .downstream_xready(downstream_rready),
       .downstream_xvalid(downstream_rvalid),
-      .downstream_xid(downstream_rid),
+      .downstream_xid(downstream_rid_min),
       .downstream_xresp(br_amba::axi_resp_t'(downstream_rresp)),
       .downstream_xlast(downstream_rlast),
       .downstream_xdata({downstream_ruser, downstream_rdata})
@@ -526,9 +576,7 @@ module br_amba_axi_isolate_sub #(
           upstream_rlast
       ) + $bits(
           upstream_ruser
-      ) + $bits(
-          upstream_rid
-      )),
+      ) + ArMinIdWidth),
       .EnableAssertPushValidStability(0),
       .EnableAssertPushDataStability(0)
   ) br_flow_reg_fwd_us_r (
@@ -542,16 +590,16 @@ module br_amba_axi_isolate_sub #(
         upstream_rresp_int,
         upstream_rlast_int,
         upstream_ruser_int,
-        upstream_rid_int
+        upstream_rid_min_int
       }),
       //
       .pop_ready(upstream_rready),
       .pop_valid(upstream_rvalid),
-      .pop_data({upstream_rdata, upstream_rresp, upstream_rlast, upstream_ruser, upstream_rid})
+      .pop_data({upstream_rdata, upstream_rresp, upstream_rlast, upstream_ruser, upstream_rid_min})
   );
 
   br_flow_reg_fwd #(
-      .Width($bits(upstream_bresp) + $bits(upstream_buser) + $bits(upstream_bid)),
+      .Width($bits(upstream_bresp) + $bits(upstream_buser) + AwMinIdWidth),
       .EnableAssertPushValidStability(0),
       .EnableAssertPushDataStability(0)
   ) br_flow_reg_fwd_us_aw (
@@ -560,10 +608,10 @@ module br_amba_axi_isolate_sub #(
       //
       .push_ready(upstream_bready_int),
       .push_valid(upstream_bvalid_int),
-      .push_data ({upstream_bresp_int, upstream_buser_int, upstream_bid_int}),
+      .push_data ({upstream_bresp_int, upstream_buser_int, upstream_bid_min_int}),
       //
       .pop_ready (upstream_bready),
       .pop_valid (upstream_bvalid),
-      .pop_data  ({upstream_bresp, upstream_buser, upstream_bid})
+      .pop_data  ({upstream_bresp, upstream_buser, upstream_bid_min})
   );
 endmodule

--- a/amba/rtl/internal/BUILD.bazel
+++ b/amba/rtl/internal/BUILD.bazel
@@ -111,6 +111,7 @@ br_verilog_elab_and_lint_test_suite(
         "AxiIdCount": [
             "1",
             "2",
+            "6",
             "128",
         ],
         "UseDynamicFifo": [

--- a/amba/rtl/internal/br_amba_iso_resp_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_resp_tracker.sv
@@ -122,10 +122,12 @@ module br_amba_iso_resp_tracker #(
 
   // Integration checks
   `BR_ASSERT_STATIC(max_outstanding_gte_1_a, MaxOutstanding > 1)
-  `BR_ASSERT_STATIC(max_outstanding_gt_skew_a, MaxOutstanding > MaxTransactionSkew)
+  `BR_ASSERT_STATIC(max_outstanding_gt_skew_a,
+                    !EnableWlastTracking || MaxOutstanding > MaxTransactionSkew)
   `BR_ASSERT_STATIC(max_axi_burst_len_1_or_amba_a,
                     MaxAxiBurstLen == 1 || MaxAxiBurstLen == 2 ** br_amba::AxiBurstLenWidth)
-  `BR_ASSERT_STATIC(axi_id_width_gte_clog2_a, AxiIdWidth >= $clog2(AxiIdCount))
+  `BR_ASSERT_STATIC(axi_id_count_gte_1_a, AxiIdCount >= 1)
+  `BR_ASSERT_STATIC(axi_id_width_gte_clog2_a, AxiIdWidth >= br_math::clamped_clog2(AxiIdCount))
   `BR_ASSERT_STATIC(per_id_fifo_depth_gte_1_a, PerIdFifoDepth >= 1)
   `BR_ASSERT_INTG(axlen_legal_range_a, upstream_axvalid |-> upstream_axlen < MaxAxiBurstLen)
   // Check that the isolate request can only fall when the tracker is empty and the upstream


### PR DESCRIPTION
- number of active IDs and outstanding txn counts may be set indepdently for read vs write
- better handling of non-power-of-2 number of active IDs

<!-- spr-stack:start -->
**Stack**:
- ➡ #1043

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->