### PR TITLE
[fv] disable unreachable cover when no staging buffer

### DIFF
--- a/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv.jg.tcl
@@ -12,6 +12,8 @@ assume -name no_data_ram_rd_data_valid {rst |-> data_ram_rd_data_valid == 'd0}
 assume -name no_ptr_ram_rd_data_valid {rst |-> ptr_ram_rd_data_valid == 'd0}
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
+set DataRamReadLatency $param_list(DataRamReadLatency)
+set RegisterPopOutputs $param_list(RegisterPopOutputs)
 for {set i 0} {$i < $NumReadPorts} {incr i} {
   assume -name grant_onehot_during_reset_$i "\$onehot0(arb_grant\[$i\])"
 }
@@ -30,6 +32,13 @@ set_prove_time_limit 600s
 # ready to hold until valid is asserted.
 # TODO(zhemao): Find a way to disable in RTL
 cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
+
+# DataRamReadLatency=0 and RegisterPopOutputs=0 selects the no-staging-buffer
+# path. There, pop_valid is gated by pop_ready through the RAM-read fork, so
+# the internal pop-side backpressure cover is structurally unreachable.
+if {$DataRamReadLatency == 0 && $RegisterPopOutputs eq "1'b0"} {
+  cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.gen_backpressure_checks.gen_cover_without_stability.gen_per_flow*0*.backpressure_c
+}
 
 # prove command
 prove -all

--- a/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_fpv.jg.tcl
@@ -18,6 +18,8 @@ assume -name no_data_ram_rd_data_valid {rst | push_sender_in_reset |-> data_ram_
 assume -name no_ptr_ram_rd_data_valid {rst | push_sender_in_reset |-> ptr_ram_rd_data_valid == 'd0}
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
+set DataRamReadLatency $param_list(DataRamReadLatency)
+set RegisterPopOutputs $param_list(RegisterPopOutputs)
 for {set i 0} {$i < $NumReadPorts} {incr i} {
   assume -name grant_onehot_during_reset_$i "\$onehot0(arb_grant\[$i\])"
 }
@@ -37,6 +39,13 @@ set_prove_time_limit 600s
 # ready to hold until valid is asserted.
 # TODO(zhemao): Find a way to disable in RTL
 cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
+
+# DataRamReadLatency=0 and RegisterPopOutputs=0 selects the no-staging-buffer
+# path. There, pop_valid is gated by pop_ready through the RAM-read fork, so
+# the internal pop-side backpressure cover is structurally unreachable.
+if {$DataRamReadLatency == 0 && $RegisterPopOutputs eq "1'b0"} {
+  cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.gen_backpressure_checks.gen_cover_without_stability.gen_per_flow*0*.backpressure_c
+}
 
 # prove command
 prove -all


### PR DESCRIPTION
DUT defines:

`localparam bit HasStagingBuffer = (RamReadLatency > 0) || RegisterPopOutputs;`
So when DataRamReadLatency == 0 && RegisterPopOutputs == 0, HasStagingBuffer is false, and RTL elaborates the gen_no_buffer path instead of instantiating br_fifo_staging_buffer.

In that no-buffer path, pop_valid comes from a br_flow_fork:
```
.pop_valid_unstable({fifo_ram_rd_addr_valid[i], pop_valid[i]}),
.pop_ready({fifo_ram_rd_addr_ready[i], pop_ready[i]})
```
For the pop_valid[i] leg, the fork only asserts valid when the other leg is ready. The RAM-read-address leg is only ready when a legal read grant exists, and a legal grant requires a request. But the request side is itself gated by pop_ready[i]. Therefore if pop_ready[i] == 0, RTL cannot also have pop_valid[i] == 1.

That makes the internal cover !ready && valid on gen_per_flow[0] structurally unreachable in no-buffer mode.

After this fix, tot fifo regression is clean.