### PR TITLE
[fv] Add zero-filled value check on last flit

### DIFF
--- a/flow/fpv/serializer/br_flow_deserializer_fpv_monitor.sv
+++ b/flow/fpv/serializer/br_flow_deserializer_fpv_monitor.sv
@@ -23,7 +23,7 @@
 //     3     | 1'b1       | 8'h01     | 1'b0      | stable        | 1'b1      | 32'h01234567 | 1'b0     | 2'd0                     | 3'd2
 //     4     | 1'b1       | 8'h0D     | 1'b0      | 3'd5          | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'd0                     | 3'dX
 //     5     | 1'b1       | 8'hF0     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'd0                     | 3'dX
-//     6     | 1'b1       | 8'hAD     | 1'b1      | stable        | 1'b1      | 32'hXXADF00D | 1'b1     | 2'd1                     | 3'd5
+//     6     | 1'b1       | 8'hAD     | 1'b1      | stable        | 1'b1      | 32'h00ADF00D | 1'b1     | 2'd1                     | 3'd5
 
 `include "br_asserts.svh"
 `include "br_registers.svh"
@@ -103,11 +103,21 @@ module br_flow_deserializer_fpv_monitor #(
         `BR_ASSERT(data_integrity_a,
                    pop_valid && (pop_last_dont_care_count == i) |->
                   pop_data[PopMsb-1:PopLsb] == fv_pop_data[PopMsb-1:PopLsb])
+        if (i > 0) begin : gen_tail
+          `BR_ASSERT(tail_zero_fill_a,
+                     pop_valid && pop_last && (pop_last_dont_care_count == i) |->
+                     pop_data[PopLsb-1:0] == '0)
+        end
       end else begin : gen_lsb
         localparam int PopMsb = PushWidth * (MAX + 1 - i);
         `BR_ASSERT(data_integrity_a,
                    pop_valid && (pop_last_dont_care_count == i) |->
                   pop_data[PopMsb-1:0] == fv_pop_data[PopMsb-1:0])
+        if (i > 0) begin : gen_tail
+          `BR_ASSERT(tail_zero_fill_a,
+                     pop_valid && pop_last && (pop_last_dont_care_count == i) |->
+                     pop_data[PopWidth-1:PopMsb] == '0)
+        end
       end
     end
   end else begin : gen_pass_through

--- a/flow/rtl/br_flow_deserializer.sv
+++ b/flow/rtl/br_flow_deserializer.sv
@@ -73,7 +73,7 @@
 //     3     | 1'b1       | 8'h01     | 1'b0      | stable        | 1'b1      | 32'h01234567 | 1'b0     | 2'd0                     | 3'd2
 //     4     | 1'b1       | 8'h0D     | 1'b0      | 3'd5          | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'd0                     | 3'dX
 //     5     | 1'b1       | 8'hF0     | 1'b0      | stable        | 1'b0      | 32'hXXXXXXXX | 1'bX     | 2'd0                     | 3'dX
-//     6     | 1'b1       | 8'hAD     | 1'b1      | stable        | 1'b1      | 32'hXXADF00D | 1'b1     | 2'd1                     | 3'd5
+//     6     | 1'b1       | 8'hAD     | 1'b1      | stable        | 1'b1      | 32'h00ADF00D | 1'b1     | 2'd1                     | 3'd5
 
 `include "br_asserts.svh"
 `include "br_asserts_internal.svh"


### PR DESCRIPTION
FV missed this bug because I missed this in RTL comment:
// If DeserializeMostSignificantFirst is 1, then the zero-filled values occupy the least-significant portion of
// the final pop flit; otherwise, they occupy the most-significant portion.

Added checker on this and modified typo in RTL/FPV comment.