### PR TITLE
[codex] fix br gates cdc reset sync macro

### DIFF
--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -222,6 +222,7 @@ verilog_library(
     deps = [
         ":br_asserts",
         ":br_gates",
+        "//cdc/rtl:br_cdc_rst_sync",
         "//gate/rtl:br_gate_mock",
     ],
 )

--- a/macros/br_gates.svh
+++ b/macros/br_gates.svh
@@ -136,7 +136,7 @@ br_gate_cdc_sync_arst #(__stages__) br_gate_cdc_sync_arst_``__out__`` ( \
 
 // Reset Synchronizer
 `define BR_GATE_CDC_RST_SYNC(__srst__, __arst__, __clk__) \
-br_cdc_rst_sync #(__stages__) br_cdc_rst_sync_``__srst__`` ( \
+br_cdc_rst_sync br_cdc_rst_sync_``__srst__`` ( \
     .clk(__clk__), \
     .arst(__arst__), \
     .srst(__srst__) \

--- a/macros/br_gates_test.sv
+++ b/macros/br_gates_test.sv
@@ -22,6 +22,10 @@ module br_gates_test;
   logic out_xor2;
   logic out_mux;
   logic out_clk_mux;
+  logic cdc_clk;
+  logic cdc_arst;
+  logic cdc_srst;
+  logic cdc_srst_stages;
 
   `BR_GATE_BUF(out_buf, in0)
   `BR_GATE_CLK_BUF(out_clk_buf, in0)
@@ -32,6 +36,8 @@ module br_gates_test;
   `BR_GATE_XOR2(out_xor2, in0, in1)
   `BR_GATE_MUX2(out_mux, in0, in1, mux_sel)
   `BR_GATE_CLK_MUX2(out_clk_mux, in0, in1, mux_sel)
+  `BR_GATE_CDC_RST_SYNC(cdc_srst, cdc_arst, cdc_clk)
+  `BR_GATE_CDC_RST_SYNC_STAGES(cdc_srst_stages, cdc_arst, cdc_clk, 2)
 
 
   `BR_ASSERT_COMB(out_buf_check, out_buf == in0)
@@ -49,6 +55,8 @@ module br_gates_test;
     in0 = 1'b0;
     in1 = 1'b0;
     mux_sel = 1'b0;
+    cdc_clk = 1'b0;
+    cdc_arst = 1'b0;
 
     #5 in0 = 1'b1;
     #5 mux_sel = 1'b1;


### PR DESCRIPTION
## Summary

Fixes #1064.

This removes the invalid `#__stages__` parameter override from the default `BR_GATE_CDC_RST_SYNC` macro so `br_cdc_rst_sync` uses its default `NumStages` parameter. The explicit-stage `BR_GATE_CDC_RST_SYNC_STAGES` variant remains unchanged.

The macro elaboration test now instantiates both the default and explicit-stage reset synchronizer wrappers, with the required `br_cdc_rst_sync` dependency added to the macro test target.

## Root Cause

`BR_GATE_CDC_RST_SYNC` accepted only `__srst__`, `__arst__`, and `__clk__`, but expanded to `br_cdc_rst_sync #(__stages__)`. Because `__stages__` was not a macro argument, any user of the default wrapper produced an unresolved token during elaboration instead of using the module default.

## Validation

- `bazel run //:check_env`
- `bazel test //macros:br_gates_elab_test --test_output=errors`
- `bazel test //cdc/rtl:br_cdc_rst_sync_test_suite_elab_test --test_output=errors`
- `git diff --check`
- pre-commit hooks during commit