### PR TITLE
[fv] FPV fix for issue #1068

### DIFF
--- a/fifo/fpv/br_fifo_fv_ram.sv
+++ b/fifo/fpv/br_fifo_fv_ram.sv
@@ -65,6 +65,15 @@ module br_fifo_fv_ram #(
     end
   end
 
+  // ----------FV assertions----------
+  for (genvar a = 0; a < NumWritePorts; a++) begin : gen_wr_conflict_a
+    for (genvar b = a + 1; b < NumWritePorts; b++) begin : gen_wr_conflict_b
+      // If two write ports can fire together, they must not hit the same address.
+      `BR_ASSERT(wr_conflict_a,
+                 !(ram_wr_valid[a] && ram_wr_valid[b] && (ram_wr_addr[a] == ram_wr_addr[b])))
+    end
+  end
+
   // ----------wolper coloring invariant----------
   if (WolperColorEn) begin : gen_invariant
     `BR_ASSERT(fv_invariant_at_most_two_ones_a, $countones(fv_magic_col) <= 2)

--- a/fpv/lib/fv_ram.sv
+++ b/fpv/lib/fv_ram.sv
@@ -58,4 +58,13 @@ module fv_ram #(
     end
   end
 
+  // ----------FV assertions----------
+  for (genvar a = 0; a < NumWritePorts; a++) begin : gen_wr_conflict_a
+    for (genvar b = a + 1; b < NumWritePorts; b++) begin : gen_wr_conflict_b
+      // If two write ports can fire together, they must not hit the same address.
+      `BR_ASSERT(wr_conflict_a,
+                 !(ram_wr_valid[a] && ram_wr_valid[b] && (ram_wr_addr[a] == ram_wr_addr[b])))
+    end
+  end
+
 endmodule : fv_ram

--- a/tracker/fpv/br_tracker_linked_list_ctrl_fpv_monitor.sv
+++ b/tracker/fpv/br_tracker_linked_list_ctrl_fpv_monitor.sv
@@ -44,15 +44,14 @@ module br_tracker_linked_list_ctrl_fpv_monitor #(
   // bit vector tracking which entry of RAM is in use
   always_comb begin
     fv_entry_used_nxt = fv_entry_used;
-    // A popped head is available for same-cycle reuse by next_tail.
-    if (head_valid & head_ready) begin
-      fv_entry_used_nxt[head] = 1'd0;
-    end
     for (int i = 0; i < NumWritePorts; i++) begin
       `BR_ASSUME(tail_unique_a, next_tail_valid[i] |-> !fv_entry_used_nxt[next_tail[i]])
       if (next_tail_valid[i]) begin
         fv_entry_used_nxt[next_tail[i]] = 1'd1;
       end
+    end
+    if (head_valid & head_ready) begin
+      fv_entry_used_nxt[head] = 1'd0;
     end
   end
 
@@ -70,6 +69,7 @@ module br_tracker_linked_list_ctrl_fpv_monitor #(
   // ----------FV assumptions----------
   for (genvar n = 0; n < NumWritePorts; n++) begin : gen_asm
     `BR_ASSUME(tail_in_range_a, next_tail_valid[n] |-> next_tail[n] < Depth)
+    `BR_ASSUME(tail_not_in_use_a, next_tail_valid[n] |-> !fv_entry_used[next_tail[n]])
   end
   // model RAM read data
   if (RamReadLatency == 0) begin : gen_latency0
