### PR TITLE
Decouple backpressure covers from no-backpressure asserts

### DIFF
--- a/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_basic_fpv_monitor.sv
@@ -18,6 +18,9 @@ module br_cdc_fifo_basic_fpv_monitor #(
     parameter int RamReadLatency = 1,
     parameter int PushExtraDelay = 0,
     parameter int PopExtraDelay = 0,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
     // FV system clk and rst
@@ -46,7 +49,6 @@ module br_cdc_fifo_basic_fpv_monitor #(
     input logic pop_empty,
     input logic [CountWidth-1:0] pop_items
 );
-
   localparam int ResetActiveDelay = 1;
   // Adding ExtraDelay to account for any extra flops when instantiating br_cdc_fifo.
   // Need to make sure that on push reset, the updated push_count is not visible
@@ -69,7 +71,7 @@ module br_cdc_fifo_basic_fpv_monitor #(
       `BR_ASSUME_CR(push_data_stable_a, push_valid && !push_ready |=> $stable(push_data), push_clk,
                     push_rst)
     end
-  end else begin : gen_no_back_pressure
+  end else if (EnableAssertNoPushBackpressure) begin : gen_no_back_pressure
     `BR_ASSUME_CR(no_back_pressure_a, push_valid |-> push_ready, push_clk, push_rst)
   end
 

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
@@ -17,6 +17,9 @@ module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -39,6 +42,7 @@ module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
     input logic             pop_ram_rd_data_valid,
     input logic [Width-1:0] pop_ram_rd_data
 );
+
   // Push-side output signals
   logic                             push_ready;
   // Push-side status flags
@@ -85,6 +89,7 @@ module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
       .RamReadLatency(RamReadLatency),
       .NumSyncStages(NumSyncStages),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
@@ -118,6 +123,7 @@ module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
       .Width(Width),
       .NumSyncStages(NumSyncStages),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .RamWriteLatency(RamWriteLatency),

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor.sv
@@ -27,6 +27,9 @@ module br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -49,7 +52,6 @@ module br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor #(
     input logic             pop_ram_rd_data_valid,
     input logic [Width-1:0] pop_ram_rd_data
 );
-
   // ----------Push-side interface----------
   logic                             push_ready;
   // Push-side status flags
@@ -100,6 +102,7 @@ module br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor #(
       .RamWriteLatency(RamWriteLatency),
       .NumSyncStages(NumSyncStages),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
@@ -155,6 +158,7 @@ module br_cdc_fifo_ctrl_push_pop_1r1w_fpv_monitor #(
       .Width(Width),
       .NumSyncStages(NumSyncStages),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .RamWriteLatency(RamWriteLatency),

--- a/cdc/fpv/br_cdc_fifo_flops_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_flops_fpv_monitor.sv
@@ -22,6 +22,9 @@ module br_cdc_fifo_flops_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -40,7 +43,6 @@ module br_cdc_fifo_flops_fpv_monitor #(
     input logic pop_rst,
     input logic pop_ready
 );
-
   localparam int RamReadLatency =
       FlopRamAddressDepthStages + FlopRamReadDataDepthStages + FlopRamReadDataWidthStages;
   localparam int RamWriteLatency = FlopRamAddressDepthStages + 1;
@@ -69,6 +71,7 @@ module br_cdc_fifo_flops_fpv_monitor #(
       .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages),
       .EnableStructuredGatesDataQualification(EnableStructuredGatesDataQualification),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
@@ -96,6 +99,7 @@ module br_cdc_fifo_flops_fpv_monitor #(
       .Width(Width),
       .NumSyncStages(NumSyncStages),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .RamWriteLatency(RamWriteLatency),

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
@@ -65,7 +65,8 @@ module br_cdc_fifo_ctrl_1r1w #(
     // The number of synchronization stages to use for the gray counts.
     parameter int NumSyncStages = 3,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -76,6 +77,9 @@ module br_cdc_fifo_ctrl_1r1w #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -118,6 +122,7 @@ module br_cdc_fifo_ctrl_1r1w #(
     input  logic                 pop_ram_rd_data_valid,
     input  logic [    Width-1:0] pop_ram_rd_data
 );
+
   //------------------------------------------
   // Integration checks
   //------------------------------------------
@@ -139,6 +144,7 @@ module br_cdc_fifo_ctrl_1r1w #(
       .RamWriteLatency(RamWriteLatency),
       .NumSyncStages(NumSyncStages),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_push_1r1w.sv
@@ -33,7 +33,8 @@ module br_cdc_fifo_ctrl_push_1r1w #(
     // before synchronization to the pop clock domain.
     parameter bit RegisterResetActive = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -44,6 +45,9 @@ module br_cdc_fifo_ctrl_push_1r1w #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -77,6 +81,7 @@ module br_cdc_fifo_ctrl_push_1r1w #(
     output logic [CountWidth-1:0] push_push_count_gray,
     output logic                  push_reset_active_push
 );
+
   //------------------------------------------
   // Integration checks
   //------------------------------------------
@@ -95,6 +100,7 @@ module br_cdc_fifo_ctrl_push_1r1w #(
       .RamWriteLatency(RamWriteLatency),
       .RegisterResetActive(RegisterResetActive),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/cdc/rtl/br_cdc_fifo_flops.sv
+++ b/cdc/rtl/br_cdc_fifo_flops.sv
@@ -66,7 +66,8 @@ module br_cdc_fifo_flops #(
     // concerns!).
     parameter bit EnableStructuredGatesDataQualification = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -77,6 +78,9 @@ module br_cdc_fifo_flops #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
 
     // Internal computed parameters
     localparam int AddrWidth  = $clog2(Depth),
@@ -139,6 +143,7 @@ module br_cdc_fifo_flops #(
       .RamReadLatency(RamReadLatency),
       .NumSyncStages(NumSyncStages),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/cdc/rtl/br_cdc_reg.sv
+++ b/cdc/rtl/br_cdc_reg.sv
@@ -32,7 +32,8 @@ module br_cdc_reg #(
     // Do not decrease below that unless you have a good reason.
     parameter int NumSyncStages = 3,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -42,7 +43,10 @@ module br_cdc_reg #(
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     // Push-side interface
     input  logic             push_clk,
@@ -78,6 +82,7 @@ module br_cdc_reg #(
       .Width(Width),
       .RegisterResetActive(RegisterResetActive),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_push_ctrl.sv
@@ -11,7 +11,8 @@ module br_cdc_fifo_push_ctrl #(
     parameter int RamWriteLatency = 1,
     parameter bit RegisterResetActive = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = 1,
@@ -22,6 +23,9 @@ module br_cdc_fifo_push_ctrl #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -56,6 +60,8 @@ module br_cdc_fifo_push_ctrl #(
   //------------------------------------------
   `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_COVER_INTG(full_c, full)
 
   //------------------------------------------
@@ -94,6 +100,7 @@ module br_cdc_fifo_push_ctrl #(
       .Width(Width),
       .EnableBypass(1'b0),  // Bypass is not enabled for CDC
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/cdc/rtl/internal/br_cdc_reg_push.sv
+++ b/cdc/rtl/internal/br_cdc_reg_push.sv
@@ -12,7 +12,10 @@ module br_cdc_reg_push #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertPushDataKnown = 1,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,
@@ -27,11 +30,16 @@ module br_cdc_reg_push #(
     input logic reset_active_pop,
     input logic pop_flag
 );
+
   // Integration Checks
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+
   br_flow_checks_valid_data_intg #(
       .NumFlows(1),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),

--- a/credit/fpv/br_credit_sender_fpv_monitor.sv
+++ b/credit/fpv/br_credit_sender_fpv_monitor.sv
@@ -17,6 +17,9 @@ module br_credit_sender_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int CounterWidth = $clog2(MaxCredit + 1),
     localparam int PopCreditWidth = $clog2(PopCreditMaxChange + 1)
 ) (
@@ -44,7 +47,6 @@ module br_credit_sender_fpv_monitor #(
     // Dynamic amount of available credit.
     input logic [CounterWidth-1:0] credit_available
 );
-
   // ----------FV modeling code----------
   localparam int N = NumFlows == 1 ? 1 : $clog2(NumFlows);
   logic [N-1:0] fv_flow;
@@ -64,7 +66,8 @@ module br_credit_sender_fpv_monitor #(
   `BR_ASSUME(credit_withhold_a, credit_withhold <= MaxCredit)
   `BR_ASSUME(credit_withhold_liveness_a, s_eventually (credit_withhold < fv_max_credit))
   for (genvar n = 0; n < NumFlows; n++) begin : gen_asm
-    if (!EnableCoverPushBackpressure) begin : gen_no_push_backpressure
+    if (!EnableCoverPushBackpressure &&
+        EnableAssertNoPushBackpressure) begin : gen_no_push_backpressure
       `BR_ASSUME(no_push_backpressure_a, !push_ready[n] |-> !push_valid[n])
     end
     if (EnableAssertPushValidStability) begin : gen_push_valid_stable
@@ -89,7 +92,8 @@ module br_credit_sender_fpv_monitor #(
                push_valid[fv_flow] && !push_ready[fv_flow] |=> $stable(push_data[fv_flow]))
   end
 
-  if (!EnableCoverPushBackpressure) begin : gen_no_push_backpressure
+  if (!EnableCoverPushBackpressure &&
+      EnableAssertNoPushBackpressure) begin : gen_no_push_backpressure
     `BR_ASSUME(no_push_backpressure_a, !push_ready[fv_flow] |-> !push_valid[fv_flow])
   end
 
@@ -121,6 +125,7 @@ bind br_credit_sender br_credit_sender_fpv_monitor #(
     .PopCreditMaxChange(PopCreditMaxChange),
     .RegisterPopOutputs(RegisterPopOutputs),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/credit/rtl/BUILD.bazel
+++ b/credit/rtl/BUILD.bazel
@@ -60,6 +60,28 @@ br_verilog_elab_and_lint_test_suite(
 )
 
 br_verilog_elab_and_lint_test_suite(
+    name = "br_credit_counter_test_suite_no_decrement_backpressure",
+    params = {
+        "MaxValue": [
+            "2",
+            "4",
+        ],
+        "MaxChange": [
+            "1",
+            "2",
+        ],
+        "EnableCoverDecrementBackpressure": [
+            "0",
+        ],
+        "EnableAssertNoDecrementBackpressure": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_credit_counter"],
+)
+
+br_verilog_elab_and_lint_test_suite(
     name = "br_credit_counter_test_suite_large_maxes",
     params = {
         "MaxValueWidth": ["64"],

--- a/credit/rtl/br_credit_counter.sv
+++ b/credit/rtl/br_credit_counter.sv
@@ -53,7 +53,8 @@ module br_credit_counter #(
     // Otherwise, assert that doesn't happen.
     parameter bit EnableCoverZeroDecrement = 1,
     // If 1, cover the case where decr_valid is high and decr_ready is low.
-    // Otherwise, assert that doesn't happen.
+    // Otherwise, disable decrement backpressure coverage. By default, this also
+    // asserts that decrement backpressure is impossible.
     parameter bit EnableCoverDecrementBackpressure = 1,
     // If 1, cover that withhold can be non-zero.
     // Otherwise, assert that it is always zero.
@@ -74,6 +75,9 @@ module br_credit_counter #(
     // the minimum number of credits that it stored at any point during the test.
     // Mutually exclusive with EnableAssertFinalMaxValue.
     parameter bit EnableAssertFinalMinValue = 0,
+    // If 1, assert that decrement backpressure is impossible.
+    // Can only be enabled if EnableCoverDecrementBackpressure is disabled.
+    parameter bit EnableAssertNoDecrementBackpressure = !EnableCoverDecrementBackpressure,
     localparam int MaxValueP1Width = MaxValueWidth + 1,
     localparam int MaxChangeP1Width = MaxChangeWidth + 1,
     localparam int ValueWidth = $clog2(MaxValueP1Width'(MaxValue) + 1),
@@ -111,6 +115,8 @@ module br_credit_counter #(
   `BR_ASSERT_STATIC(cover_max_value_lte_max_value_a, CoverMaxValue <= MaxValue)
   `BR_ASSERT_STATIC(assert_final_value_mutually_exclusive_a,
                     !(EnableAssertFinalMaxValue && EnableAssertFinalMinValue))
+  `BR_ASSERT_STATIC(legal_assert_no_decrement_backpressure_a,
+                    !(EnableAssertNoDecrementBackpressure && EnableCoverDecrementBackpressure))
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_incr_valid_a, !incr_valid)
@@ -179,7 +185,7 @@ module br_credit_counter #(
 
   if (EnableCoverDecrementBackpressure) begin : gen_cover_decr_gt_available
     `BR_COVER_INTG(decr_gt_available_c, decr_valid && decr > available)
-  end else begin : gen_assert_decr_lte_available
+  end else if (EnableAssertNoDecrementBackpressure) begin : gen_assert_decr_lte_available
     `BR_ASSERT_INTG(decr_lte_available_a, decr_valid |-> decr <= available)
   end
 

--- a/credit/rtl/br_credit_sender.sv
+++ b/credit/rtl/br_credit_sender.sv
@@ -77,7 +77,8 @@ module br_credit_sender #(
     // If 1, add 1 cycle of retiming to pop outputs.
     parameter bit RegisterPopOutputs = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -99,7 +100,10 @@ module br_credit_sender #(
     // The maximum credit count value that will be checked by covers.
     parameter int CoverMaxCredit = MaxCredit,
 
