### PR TITLE
Pin pre-commit cache action explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,18 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       # actions/setup-python v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-      # pre-commit/action v3.0.1
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+      - name: Show installed Python packages
+        run: python -m pip freeze --local
+      - name: Cache pre-commit environments
+        # actions/cache v4.3.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   # Run bazel build and tests in order in one job to avoid parallel jobs that make
   # build logs appear out of sequence across the CI workflow.


### PR DESCRIPTION
Replace the pre-commit composite action with equivalent explicit steps so the nested actions/cache dependency is pinned directly.