@@ -85,6 +85,15 @@ module br_tracker_linked_list_ctrl_fpv_monitor #(
   `BR_ASSERT(head_valid_ready_a, head_valid && !head_ready |=> head_valid && $stable(head))
   `BR_ASSERT(empty_check_a, (fv_entry_used == 'd0) == empty)
   `BR_ASSERT(items_check_a, $countones(fv_entry_used) == items)
+
+  for (genvar a = 0; a < NumWritePorts; a++) begin : gen_a
+    for (genvar b = a + 1; b < NumWritePorts; b++) begin : gen_b
+      // If two write ports can fire together, they must not hit the same address.
+      `BR_ASSERT(ptr_ram_wr_conflict_a,
+                 !(ptr_ram_wr_valid[a] && ptr_ram_wr_valid[b] &&
+            (ptr_ram_wr_addr[a] == ptr_ram_wr_addr[b])))
+    end
+  end
 
   // ----------Data integrity/ordering Check----------
   // If there are multiple writes on the same cycle,
@@ -108,15 +117,6 @@ module br_tracker_linked_list_ctrl_fpv_monitor #(
   // ----------Critical Covers----------
   `BR_COVER(all_next_tail_valid_c, &next_tail_valid)
   `BR_COVER(all_entry_used_c, &fv_entry_used)
-
-  // ----------Bug Reproduction Assertions----------
-  for (genvar a = 0; a < NumWritePorts; a++) begin : gen_a
-    for (genvar b = a + 1; b < NumWritePorts; b++) begin : gen_b
-      `BR_ASSERT(
-          ptr_ram_wr_conflict_a,
-          (ptr_ram_wr_valid[a] && ptr_ram_wr_valid[b]) |-> ptr_ram_wr_addr[a] != ptr_ram_wr_addr[b])
-    end
-  end
 
 endmodule : br_tracker_linked_list_ctrl_fpv_monitor
 

--- a/tracker/fpv/br_tracker_linked_list_ctrl_fpv_monitor.sv
+++ b/tracker/fpv/br_tracker_linked_list_ctrl_fpv_monitor.sv
@@ -44,14 +44,15 @@ module br_tracker_linked_list_ctrl_fpv_monitor #(
   // bit vector tracking which entry of RAM is in use
   always_comb begin
     fv_entry_used_nxt = fv_entry_used;
+    // A popped head is available for same-cycle reuse by next_tail.
+    if (head_valid & head_ready) begin
+      fv_entry_used_nxt[head] = 1'd0;
+    end
     for (int i = 0; i < NumWritePorts; i++) begin
       `BR_ASSUME(tail_unique_a, next_tail_valid[i] |-> !fv_entry_used_nxt[next_tail[i]])
       if (next_tail_valid[i]) begin
         fv_entry_used_nxt[next_tail[i]] = 1'd1;
       end
-    end
-    if (head_valid & head_ready) begin
-      fv_entry_used_nxt[head] = 1'd0;
     end
   end
 
@@ -69,7 +70,6 @@ module br_tracker_linked_list_ctrl_fpv_monitor #(
   // ----------FV assumptions----------
   for (genvar n = 0; n < NumWritePorts; n++) begin : gen_asm
     `BR_ASSUME(tail_in_range_a, next_tail_valid[n] |-> next_tail[n] < Depth)
-    `BR_ASSUME(tail_not_in_use_a, next_tail_valid[n] |-> !fv_entry_used[next_tail[n]])
   end
   // model RAM read data
   if (RamReadLatency == 0) begin : gen_latency0
@@ -108,6 +108,15 @@ module br_tracker_linked_list_ctrl_fpv_monitor #(
   // ----------Critical Covers----------
   `BR_COVER(all_next_tail_valid_c, &next_tail_valid)
   `BR_COVER(all_entry_used_c, &fv_entry_used)
+
+  // ----------Bug Reproduction Assertions----------
+  for (genvar a = 0; a < NumWritePorts; a++) begin : gen_a
+    for (genvar b = a + 1; b < NumWritePorts; b++) begin : gen_b
+      `BR_ASSERT(
+          ptr_ram_wr_conflict_a,
+          (ptr_ram_wr_valid[a] && ptr_ram_wr_valid[b]) |-> ptr_ram_wr_addr[a] != ptr_ram_wr_addr[b])
+    end
+  end
 
 endmodule : br_tracker_linked_list_ctrl_fpv_monitor
 


### PR DESCRIPTION
While analyzing issue 1068, I found out fv_ram can mask bug.
The FV monitor’s abstract RAM model is:

```
always_ff @(posedge clk) begin
  for (int i = 0; i < NumWritePorts; i++) begin
    if (ptr_ram_wr_valid[i]) begin
      fv_ram[ptr_ram_wr_addr[i]] <= ptr_ram_wr_data[i];
    end
  end
end
```
When both ports write fv_ram[2] in the same procedural block, the later nonblocking assignment wins in the model. Since the loop visits port 0 before port 1, the model effectively resolves the collision as:

fv_ram[2] = 1
That is exactly the “good” result the controller wanted. So the scoreboard sees a valid chain, 2 -> 1, and just pass.

So, I added explicit checks to check address collision: ptr_ram_wr_conflict_a.
This is added in all fv_ram usage in bedrock.