-    localparam int CounterWidth   = $clog2(MaxCredit + 1),
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    localparam int CounterWidth = $clog2(MaxCredit + 1),
     localparam int PopCreditWidth = $clog2(PopCreditMaxChange + 1)
 ) (
     // Posedge-triggered clock.
@@ -146,6 +150,7 @@ module br_credit_sender #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),
@@ -196,6 +201,7 @@ module br_credit_sender #(
       .EnableCoverZeroIncrement(0),
       .EnableCoverZeroDecrement(NumFlows > 1),
       .EnableCoverDecrementBackpressure(NumFlows == 1 && EnableCoverPushBackpressure),
+      .EnableAssertNoDecrementBackpressure((NumFlows != 1) || EnableAssertNoPushBackpressure),
       .EnableCoverWithhold(EnableCoverCreditWithhold),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
       .CoverMaxValue(CoverMaxCredit),

--- a/credit/rtl/br_credit_sender_vc.sv
+++ b/credit/rtl/br_credit_sender_vc.sv
@@ -29,7 +29,8 @@ module br_credit_sender_vc #(
     // If 1, add 1 cycle of retiming to pop outputs.
     parameter bit RegisterPopOutputs = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -41,6 +42,9 @@ module br_credit_sender_vc #(
     // the maximum number of credits that it stored at any point during the test.
     parameter bit EnableAssertFinalMaxValue = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int VcWidth = $clog2(NumVcs),
     localparam int CounterWidth = $clog2(MaxCredit + 1),
     localparam int PopCreditWidth = $clog2(PopCreditMaxChange + 1)
@@ -90,6 +94,8 @@ module br_credit_sender_vc #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_vcs_in_range_a, (NumVcs >= 2))
   `BR_ASSERT_STATIC(pop_credit_max_change_in_range_a, (PopCreditMaxChange <= MaxCredit))
 
@@ -139,6 +145,7 @@ module br_credit_sender_vc #(
     br_flow_fork #(
         .NumFlows(2),
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
         .EnableAssertPushValidStability(EnableAssertPushValidStability),
         .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
     ) br_flow_fork_push (
@@ -159,6 +166,7 @@ module br_credit_sender_vc #(
       .NumFlows(NumVcs),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/fifo/fpv/br_fifo/br_fifo_basic_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo/br_fifo_basic_fpv_monitor.sv
@@ -15,6 +15,9 @@ module br_fifo_basic_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
     input logic clk,
@@ -43,7 +46,6 @@ module br_fifo_basic_fpv_monitor #(
     input logic [CountWidth-1:0] items,
     input logic [CountWidth-1:0] items_next
 );
-
   // ----------FV assumptions----------
   `BR_ASSUME(pop_ready_liveness_a, s_eventually (pop_ready))
   if (EnableCoverPushBackpressure) begin : gen_backpressure
@@ -53,7 +55,7 @@ module br_fifo_basic_fpv_monitor #(
     if (EnableAssertPushDataStability) begin : gen_push_data_stable
       `BR_ASSUME(push_data_stable_a, push_valid && !push_ready |=> $stable(push_data))
     end
-  end else begin : gen_no_back_pressure
+  end else if (EnableAssertNoPushBackpressure) begin : gen_no_back_pressure
     `BR_ASSUME(no_backpressure_a, push_valid |-> push_ready)
   end
 

--- a/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_fpv_monitor.sv
@@ -17,6 +17,9 @@ module br_fifo_ctrl_1r1w_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = br_math::clamped_clog2(RamDepth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -54,7 +57,6 @@ module br_fifo_ctrl_1r1w_fpv_monitor #(
     input logic                 ram_rd_data_valid,
     input logic [    Width-1:0] ram_rd_data
 );
-
   localparam bit WolperColorEn = 1;
   logic [$clog2(Width)-1:0] magic_bit_index;
   `BR_ASSUME(magic_bit_index_range_a, $stable(magic_bit_index) && (magic_bit_index < Width))
@@ -87,6 +89,7 @@ module br_fifo_ctrl_1r1w_fpv_monitor #(
       .Width(Width),
       .EnableBypass(EnableBypass),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_fifo_basic_fpv_monitor (
@@ -119,6 +122,7 @@ bind br_fifo_ctrl_1r1w br_fifo_ctrl_1r1w_fpv_monitor #(
     .RamReadLatency(RamReadLatency),
     .RamDepth(RamDepth),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability)
 ) monitor (.*);

--- a/fifo/fpv/br_fifo/br_fifo_flops_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo/br_fifo_flops_fpv_monitor.sv
@@ -20,6 +20,9 @@ module br_fifo_flops_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -48,7 +51,6 @@ module br_fifo_flops_fpv_monitor #(
     input logic [CountWidth-1:0] items,
     input logic [CountWidth-1:0] items_next
 );
-
   localparam bit WolperColorEn = 1;
   logic [$clog2(Width)-1:0] magic_bit_index;
   `BR_ASSUME(magic_bit_index_range_a, $stable(magic_bit_index) && (magic_bit_index < Width))
@@ -59,6 +61,7 @@ module br_fifo_flops_fpv_monitor #(
       .Width(Width),
       .EnableBypass(EnableBypass),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) br_fifo_basic_fpv_monitor (
@@ -94,6 +97,7 @@ bind br_fifo_flops br_fifo_flops_fpv_monitor #(
     .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages),
     .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability)
 ) monitor (.*);

--- a/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv_monitor.sv
@@ -23,6 +23,9 @@ module br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
@@ -138,6 +141,7 @@ module br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv_monitor #(
       .StagingBufferDepth(StagingBufferDepth),
       .HasStagingBuffer(HasStagingBuffer),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) fv_checker (
@@ -167,6 +171,7 @@ bind br_fifo_shared_dynamic_ctrl_ext_arbiter br_fifo_shared_dynamic_ctrl_ext_arb
     .DataRamReadLatency(DataRamReadLatency),
     .PointerRamReadLatency(PointerRamReadLatency),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_basic_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_basic_fpv_monitor.sv
@@ -18,6 +18,9 @@ module br_fifo_shared_dynamic_basic_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
@@ -35,7 +38,6 @@ module br_fifo_shared_dynamic_basic_fpv_monitor #(
     input logic [NumFifos-1:0] pop_ready,
     input logic [NumFifos-1:0][Width-1:0] pop_data
 );
-
   // ----------FV Modeling Code----------
   localparam int PortWidth = br_math::clamped_clog2(NumWritePorts);
   // pick a random FIFO to check
@@ -67,7 +69,7 @@ module br_fifo_shared_dynamic_basic_fpv_monitor #(
             push_data_stable_a,
             push_valid[i] && !push_ready[i] |=> $stable(push_data[i]) && $stable(push_fifo_id[i]))
       end
-    end else begin : gen_no_backpressure
+    end else if (EnableAssertNoPushBackpressure) begin : gen_no_backpressure
       `BR_ASSUME(no_backpressure_a, push_valid[i] |-> push_ready[i])
     end
   end

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv_monitor.sv
@@ -21,6 +21,9 @@ module br_fifo_shared_dynamic_ctrl_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
@@ -58,7 +61,6 @@ module br_fifo_shared_dynamic_ctrl_fpv_monitor #(
     input logic [NumReadPorts-1:0] ptr_ram_rd_data_valid,
     input logic [NumReadPorts-1:0][AddrWidth-1:0] ptr_ram_rd_data
 );
-
   localparam bit WolperColorEn = 0;
   logic [$clog2(Width)-1:0] magic_bit_index;
   `BR_ASSUME(magic_bit_index_range_a, $stable(magic_bit_index) && (magic_bit_index < Width))
@@ -118,6 +120,7 @@ module br_fifo_shared_dynamic_ctrl_fpv_monitor #(
       .StagingBufferDepth(StagingBufferDepth),
       .HasStagingBuffer(HasStagingBuffer),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) fv_checker (
@@ -146,6 +149,7 @@ bind br_fifo_shared_dynamic_ctrl br_fifo_shared_dynamic_ctrl_fpv_monitor #(
     .DataRamReadLatency(DataRamReadLatency),
     .PointerRamReadLatency(PointerRamReadLatency),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv_monitor.sv
@@ -29,6 +29,9 @@ module br_fifo_shared_dynamic_flops_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
@@ -46,7 +49,6 @@ module br_fifo_shared_dynamic_flops_fpv_monitor #(
     input logic [NumFifos-1:0] pop_ready,
     input logic [NumFifos-1:0][Width-1:0] pop_data
 );
-
   localparam bit WolperColorEn = 0;
   logic [$clog2(Width)-1:0] magic_bit_index;
   `BR_ASSUME(magic_bit_index_range_a, $stable(magic_bit_index) && (magic_bit_index < Width))
@@ -66,6 +68,7 @@ module br_fifo_shared_dynamic_flops_fpv_monitor #(
       .StagingBufferDepth(StagingBufferDepth),
       .HasStagingBuffer(HasStagingBuffer),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) fv_checker (
@@ -102,6 +105,7 @@ bind br_fifo_shared_dynamic_flops br_fifo_shared_dynamic_flops_fpv_monitor #(
     .PointerRamReadDataDepthStages(PointerRamReadDataDepthStages),
     .PointerRamReadDataWidthStages(PointerRamReadDataWidthStages),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_basic_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_basic_fpv_monitor.sv
@@ -17,6 +17,9 @@ module br_fifo_shared_pstatic_basic_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
@@ -78,7 +81,7 @@ module br_fifo_shared_pstatic_basic_fpv_monitor #(
       `BR_ASSUME(push_data_stable_a,
                  push_valid && !push_ready |=> $stable(push_data) && $stable(push_fifo_id))
     end
-  end else begin : gen_no_back_pressure
+  end else if (EnableAssertNoPushBackpressure) begin : gen_no_back_pressure
     `BR_ASSUME(no_backpressure_a, push_valid |-> push_ready)
   end
   if (!HasStagingBuffer) begin : gen_pop_ready_stable

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_ctrl_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_ctrl_fpv_monitor.sv
@@ -17,6 +17,9 @@ module br_fifo_shared_pstatic_ctrl_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
@@ -63,7 +66,6 @@ module br_fifo_shared_pstatic_ctrl_fpv_monitor #(
     input logic                 ram_rd_data_valid,
     input logic [    Width-1:0] ram_rd_data
 );
-
   localparam bit WolperColorEn = 0;
   logic [$clog2(Width)-1:0] magic_bit_index;
   `BR_ASSUME(magic_bit_index_range_a, $stable(magic_bit_index) && (magic_bit_index < Width))
@@ -99,6 +101,7 @@ module br_fifo_shared_pstatic_ctrl_fpv_monitor #(
       .RegisterPopOutputs(RegisterPopOutputs),
       .RamReadLatency(RamReadLatency),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) fv_checker (
@@ -128,6 +131,7 @@ bind br_fifo_shared_pstatic_ctrl br_fifo_shared_pstatic_ctrl_fpv_monitor #(
     .RegisterPopOutputs(RegisterPopOutputs),
     .RamReadLatency(RamReadLatency),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_fpv_monitor.sv
@@ -21,6 +21,9 @@ module br_fifo_shared_pstatic_flops_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
@@ -57,7 +60,6 @@ module br_fifo_shared_pstatic_flops_fpv_monitor #(
     input logic [NumFifos-1:0][Width-1:0] pop_data,
     input logic [NumFifos-1:0]            pop_empty
 );
-
   localparam bit WolperColorEn = 0;
   logic [$clog2(Width)-1:0] magic_bit_index;
   `BR_ASSUME(magic_bit_index_range_a, $stable(magic_bit_index) && (magic_bit_index < Width))
@@ -76,6 +78,7 @@ module br_fifo_shared_pstatic_flops_fpv_monitor #(
       .RegisterPopOutputs(RegisterPopOutputs),
       .RamReadLatency(RamReadLatency),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) fv_checker (
@@ -109,6 +112,7 @@ bind br_fifo_shared_pstatic_flops br_fifo_shared_pstatic_flops_fpv_monitor #(
     .RamReadDataDepthStages(RamReadDataDepthStages),
     .RamReadDataWidthStages(RamReadDataWidthStages),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/fifo/rtl/br_fifo_ctrl_1r1w.sv
+++ b/fifo/rtl/br_fifo_ctrl_1r1w.sv
@@ -77,7 +77,8 @@ module br_fifo_ctrl_1r1w #(
     // backing RAM is an SRAM of slightly larger depth than the FIFO depth).
     parameter int RamDepth = Depth,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -88,6 +89,9 @@ module br_fifo_ctrl_1r1w #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = br_math::clamped_clog2(RamDepth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -127,6 +131,7 @@ module br_fifo_ctrl_1r1w #(
     input  logic                 ram_rd_data_valid,
     input  logic [    Width-1:0] ram_rd_data
 );
+
   // Right now, we assume that data can be read the cycle after the
   // write for it is issued.
   // TODO(zhemao): Find a way to deal with longer hazard latencies
@@ -159,6 +164,7 @@ module br_fifo_ctrl_1r1w #(
       .EnableBypass(EnableBypass),
       .RamDepth(RamDepth),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/fifo/rtl/br_fifo_flops.sv
+++ b/fifo/rtl/br_fifo_flops.sv
@@ -63,7 +63,8 @@ module br_fifo_flops #(
     // Must be at least 0.
     parameter int FlopRamReadDataWidthStages = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -74,6 +75,9 @@ module br_fifo_flops #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
 
     // Internal computed parameters
     localparam int CountWidth = $clog2(Depth + 1)
@@ -142,6 +146,7 @@ module br_fifo_flops #(
       .RamReadLatency(RamReadLatency),
       .RamDepth(RamDepth),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
@@ -88,7 +88,8 @@ module br_fifo_shared_dynamic_ctrl #(
     // The number of cycles between pointer ram read address and read data. Must be >=0.
     parameter int PointerRamReadLatency = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -101,6 +102,9 @@ module br_fifo_shared_dynamic_ctrl #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
@@ -142,6 +146,8 @@ module br_fifo_shared_dynamic_ctrl #(
 );
 
   // Integration Checks
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_write_ports_in_range_a, NumWritePorts >= 1)
   `BR_ASSERT_STATIC(legal_num_read_ports_a, NumReadPorts >= 1 && br_math::is_power_of_2(
                     NumReadPorts))
