### PR TITLE
[fv] Add Numflows > 1 to eliminate unreachable covers

### DIFF
--- a/flow/rtl/br_flow_demux_select_unstable.sv
+++ b/flow/rtl/br_flow_demux_select_unstable.sv
@@ -91,7 +91,9 @@ module br_flow_demux_select_unstable #(
       .data (push_data)
   );
 
-  if (EnableCoverPushBackpressure && EnableAssertPushValidStability) begin : gen_select_checks
+  if (NumFlows > 1 &&
+      EnableCoverPushBackpressure &&
+      EnableAssertPushValidStability) begin : gen_select_checks
     if (EnableAssertSelectStability) begin : gen_select_stability_check
       `BR_ASSERT_INTG(select_stable_a,
                       (!push_ready && push_valid) |=> push_valid && $stable(select))
@@ -134,8 +136,10 @@ module br_flow_demux_select_unstable #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  if (EnableCoverPushBackpressure && EnableAssertPushValidStability && !EnableAssertSelectStability)
-  begin : gen_stable_push_valid
+  if (NumFlows > 1 &&
+      EnableCoverPushBackpressure &&
+      EnableAssertPushValidStability &&
+      !EnableAssertSelectStability) begin : gen_stable_push_valid
     for (genvar i = 0; i < NumFlows; i++) begin : gen_pop_unstable_checks
       `BR_ASSERT_IMPL(
           pop_valid_instability_caused_by_select_a,

--- a/flow/rtl/br_flow_fork_select_multihot.sv
+++ b/flow/rtl/br_flow_fork_select_multihot.sv
@@ -69,9 +69,10 @@ module br_flow_fork_select_multihot #(
       .valid(push_valid),
       .data (push_select_multihot)
   );
-  if (EnableCoverSelectMultihot) begin : gen_cover_select_multihot
+  if (NumFlows > 1 && EnableCoverSelectMultihot) begin : gen_cover_select_multihot
     `BR_COVER_INTG(select_multihot_c, push_valid && $countones(push_select_multihot) > 1)
-  end else begin : gen_assert_onehot_select
+  end
+  if (!EnableCoverSelectMultihot) begin : gen_assert_onehot_select
     `BR_ASSERT_INTG(select_onehot_a, push_valid |-> $onehot(push_select_multihot))
   end
   `BR_ASSERT_INTG(select_multihot_known_a, push_valid |-> !$isunknown(push_select_multihot))


### PR DESCRIPTION
This change guards select-instability and multihot-select cover properties with NumFlows > 1.
For NumFlows == 1, these covers are structurally unreachable.
I have run FPV on br_flow/fpv directory, TOT is clean.