### PR TITLE
[fv] Add br_mux_onehot FPV

### DIFF
--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -25,7 +25,7 @@ import uvm_pkg::*;
 //       are no-ops.
 // * BR_ENABLE_FPV -- if not defined, then all BR_*_FPV macros are no-ops.
 // * BR_DISABLE_ASSERT_IMM -- if defined, then all BR_ASSERT_IMM*, BR_COVER_IMM*,
-//       BR_ASSERT_COMB*, and BR_ASSERT_IMM* macros are no-ops.
+//       BR_ASSERT_COMB*, and BR_COVER_COMB* macros are no-ops.
 // * BR_DISABLE_FINAL_CHECKS -- if defined, then all BR_ASSERT_FINAL macros are no-ops.
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -253,6 +253,35 @@ end
 `endif  // BR_ENABLE_FPV
 `else  // BR_ASSERT_ON
 `define BR_ASSERT_COMB_FPV(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
+`ifdef BR_ASSERT_ON
+`ifndef BR_DISABLE_ASSERT_IMM
+`define BR_ASSUME_COMB(__name__, __expr__) \
+always_comb begin  : gen_``__name__ \
+assume (__expr__); \
+end
+`else  // BR_DISABLE_ASSERT_IMM
+`define BR_ASSUME_COMB(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_DISABLE_ASSERT_IMM
+`else  // BR_ASSERT_ON
+`define BR_ASSUME_COMB(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ASSERT_ON
+
+// FPV version macros
+`ifdef BR_ASSERT_ON
+`ifdef BR_ENABLE_FPV
+`define BR_ASSUME_COMB_FPV(__name__, __expr__) \
+`BR_ASSUME_COMB(__name__, __expr__);
+`else  // BR_ENABLE_FPV
+`define BR_ASSUME_COMB_FPV(__name__, __expr__) \
+`BR_NOOP
+`endif  // BR_ENABLE_FPV
+`else  // BR_ASSERT_ON
+`define BR_ASSUME_COMB_FPV(__name__, __expr__) \
 `BR_NOOP
 `endif  // BR_ASSERT_ON
 

--- a/macros/br_asserts_test.sv
+++ b/macros/br_asserts_test.sv
@@ -118,6 +118,12 @@ module br_asserts_test;
   `BR_ASSERT_COMB(inputs_nonzero_a, (a != 0) || (b != 0))
   `BR_ASSERT_COMB_FPV(inputs_nonzero_fpv_a, (a != 0) || (b != 0))
 
+  // Use BR_ASSUME_COMB
+  // Not really useful (redundant with assert above) but it
+  // should work like an assert when not being used in formal
+  `BR_ASSUME_COMB(inputs_nonzero_m, (a != 0) || (b != 0))
+  `BR_ASSUME_COMB_FPV(inputs_nonzero_fpv_m, (a != 0) || (b != 0))
+
   // Use BR_COVER
   `BR_COVER(sum_overflow_a, sum > 15)
   `BR_COVER_FPV(sum_overflow_fpv_a, sum > 15)

--- a/mux/fpv/BUILD.bazel
+++ b/mux/fpv/BUILD.bazel
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_fpv_test_tools_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:private"])
+
+verilog_library(
+    name = "br_mux_onehot_fpv_monitor",
+    srcs = ["br_mux_onehot_fpv_monitor.sv"],
+    deps = [
+        "//macros:br_asserts",
+        "//macros:br_registers",
+        "//mux/rtl:br_mux_onehot",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_mux_onehot_fpv_monitor_elab_test",
+    tool = "verific",
+    deps = [":br_mux_onehot_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_mux_onehot_fpv_test_tools_suite",
+    custom_tcl_body = "br_mux_onehot_fpv.jg.tcl",
+    params = {
+        "EnableAssertSelectOnehot": [
+            "0",
+            "1",
+        ],
+        "NumSymbolsIn": [
+            "1",
+            "3",
+            "4",
+        ],
+        "SymbolWidth": [
+            "1",
+            "5",
+            "8",
+        ],
+    },
+    tools = {
+        "jg": "br_mux_onehot_fpv.jg.tcl",
+    },
+    top = "br_mux_onehot",
+    deps = [":br_mux_onehot_fpv_monitor"],
+)

--- a/mux/fpv/br_mux_onehot_fpv.jg.tcl
+++ b/mux/fpv/br_mux_onehot_fpv.jg.tcl
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# br_mux_onehot is a combinational DUT with no clock or reset ports.
+clock -none
+reset -none
+get_design_info
+
+prove -all

--- a/mux/fpv/br_mux_onehot_fpv_monitor.sv
+++ b/mux/fpv/br_mux_onehot_fpv_monitor.sv
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL onehot select multiplexer FPV monitor
+//
+// Testplan:
+//
+// Design specification:
+// - br_mux_onehot is a combinational N-to-1 multiplexer.
+// - NumSymbolsIn must be at least 1.
+// - SymbolWidth must be at least 1.
+// - select is expected to be onehot0 when EnableAssertSelectOnehot is set.
+// - When select has exactly one asserted bit, out should equal the selected
+//   input symbol.
+// - When select is all zero, out should be zero for NumSymbolsIn > 1.
+// - When NumSymbolsIn is 1, out should equal the single input regardless of
+//   select in synthesis semantics.
+// - When EnableAssertSelectOnehot is 0 and select is multihot, output behavior
+//   is intentionally undefined. Under SIMULATION, the DUT drives X for that
+//   case; formal proof should avoid constraining or asserting a concrete value.
+//
+// Input assumptions:
+// - Parameter legality follows the DUT static assertions.
+// - The initial proof milestone should constrain select to onehot0 only for
+//   properties that describe defined mux behavior.
+//
+// Planned summary checks:
+// - Defined select values produce the selected input data.
+// - Onehot select values produce exactly the selected input symbol.
+// - Zero select produces a zero output for multi-input muxes.
+// - Parameter sweeps cover single-input, multi-input, narrow, and wider data
+//   paths, with EnableAssertSelectOnehot both enabled and disabled.
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_mux_onehot_fpv_monitor #(
+    parameter int NumSymbolsIn = 1,
+    parameter int SymbolWidth = 1,
+    parameter bit EnableAssertSelectOnehot = 1
+) (
+    input logic [NumSymbolsIn-1:0]                  select,
+    input logic [NumSymbolsIn-1:0][SymbolWidth-1:0] in,
+    input logic [ SymbolWidth-1:0]                  out
+);
+
+  if (EnableAssertSelectOnehot) begin : gen_select_onehot0_assume
+    // Constrain the primary input to the DUT's defined integration contract.
+    `BR_ASSUME_COMB(select_onehot0_a, $onehot0(select))
+  end
+
+  if (NumSymbolsIn == 1) begin : gen_single_input_checks
+    // A single-input mux must forward its only input under synthesis
+    // semantics, regardless of the value of select.
+    `BR_ASSERT_COMB(single_input_out_a, out == in[0])
+
+    // Cover the case where the single input is selected.
+    `BR_COVER_COMB(single_input_selected_c, select[0])
+
+    // Cover the case where the single input is not selected.
+    `BR_COVER_COMB(single_input_unselected_c, !select[0])
+  end else begin : gen_multi_input_checks
+    // When no input is selected, the OR-reduction should drive zero.
+    `BR_ASSERT_COMB(zero_select_out_a, select == '0 |-> out == '0)
+
+    // Cover the all-zero select case.
+    `BR_COVER_COMB(zero_select_c, select == '0)
+
+    if (!EnableAssertSelectOnehot) begin : gen_multihot_allowed_cover
+      // Cover the undefined multihot space when the DUT is configured to allow
+      // it, without constraining the output value.
+      `BR_COVER_COMB(multihot_select_allowed_c, !$onehot0(select))
+    end
+
+    for (genvar i = 0; i < NumSymbolsIn; i++) begin : gen_selected_input_checks
+      if (EnableAssertSelectOnehot) begin : gen_selected_input_assert
+        // Onehot selection of this lane must forward exactly this input symbol.
+        `BR_ASSERT_COMB(selected_input_out_a, select[i] |-> out == in[i])
+      end
+
+      // Cover each input lane being selected.
+      `BR_COVER_COMB(selected_input_c, $onehot(select) && select[i])
+    end
+  end
+
+endmodule : br_mux_onehot_fpv_monitor
+
+bind br_mux_onehot br_mux_onehot_fpv_monitor #(
+    .NumSymbolsIn(NumSymbolsIn),
+    .SymbolWidth(SymbolWidth),
+    .EnableAssertSelectOnehot(EnableAssertSelectOnehot)
+) monitor (.*);

--- a/mux/fpv/br_mux_onehot_fpv_monitor.sv
+++ b/mux/fpv/br_mux_onehot_fpv_monitor.sv
@@ -60,7 +60,7 @@ module br_mux_onehot_fpv_monitor #(
     `BR_COVER_COMB(single_input_unselected_c, !select[0])
   end else begin : gen_multi_input_checks
     // When no input is selected, the OR-reduction should drive zero.
-    `BR_ASSERT_COMB(zero_select_out_a, select == '0 |-> out == '0)
+    `BR_ASSERT_COMB(zero_select_out_a, select != '0 || out == '0)
 
     // Cover the all-zero select case.
     `BR_COVER_COMB(zero_select_c, select == '0)
@@ -74,7 +74,7 @@ module br_mux_onehot_fpv_monitor #(
     for (genvar i = 0; i < NumSymbolsIn; i++) begin : gen_selected_input_checks
       if (EnableAssertSelectOnehot) begin : gen_selected_input_assert
         // Onehot selection of this lane must forward exactly this input symbol.
-        `BR_ASSERT_COMB(selected_input_out_a, select[i] |-> out == in[i])
+        `BR_ASSERT_COMB(selected_input_out_a, !select[i] || out == in[i])
       end
 
       // Cover each input lane being selected.


### PR DESCRIPTION
When NumSymbolsIn = 1, this mux is a passthrough, so out = in.
However, in https://github.com/xlsynth/bedrock-rtl/issues/1065, Codex found a discrepancy on how RTL handles  NumSymbolsIn = 1 vs NumSymbolsIn > 1.

Need RTL designer's clarification on this issue.