@@ -170,6 +176,7 @@ module br_fifo_shared_dynamic_ctrl #(
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_fifo_shared_dynamic_push_ctrl_inst (

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_ext_arbiter.sv
@@ -93,7 +93,8 @@ module br_fifo_shared_dynamic_ctrl_ext_arbiter #(
     // If 0, the arbiter may not grant in a cycle even when there is a request.
     parameter bit ArbiterAlwaysGrants = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -106,6 +107,9 @@ module br_fifo_shared_dynamic_ctrl_ext_arbiter #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
@@ -151,6 +155,8 @@ module br_fifo_shared_dynamic_ctrl_ext_arbiter #(
 );
 
   // Integration Checks
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_write_ports_in_range_a, NumWritePorts >= 1)
   `BR_ASSERT_STATIC(legal_num_read_ports_a, NumReadPorts >= 1 && br_math::is_power_of_2(
                     NumReadPorts))
@@ -179,6 +185,7 @@ module br_fifo_shared_dynamic_ctrl_ext_arbiter #(
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_fifo_shared_dynamic_push_ctrl_inst (

--- a/fifo/rtl/br_fifo_shared_dynamic_flops.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_flops.sv
@@ -110,7 +110,8 @@ module br_fifo_shared_dynamic_flops #(
     // Number of stages in the width dimension on the pointer flop RAM.
     parameter int PointerRamReadDataWidthStages = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -123,6 +124,9 @@ module br_fifo_shared_dynamic_flops #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
@@ -239,6 +243,7 @@ module br_fifo_shared_dynamic_flops #(
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_fifo_shared_dynamic_ctrl_inst (

--- a/fifo/rtl/br_fifo_shared_pstatic_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_pstatic_ctrl.sv
@@ -64,7 +64,8 @@ module br_fifo_shared_pstatic_ctrl #(
     // The number of cycles between ram read address and read data. Must be >=0.
     parameter int RamReadLatency = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -77,6 +78,9 @@ module br_fifo_shared_pstatic_ctrl #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
@@ -124,6 +128,8 @@ module br_fifo_shared_pstatic_ctrl #(
 );
 
   // Integration Checks
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   // TODO(zhemao): Support multiple read and write ports for pseudo-static FIFOs
   `BR_ASSERT_STATIC(one_write_port_a, NumWritePorts == 1)
   `BR_ASSERT_STATIC(one_read_port_a, NumReadPorts == 1)
@@ -164,6 +170,7 @@ module br_fifo_shared_pstatic_ctrl #(
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_fifo_shared_pstatic_push_ctrl_inst (

--- a/fifo/rtl/br_fifo_shared_pstatic_flops.sv
+++ b/fifo/rtl/br_fifo_shared_pstatic_flops.sv
@@ -75,7 +75,8 @@ module br_fifo_shared_pstatic_flops #(
     // Number of stages in the width dimension on the data flop RAM.
     parameter int RamReadDataWidthStages = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -88,6 +89,9 @@ module br_fifo_shared_pstatic_flops #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
@@ -180,6 +184,7 @@ module br_fifo_shared_pstatic_flops #(
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_fifo_shared_pstatic_ctrl_inst (

--- a/fifo/rtl/fifo_codegen/br_fifo_shared.sv.jinja2
+++ b/fifo/rtl/fifo_codegen/br_fifo_shared.sv.jinja2
@@ -296,7 +296,8 @@ module {{ module_name }} #(
     parameter bit EnableCoverPushSenderInReset = 1,
 {%- else %}{# push_ready #}
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -310,6 +311,11 @@ module {{ module_name }} #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+{%- if not push_credit %}
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+{%- endif %}
 
 {%- if push_credit %}
     localparam int PushCreditWidth = $clog2(NumWritePorts + 1),
@@ -447,6 +453,10 @@ module {{ module_name }} #(
 );
 
   // Integration Checks
+{%- if ctrl_only and not push_credit %}
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+{%- endif %}
 {%- if ctrl_only %}
 {%-   if dynamic %}
   `BR_ASSERT_STATIC(num_write_ports_in_range_a, NumWritePorts >= 1)
@@ -559,6 +569,7 @@ module {{ module_name }} #(
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
 {%-   endif %}
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
@@ -916,6 +927,7 @@ module {{ module_name }} #(
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
 {%-   endif %}{# push_credit #}
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -13,7 +13,8 @@ module br_fifo_push_ctrl #(
     parameter bit EnableBypass = 1,
     parameter int RamDepth = Depth,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = 1,
@@ -24,6 +25,9 @@ module br_fifo_push_ctrl #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = br_math::clamped_clog2(RamDepth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -62,6 +66,8 @@ module br_fifo_push_ctrl #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
 
@@ -86,6 +92,7 @@ module br_fifo_push_ctrl #(
       .Width(Width),
       .EnableBypass(EnableBypass),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/fifo/rtl/internal/br_fifo_push_ctrl_core.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_core.sv
@@ -14,7 +14,8 @@ module br_fifo_push_ctrl_core #(
     parameter int Width = 1,
     parameter bit EnableBypass = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -25,6 +26,9 @@ module br_fifo_push_ctrl_core #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
     // Posedge-triggered clock.
@@ -63,6 +67,8 @@ module br_fifo_push_ctrl_core #(
   // Integration checks
   //------------------------------------------
 
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 1)
   `BR_ASSERT_IMPL(addr_base_lte_addr_bound_a, addr_base <= addr_bound)
   `BR_ASSERT_IMPL(addr_bound_in_range_a, addr_bound < Depth)
@@ -71,6 +77,7 @@ module br_fifo_push_ctrl_core #(
       .NumFlows(1),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
@@ -20,7 +20,8 @@ module br_fifo_shared_dynamic_push_ctrl #(
     // is indicated by dealloc_count.
     parameter int DeallocCountDelay = 2,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -35,6 +36,9 @@ module br_fifo_shared_dynamic_push_ctrl #(
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth),
     localparam int FifoCountWidth = $clog2(NumFifos + 1)
@@ -66,6 +70,9 @@ module br_fifo_shared_dynamic_push_ctrl #(
 
   // Integration Assertions
 
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+
 `ifdef BR_ASSERT_ON
 `ifndef BR_DISABLE_INTG_CHECKS
 
@@ -79,6 +86,7 @@ module br_fifo_shared_dynamic_push_ctrl #(
       .NumFlows(NumWritePorts),
       .Width(Width + FifoIdWidth),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),

--- a/fifo/rtl/internal/br_fifo_shared_pstatic_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_pstatic_push_ctrl.sv
@@ -19,7 +19,8 @@ module br_fifo_shared_pstatic_push_ctrl #(
     // Width of the data
     parameter int Width = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -33,8 +34,11 @@ module br_fifo_shared_pstatic_push_ctrl #(
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
-    localparam int AddrWidth   = br_math::clamped_clog2(Depth)
+    localparam int AddrWidth = br_math::clamped_clog2(Depth)
 ) (
     input logic clk,
     input logic rst,
@@ -63,6 +67,9 @@ module br_fifo_shared_pstatic_push_ctrl #(
 
   // Integration Assertions
 
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+
 `ifdef BR_ASSERT_ON
 `ifndef BR_DISABLE_INTG_CHECKS
   logic [Width+FifoIdWidth-1:0] push_comb_data;
@@ -73,6 +80,7 @@ module br_fifo_shared_pstatic_push_ctrl #(
       .NumFlows(1),
       .Width(Width + FifoIdWidth),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),
@@ -106,6 +114,7 @@ module br_fifo_shared_pstatic_push_ctrl #(
         // TODO(zhemao): Add bypass support.
         .EnableBypass(0),
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
         // Core can only have valid stability if the fifo_id is stable,
         // so pass the data stability parameter instead of the
         // valid stability parameter.
@@ -137,6 +146,7 @@ module br_fifo_shared_pstatic_push_ctrl #(
       .NumFlows(NumFifos),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       // push_fifo_id should always be stable if valid is stable.
       .EnableAssertSelectStability(EnableAssertPushDataStability),

--- a/flow/fpv/arb/br_flow_arb_basic_fpv_monitor.sv
+++ b/flow/fpv/arb/br_flow_arb_basic_fpv_monitor.sv
@@ -9,7 +9,10 @@
 module br_flow_arb_basic_fpv_monitor #(
     parameter int NumFlows = 1,
     parameter bit EnableCoverPushBackpressure = 1,
-    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                clk,
     input logic                rst,
@@ -18,12 +21,11 @@ module br_flow_arb_basic_fpv_monitor #(
     input logic                pop_ready,
     input logic                pop_valid_unstable
 );
-
   // ----------FV assumptions----------
   `BR_ASSUME(pop_ready_liveness_a, s_eventually (pop_ready))
 
   for (genvar n = 0; n < NumFlows; n++) begin : gen_asm
-    if (!EnableCoverPushBackpressure) begin : gen_no_backpressure
+    if (!EnableCoverPushBackpressure && EnableAssertNoPushBackpressure) begin : gen_no_backpressure
       `BR_ASSUME(no_backpressure_a, !push_ready[n] |-> !push_valid[n])
     end
     if (EnableAssertPushValidStability) begin : gen_push_valid

--- a/flow/fpv/arb/br_flow_arb_fixed_fpv_monitor.sv
+++ b/flow/fpv/arb/br_flow_arb_fixed_fpv_monitor.sv
@@ -10,7 +10,10 @@ module br_flow_arb_fixed_fpv_monitor #(
     parameter int NumFlows = 1,
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                clk,
     input logic                rst,
@@ -21,11 +24,11 @@ module br_flow_arb_fixed_fpv_monitor #(
     // RTL internal signal
     input logic [NumFlows-1:0] grant
 );
-
   // ----------Instantiate basic checks----------
   br_flow_arb_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability)
   ) fv_checker (
       .clk,
@@ -52,6 +55,7 @@ endmodule : br_flow_arb_fixed_fpv_monitor
 bind br_flow_arb_fixed br_flow_arb_fixed_fpv_monitor #(
     .NumFlows(NumFlows),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
 ) monitor (.*);

--- a/flow/fpv/arb/br_flow_arb_lru_fpv_monitor.sv
+++ b/flow/fpv/arb/br_flow_arb_lru_fpv_monitor.sv
@@ -3,14 +3,16 @@
 
 // Bedrock-RTL Flow-Controlled Arbiter (LRU) FPV monitor
 
-`include "br_asserts.svh"
 `include "br_fv.svh"
 
 module br_flow_arb_lru_fpv_monitor #(
     parameter int NumFlows = 1,
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                clk,
     input logic                rst,
@@ -21,11 +23,11 @@ module br_flow_arb_lru_fpv_monitor #(
     // RTL internal signal
     input logic [NumFlows-1:0] grant
 );
-
   // ----------Instantiate basic checks----------
   br_flow_arb_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability)
   ) fv_checker (
       .clk,
@@ -53,6 +55,7 @@ endmodule : br_flow_arb_lru_fpv_monitor
 bind br_flow_arb_lru br_flow_arb_lru_fpv_monitor #(
     .NumFlows(NumFlows),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
 ) monitor (.*);

--- a/flow/fpv/arb/br_flow_arb_rr_fpv_monitor.sv
+++ b/flow/fpv/arb/br_flow_arb_rr_fpv_monitor.sv
@@ -3,14 +3,16 @@
 
 // Bedrock-RTL Flow-Controlled Arbiter (Round Robin) FPV monitor
 
-`include "br_asserts.svh"
 `include "br_fv.svh"
 
 module br_flow_arb_rr_fpv_monitor #(
     parameter int NumFlows = 1,
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                clk,
     input logic                rst,
@@ -21,11 +23,11 @@ module br_flow_arb_rr_fpv_monitor #(
     // RTL internal signal
     input logic [NumFlows-1:0] grant
 );
-
   // ----------Instantiate basic checks----------
   br_flow_arb_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability)
   ) fv_checker (
       .clk,
@@ -53,6 +55,7 @@ endmodule : br_flow_arb_rr_fpv_monitor
 bind br_flow_arb_rr br_flow_arb_rr_fpv_monitor #(
     .NumFlows(NumFlows),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
 ) monitor (.*);

--- a/flow/fpv/demux/br_flow_demux_basic_fpv_monitor.sv
+++ b/flow/fpv/demux/br_flow_demux_basic_fpv_monitor.sv
@@ -14,7 +14,10 @@ module br_flow_demux_basic_fpv_monitor #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertSelectStability = 0,
     parameter bit EnableAssertPopValidStability = 1,
-    parameter bit EnableAssertPopDataStability = 1
+    parameter bit EnableAssertPopDataStability = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                                   clk,
     input logic                                   rst,
@@ -26,7 +29,6 @@ module br_flow_demux_basic_fpv_monitor #(
     input logic [        NumFlows-1:0]            pop_valid,
     input logic [        NumFlows-1:0][Width-1:0] pop_data
 );
-
   // pick a random constant for assertion
   logic [$clog2(NumFlows)-1:0] fv_idx;
   `BR_ASSUME(fv_idx_a, $stable(fv_idx) && fv_idx < NumFlows)
@@ -43,7 +45,8 @@ module br_flow_demux_basic_fpv_monitor #(
     `BR_ASSUME(push_data_stable_a, push_valid && !push_ready |=> $stable(push_data))
   end
 
