### PR TITLE
[fv] Add same cycle write address conflict assertion to fv_ram

### DIFF
--- a/fifo/fpv/BUILD.bazel
+++ b/fifo/fpv/BUILD.bazel
@@ -18,6 +18,8 @@ verilog_library(
     name = "br_fifo_fv_ram",
     srcs = ["br_fifo_fv_ram.sv"],
     deps = [
+        "//macros:br_asserts",
+        "//macros:br_registers",
         "//pkg:br_math_pkg",
     ],
 )

--- a/fifo/fpv/br_fifo_fv_ram.sv
+++ b/fifo/fpv/br_fifo_fv_ram.sv
@@ -52,6 +52,17 @@ module br_fifo_fv_ram #(
     end
   end
 
+  // ----------FV assertions----------
+  if (NumWritePorts > 1) begin : gen_write_conflict_checks
+    for (genvar porta = 0; porta < (NumWritePorts - 1); porta++) begin : gen_write_conflict_a
+      for (genvar portb = porta + 1; portb < NumWritePorts; portb++) begin : gen_write_conflict_b
+        `BR_ASSERT(no_write_conflict_a,
+                   (ram_wr_valid[porta] && ram_wr_valid[portb]) |->
+                       ram_wr_addr[porta] != ram_wr_addr[portb])
+      end
+    end
+  end
+
   // ----------FV assumptions----------
   for (genvar r = 0; r < NumReadPorts; r++) begin : gen_asm
     if (RamReadLatency == 0) begin : gen_lat0

--- a/fpv/lib/fv_ram.sv
+++ b/fpv/lib/fv_ram.sv
@@ -45,6 +45,17 @@ module fv_ram #(
   end
   `BR_REGN(fv_ram_data, fv_ram_data_next)
 
+  // ----------FV assertions----------
+  if (NumWritePorts > 1) begin : gen_write_conflict_checks
+    for (genvar porta = 0; porta < (NumWritePorts - 1); porta++) begin : gen_write_conflict_a
+      for (genvar portb = porta + 1; portb < NumWritePorts; portb++) begin : gen_write_conflict_b
+        `BR_ASSERT(no_write_conflict_a,
+                   (ram_wr_valid[porta] && ram_wr_valid[portb]) |->
+                       ram_wr_addr[porta] != ram_wr_addr[portb])
+      end
+    end
+  end
+
   // ----------FV assumptions----------
   for (genvar r = 0; r < NumReadPorts; r++) begin : gen_asm
     if (RamReadLatency == 0) begin : gen_lat0

--- a/vcf_2025_env.sh
+++ b/vcf_2025_env.sh
@@ -1,5 +1,0 @@
-source /eda-tools/oai/chili-hw-infra/latest/env/bash/bashrc
-module load jalapeno_setup/latest
-module load synopsys/vc_formal/X-2025.06-SP2-3
-which vcf
-printenv

--- a/vcf_2025_env.sh
+++ b/vcf_2025_env.sh
@@ -1,0 +1,5 @@
+source /eda-tools/oai/chili-hw-infra/latest/env/bash/bashrc
+module load jalapeno_setup/latest
+module load synopsys/vc_formal/X-2025.06-SP2-3
+which vcf
+printenv


### PR DESCRIPTION
For bedrock, fv_ram is only used at 3 places.
Two are changed in this PR, LinkedList reference is changed in PR #1070.