### PR TITLE
[Bazel] Use zipapp for Verilog runner tests.

### DIFF
--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -56,6 +56,11 @@ def _write_executable_shell_script(ctx, executable_file, cmd, verbose = True, en
     if env_exports:
         for key, value in env_exports.items():
             lines.append("export {}={}".format(key, value))
+
+    # Bazel 9 exports an rlocation compatibility function whose body contains a
+    # literal "ERROR:" message. Some EDA plugins scan captured shell output for
+    # diagnostics, so keep that helper out of child tool environments.
+    lines.append("unset -f rlocation 2>/dev/null || true")
     if verbose:
         lines.append("pwd")
     lines.append(cmd)
@@ -104,7 +109,11 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
     """
     data_files = getattr(ctx.files, "data", [])
     runfiles = list(data_files)
-    runfiles += ctx.files.verilog_runner_tool
+    verilog_runner_files_to_run = ctx.attr.verilog_runner_tool[DefaultInfo].files_to_run
+    if test and not verilog_runner_files_to_run.executable:
+        fail("verilog_runner_tool must be an executable target for Verilog tests.")
+    if test or not verilog_runner_files_to_run.executable:
+        runfiles += ctx.files.verilog_runner_tool
     runfiles += ctx.files.verilog_runner_data
     runfiles += ctx.files.verilog_runner_plugins
     srcs = get_transitive(ctx = ctx, srcs_not_hdrs = True).to_list()
@@ -151,12 +160,15 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
         args += ctx.attr.runner_flags[VerilogRunnerFlagsInfo].runner_flags
     args += extra_args
 
-    # TODO: This is a hack. We should use the py_binary target directly, but I'm not sure how to get the environment
-    # to work correctly when we wrap the py_binary in a shell script that gets invoked later.
+    generator_tools = []
     if test:
-        runner_path = ctx.files.verilog_runner_tool[0].short_path
+        runner_cmd_prefix = [verilog_runner_files_to_run.executable.short_path]
+    elif verilog_runner_files_to_run.executable:
+        runner_cmd_prefix = [verilog_runner_files_to_run.executable.path]
+        generator_tools = [verilog_runner_files_to_run]
     else:
         runner_path = ctx.files.verilog_runner_tool[0].path
+        runner_cmd_prefix = ["python3", runner_path]
     plugin_paths = []
     for plugin in ctx.files.verilog_runner_plugins:
         if plugin.dirname not in plugin_paths:
@@ -167,8 +179,12 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
         "VERILOG_RUNNER_PLUGIN_PATH": "${VERILOG_RUNNER_PLUGIN_PATH}:" + verilog_runner_plugin_paths,
     }
 
-    verilog_runner_cmd = " ".join(["python3"] + [runner_path] + [subcmd] + args + src_files)
+    verilog_runner_cmd = " ".join(runner_cmd_prefix + [subcmd] + args + src_files)
     verilog_runner_runfiles = ctx.runfiles(files = srcs + hdrs + runfiles + extra_runfiles)
+    if test:
+        verilog_runner_runfiles = verilog_runner_runfiles.merge(
+            ctx.attr.verilog_runner_tool[DefaultInfo].default_runfiles,
+        )
     if test:
         runner = ctx.label.name + "_runner.sh"
         runner_executable_file = ctx.actions.declare_file(runner)
@@ -220,6 +236,7 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
             outputs = [ctx.outputs.tarball],
             executable = generator_executable_file,
             arguments = [],
+            tools = generator_tools,
             use_default_shell_env = True,
             progress_message = "Generating FPV sandbox for %{label}",
         )
@@ -325,7 +342,7 @@ rule_verilog_elab_test = rule(
         "defines": attr.string_list(doc = "Preprocessor defines to pass to the Verilog compiler."),
         "params": attr.string_dict(doc = "Verilog module parameters to set in the instantiation of the top-level module."),
         "top": attr.string(doc = "The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name."),
-        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The executable Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner_zipapp", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,
@@ -408,7 +425,7 @@ rule_verilog_lint_test = rule(
             allow_files = True,
             doc = "The lint policy file to use. If not provided, then the default tool policy is used (typically provided through an environment variable).",
         ),
-        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The executable Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner_zipapp", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,
@@ -494,7 +511,7 @@ rule_verilog_sim_test = rule(
             doc = "Run UVM test.",
             default = False,
         ),
-        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The executable Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner_zipapp", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,
@@ -608,7 +625,7 @@ rule_verilog_fpv_test = rule(
             doc = "Only run elaboration.",
             default = False,
         ),
-        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The executable Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner_zipapp", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,
@@ -708,7 +725,7 @@ rule_verilog_fpv_sandbox = rule(
             doc = "Only run elaboration.",
             default = False,
         ),
-        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -80,7 +80,7 @@ Tests that a Verilog or SystemVerilog design elaborates. Needs VERILOG_RUNNER_PL
 | <a id="rule_verilog_elab_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_elab_test-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_elab_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
-| <a id="rule_verilog_elab_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
+| <a id="rule_verilog_elab_test-verilog_runner_tool"></a>verilog_runner_tool |  The executable Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner_zipapp"`  |
 
 
 <a id="rule_verilog_fpv_sandbox"></a>
@@ -120,7 +120,7 @@ Writes FPV files and run scripts into a tarball for independent execution outsid
 | <a id="rule_verilog_fpv_sandbox-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_fpv_sandbox-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_fpv_sandbox-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
-| <a id="rule_verilog_fpv_sandbox-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
+| <a id="rule_verilog_fpv_sandbox-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner"`  |
 
 
 <a id="rule_verilog_fpv_test"></a>
@@ -160,7 +160,7 @@ Runs Verilog/SystemVerilog compilation and formal verification in one command. T
 | <a id="rule_verilog_fpv_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_fpv_test-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_fpv_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
-| <a id="rule_verilog_fpv_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
+| <a id="rule_verilog_fpv_test-verilog_runner_tool"></a>verilog_runner_tool |  The executable Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner_zipapp"`  |
 
 
 <a id="rule_verilog_lint_test"></a>
@@ -194,7 +194,7 @@ Tests that a Verilog or SystemVerilog design passes a set of static lint checks.
 | <a id="rule_verilog_lint_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_lint_test-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_lint_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
-| <a id="rule_verilog_lint_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
+| <a id="rule_verilog_lint_test-verilog_runner_tool"></a>verilog_runner_tool |  The executable Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner_zipapp"`  |
 
 
 <a id="rule_verilog_sim_test"></a>
@@ -231,7 +231,7 @@ Runs Verilog/SystemVerilog compilation and simulation in one command. This rule 
 | <a id="rule_verilog_sim_test-uvm"></a>uvm |  Run UVM test.   | Boolean | optional |  `False`  |
 | <a id="rule_verilog_sim_test-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_sim_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py"]`  |
-| <a id="rule_verilog_sim_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
+| <a id="rule_verilog_sim_test-verilog_runner_tool"></a>verilog_runner_tool |  The executable Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner_zipapp"`  |
 | <a id="rule_verilog_sim_test-waves"></a>waves |  Enable waveform dumping.   | Boolean | optional |  `False`  |
 
 

--- a/python/verilog_runner/BUILD.bazel
+++ b/python/verilog_runner/BUILD.bazel
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@rules_python//python/zipapp:py_zipapp_binary.bzl", "py_zipapp_binary")
 
 package(default_visibility = ["//visibility:public"])
 
-# TODO: This is a hack. We should use the py_binary target directly, but I'm not sure how to get the environment
-# to work correctly when we wrap the py_binary in a shell script that gets invoked later.
 exports_files([
     "verilog_runner.py",
     "cli.py",
@@ -37,9 +36,16 @@ py_binary(
         "plugins.py",
         "verilog_runner.py",
     ],
+    imports = ["."],
+    legacy_create_init = False,
     deps = [
         ":util",
     ],
+)
+
+py_zipapp_binary(
+    name = "verilog_runner_zipapp",
+    binary = ":verilog_runner",
 )
 
 py_test(

--- a/python/verilog_runner/verilog_runner.py
+++ b/python/verilog_runner/verilog_runner.py
@@ -8,6 +8,8 @@ import logging
 import os
 import sys
 
+sys.path.insert(0, os.path.dirname(__file__))
+
 from cli import Elab, Lint, Sim, Fpv, add_common_args, parse_params
 from plugins import discover_plugins
 from util import print_greeting, init_root_logger


### PR DESCRIPTION
Add a `zipapp` entry point for the Verilog runner and make Verilog test rules use it by default. This avoids expanding the full `rules_python` runtime tree into each test action's runfiles under Bazel 9 while keeping the FPV sandbox path on the normal `py_binary`.

Keep `verilog_runner_data` in test runfiles unconditionally so downstream custom runner setups continue to work with the documented public `attr`.