-  if (!EnableCoverPushBackpressure) begin : gen_no_push_backpressure
+  if (!EnableCoverPushBackpressure &&
+      EnableAssertNoPushBackpressure) begin : gen_no_push_backpressure
     `BR_ASSUME(no_push_backpressure_a, !push_ready |-> !push_valid)
   end
 

--- a/flow/fpv/demux/br_flow_demux_select_fpv_monitor.sv
+++ b/flow/fpv/demux/br_flow_demux_select_fpv_monitor.sv
@@ -14,7 +14,10 @@ module br_flow_demux_select_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertSelectStability = 0,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                                   clk,
     input logic                                   rst,
@@ -26,12 +29,12 @@ module br_flow_demux_select_fpv_monitor #(
     input logic [        NumFlows-1:0]            pop_valid,
     input logic [        NumFlows-1:0][Width-1:0] pop_data
 );
-
   // ----------Instantiate basic checks----------
   br_flow_demux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertSelectStability(EnableAssertSelectStability),
@@ -67,6 +70,7 @@ bind br_flow_demux_select br_flow_demux_select_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertSelectStability(EnableAssertSelectStability),

--- a/flow/fpv/demux/br_flow_demux_select_unstable_fpv_monitor.sv
+++ b/flow/fpv/demux/br_flow_demux_select_unstable_fpv_monitor.sv
@@ -13,7 +13,10 @@ module br_flow_demux_select_unstable_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertSelectStability = 0,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                                   clk,
     input logic                                   rst,
@@ -25,12 +28,12 @@ module br_flow_demux_select_unstable_fpv_monitor #(
     input logic [        NumFlows-1:0]            pop_valid_unstable,
     input logic [        NumFlows-1:0][Width-1:0] pop_data_unstable
 );
-
   // ----------Instantiate basic checks----------
   br_flow_demux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertSelectStability(EnableAssertSelectStability),
@@ -62,6 +65,7 @@ bind br_flow_demux_select_unstable br_flow_demux_select_unstable_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertSelectStability(EnableAssertSelectStability),

--- a/flow/fpv/fork/br_flow_fork_fpv_monitor.sv
+++ b/flow/fpv/fork/br_flow_fork_fpv_monitor.sv
@@ -9,7 +9,10 @@ module br_flow_fork_fpv_monitor #(
     parameter int NumFlows = 1,
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,
@@ -24,7 +27,6 @@ module br_flow_fork_fpv_monitor #(
     input logic [NumFlows-1:0] pop_ready,
     input logic [NumFlows-1:0] pop_valid_unstable
 );
-
   // ----------FV assumptions----------
   for (genvar n = 0; n < NumFlows; n++) begin : gen_asm
     `BR_ASSUME(pop_ready_liveness_a, s_eventually (pop_ready[n]))
@@ -34,7 +36,7 @@ module br_flow_fork_fpv_monitor #(
     `BR_ASSUME(push_valid_stable_a, push_valid && !push_ready |=> push_valid)
   end
 
-  if (!EnableCoverPushBackpressure) begin : gen_no_backpressure
+  if (!EnableCoverPushBackpressure && EnableAssertNoPushBackpressure) begin : gen_no_backpressure
     `BR_ASSUME(no_backpressure_a, !push_ready |-> !push_valid)
   end
 
@@ -50,6 +52,7 @@ endmodule : br_flow_fork_fpv_monitor
 bind br_flow_fork br_flow_fork_fpv_monitor #(
     .NumFlows(NumFlows),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
 ) monitor (.*);

--- a/flow/fpv/fork/br_flow_fork_select_multihot_fpv_monitor.sv
+++ b/flow/fpv/fork/br_flow_fork_select_multihot_fpv_monitor.sv
@@ -11,7 +11,10 @@ module br_flow_fork_select_multihot_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertSelectMultihotStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,
@@ -27,7 +30,6 @@ module br_flow_fork_select_multihot_fpv_monitor #(
     input logic [NumFlows-1:0] pop_ready,
     input logic [NumFlows-1:0] pop_valid_unstable
 );
-
   // ----------FV assumptions----------
   for (genvar n = 0; n < NumFlows; n++) begin : gen_asm
     `BR_ASSUME(pop_ready_liveness_a, s_eventually (pop_ready[n]))
@@ -45,7 +47,7 @@ module br_flow_fork_select_multihot_fpv_monitor #(
   end
   `BR_ASSUME(legal_select_a, push_valid |-> |push_select_multihot)
 
-  if (!EnableCoverPushBackpressure) begin : gen_no_backpressure
+  if (!EnableCoverPushBackpressure && EnableAssertNoPushBackpressure) begin : gen_no_backpressure
     `BR_ASSUME(no_backpressure_a, !push_ready |-> !push_valid)
   end
 
@@ -64,6 +66,7 @@ bind br_flow_fork_select_multihot br_flow_fork_select_multihot_fpv_monitor #(
     .NumFlows(NumFlows),
     .EnableCoverSelectMultihot(EnableCoverSelectMultihot),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertSelectMultihotStability(EnableAssertSelectMultihotStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_burst_mux_basic_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_burst_mux_basic_fpv_monitor.sv
@@ -15,7 +15,13 @@ module br_flow_burst_mux_basic_fpv_monitor #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableCoverPopBackpressure = EnableCoverPushBackpressure,
     parameter bit EnableAssertPopValidStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertPopDataStability = 0
+    parameter bit EnableAssertPopDataStability = 0,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, assert that pop-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPopBackpressure is disabled.
+    parameter bit EnableAssertNoPopBackpressure = !EnableCoverPopBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -48,7 +54,7 @@ module br_flow_burst_mux_basic_fpv_monitor #(
     `BR_ASSUME(push_last_liveness_a, s_eventually (push_valid[n] && push_last[n]))
     // Color the low bits of each flow's payload with that flow's index.
     `BR_ASSUME(color_push_data_a, push_valid[n] |-> push_data[n][FlowIdWidth-1:0] == n)
-    if (!EnableCoverPushBackpressure) begin : gen_no_backpressure
+    if (!EnableCoverPushBackpressure && EnableAssertNoPushBackpressure) begin : gen_no_backpressure
       `BR_ASSUME(no_backpressure_a, !push_ready[n] |-> !push_valid[n])
     end
     if (EnableAssertPushValidStability) begin : gen_push_valid
@@ -72,6 +78,8 @@ module br_flow_burst_mux_basic_fpv_monitor #(
       `BR_COVER(pop_data_unstable_c,
                 (pop_valid && !pop_ready) ##1 (!$stable(pop_data) || !$stable(pop_last)))
     end
+  end else if (EnableAssertNoPopBackpressure) begin : gen_no_pop_backpressure
+    `BR_ASSERT(no_pop_backpressure_a, pop_valid |-> pop_ready)
   end
 
   // ----------Burst Check----------

--- a/flow/fpv/mux/br_flow_burst_mux_fixed_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_burst_mux_fixed_fpv_monitor.sv
@@ -12,7 +12,10 @@ module br_flow_burst_mux_fixed_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -27,15 +30,16 @@ module br_flow_burst_mux_fixed_fpv_monitor #(
     // RTL internal signal
     input logic [NumFlows-1:0]            grant
 );
-
   // ----------Instantiate basic checks----------
   br_flow_burst_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPopDataStability(0)
   ) fv_checker (
       .clk,
@@ -78,6 +82,7 @@ bind br_flow_burst_mux_fixed br_flow_burst_mux_fixed_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_burst_mux_fixed_stable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_burst_mux_fixed_stable_fpv_monitor.sv
@@ -13,7 +13,10 @@ module br_flow_burst_mux_fixed_stable_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -26,12 +29,12 @@ module br_flow_burst_mux_fixed_stable_fpv_monitor #(
     input logic                           pop_last,
     input logic [   Width-1:0]            pop_data
 );
-
   // ----------Instantiate basic checks----------
   br_flow_burst_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(1),
@@ -83,6 +86,7 @@ bind br_flow_burst_mux_fixed_stable br_flow_burst_mux_fixed_stable_fpv_monitor #
     .Width(Width),
     .RegisterPopReady(RegisterPopReady),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_burst_mux_lru_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_burst_mux_lru_fpv_monitor.sv
@@ -3,15 +3,16 @@
 
 // Bedrock-RTL Flow-Controlled Burst Multiplexer (Least-Recently-Used)
 
-`include "br_asserts.svh"
-
 module br_flow_burst_mux_lru_fpv_monitor #(
     parameter int NumFlows = 1,
     parameter int Width = 1,
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -28,15 +29,16 @@ module br_flow_burst_mux_lru_fpv_monitor #(
     input logic [NumFlows-1:0]            grant_from_arb,
     input logic                           enable_priority_update
 );
-
   // ----------Instantiate basic checks----------
   br_flow_burst_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPopDataStability(0)
   ) fv_checker (
       .clk,
@@ -69,6 +71,7 @@ bind br_flow_burst_mux_lru br_flow_burst_mux_lru_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_burst_mux_lru_stable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_burst_mux_lru_stable_fpv_monitor.sv
@@ -3,8 +3,6 @@
 
 // Bedrock-RTL Flow-Controlled Stable Burst Multiplexer (Least-Recently-Used)
 
-`include "br_asserts.svh"
-
 module br_flow_burst_mux_lru_stable_fpv_monitor #(
     parameter int NumFlows = 1,
     parameter int Width = 1,
@@ -12,7 +10,10 @@ module br_flow_burst_mux_lru_stable_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -28,12 +29,12 @@ module br_flow_burst_mux_lru_stable_fpv_monitor #(
     input logic [NumFlows-1:0]            grant,
     input logic                           enable_priority_update
 );
-
   // ----------Instantiate basic checks----------
   br_flow_burst_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(1),
@@ -70,6 +71,7 @@ bind br_flow_burst_mux_lru_stable br_flow_burst_mux_lru_stable_fpv_monitor #(
     .Width(Width),
     .RegisterPopReady(RegisterPopReady),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_burst_mux_rr_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_burst_mux_rr_fpv_monitor.sv
@@ -12,7 +12,10 @@ module br_flow_burst_mux_rr_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -27,15 +30,16 @@ module br_flow_burst_mux_rr_fpv_monitor #(
     // RTL internal signals
     input logic [NumFlows-1:0]            grant
 );
-
   // ----------Instantiate basic checks----------
   br_flow_burst_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPopDataStability(0)
   ) fv_checker (
       .clk,
@@ -72,6 +76,7 @@ bind br_flow_burst_mux_rr br_flow_burst_mux_rr_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_burst_mux_rr_stable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_burst_mux_rr_stable_fpv_monitor.sv
@@ -3,8 +3,6 @@
 
 // Bedrock-RTL Flow-Controlled Stable Burst Multiplexer (Round-Robin)
 
-`include "br_asserts.svh"
-
 module br_flow_burst_mux_rr_stable_fpv_monitor #(
     parameter int NumFlows = 1,
     parameter int Width = 1,
@@ -12,7 +10,10 @@ module br_flow_burst_mux_rr_stable_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -28,12 +29,12 @@ module br_flow_burst_mux_rr_stable_fpv_monitor #(
     input logic [NumFlows-1:0]            grant,
     input logic                           enable_priority_update
 );
-
   // ----------Instantiate basic checks----------
   br_flow_burst_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(1),
@@ -70,6 +71,7 @@ bind br_flow_burst_mux_rr_stable br_flow_burst_mux_rr_stable_fpv_monitor #(
     .Width(Width),
     .RegisterPopReady(RegisterPopReady),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_mux_basic_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_basic_fpv_monitor.sv
@@ -16,7 +16,13 @@ module br_flow_mux_basic_fpv_monitor #(
     parameter bit EnableAssertPopValidStability = EnableAssertPushValidStability,
     parameter bit EnableAssertPopDataStability = 0,
     parameter bit EnableAssertMustGrant = 1,
-    parameter bit DelayedGrant = 0
+    parameter bit DelayedGrant = 0,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, assert that pop-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPopBackpressure is disabled.
+    parameter bit EnableAssertNoPopBackpressure = !EnableCoverPopBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -32,7 +38,7 @@ module br_flow_mux_basic_fpv_monitor #(
   `BR_ASSUME(pop_ready_liveness_a, s_eventually (pop_ready))
 
   for (genvar n = 0; n < NumFlows; n++) begin : gen_asm
-    if (!EnableCoverPushBackpressure) begin : gen_no_backpressure
+    if (!EnableCoverPushBackpressure && EnableAssertNoPushBackpressure) begin : gen_no_backpressure
       `BR_ASSUME(no_backpressure_a, !push_ready[n] |-> !push_valid[n])
     end
     if (EnableAssertPushValidStability) begin : gen_push_valid
@@ -53,6 +59,8 @@ module br_flow_mux_basic_fpv_monitor #(
     end else if (NumFlows != 1) begin : gen_pop_data_unstable
       `BR_COVER(pop_data_unstable_c, (pop_valid && !pop_ready) ##1 !$stable(pop_data))
     end
+  end else if (EnableAssertNoPopBackpressure) begin : gen_no_pop_backpressure
+    `BR_ASSERT(no_pop_backpressure_a, pop_valid |-> pop_ready)
   end
 
   // ----------Critical Covers----------

--- a/flow/fpv/mux/br_flow_mux_fixed_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_fixed_fpv_monitor.sv
@@ -12,7 +12,10 @@ module br_flow_mux_fixed_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -23,15 +26,16 @@ module br_flow_mux_fixed_fpv_monitor #(
     input logic                           pop_valid_unstable,
     input logic [   Width-1:0]            pop_data_unstable
 );
-
   // ----------Instantiate basic checks----------
   br_flow_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPushBackpressure),
       // Pop data can never be stable
       .EnableAssertPopDataStability(0)
   ) fv_checker (
@@ -71,6 +75,7 @@ bind br_flow_mux_fixed br_flow_mux_fixed_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_mux_fixed_stable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_fixed_stable_fpv_monitor.sv
@@ -13,7 +13,10 @@ module br_flow_mux_fixed_stable_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -24,12 +27,12 @@ module br_flow_mux_fixed_stable_fpv_monitor #(
     input logic                           pop_valid,
     input logic [   Width-1:0]            pop_data
 );
-
   // ----------Instantiate basic checks----------
   br_flow_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(1),
@@ -78,6 +81,7 @@ bind br_flow_mux_fixed_stable br_flow_mux_fixed_stable_fpv_monitor #(
     .Width(Width),
     .RegisterPopReady(RegisterPopReady),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_mux_lru_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_lru_fpv_monitor.sv
@@ -12,7 +12,10 @@ module br_flow_mux_lru_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -25,15 +28,16 @@ module br_flow_mux_lru_fpv_monitor #(
     // RTL internal signal
     input logic [NumFlows-1:0]            grant
 );
-
   // ----------Instantiate basic checks----------
   br_flow_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPopDataStability(0)
   ) fv_checker (
       .clk,
@@ -68,6 +72,7 @@ bind br_flow_mux_lru br_flow_mux_lru_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_mux_lru_stable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_lru_stable_fpv_monitor.sv
@@ -14,7 +14,10 @@ module br_flow_mux_lru_stable_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -28,7 +31,6 @@ module br_flow_mux_lru_stable_fpv_monitor #(
     input logic [NumFlows-1:0]            grant,
     input logic                           enable_priority_update
 );
-
   localparam int MaxPending = NumFlows == 1 ? 2 : NumFlows;
 
   // ----------Instantiate basic checks----------
@@ -36,6 +38,7 @@ module br_flow_mux_lru_stable_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(1),
@@ -91,6 +94,7 @@ bind br_flow_mux_lru_stable br_flow_mux_lru_stable_fpv_monitor #(
     .Width(Width),
     .RegisterPopReady(RegisterPopReady),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_mux_rr_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_rr_fpv_monitor.sv
@@ -12,7 +12,10 @@ module br_flow_mux_rr_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -25,15 +28,16 @@ module br_flow_mux_rr_fpv_monitor #(
     // RTL internal signal
     input logic [NumFlows-1:0]            grant
 );
-
   // ----------Instantiate basic checks----------
   br_flow_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPopDataStability(0)
   ) fv_checker (
       .clk,
@@ -68,6 +72,7 @@ bind br_flow_mux_rr br_flow_mux_rr_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_mux_rr_stable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_rr_stable_fpv_monitor.sv
@@ -13,7 +13,10 @@ module br_flow_mux_rr_stable_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                           clk,
     input logic                           rst,
@@ -27,12 +30,12 @@ module br_flow_mux_rr_stable_fpv_monitor #(
     input logic [NumFlows-1:0]            grant,
     input logic                           enable_priority_update
 );
-
   // ----------Instantiate basic checks----------
   br_flow_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverPopBackpressure(1),
@@ -88,6 +91,7 @@ bind br_flow_mux_rr_stable br_flow_mux_rr_stable_fpv_monitor #(
     .Width(Width),
     .RegisterPopReady(RegisterPopReady),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/mux/br_flow_mux_select_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_select_fpv_monitor.sv
@@ -14,7 +14,10 @@ module br_flow_mux_select_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertSelectStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                                   clk,
     input logic                                   rst,
@@ -26,14 +29,15 @@ module br_flow_mux_select_fpv_monitor #(
     input logic                                   pop_valid,
     input logic [           Width-1:0]            pop_data
 );
-
   // ----------Instantiate basic checks----------
   br_flow_mux_basic_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableCoverPopBackpressure(1),
       // Final flow mux stage ensures output is always stable
       .EnableAssertPopValidStability(1),
       .EnableAssertPopDataStability(1),
@@ -70,6 +74,7 @@ bind br_flow_mux_select br_flow_mux_select_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertSelectStability(EnableAssertSelectStability),

--- a/flow/fpv/mux/br_flow_mux_select_unstable_fpv_monitor.sv
+++ b/flow/fpv/mux/br_flow_mux_select_unstable_fpv_monitor.sv
@@ -13,7 +13,10 @@ module br_flow_mux_select_unstable_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertSelectStability = 0,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic                                   clk,
     input logic                                   rst,
@@ -25,7 +28,6 @@ module br_flow_mux_select_unstable_fpv_monitor #(
     input logic                                   pop_valid_unstable,
     input logic [           Width-1:0]            pop_data_unstable
 );
-
   // ----------Instantiate basic checks----------
   localparam bit EnableAssertPopValidStability =
       EnableAssertPushValidStability && EnableAssertSelectStability;
@@ -36,6 +38,7 @@ module br_flow_mux_select_unstable_fpv_monitor #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPopValidStability(EnableAssertPopValidStability),
@@ -70,6 +73,7 @@ bind br_flow_mux_select_unstable br_flow_mux_select_unstable_fpv_monitor #(
     .NumFlows(NumFlows),
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertSelectStability(EnableAssertSelectStability),

--- a/flow/fpv/reg/br_flow_reg_basic_fpv_monitor.sv
+++ b/flow/fpv/reg/br_flow_reg_basic_fpv_monitor.sv
@@ -9,7 +9,10 @@ module br_flow_reg_basic_fpv_monitor #(
     parameter int Width = 1,
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
-    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic             clk,
     input logic             rst,
@@ -20,11 +23,10 @@ module br_flow_reg_basic_fpv_monitor #(
     input logic             pop_valid,
     input logic [Width-1:0] pop_data
 );
-
   // ----------FV assumptions----------
   `BR_ASSUME(pop_ready_liveness_a, s_eventually (pop_ready))
 
-  if (!EnableCoverPushBackpressure) begin : gen_no_backpressure
+  if (!EnableCoverPushBackpressure && EnableAssertNoPushBackpressure) begin : gen_no_backpressure
     `BR_ASSUME(no_backpressure_a, !push_ready |-> !push_valid)
   end
 

--- a/flow/fpv/reg/br_flow_reg_both_fpv_monitor.sv
+++ b/flow/fpv/reg/br_flow_reg_both_fpv_monitor.sv
@@ -10,7 +10,10 @@ module br_flow_reg_both_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic             clk,
     input logic             rst,
@@ -21,11 +24,11 @@ module br_flow_reg_both_fpv_monitor #(
     input logic             pop_valid,
     input logic [Width-1:0] pop_data
 );
-
   // ----------Instantiate basic checks----------
   br_flow_reg_basic_fpv_monitor #(
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) fv_checker (
@@ -48,6 +51,7 @@ endmodule : br_flow_reg_both_fpv_monitor
 bind br_flow_reg_both br_flow_reg_both_fpv_monitor #(
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/reg/br_flow_reg_fwd_fpv_monitor.sv
+++ b/flow/fpv/reg/br_flow_reg_fwd_fpv_monitor.sv
@@ -10,7 +10,10 @@ module br_flow_reg_fwd_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic             clk,
     input logic             rst,
@@ -21,11 +24,11 @@ module br_flow_reg_fwd_fpv_monitor #(
     input logic             pop_valid,
     input logic [Width-1:0] pop_data
 );
-
   // ----------Instantiate basic checks----------
   br_flow_reg_basic_fpv_monitor #(
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) fv_checker (
@@ -48,6 +51,7 @@ endmodule : br_flow_reg_fwd_fpv_monitor
 bind br_flow_reg_fwd br_flow_reg_fwd_fpv_monitor #(
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/reg/br_flow_reg_none_fpv_monitor.sv
+++ b/flow/fpv/reg/br_flow_reg_none_fpv_monitor.sv
@@ -10,7 +10,10 @@ module br_flow_reg_none_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic             clk,
     input logic             rst,
@@ -21,11 +24,11 @@ module br_flow_reg_none_fpv_monitor #(
     input logic             pop_valid,
     input logic [Width-1:0] pop_data
 );
-
   // ----------Instantiate basic checks----------
   br_flow_reg_basic_fpv_monitor #(
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) fv_checker (
@@ -48,6 +51,7 @@ endmodule : br_flow_reg_none_fpv_monitor
 bind br_flow_reg_none br_flow_reg_none_fpv_monitor #(
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/reg/br_flow_reg_rev_fpv_monitor.sv
+++ b/flow/fpv/reg/br_flow_reg_rev_fpv_monitor.sv
@@ -10,7 +10,10 @@ module br_flow_reg_rev_fpv_monitor #(
     parameter bit EnableCoverPushBackpressure = 1,
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic             clk,
     input logic             rst,
@@ -21,11 +24,11 @@ module br_flow_reg_rev_fpv_monitor #(
     input logic             pop_valid,
     input logic [Width-1:0] pop_data
 );
-
   // ----------Instantiate basic checks----------
   br_flow_reg_basic_fpv_monitor #(
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability)
   ) fv_checker (
@@ -48,6 +51,7 @@ endmodule : br_flow_reg_rev_fpv_monitor
 bind br_flow_reg_rev br_flow_reg_rev_fpv_monitor #(
     .Width(Width),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/fpv/xbar/br_flow_xbar_basic_fpv_monitor.sv
+++ b/flow/fpv/xbar/br_flow_xbar_basic_fpv_monitor.sv
@@ -16,6 +16,9 @@ module br_flow_xbar_basic_fpv_monitor #(
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertPushDestinationStability = EnableAssertPushValidStability,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int PushDestIdWidth = br_math::clamped_clog2(NumPushFlows),
     localparam int DestIdWidth = br_math::clamped_clog2(NumPopFlows)
 ) (
@@ -34,7 +37,6 @@ module br_flow_xbar_basic_fpv_monitor #(
     input logic [PushDestIdWidth-1:0] fv_push_id,
     input logic [DestIdWidth-1:0] fv_pop_id
 );
-
   localparam int Latency = RegisterDemuxOutputs + RegisterPopOutputs;
   // when push_valid & push_ready from fv_push_id are sending to fv_pop_id
   logic fv_push_vr;
@@ -67,7 +69,7 @@ module br_flow_xbar_basic_fpv_monitor #(
         `BR_ASSUME(push_dest_id_stable_a,
                    push_valid[i] && !push_ready[i] |=> $stable(push_dest_id[i]))
       end
-    end else begin : gen_no_push_backpressure
+    end else if (EnableAssertNoPushBackpressure) begin : gen_no_push_backpressure
       `BR_ASSUME(no_backpressure_a, !push_ready[i] |-> !push_valid[i])
     end
   end

--- a/flow/fpv/xbar/br_flow_xbar_fixed_fpv_monitor.sv
+++ b/flow/fpv/xbar/br_flow_xbar_fixed_fpv_monitor.sv
@@ -17,6 +17,9 @@ module br_flow_xbar_fixed_fpv_monitor #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertPushDestinationStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int DestIdWidth = br_math::clamped_clog2(NumPopFlows)
 ) (
     input logic clk,
@@ -34,7 +37,6 @@ module br_flow_xbar_fixed_fpv_monitor #(
     // RTL internal signals
     input logic [NumPopFlows-1:0][NumPushFlows-1:0] grant
 );
-
   // ----------FV Modeling Code----------
   logic [$clog2(NumPushFlows)-1:0] i, j;
   logic push_valid_i;
@@ -63,6 +65,7 @@ module br_flow_xbar_fixed_fpv_monitor #(
       .RegisterDemuxOutputs(RegisterDemuxOutputs),
       .RegisterPopOutputs(RegisterPopOutputs),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDestinationStability(EnableAssertPushDestinationStability)
@@ -104,6 +107,7 @@ bind br_flow_xbar_fixed br_flow_xbar_fixed_fpv_monitor #(
     .RegisterDemuxOutputs(RegisterDemuxOutputs),
     .RegisterPopOutputs(RegisterPopOutputs),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertPushDestinationStability(EnableAssertPushDestinationStability),

--- a/flow/fpv/xbar/br_flow_xbar_lru_fpv_monitor.sv
+++ b/flow/fpv/xbar/br_flow_xbar_lru_fpv_monitor.sv
@@ -17,6 +17,9 @@ module br_flow_xbar_lru_fpv_monitor #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertPushDestinationStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int DestIdWidth = br_math::clamped_clog2(NumPopFlows)
 ) (
     input logic clk,
@@ -36,7 +39,6 @@ module br_flow_xbar_lru_fpv_monitor #(
     input logic [NumPopFlows-1:0][NumPushFlows-1:0] grant,
     input logic [NumPopFlows-1:0] enable_priority_update
 );
-
   // ----------FV Modeling Code----------
   // pick a random pair of input/outout flow to check
   logic [DestIdWidth-1:0] fv_push_id;
@@ -52,6 +54,7 @@ module br_flow_xbar_lru_fpv_monitor #(
       .RegisterDemuxOutputs(RegisterDemuxOutputs),
       .RegisterPopOutputs(RegisterPopOutputs),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDestinationStability(EnableAssertPushDestinationStability)
@@ -90,6 +93,7 @@ bind br_flow_xbar_lru br_flow_xbar_lru_fpv_monitor #(
     .RegisterDemuxOutputs(RegisterDemuxOutputs),
     .RegisterPopOutputs(RegisterPopOutputs),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertPushDestinationStability(EnableAssertPushDestinationStability),

--- a/flow/fpv/xbar/br_flow_xbar_rr_fpv_monitor.sv
+++ b/flow/fpv/xbar/br_flow_xbar_rr_fpv_monitor.sv
@@ -17,6 +17,9 @@ module br_flow_xbar_rr_fpv_monitor #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     parameter bit EnableAssertPushDestinationStability = EnableAssertPushValidStability,
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int DestIdWidth = br_math::clamped_clog2(NumPopFlows)
 ) (
     input logic clk,
@@ -36,7 +39,6 @@ module br_flow_xbar_rr_fpv_monitor #(
     input logic [NumPopFlows-1:0][NumPushFlows-1:0] grant,
     input logic [NumPopFlows-1:0] enable_priority_update
 );
-
   // ----------FV Modeling Code----------
   // pick a random pair of input/outout flow to check
   logic [DestIdWidth-1:0] fv_push_id;
@@ -52,6 +54,7 @@ module br_flow_xbar_rr_fpv_monitor #(
       .RegisterDemuxOutputs(RegisterDemuxOutputs),
       .RegisterPopOutputs(RegisterPopOutputs),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDestinationStability(EnableAssertPushDestinationStability)
@@ -91,6 +94,7 @@ bind br_flow_xbar_rr br_flow_xbar_rr_fpv_monitor #(
     .RegisterDemuxOutputs(RegisterDemuxOutputs),
     .RegisterPopOutputs(RegisterPopOutputs),
     .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
     .EnableAssertPushValidStability(EnableAssertPushValidStability),
     .EnableAssertPushDataStability(EnableAssertPushDataStability),
     .EnableAssertPushDestinationStability(EnableAssertPushDestinationStability),

--- a/flow/rtl/br_flow_arb_fixed.sv
+++ b/flow/rtl/br_flow_arb_fixed.sv
@@ -18,12 +18,16 @@ module br_flow_arb_fixed #(
     // Must be at least 1
     parameter int NumFlows = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     // Only used for assertions
     // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ NOT_READ
@@ -62,6 +66,7 @@ module br_flow_arb_fixed #(
   br_flow_arb_core #(
       .NumFlows(NumFlows),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_flow_arb_core (

--- a/flow/rtl/br_flow_arb_lru.sv
+++ b/flow/rtl/br_flow_arb_lru.sv
@@ -20,12 +20,16 @@ module br_flow_arb_lru #(
     // Must be at least 1
     parameter int NumFlows = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,
@@ -64,6 +68,7 @@ module br_flow_arb_lru #(
   br_flow_arb_core #(
       .NumFlows(NumFlows),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_flow_arb_core (

--- a/flow/rtl/br_flow_arb_rr.sv
+++ b/flow/rtl/br_flow_arb_rr.sv
@@ -20,12 +20,16 @@ module br_flow_arb_rr #(
     // Must be at least 1
     parameter int NumFlows = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,
@@ -64,6 +68,7 @@ module br_flow_arb_rr #(
   br_flow_arb_core #(
       .NumFlows(NumFlows),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_flow_arb_core (

--- a/flow/rtl/br_flow_burst_mux_fixed.sv
+++ b/flow/rtl/br_flow_burst_mux_fixed.sv
@@ -23,7 +23,8 @@ module br_flow_burst_mux_fixed #(
     parameter int NumFlows = 1,  // Must be at least 1
     parameter int Width = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -32,7 +33,10 @@ module br_flow_burst_mux_fixed #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -49,6 +53,8 @@ module br_flow_burst_mux_fixed #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_requesters_gte_1_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
 
@@ -70,6 +76,7 @@ module br_flow_burst_mux_fixed #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_burst_mux_fixed_stable.sv
+++ b/flow/rtl/br_flow_burst_mux_fixed_stable.sv
@@ -24,7 +24,8 @@ module br_flow_burst_mux_fixed_stable #(
     // from pop_ready to push_ready.
     parameter bit RegisterPopReady = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -33,7 +34,10 @@ module br_flow_burst_mux_fixed_stable #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -50,6 +54,8 @@ module br_flow_burst_mux_fixed_stable #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
 
@@ -72,6 +78,7 @@ module br_flow_burst_mux_fixed_stable #(
       .Width(Width),
       .RegisterPopReady(RegisterPopReady),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_burst_mux_lru.sv
+++ b/flow/rtl/br_flow_burst_mux_lru.sv
@@ -21,7 +21,8 @@ module br_flow_burst_mux_lru #(
     parameter int NumFlows = 1,  // Must be at least 1
     parameter int Width = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -30,7 +31,10 @@ module br_flow_burst_mux_lru #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -47,6 +51,8 @@ module br_flow_burst_mux_lru #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_requesters_gte_1_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
 
@@ -72,6 +78,7 @@ module br_flow_burst_mux_lru #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_burst_mux_lru_stable.sv
+++ b/flow/rtl/br_flow_burst_mux_lru_stable.sv
@@ -23,7 +23,8 @@ module br_flow_burst_mux_lru_stable #(
     // from pop_ready to push_ready.
     parameter bit RegisterPopReady = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -32,7 +33,10 @@ module br_flow_burst_mux_lru_stable #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -49,6 +53,8 @@ module br_flow_burst_mux_lru_stable #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
 
@@ -75,6 +81,7 @@ module br_flow_burst_mux_lru_stable #(
       .Width(Width),
       .RegisterPopReady(RegisterPopReady),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_burst_mux_rr.sv
+++ b/flow/rtl/br_flow_burst_mux_rr.sv
@@ -20,7 +20,8 @@ module br_flow_burst_mux_rr #(
     parameter int NumFlows = 1,  // Must be at least 1
     parameter int Width = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -29,7 +30,10 @@ module br_flow_burst_mux_rr #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -79,6 +83,7 @@ module br_flow_burst_mux_rr #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_burst_mux_rr_stable.sv
+++ b/flow/rtl/br_flow_burst_mux_rr_stable.sv
@@ -23,7 +23,8 @@ module br_flow_burst_mux_rr_stable #(
     // from pop_ready to push_ready.
     parameter bit RegisterPopReady = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -32,7 +33,10 @@ module br_flow_burst_mux_rr_stable #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -49,6 +53,8 @@ module br_flow_burst_mux_rr_stable #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
 
@@ -75,6 +81,7 @@ module br_flow_burst_mux_rr_stable #(
       .Width(Width),
       .RegisterPopReady(RegisterPopReady),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_demux_select.sv
+++ b/flow/rtl/br_flow_demux_select.sv
@@ -20,7 +20,8 @@ module br_flow_demux_select #(
     // Must be at least 1
     parameter int Width = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -33,6 +34,9 @@ module br_flow_demux_select #(
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int SelectWidth = br_math::clamped_clog2(NumFlows)
 ) (
     input logic clk,
@@ -65,6 +69,7 @@ module br_flow_demux_select #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertSelectStability(EnableAssertSelectStability),
@@ -88,6 +93,7 @@ module br_flow_demux_select #(
     br_flow_reg_fwd #(
         .Width(Width),
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
         // We know that valid and data can be unstable internally.
         // This register hides that instability from the pop interface.
         .EnableAssertPushValidStability(

--- a/flow/rtl/br_flow_demux_select_unstable.sv
+++ b/flow/rtl/br_flow_demux_select_unstable.sv
@@ -27,7 +27,8 @@ module br_flow_demux_select_unstable #(
     // Must be at least 1
     parameter int Width = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -40,6 +41,9 @@ module br_flow_demux_select_unstable #(
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int SelectWidth = br_math::clamped_clog2(NumFlows)
 ) (
     // Used only for assertions
@@ -70,6 +74,8 @@ module br_flow_demux_select_unstable #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_must_be_at_least_one_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
   `BR_ASSERT_STATIC(select_stability_implies_valid_stability_a,
@@ -79,6 +85,7 @@ module br_flow_demux_select_unstable #(
       .NumFlows(1),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),
@@ -147,6 +154,7 @@ module br_flow_demux_select_unstable #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       // Pop valid and data can only be stable if select is stable.
       .EnableAssertValidStability(EnableAssertPushValidStability && EnableAssertSelectStability),
       .EnableAssertDataStability(EnableAssertPushDataStability && EnableAssertSelectStability),

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -89,7 +89,8 @@ module br_flow_deserializer #(
     // Width of the sideband metadata (not serialized). Must be at least 1.
     parameter int MetadataWidth = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, the most significant bits of the packet are received first (big endian).
     // If 0, the least significant bits are received first (little endian).
@@ -100,6 +101,9 @@ module br_flow_deserializer #(
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int DeserializationRatio = PopWidth / PushWidth,
     // Vector widths cannot be 0, so we need to special-case when DeserializationRatio == 1
     // even though the pop_last_dont_care_count port will be unused downstream in that case.
@@ -143,6 +147,8 @@ module br_flow_deserializer #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(push_width_gte_1_a, PushWidth >= 1)
   `BR_ASSERT_STATIC(pop_width_multiple_of_push_width_a, (PopWidth % PushWidth) == 0)
   `BR_ASSERT_STATIC(metadata_width_gte_1_a, MetadataWidth >= 1)
@@ -156,6 +162,7 @@ module br_flow_deserializer #(
       // has been received. If the push data is unstable during reception, then the data
       // integrity is compromised.
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableCoverPushBackpressure),
       .EnableAssertDataStability(EnableCoverPushBackpressure),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_fork.sv
+++ b/flow/rtl/br_flow_fork.sv
@@ -14,12 +14,16 @@
 module br_flow_fork #(
     parameter int NumFlows = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     // Used only for assertions
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
@@ -43,12 +47,15 @@ module br_flow_fork #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
 
   br_flow_checks_valid_data_intg #(
       .NumFlows(1),
       .Width(1),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       // Data is always stable when valid is since it is constant.
       .EnableAssertDataStability(EnableAssertPushValidStability),
@@ -84,6 +91,7 @@ module br_flow_fork #(
       .NumFlows(NumFlows),
       .Width(1),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       // We know that the pop valids can be unstable.
       .EnableAssertValidStability(0),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/rtl/br_flow_fork_select_multihot.sv
+++ b/flow/rtl/br_flow_fork_select_multihot.sv
@@ -18,14 +18,18 @@ module br_flow_fork_select_multihot #(
     // If 0, assert that the push_select_multihot signal is always onehot when valid is high.
     parameter bit EnableCoverSelectMultihot = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, assert that push_select_multihot is stable when backpressured.
     parameter bit EnableAssertSelectMultihotStability = EnableAssertPushValidStability,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     // Used only for assertions
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
@@ -52,6 +56,8 @@ module br_flow_fork_select_multihot #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
 
   `BR_ASSERT_INTG(select_not_0_when_valid_a, push_valid |-> (|push_select_multihot))
@@ -59,6 +65,7 @@ module br_flow_fork_select_multihot #(
       .NumFlows(1),
       .Width(NumFlows),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertSelectMultihotStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
@@ -112,6 +119,7 @@ module br_flow_fork_select_multihot #(
       .NumFlows(NumFlows),
       .Width(1),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPopValidStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_flow_checks_valid_data_impl (

--- a/flow/rtl/br_flow_join.sv
+++ b/flow/rtl/br_flow_join.sv
@@ -13,12 +13,16 @@
 module br_flow_join #(
     parameter int NumFlows = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,  // Used only for assertions
@@ -38,13 +42,15 @@ module br_flow_join #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_gte1_a, NumFlows >= 1)
-
 
   br_flow_checks_valid_data_intg #(
       .NumFlows(NumFlows),
       .Width(1),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       // Data is always stable when valid is since it is constant.
       .EnableAssertDataStability(EnableAssertPushValidStability),

--- a/flow/rtl/br_flow_mux_fixed.sv
+++ b/flow/rtl/br_flow_mux_fixed.sv
@@ -21,7 +21,8 @@ module br_flow_mux_fixed #(
     parameter int NumFlows = 1,  // Must be at least 1
     parameter int Width = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -30,7 +31,10 @@ module br_flow_mux_fixed #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     // ri lint_check_waive NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic                           clk,                 // Only used for assertions
@@ -75,6 +79,7 @@ module br_flow_mux_fixed #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_mux_fixed_stable.sv
+++ b/flow/rtl/br_flow_mux_fixed_stable.sv
@@ -22,7 +22,8 @@ module br_flow_mux_fixed_stable #(
     // from pop_ready to push_ready.
     parameter bit RegisterPopReady = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -31,7 +32,10 @@ module br_flow_mux_fixed_stable #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -71,6 +75,7 @@ module br_flow_mux_fixed_stable #(
       .Width(Width),
       .RegisterPopReady(RegisterPopReady),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_mux_lru.sv
+++ b/flow/rtl/br_flow_mux_lru.sv
@@ -19,7 +19,8 @@ module br_flow_mux_lru #(
     parameter int NumFlows = 1,  // Must be at least 1
     parameter int Width = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -28,7 +29,10 @@ module br_flow_mux_lru #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -75,6 +79,7 @@ module br_flow_mux_lru #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_mux_lru_stable.sv
+++ b/flow/rtl/br_flow_mux_lru_stable.sv
@@ -21,7 +21,8 @@ module br_flow_mux_lru_stable #(
     // from pop_ready to push_ready.
     parameter bit RegisterPopReady = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -30,7 +31,10 @@ module br_flow_mux_lru_stable #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -74,6 +78,7 @@ module br_flow_mux_lru_stable #(
       .Width(Width),
       .RegisterPopReady(RegisterPopReady),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_mux_rr.sv
+++ b/flow/rtl/br_flow_mux_rr.sv
@@ -19,7 +19,8 @@ module br_flow_mux_rr #(
     parameter int NumFlows = 1,  // Must be at least 1
     parameter int Width = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -28,7 +29,10 @@ module br_flow_mux_rr #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -75,6 +79,7 @@ module br_flow_mux_rr #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_mux_rr_stable.sv
+++ b/flow/rtl/br_flow_mux_rr_stable.sv
@@ -21,7 +21,8 @@ module br_flow_mux_rr_stable #(
     // from pop_ready to push_ready.
     parameter bit RegisterPopReady = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -30,7 +31,10 @@ module br_flow_mux_rr_stable #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -74,6 +78,7 @@ module br_flow_mux_rr_stable #(
       .Width(Width),
       .RegisterPopReady(RegisterPopReady),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_mux_select.sv
+++ b/flow/rtl/br_flow_mux_select.sv
@@ -20,7 +20,8 @@ module br_flow_mux_select #(
     // Must be at least 1
     parameter int Width = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -33,6 +34,9 @@ module br_flow_mux_select #(
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int SelectWidth = br_math::clamped_clog2(NumFlows)
 ) (
     input logic clk,
@@ -68,6 +72,7 @@ module br_flow_mux_select #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertSelectStability(EnableAssertSelectStability),
@@ -94,6 +99,7 @@ module br_flow_mux_select #(
   br_flow_reg_fwd #(
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertInternalValidStability),
       .EnableAssertPushDataStability(EnableAssertInternalDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_mux_select_unstable.sv
+++ b/flow/rtl/br_flow_mux_select_unstable.sv
@@ -30,7 +30,8 @@ module br_flow_mux_select_unstable #(
     // Must be at least 1
     parameter int Width = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -43,6 +44,9 @@ module br_flow_mux_select_unstable #(
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int SelectWidth = br_math::clamped_clog2(NumFlows)
 
 ) (
@@ -71,6 +75,8 @@ module br_flow_mux_select_unstable #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_must_be_at_least_one_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(width_gte_1_a, Width >= 1)
   `BR_ASSERT_STATIC(select_only_stable_if_valid_stable_a,
@@ -82,6 +88,7 @@ module br_flow_mux_select_unstable #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),
@@ -155,6 +162,7 @@ module br_flow_mux_select_unstable #(
       .NumFlows(1),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPopValidStability),
       .EnableAssertDataStability(EnableAssertPopDataStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)

--- a/flow/rtl/br_flow_reg_both.sv
+++ b/flow/rtl/br_flow_reg_both.sv
@@ -23,7 +23,8 @@ module br_flow_reg_both #(
     // Must be at least 1
     parameter int Width = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -32,7 +33,10 @@ module br_flow_reg_both #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,  // Synchronous active-high
@@ -68,6 +72,7 @@ module br_flow_reg_both #(
   br_flow_reg_rev #(
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_reg_fwd.sv
+++ b/flow/rtl/br_flow_reg_fwd.sv
@@ -25,7 +25,8 @@ module br_flow_reg_fwd #(
     // Must be at least 1
     parameter int Width = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -34,7 +35,10 @@ module br_flow_reg_fwd #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,  // Synchronous active-high
@@ -51,12 +55,15 @@ module br_flow_reg_fwd #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
 
   br_flow_checks_valid_data_intg #(
       .NumFlows(1),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_reg_none.sv
+++ b/flow/rtl/br_flow_reg_none.sv
@@ -28,7 +28,8 @@ module br_flow_reg_none #(
     // Must be at least 1
     parameter int Width = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -37,7 +38,10 @@ module br_flow_reg_none #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,
@@ -54,12 +58,15 @@ module br_flow_reg_none #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
 
   br_flow_checks_valid_data_intg #(
       .NumFlows(1),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_reg_rev.sv
+++ b/flow/rtl/br_flow_reg_rev.sv
@@ -25,7 +25,8 @@ module br_flow_reg_rev #(
     // Must be at least 1
     parameter int Width = 1,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -34,7 +35,10 @@ module br_flow_reg_rev #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input logic clk,
     input logic rst,  // Synchronous active-high
@@ -51,12 +55,15 @@ module br_flow_reg_rev #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
 
   br_flow_checks_valid_data_intg #(
       .NumFlows(1),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/br_flow_xbar_fixed.sv
+++ b/flow/rtl/br_flow_xbar_fixed.sv
@@ -32,7 +32,8 @@ module br_flow_xbar_fixed #(
     // If 0, pop_valid/pop_data come directly from the muxes and may be unstable.
     parameter bit RegisterPopOutputs = 0,
     // If 1, cover that the push_ready signal can be backpressured.
-    // If 0, assert that push backpressure is not possible.
+    // If 0, disable push backpressure coverage. By default, this also
+    // asserts that push backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -47,6 +48,9 @@ module br_flow_xbar_fixed #(
     // register stages are empty at end of simulation.
     parameter bit EnableAssertFinalNotValid = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int DestIdWidth = br_math::clamped_clog2(NumPopFlows)
 ) (
     input logic clk,
@@ -82,6 +86,7 @@ module br_flow_xbar_fixed #(
       .RegisterDemuxOutputs(RegisterDemuxOutputs),
       .RegisterPopOutputs(RegisterPopOutputs),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDestinationStability(EnableAssertPushDestinationStability),

--- a/flow/rtl/br_flow_xbar_lru.sv
+++ b/flow/rtl/br_flow_xbar_lru.sv
@@ -31,7 +31,8 @@ module br_flow_xbar_lru #(
     // If 0, pop_valid/pop_data come directly from the muxes and may be unstable.
     parameter bit RegisterPopOutputs = 0,
     // If 1, cover that the push_ready signal can be backpressured.
-    // If 0, assert that push backpressure is not possible.
+    // If 0, disable push backpressure coverage. By default, this also
+    // asserts that push backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -46,6 +47,9 @@ module br_flow_xbar_lru #(
     // register stages are empty at end of simulation.
     parameter bit EnableAssertFinalNotValid = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int DestIdWidth = br_math::clamped_clog2(NumPopFlows)
 ) (
     input logic clk,
@@ -82,6 +86,7 @@ module br_flow_xbar_lru #(
       .RegisterDemuxOutputs(RegisterDemuxOutputs),
       .RegisterPopOutputs(RegisterPopOutputs),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDestinationStability(EnableAssertPushDestinationStability),

--- a/flow/rtl/br_flow_xbar_rr.sv
+++ b/flow/rtl/br_flow_xbar_rr.sv
@@ -34,7 +34,8 @@ module br_flow_xbar_rr #(
     // If 0, pop_valid/pop_data come directly from the muxes and may be unstable.
     parameter bit RegisterPopOutputs = 0,
     // If 1, cover that the push_ready signal can be backpressured.
-    // If 0, assert that push backpressure is not possible.
+    // If 0, disable push backpressure coverage. By default, this also
+    // asserts that push backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -49,6 +50,9 @@ module br_flow_xbar_rr #(
     // register stages are empty at end of simulation.
     parameter bit EnableAssertFinalNotValid = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int DestIdWidth = br_math::clamped_clog2(NumPopFlows)
 ) (
     input logic clk,
@@ -85,6 +89,7 @@ module br_flow_xbar_rr #(
       .RegisterDemuxOutputs(RegisterDemuxOutputs),
       .RegisterPopOutputs(RegisterPopOutputs),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDestinationStability(EnableAssertPushDestinationStability),

--- a/flow/rtl/internal/BUILD.bazel
+++ b/flow/rtl/internal/BUILD.bazel
@@ -220,6 +220,10 @@ br_verilog_elab_and_lint_test_suite(
         "EnableCoverBackpressure": [
             "0",
         ],
+        "EnableAssertNoBackpressure": [
+            "0",
+            "1",
+        ],
     },
     deps = [":br_flow_checks_valid_data_intg"],
 )
@@ -274,6 +278,10 @@ br_verilog_elab_and_lint_test_suite(
         ],
         "EnableCoverBackpressure": [
             "0",
+        ],
+        "EnableAssertNoBackpressure": [
+            "0",
+            "1",
         ],
     },
     deps = [":br_flow_checks_valid_data_impl"],

--- a/flow/rtl/internal/br_flow_arb_core.sv
+++ b/flow/rtl/internal/br_flow_arb_core.sv
@@ -16,7 +16,8 @@ module br_flow_arb_core #(
     parameter int NumFlows = 1,
 
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     // If 0, cover that push_valid can be unstable when backpressured.
@@ -24,10 +25,17 @@ module br_flow_arb_core #(
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     // If 1, cover that the pop side experiences backpressure.
-    // If 0, assert that there is never pop backpressure.
+    // If 0, disable pop backpressure coverage. By default, this also
+    // asserts that pop backpressure is impossible.
     parameter bit EnableCoverPopBackpressure = EnableCoverPushBackpressure,
     // Set to 1 if the arbiter is guaranteed to grant in a cycle when any request is asserted.
-    parameter bit ArbiterAlwaysGrants = 1
+    parameter bit ArbiterAlwaysGrants = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, assert that pop-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPopBackpressure is disabled.
+    parameter bit EnableAssertNoPopBackpressure = !EnableCoverPopBackpressure
 ) (
     // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
     input logic clk,  // Only used for assertions
@@ -49,10 +57,16 @@ module br_flow_arb_core #(
   // Integration checks
   //------------------------------------------
 
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+  `BR_ASSERT_STATIC(legal_assert_no_pop_backpressure_a,
+                    !(EnableAssertNoPopBackpressure && EnableCoverPopBackpressure))
+
   br_flow_checks_valid_data_intg #(
       .NumFlows(NumFlows),
       .Width(1),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       // Data is always stable when valid is stable since it is constant.
       .EnableAssertDataStability(EnableAssertPushValidStability),
@@ -102,6 +116,7 @@ module br_flow_arb_core #(
       // Since push_ready can only be true if pop_ready is,
       // pop side can only have backpressure if push side has backpressure.
       .EnableCoverBackpressure(EnableCoverPopBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPopBackpressure),
       .EnableAssertValidStability(EnableAssertPopValidStability),
       // Data is always stable when valid is stable since it is constant.
       .EnableAssertDataStability(EnableAssertPopValidStability),

--- a/flow/rtl/internal/br_flow_burst_mux_core.sv
+++ b/flow/rtl/internal/br_flow_burst_mux_core.sv
@@ -14,7 +14,8 @@ module br_flow_burst_mux_core #(
     parameter int NumFlows = 1,  // Must be at least 1
     parameter int Width = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -23,7 +24,10 @@ module br_flow_burst_mux_core #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -47,6 +51,8 @@ module br_flow_burst_mux_core #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
 
@@ -83,6 +89,7 @@ module br_flow_burst_mux_core #(
       .NumFlows(NumFlows),
       .Width(PayloadWidth),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),

--- a/flow/rtl/internal/br_flow_burst_mux_core_stable.sv
+++ b/flow/rtl/internal/br_flow_burst_mux_core_stable.sv
@@ -21,7 +21,8 @@ module br_flow_burst_mux_core_stable #(
     // from pop_ready to push_ready.
     parameter bit RegisterPopReady = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
@@ -30,7 +31,10 @@ module br_flow_burst_mux_core_stable #(
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     input  logic                           clk,
     input  logic                           rst,
@@ -54,6 +58,8 @@ module br_flow_burst_mux_core_stable #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
 
@@ -73,6 +79,7 @@ module br_flow_burst_mux_core_stable #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
@@ -97,6 +104,7 @@ module br_flow_burst_mux_core_stable #(
     br_flow_reg_both #(
         .Width(PayloadWidth),
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
         .EnableAssertPushValidStability(EnableAssertPushValidStability),
         // internal_pop_payload_unstable cannot be stable
         .EnableAssertPushDataStability(0),
@@ -116,6 +124,7 @@ module br_flow_burst_mux_core_stable #(
     br_flow_reg_fwd #(
         .Width(PayloadWidth),
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
         .EnableAssertPushValidStability(EnableAssertPushValidStability),
         // internal_pop_payload_unstable cannot be stable
         .EnableAssertPushDataStability(0),

--- a/flow/rtl/internal/br_flow_checks_valid_data_impl.sv
+++ b/flow/rtl/internal/br_flow_checks_valid_data_impl.sv
@@ -19,7 +19,8 @@ module br_flow_checks_valid_data_impl #(
     // The width of the data signal. Must be at least 1.
     parameter int Width = 1,
     // If 1, cover that there is backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableCoverBackpressure = 1,
     // If 1, assert that valid is stable when backpressured.
@@ -35,7 +36,10 @@ module br_flow_checks_valid_data_impl #(
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that there is never backpressure.
+    // Can only be enabled if EnableCoverBackpressure is disabled.
+    parameter bit EnableAssertNoBackpressure = !EnableCoverBackpressure
 ) (
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,
@@ -49,6 +53,8 @@ module br_flow_checks_valid_data_impl #(
                     !(EnableAssertValidStability && !EnableCoverBackpressure))
   `BR_ASSERT_STATIC(legal_assert_data_stability_a,
                     !(EnableAssertDataStability && !EnableAssertValidStability))
+  `BR_ASSERT_STATIC(legal_assert_no_backpressure_a,
+                    !(EnableAssertNoBackpressure && EnableCoverBackpressure))
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_valid_a, !valid)
@@ -73,7 +79,7 @@ module br_flow_checks_valid_data_impl #(
         `BR_COVER_IMPL(backpressure_c, !ready[i] && valid[i])
       end
     end
-  end else begin : gen_no_backpressure_checks
+  end else if (EnableAssertNoBackpressure) begin : gen_no_backpressure_checks
     for (genvar i = 0; i < NumFlows; i++) begin : gen_no_backpressure_per_flow
       `BR_ASSERT_IMPL(no_backpressure_a, valid[i] |-> ready[i])
     end

--- a/flow/rtl/internal/br_flow_checks_valid_data_intg.sv
+++ b/flow/rtl/internal/br_flow_checks_valid_data_intg.sv
@@ -19,7 +19,8 @@ module br_flow_checks_valid_data_intg #(
     // The width of the data signal. Must be at least 1.
     parameter int Width = 1,
     // If 1, cover that there is backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableCoverBackpressure = 1,
     // If 1, assert that valid is stable when backpressured.
@@ -35,7 +36,10 @@ module br_flow_checks_valid_data_intg #(
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertDataKnown = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that there is never backpressure.
+    // Can only be enabled if EnableCoverBackpressure is disabled.
+    parameter bit EnableAssertNoBackpressure = !EnableCoverBackpressure
 ) (
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,
@@ -49,6 +53,8 @@ module br_flow_checks_valid_data_intg #(
                     !(EnableAssertValidStability && !EnableCoverBackpressure))
   `BR_ASSERT_STATIC(legal_assert_data_stability_a,
                     !(EnableAssertDataStability && !EnableAssertValidStability))
+  `BR_ASSERT_STATIC(legal_assert_no_backpressure_a,
+                    !(EnableAssertNoBackpressure && EnableCoverBackpressure))
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_valid_a, !valid)
@@ -73,7 +79,7 @@ module br_flow_checks_valid_data_intg #(
         `BR_COVER_INTG(backpressure_c, !ready[i] && valid[i])
       end
     end
-  end else begin : gen_no_backpressure_checks
+  end else if (EnableAssertNoBackpressure) begin : gen_no_backpressure_checks
     for (genvar i = 0; i < NumFlows; i++) begin : gen_no_backpressure_per_flow
       `BR_ASSERT_INTG(no_backpressure_a, valid[i] |-> ready[i])
     end

--- a/flow/rtl/internal/br_flow_mux_core.sv
+++ b/flow/rtl/internal/br_flow_mux_core.sv
@@ -19,7 +19,8 @@ module br_flow_mux_core #(
     parameter int NumFlows = 1,  // Must be at least 1
     parameter int Width = 1,  // Must be at least 1
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = 1,
@@ -30,10 +31,17 @@ module br_flow_mux_core #(
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     // If 1, then cover cases in which pop is backpressured.
-    // Otherwise, assert that pop is never backpressured.
+    // Otherwise, disable pop backpressure coverage. By default, this also
+    // asserts that pop backpressure is impossible.
     parameter bit EnableCoverPopBackpressure = EnableCoverPushBackpressure,
     // Set to 1 if the arbiter is guaranteed to grant in a cycle when any request is asserted.
-    parameter bit ArbiterAlwaysGrants = 1
+    parameter bit ArbiterAlwaysGrants = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, assert that pop-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPopBackpressure is disabled.
+    parameter bit EnableAssertNoPopBackpressure = !EnableCoverPopBackpressure
 ) (
     // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
     input  logic                           clk,                     // Used for assertions only
@@ -56,6 +64,10 @@ module br_flow_mux_core #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+  `BR_ASSERT_STATIC(legal_assert_no_pop_backpressure_a,
+                    !(EnableAssertNoPopBackpressure && EnableCoverPopBackpressure))
   `BR_ASSERT_STATIC(numflows_gte_2_a, NumFlows >= 1)
   `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
   `BR_ASSERT_STATIC(pop_backpressure_implies_push_backpressure_a,
@@ -69,6 +81,7 @@ module br_flow_mux_core #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(EnableAssertPushDataStability),
       .EnableAssertDataKnown(EnableAssertPushDataKnown),
@@ -88,9 +101,11 @@ module br_flow_mux_core #(
   br_flow_arb_core #(
       .NumFlows(NumFlows),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
       .EnableCoverPopBackpressure(EnableCoverPopBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPopBackpressure),
       .ArbiterAlwaysGrants(ArbiterAlwaysGrants)
   ) br_flow_arb_core (
       .clk,
@@ -125,6 +140,7 @@ module br_flow_mux_core #(
       .NumFlows(1),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPopBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPopBackpressure),
       .EnableAssertValidStability(EnableAssertPopValidStability),
       // pop_data_unstable is unstable regardless of whether push_data is stable
       .EnableAssertDataStability(0),

--- a/flow/rtl/internal/br_flow_mux_core_stable.sv
+++ b/flow/rtl/internal/br_flow_mux_core_stable.sv
@@ -12,7 +12,6 @@
 // A flow register is added to the output to ensure that the pop_data
 // is stable.
 
-`include "br_asserts.svh"
 `include "br_asserts_internal.svh"
 
 module br_flow_mux_core_stable #(
@@ -23,7 +22,8 @@ module br_flow_mux_core_stable #(
     // from pop_ready to push_ready.
     parameter bit RegisterPopReady = 0,
     // If 1, cover that the push side experiences backpressure.
-    // If 0, assert that there is never backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = 1,
@@ -34,7 +34,10 @@ module br_flow_mux_core_stable #(
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     // Set to 1 if the arbiter is guaranteed to grant in a cycle when any request is asserted.
-    parameter bit ArbiterAlwaysGrants = 1
+    parameter bit ArbiterAlwaysGrants = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
 ) (
     // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
     input  logic                           clk,                     // Used for assertions only
@@ -72,6 +75,7 @@ module br_flow_mux_core_stable #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
@@ -96,6 +100,7 @@ module br_flow_mux_core_stable #(
     br_flow_reg_both #(
         .Width(Width),
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
         .EnableAssertPushValidStability(EnableAssertPushValidStability),
         // internal_pop_data cannot be stable
         .EnableAssertPushDataStability(0),
@@ -115,6 +120,7 @@ module br_flow_mux_core_stable #(
     br_flow_reg_fwd #(
         .Width(Width),
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
         .EnableAssertPushValidStability(EnableAssertPushValidStability),
         // internal_pop_data cannot be stable
         .EnableAssertPushDataStability(0),

--- a/flow/rtl/internal/br_flow_xbar_core.sv
+++ b/flow/rtl/internal/br_flow_xbar_core.sv
@@ -19,6 +19,9 @@ module br_flow_xbar_core #(
     parameter bit EnableAssertPushDataKnown = 1,
     parameter bit EnableAssertFinalNotValid = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int DestIdWidth = br_math::clamped_clog2(NumPopFlows)
 ) (
     input logic clk,
@@ -67,6 +70,7 @@ module br_flow_xbar_core #(
         .NumFlows(NumPopFlows),
         .Width(Width),
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
         .EnableAssertPushValidStability(EnableAssertPushValidStability),
         .EnableAssertPushDataStability(EnableAssertPushDataStability),
         .EnableAssertSelectStability(EnableAssertPushDestinationStability),
@@ -89,6 +93,7 @@ module br_flow_xbar_core #(
         br_flow_reg_fwd #(
             .Width(Width),
             .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+            .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
             .EnableAssertPushValidStability(
                 EnableAssertPushValidStability && EnableAssertPushDestinationStability),
             .EnableAssertPushDataStability(
@@ -121,6 +126,7 @@ module br_flow_xbar_core #(
         // mux_in to be backpressured and mux_in_valid/data
         // must be stable.
         .EnableCoverPushBackpressure(EnableCoverPushBackpressure || RegisterDemuxOutputs),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure && !RegisterDemuxOutputs),
         .EnableAssertPushValidStability(
             (EnableAssertPushValidStability && EnableAssertPushDestinationStability) ||
             RegisterDemuxOutputs),
@@ -148,6 +154,7 @@ module br_flow_xbar_core #(
       br_flow_reg_fwd #(
           .Width(Width),
           .EnableCoverPushBackpressure(EnableCoverPushBackpressure || RegisterDemuxOutputs),
+          .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure && !RegisterDemuxOutputs),
           .EnableAssertPushValidStability(
               (EnableAssertPushValidStability && EnableAssertPushDestinationStability) ||
               RegisterDemuxOutputs),

--- a/multi_xfer/rtl/br_multi_xfer_distributor_rr.sv
+++ b/multi_xfer/rtl/br_multi_xfer_distributor_rr.sv
@@ -23,7 +23,8 @@ module br_multi_xfer_distributor_rr #(
     // The number of flows to distribute to. Must be at least NumSymbols.
     parameter int NumFlows = 2,
     // If 1, cover that push_sendable can be greater than push_receivable.
-    // If 0, assert that push_sendable is always less than or equal to push_receivable.
+    // If 0, disable push backpressure coverage. By default, this also
+    // asserts that push_sendable is no greater than push_receivable.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, cover that there are more pop flows ready to accept than
     // sendable symbols.
@@ -36,6 +37,9 @@ module br_multi_xfer_distributor_rr #(
     // If 1, assert that push_sendable is 0 at the end of simulation.
     parameter bit EnableAssertFinalNotSendable = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int CountWidth = $clog2(NumSymbols + 1)
 ) (
     input logic clk,
@@ -62,6 +66,7 @@ module br_multi_xfer_distributor_rr #(
       .SymbolWidth(SymbolWidth),
       .NumFlows(NumFlows),
       .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableCoverMorePopReadyThanSendable(EnableCoverMorePopReadyThanSendable),
       .EnableAssertFinalNotSendable(EnableAssertFinalNotSendable)

--- a/multi_xfer/rtl/br_multi_xfer_reg_fwd.sv
+++ b/multi_xfer/rtl/br_multi_xfer_reg_fwd.sv
@@ -29,7 +29,8 @@ module br_multi_xfer_reg_fwd #(
     // Must be at least 1.
     parameter int SymbolWidth = 1,
     // If 1, cover that push_sendable can be greater than push_receivable.
-    // If 0, assert that push_sendable is always less than or equal to push_receivable.
+    // If 0, disable push backpressure coverage. By default, this also
+    // asserts that push_sendable is no greater than push_receivable.
     parameter bit EnableCoverPushBackpressure = 1,
     // If 1, assert that push_data is stable when push_sendable > push_receivable.
     // If 0, cover that push_data is unstable when push_sendable > push_receivable.
@@ -38,6 +39,9 @@ module br_multi_xfer_reg_fwd #(
     // at end of simulation.
     parameter int EnableAssertFinalNotSendable = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int CountWidth = $clog2(NumSymbols + 1)
 ) (
     input logic clk,
@@ -53,6 +57,8 @@ module br_multi_xfer_reg_fwd #(
 );
 
   // Integration Assertions
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(legal_num_symbols_a, NumSymbols >= 2)
   `BR_ASSERT_STATIC(legal_symbol_width_a, SymbolWidth >= 1)
 
@@ -60,6 +66,7 @@ module br_multi_xfer_reg_fwd #(
       .NumSymbols(NumSymbols),
       .SymbolWidth(SymbolWidth),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertDataStability(EnableAssertPushDataStability)
   ) br_multi_xfer_checks_sendable_data_intg_push (
       .clk(clk),

--- a/multi_xfer/rtl/internal/BUILD.bazel
+++ b/multi_xfer/rtl/internal/BUILD.bazel
@@ -35,6 +35,31 @@ br_verilog_elab_and_lint_test_suite(
     ],
 )
 
+br_verilog_elab_and_lint_test_suite(
+    name = "br_multi_xfer_checks_sendable_data_intg_test_suite_no_backpressure",
+    disable_lint_rules = ["NO_OUTPUT"],
+    params = {
+        "NumSymbols": [
+            "1",
+            "2",
+        ],
+        "SymbolWidth": [
+            "1",
+            "8",
+        ],
+        "EnableCoverBackpressure": [
+            "0",
+        ],
+        "EnableAssertNoBackpressure": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [
+        ":br_multi_xfer_checks_sendable_data_intg",
+    ],
+)
+
 verilog_library(
     name = "br_multi_xfer_checks_sendable_data_impl",
     srcs = ["br_multi_xfer_checks_sendable_data_impl.sv"],
@@ -58,6 +83,31 @@ br_verilog_elab_and_lint_test_suite(
             "1",
             "3",
             "8",
+        ],
+    },
+    deps = [
+        ":br_multi_xfer_checks_sendable_data_impl",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_multi_xfer_checks_sendable_data_impl_test_suite_no_backpressure",
+    disable_lint_rules = ["NO_OUTPUT"],
+    params = {
+        "NumSymbols": [
+            "1",
+            "2",
+        ],
+        "SymbolWidth": [
+            "1",
+            "8",
+        ],
+        "EnableCoverBackpressure": [
+            "0",
+        ],
+        "EnableAssertNoBackpressure": [
+            "0",
+            "1",
         ],
     },
     deps = [

--- a/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_impl.sv
+++ b/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_impl.sv
@@ -18,6 +18,7 @@ module br_multi_xfer_checks_sendable_data_impl #(
     parameter int SymbolWidth = 1,
     parameter bit EnableCoverBackpressure = 1,
     parameter bit EnableAssertDataStability = 1,
+    parameter bit EnableAssertNoBackpressure = !EnableCoverBackpressure,
 
     localparam int CountWidth = $clog2(NumSymbols + 1)
 ) (
@@ -29,6 +30,9 @@ module br_multi_xfer_checks_sendable_data_impl #(
     input logic [CountWidth-1:0] sendable,
     input logic [NumSymbols-1:0][SymbolWidth-1:0] data
 );
+
+  `BR_ASSERT_STATIC(legal_assert_no_backpressure_a,
+                    !(EnableAssertNoBackpressure && EnableCoverBackpressure))
 
   if (EnableCoverBackpressure) begin : gen_backpressure_checks
     // If not all of the sendable symbols are transferred,
@@ -70,7 +74,7 @@ module br_multi_xfer_checks_sendable_data_impl #(
       `BR_COVER_IMPL(data_instability_c,
                      (sendable > receivable) ##1 data_masked != $past(data_shifted))
     end
-  end else begin : gen_no_backpressure_checks
+  end else if (EnableAssertNoBackpressure) begin : gen_no_backpressure_checks
     `BR_ASSERT_IMPL(sendable_at_most_receivable_a, sendable <= receivable)
   end
 

--- a/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_intg.sv
+++ b/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_intg.sv
@@ -18,6 +18,7 @@ module br_multi_xfer_checks_sendable_data_intg #(
     parameter int SymbolWidth = 1,
     parameter bit EnableCoverBackpressure = 1,
     parameter bit EnableAssertDataStability = 1,
+    parameter bit EnableAssertNoBackpressure = !EnableCoverBackpressure,
 
     localparam int CountWidth = $clog2(NumSymbols + 1)
 ) (
@@ -29,6 +30,9 @@ module br_multi_xfer_checks_sendable_data_intg #(
     input logic [CountWidth-1:0] sendable,
     input logic [NumSymbols-1:0][SymbolWidth-1:0] data
 );
+
+  `BR_ASSERT_STATIC(legal_assert_no_backpressure_a,
+                    !(EnableAssertNoBackpressure && EnableCoverBackpressure))
 
   if (EnableCoverBackpressure) begin : gen_backpressure_checks
     // If not all of the sendable symbols are transferred,
@@ -70,7 +74,7 @@ module br_multi_xfer_checks_sendable_data_intg #(
       `BR_COVER_INTG(data_instability_c,
                      (sendable > receivable) ##1 data_masked != $past(data_shifted))
     end
-  end else begin : gen_no_backpressure_checks
+  end else if (EnableAssertNoBackpressure) begin : gen_no_backpressure_checks
     `BR_ASSERT_INTG(sendable_at_most_receivable_a, sendable <= receivable)
   end
 

--- a/multi_xfer/rtl/internal/br_multi_xfer_distributor_core.sv
+++ b/multi_xfer/rtl/internal/br_multi_xfer_distributor_core.sv
@@ -19,6 +19,9 @@ module br_multi_xfer_distributor_core #(
     parameter bit EnableCoverMorePopReadyThanSendable = 1,
     parameter bit EnableAssertFinalNotSendable = 1,
 
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     localparam int CountWidth = $clog2(NumSymbols + 1)
 ) (
     input logic clk,
@@ -41,6 +44,7 @@ module br_multi_xfer_distributor_core #(
     input logic [CountWidth-1:0] grant_count,
     output logic enable_priority_update
 );
+
   logic [NumFlows-1:0][NumSymbols-1:0] grant_ordered_transposed;
 
   for (genvar i = 0; i < NumFlows; i++) begin : gen_grant_ordered_transposed
@@ -51,6 +55,8 @@ module br_multi_xfer_distributor_core #(
 
   // Integration Assertions
 
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(legal_num_symbols_a, NumSymbols >= 2)
   `BR_ASSERT_STATIC(legal_symbol_width_a, SymbolWidth >= 1)
   `BR_ASSERT_STATIC(legal_num_flows_a, NumFlows >= NumSymbols)
@@ -59,6 +65,7 @@ module br_multi_xfer_distributor_core #(
       .NumSymbols(NumSymbols),
       .SymbolWidth(SymbolWidth),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertDataStability(EnableAssertPushDataStability)
   ) br_multi_xfer_checks_sendable_data_intg_push (
       .clk(clk),


### PR DESCRIPTION
Add explicit EnableAssertNo*Backpressure parameters across flow, FIFO, CDC, credit, and multi-transfer RTL and monitors. Preserve existing defaults by deriving the new knobs from the matching cover parameter, while allowing users to disable both coverage and no-backpressure assertions.

Add RTL legality checks where the module owns the matching cover/assert parameters, and extend targeted parameter suites for elaboration coverage.

Co-authored-by: Codex <noreply@openai.com>
