### PR TITLE
[fv] Add br_fifo_shared_pop_ctrl credit variation FPV

### DIFF
--- a/fifo/fpv/BUILD.bazel
+++ b/fifo/fpv/BUILD.bazel
@@ -13,6 +13,16 @@ verilog_library(
     ],
 )
 
+# pop credit checkers
+verilog_library(
+    name = "br_pop_credit_fpv_monitor",
+    srcs = ["br_pop_credit_fpv_monitor.sv"],
+    deps = [
+        "//macros:br_asserts",
+        "//macros:br_registers",
+    ],
+)
+
 # FV Ram model
 verilog_library(
     name = "br_fifo_fv_ram",

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/BUILD.bazel
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/BUILD.bazel
@@ -8,10 +8,20 @@ package(default_visibility = ["//fifo/fpv:__subpackages__"])
 
 # Shared pop controller checkers
 verilog_library(
+    name = "br_fifo_shared_pop_ctrl_common_fpv_checker",
+    srcs = ["br_fifo_shared_pop_ctrl_common_fpv_checker.sv"],
+    deps = [
+        "//fpv/lib:fv_delay",
+        "//macros:br_asserts",
+        "//macros:br_registers",
+    ],
+)
+
+verilog_library(
     name = "br_fifo_shared_pop_ctrl_fpv_checker",
     srcs = ["br_fifo_shared_pop_ctrl_fpv_checker.sv"],
     deps = [
-        "//fpv/lib:fv_delay",
+        ":br_fifo_shared_pop_ctrl_common_fpv_checker",
         "//fpv/lib:fv_valid_ready_check",
         "//macros:br_asserts",
         "//macros:br_registers",
@@ -160,4 +170,82 @@ br_verilog_fpv_test_tools_suite(
     },
     top = "br_fifo_shared_pop_ctrl_ext_arbiter",
     deps = [":br_fifo_shared_pop_ctrl_ext_arbiter_fpv_monitor"],
+)
+
+#################################################################
+# Bedrock-RTL Shared Multi-FIFO Credit Pop Controller
+verilog_library(
+    name = "br_fifo_shared_pop_ctrl_credit_fpv_checker",
+    srcs = ["br_fifo_shared_pop_ctrl_credit_fpv_checker.sv"],
+    deps = [
+        ":br_fifo_shared_pop_ctrl_common_fpv_checker",
+        "//fifo/fpv:br_pop_credit_fpv_monitor",
+        "//fpv/lib:fv_valid_ready_check",
+        "//macros:br_asserts",
+        "//macros:br_registers",
+    ],
+)
+
+verilog_library(
+    name = "br_fifo_shared_pop_ctrl_credit_fpv_monitor",
+    srcs = ["br_fifo_shared_pop_ctrl_credit_fpv_monitor.sv"],
+    deps = [
+        ":br_fifo_shared_pop_ctrl_credit_fpv_checker",
+        "//fifo/rtl:br_fifo_shared_pop_ctrl_credit",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_shared_pop_ctrl_credit_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_fifo_shared_pop_ctrl_credit_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_shared_pop_ctrl_credit_test_port",
+    elab_opts = [
+        "-parameter Depth 5",
+        "-parameter PopMaxCredits 2",
+    ],
+    params = {
+        "NumFifos": [
+            "2",
+            "4",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_shared_pop_ctrl_credit_fpv.jg.tcl",
+    },
+    top = "br_fifo_shared_pop_ctrl_credit",
+    deps = [":br_fifo_shared_pop_ctrl_credit_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_shared_pop_ctrl_credit_test_latency",
+    elab_opts = [
+        "-parameter Depth 5",
+        "-parameter NumFifos 2",
+        "-parameter NumReadPorts 1",
+        "-parameter PopMaxCredits 2",
+    ],
+    params = {
+        "RamReadLatency": [
+            "0",
+            "1",
+        ],
+        "RegisterDeallocation": [
+            "0",
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_shared_pop_ctrl_credit_fpv.jg.tcl",
+    },
+    top = "br_fifo_shared_pop_ctrl_credit",
+    deps = [":br_fifo_shared_pop_ctrl_credit_fpv_monitor"],
 )

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/BUILD.bazel
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/BUILD.bazel
@@ -101,15 +101,18 @@ br_verilog_fpv_test_tools_suite(
 #################################################################
 # Bedrock-RTL Shared Multi-FIFO Pop Controller with external arbiter interface
 verilog_library(
+    name = "br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker",
+    srcs = ["br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker.sv"],
+    deps = ["//macros:br_asserts"],
+)
+
+verilog_library(
     name = "br_fifo_shared_pop_ctrl_ext_arbiter_fpv_monitor",
-    srcs = [
-        "br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker.sv",
-        "br_fifo_shared_pop_ctrl_ext_arbiter_fpv_monitor.sv",
-    ],
+    srcs = ["br_fifo_shared_pop_ctrl_ext_arbiter_fpv_monitor.sv"],
     deps = [
+        ":br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker",
         ":br_fifo_shared_pop_ctrl_fpv_checker",
         "//fifo/rtl:br_fifo_shared_pop_ctrl_ext_arbiter",
-        "//macros:br_asserts",
     ],
 )
 
@@ -248,4 +251,71 @@ br_verilog_fpv_test_tools_suite(
     },
     top = "br_fifo_shared_pop_ctrl_credit",
     deps = [":br_fifo_shared_pop_ctrl_credit_fpv_monitor"],
+)
+
+#################################################################
+# Bedrock-RTL Shared Multi-FIFO Credit Pop Controller with external arbiter interface
+verilog_library(
+    name = "br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor",
+    srcs = ["br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor.sv"],
+    deps = [
+        ":br_fifo_shared_pop_ctrl_credit_fpv_checker",
+        ":br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker",
+        "//fifo/rtl:br_fifo_shared_pop_ctrl_credit_ext_arbiter",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_shared_pop_ctrl_credit_ext_arbiter_test_port",
+    elab_opts = [
+        "-parameter Depth 5",
+        "-parameter PopMaxCredits 2",
+    ],
+    params = {
+        "NumFifos": [
+            "2",
+            "4",
+        ],
+        "NumReadPorts": [
+            "1",
+            "2",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_shared_pop_ctrl_credit_fpv.jg.tcl",
+    },
+    top = "br_fifo_shared_pop_ctrl_credit_ext_arbiter",
+    deps = [":br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_fifo_shared_pop_ctrl_credit_ext_arbiter_test_latency",
+    elab_opts = [
+        "-parameter Depth 5",
+        "-parameter NumFifos 2",
+        "-parameter NumReadPorts 1",
+        "-parameter PopMaxCredits 2",
+    ],
+    params = {
+        "RamReadLatency": [
+            "0",
+            "1",
+        ],
+        "RegisterDeallocation": [
+            "0",
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_fifo_shared_pop_ctrl_credit_fpv.jg.tcl",
+    },
+    top = "br_fifo_shared_pop_ctrl_credit_ext_arbiter",
+    deps = [":br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor"],
 )

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_common_fpv_checker.sv
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_common_fpv_checker.sv
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_fifo_shared_pop_ctrl_common_fpv_checker #(
+    parameter int NumReadPorts = 1,
+    parameter int NumFifos = 1,
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter bit RegisterDeallocation = 0,
+    parameter int RamReadLatency = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int FifoIdxWidth = (NumFifos <= 1) ? 1 : $clog2(NumFifos)
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [FifoIdxWidth-1:0] fv_fifo_id,
+    output logic [NumFifos-1:0] head_hs,
+    output logic [NumReadPorts-1:0][FifoIdxWidth-1:0] rd_fifo_id,
+    output logic [NumReadPorts-1:0] fv_rsp_valid,
+
+    input logic [NumFifos-1:0] head_valid,
+    input logic [NumFifos-1:0] head_ready,
+    input logic [NumFifos-1:0][AddrWidth-1:0] head,
+
+    input logic [NumFifos-1:0] ram_empty,
+
+    input logic [NumFifos-1:0] dealloc_valid,
+    input logic [NumFifos-1:0][AddrWidth-1:0] dealloc_entry_id,
+
+    input logic [NumReadPorts-1:0] data_ram_rd_addr_valid,
+    input logic [NumReadPorts-1:0][AddrWidth-1:0] data_ram_rd_addr,
+    input logic [NumReadPorts-1:0] data_ram_rd_data_valid
+);
+
+  assign head_hs = head_valid & head_ready;
+
+  always_comb begin
+    rd_fifo_id = '0;
+    for (int p = 0; p < NumReadPorts; p++) begin
+      for (int f = 0; f < NumFifos; f++) begin
+        if (data_ram_rd_addr_valid[p] && head_hs[f] && (data_ram_rd_addr[p] == head[f])) begin
+          rd_fifo_id[p] = FifoIdxWidth'(f);
+        end
+      end
+    end
+  end
+
+  // The symbolic FIFO selection lets one scoreboard prove per-FIFO data ordering.
+  `BR_ASSUME(fv_fifo_id_range_a, $stable(fv_fifo_id) && (fv_fifo_id < NumFifos))
+
+  for (genvar i = 0; i < NumFifos; i++) begin : gen_fifo
+    logic head_has_read_addr;
+
+    always_comb begin
+      head_has_read_addr = 1'b0;
+      for (int p = 0; p < NumReadPorts; p++) begin
+        head_has_read_addr |= data_ram_rd_addr_valid[p] && (data_ram_rd_addr[p] == head[i]);
+      end
+    end
+
+    // Pointer management must not offer a head pointer for an empty logical FIFO.
+    `BR_ASSUME(no_head_when_ram_empty_a, ram_empty[i] |-> !head_valid[i])
+
+    // Every accepted head pointer must issue exactly as a shared RAM read request.
+    `BR_ASSERT(accepted_head_has_read_a, head_hs[i] |-> head_has_read_addr)
+
+    // Exercise the deallocation path for every logical FIFO.
+    `BR_COVER(dealloc_valid_c, dealloc_valid[i])
+  end
+
+  for (genvar i = 0; i < NumFifos; i++) begin : gen_unique_heads_i
+    for (genvar j = i + 1; j < NumFifos; j++) begin : gen_unique_heads_j
+      // Shared FIFO storage must not present the same allocated entry as two FIFO heads.
+      `BR_ASSUME(unique_accepted_heads_a, !head_hs[i] || !head_hs[j] || (head[i] != head[j]))
+    end
+  end
+
+  for (genvar p = 0; p < NumReadPorts; p++) begin : gen_read_port_checks
+    logic rd_addr_matches_accepted_head;
+
+    always_comb begin
+      rd_addr_matches_accepted_head = 1'b0;
+      for (int f = 0; f < NumFifos; f++) begin
+        rd_addr_matches_accepted_head |= head_hs[f] && (data_ram_rd_addr[p] == head[f]);
+      end
+    end
+
+    // Each read request must come from a head pointer accepted in the same cycle.
+    `BR_ASSERT(read_addr_from_head_a, data_ram_rd_addr_valid[p] |-> rd_addr_matches_accepted_head)
+
+    if (RamReadLatency == 0) begin : gen_lat0
+      assign fv_rsp_valid[p] = data_ram_rd_data_valid[p] && (rd_fifo_id[p] == fv_fifo_id);
+
+      // The external RAM response valid must match the same-cycle read request.
+      `BR_ASSUME(ram_response_valid_latency_a,
+                 data_ram_rd_data_valid[p] == data_ram_rd_addr_valid[p])
+    end else begin : gen_lat_non0
+      logic fv_rsp_fifo_match;
+
+      fv_delay #(
+          .Width(1),
+          .NumStages(RamReadLatency)
+      ) fv_delay_rsp_fifo_match (
+          .clk,
+          .rst,
+          .in (rd_fifo_id[p] == fv_fifo_id),
+          .out(fv_rsp_fifo_match)
+      );
+
+      assign fv_rsp_valid[p] = data_ram_rd_data_valid[p] && fv_rsp_fifo_match;
+
+      // No RAM response may appear until a post-reset read can mature.
+      `BR_ASSUME(no_ram_response_after_reset_a,
+                 $fell(rst) |-> !data_ram_rd_data_valid[p] [* RamReadLatency])
+
+      // The external RAM response valid must match the configured delayed read request.
+      `BR_ASSUME(ram_response_valid_latency_a,
+                 ##RamReadLatency data_ram_rd_data_valid[p] == $past(
+                     data_ram_rd_addr_valid[p], RamReadLatency
+                 ))
+    end
+
+    // Exercise every shared RAM read port.
+    `BR_COVER(read_port_valid_c, data_ram_rd_addr_valid[p])
+  end
+
+  // The number of accepted heads and read requests must match cycle-by-cycle.
+  `BR_ASSERT(read_count_matches_head_hs_a, $countones(data_ram_rd_addr_valid) == $countones(head_hs
+                                                                                               ))
+
+  // The pop side can accept at most one head per physical read port per cycle.
+  `BR_ASSERT(head_hs_read_port_capacity_a, $countones(head_hs) <= NumReadPorts)
+
+  if (RegisterDeallocation) begin : gen_registered_deallocation_check
+    logic [NumFifos-1:0] expected_dealloc_valid_q;
+
+    `BR_REG(expected_dealloc_valid_q, head_hs)
+
+    // Registered deallocation valid must be the previous accepted-head vector.
+    `BR_ASSERT(dealloc_valid_registered_a, dealloc_valid == expected_dealloc_valid_q)
+
+    for (genvar i = 0; i < NumFifos; i++) begin : gen_dealloc_entry_checks
+      // Registered deallocation entry ID must name the previously accepted head entry.
+      `BR_ASSERT(dealloc_entry_id_a, ##1 dealloc_valid[i] |-> dealloc_entry_id[i] == $past(head[i]))
+    end
+  end else begin : gen_unregistered_deallocation_check
+    // Unregistered deallocation valid must match the accepted-head vector immediately.
+    `BR_ASSERT(dealloc_valid_unregistered_a, dealloc_valid == head_hs)
+
+    for (genvar i = 0; i < NumFifos; i++) begin : gen_dealloc_entry_checks
+      // Unregistered deallocation entry ID must name the same-cycle accepted head entry.
+      `BR_ASSERT(dealloc_entry_id_a, dealloc_valid[i] |-> dealloc_entry_id[i] == head[i])
+    end
+  end
+
+  if (NumReadPorts < NumFifos) begin : gen_read_contention_cover
+    // Exercise read-port contention when the configuration has fewer read ports than FIFOs.
+    `BR_COVER(read_contention_c, $countones(head_valid) > NumReadPorts)
+  end
+
+  // Exercise a cycle where the controller uses all available read ports.
+  `BR_COVER(all_read_ports_used_c, &data_ram_rd_addr_valid)
+
+endmodule : br_fifo_shared_pop_ctrl_common_fpv_checker

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor.sv
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bind wrapper for the credit shared multi-FIFO pop-controller checker on the
+// ext-arbiter variant.
+//
+// Testplan
+//
+// Design intent:
+// - Verify the credit pop controller behavior shared with br_fifo_shared_pop_ctrl_credit.
+// - Verify the external arbiter request/grant/can_grant interface contract.
+// - Reuse the common credit checker for RAM read, pop response, pop credit, empty, and
+//   deallocation behavior.
+// - Reuse the external-arbiter checker for arbiter assumptions and request assertions.
+
+module br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor #(
+    parameter int NumReadPorts = 1,
+    parameter int NumFifos = 1,
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter int PopMaxCredits = 1,
+    parameter bit RegisterDeallocation = 0,
+    parameter int RamReadLatency = 0,
+    parameter bit ArbiterAlwaysGrants = 1,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CreditWidth = $clog2(PopMaxCredits + 1),
+    localparam int FifoIdWidth = (NumFifos <= 1) ? 1 : $clog2(NumFifos)
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [NumFifos-1:0] head_valid,
+    input logic [NumFifos-1:0] head_ready,
+    input logic [NumFifos-1:0][AddrWidth-1:0] head,
+
+    input logic [NumFifos-1:0] ram_empty,
+
+    input logic pop_sender_in_reset,
+    input logic pop_receiver_in_reset,
+    input logic [NumFifos-1:0] pop_credit,
+    input logic [NumReadPorts-1:0] pop_valid,
+    input logic [NumReadPorts-1:0][FifoIdWidth-1:0] pop_fifo_id,
+    input logic [NumReadPorts-1:0][Width-1:0] pop_data,
+    input logic [NumFifos-1:0] pop_empty,
+
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_initial_pop,
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_withhold_pop,
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_available_pop,
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_count_pop,
+
+    input logic [NumFifos-1:0] dealloc_valid,
+    input logic [NumFifos-1:0][AddrWidth-1:0] dealloc_entry_id,
+
+    input logic [NumReadPorts-1:0] data_ram_rd_addr_valid,
+    input logic [NumReadPorts-1:0][AddrWidth-1:0] data_ram_rd_addr,
+    input logic [NumReadPorts-1:0] data_ram_rd_data_valid,
+    input logic [NumReadPorts-1:0][Width-1:0] data_ram_rd_data,
+
+    input logic [NumReadPorts-1:0][NumFifos-1:0] arb_request,
+    input logic [NumReadPorts-1:0][NumFifos-1:0] arb_grant,
+    input logic [NumReadPorts-1:0][NumFifos-1:0] arb_can_grant,
+    input logic [NumReadPorts-1:0] arb_enable_priority_update
+);
+
+  br_fifo_shared_pop_ctrl_credit_fpv_checker #(
+      .NumReadPorts(NumReadPorts),
+      .NumFifos(NumFifos),
+      .Depth(Depth),
+      .Width(Width),
+      .PopMaxCredits(PopMaxCredits),
+      .RegisterDeallocation(RegisterDeallocation),
+      .RamReadLatency(RamReadLatency)
+  ) checker_inst (
+      .clk,
+      .rst,
+      .head_valid,
+      .head_ready,
+      .head,
+      .ram_empty,
+      .pop_sender_in_reset,
+      .pop_receiver_in_reset,
+      .pop_credit,
+      .pop_valid,
+      .pop_fifo_id,
+      .pop_data,
+      .pop_empty,
+      .credit_initial_pop,
+      .credit_withhold_pop,
+      .credit_available_pop,
+      .credit_count_pop,
+      .dealloc_valid,
+      .dealloc_entry_id,
+      .data_ram_rd_addr_valid,
+      .data_ram_rd_addr,
+      .data_ram_rd_data_valid,
+      .data_ram_rd_data
+  );
+
+  br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker #(
+      .NumReadPorts(NumReadPorts),
+      .NumFifos(NumFifos),
+      .ArbiterAlwaysGrants(ArbiterAlwaysGrants),
+      // Credit withholding can withdraw request eligibility before grant.
+      .EnableAssertRequestStability(0)
+  ) ext_arb_checker_inst (
+      .clk,
+      .rst,
+      .arb_request,
+      .arb_grant,
+      .arb_can_grant,
+      .arb_enable_priority_update
+  );
+
+endmodule : br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor
+
+bind br_fifo_shared_pop_ctrl_credit_ext_arbiter
+    br_fifo_shared_pop_ctrl_credit_ext_arbiter_fpv_monitor #(
+    .NumReadPorts(NumReadPorts),
+    .NumFifos(NumFifos),
+    .Depth(Depth),
+    .Width(Width),
+    .PopMaxCredits(PopMaxCredits),
+    .RegisterDeallocation(RegisterDeallocation),
+    .RamReadLatency(RamReadLatency),
+    .ArbiterAlwaysGrants(ArbiterAlwaysGrants)
+) monitor (.*);

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_fpv.jg.tcl
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# clock/reset set up
+clock clk
+reset -none
+assume -reset -name set_rst_during_reset {rst && pop_receiver_in_reset}
+assume -bound 1 -name delay_rst {rst && pop_receiver_in_reset}
+assume -name deassert_rst {##1 !rst}
+assume -name pop_receiver_in_reset_stays_deasserted {!pop_receiver_in_reset |=> !pop_receiver_in_reset}
+
+get_design_info
+
+# primary input control signal should be legal during reset
+array set param_list [get_design_info -list parameter]
+set NumFifos $param_list(NumFifos)
+set PopMaxCredits $param_list(PopMaxCredits)
+set RegisterDeallocation $param_list(RegisterDeallocation)
+for {set i 0} {$i < $NumFifos} {incr i} {
+  assume -name initial_value_legal_$i "credit_initial_pop\[$i\] <= $PopMaxCredits"
+  assume -name withhold_value_legal_$i "credit_withhold_pop\[$i\] <= credit_initial_pop\[$i\]"
+  assume -name initial_value_during_reset_$i "\
+    (rst || pop_receiver_in_reset) |-> credit_initial_pop\[$i\] <= $PopMaxCredits"
+  assume -name withhold_value_during_reset_$i "(rst || pop_receiver_in_reset) |-> credit_withhold_pop\[$i\] <= credit_initial_pop\[$i\]"
+}
+assume -name no_head_valid_during_reset {(rst || pop_receiver_in_reset) |-> head_valid == 'd0}
+assume -name no_pop_credit_during_reset {(rst || pop_receiver_in_reset) |-> pop_credit == 'd0}
+assume -name no_data_ram_rd_data_valid_during_reset {(rst || pop_receiver_in_reset) |-> data_ram_rd_data_valid == 'd0}
+
+# primary output control signal should be legal during reset
+assert -name fv_rst_check_pop_sender_in_reset {pop_sender_in_reset == rst}
+assert -name fv_rst_check_pop_valid {(rst || pop_receiver_in_reset) |-> pop_valid == 'd0}
+assert -name fv_rst_check_ram_rd_addr_valid {(rst || pop_receiver_in_reset) |-> data_ram_rd_addr_valid == 'd0}
+if {$RegisterDeallocation eq "1'b1"} {
+  assert -name fv_rst_check_dealloc_valid_exit {$fell(rst || pop_receiver_in_reset) |-> dealloc_valid == 'd0}
+} else {
+  assert -name fv_rst_check_dealloc_valid {(rst || pop_receiver_in_reset) |-> dealloc_valid == 'd0}
+}
+
+# limit run time to 10-mins
+set_prove_time_limit 10m
+
+# prove command
+prove -all

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_fpv.jg.tcl
@@ -27,7 +27,6 @@ assume -name no_pop_credit_during_reset {(rst || pop_receiver_in_reset) |-> pop_
 assume -name no_data_ram_rd_data_valid_during_reset {(rst || pop_receiver_in_reset) |-> data_ram_rd_data_valid == 'd0}
 
 # primary output control signal should be legal during reset
-assert -name fv_rst_check_pop_sender_in_reset {pop_sender_in_reset == rst}
 assert -name fv_rst_check_pop_valid {(rst || pop_receiver_in_reset) |-> pop_valid == 'd0}
 assert -name fv_rst_check_ram_rd_addr_valid {(rst || pop_receiver_in_reset) |-> data_ram_rd_addr_valid == 'd0}
 if {$RegisterDeallocation eq "1'b1"} {

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_fpv_checker.sv
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_fpv_checker.sv
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL Shared Multi-FIFO Pop Controller Credit FPV checker
+//
+// Testplan
+//
+// Design intent:
+// - Manage the pop side of a shared multi-FIFO whose storage and FIFO head pointers are
+//   provided by surrounding controller logic.
+// - Track per-FIFO pop credit and issue shared RAM reads only when a FIFO has an offered
+//   head pointer and available pop credit.
+// - Return RAM read data on the shared per-read-port pop interface, with a binary FIFO ID
+//   identifying the logical FIFO that consumed credit.
+// - Generate deallocation information for accepted head pointers, optionally registering
+//   the deallocation path.
+//
+// Input assumptions:
+// - The external pointer manager only asserts head_valid for FIFOs that are nonempty.
+// - head remains stable while head_valid is asserted and head_ready is deasserted.
+// - data_ram_rd_data_valid/data_ram_rd_data follow the issued read address stream with
+//   the configured RamReadLatency.
+// - The pop credit receiver follows the Bedrock credit protocol.
+//
+// Output behavior checked:
+// - pop_sender_in_reset follows system reset.
+// - data_ram_rd_addr_valid/data_ram_rd_addr correspond to accepted head pointers.
+// - pop_valid/pop_fifo_id/pop_data preserve per-FIFO read data ordering.
+// - pop_empty reflects the external RAM empty state.
+// - credit_count_pop/credit_available_pop obey the Bedrock credit receiver model.
+// - dealloc_valid/dealloc_entry_id correspond exactly to accepted head pointers, with the
+//   configured RegisterDeallocation timing.
+// Reset interface properties are checked in the Jasper Tcl so they are not disabled by
+// assertion macros during reset.
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_fifo_shared_pop_ctrl_credit_fpv_checker #(
+    parameter int NumReadPorts = 1,
+    parameter int NumFifos = 1,
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter int PopMaxCredits = 1,
+    parameter bit RegisterDeallocation = 0,
+    parameter int RamReadLatency = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CreditWidth = $clog2(PopMaxCredits + 1),
+    localparam int FifoIdWidth = (NumFifos <= 1) ? 1 : $clog2(NumFifos),
+    localparam int ReadPortIdWidth = (NumReadPorts <= 1) ? 1 : $clog2(NumReadPorts)
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [NumFifos-1:0] head_valid,
+    input logic [NumFifos-1:0] head_ready,
+    input logic [NumFifos-1:0][AddrWidth-1:0] head,
+
+    input logic [NumFifos-1:0] ram_empty,
+
+    input logic pop_sender_in_reset,
+    input logic pop_receiver_in_reset,
+    input logic [NumFifos-1:0] pop_credit,
+
+    input logic [NumReadPorts-1:0] pop_valid,
+    input logic [NumReadPorts-1:0][FifoIdWidth-1:0] pop_fifo_id,
+    input logic [NumReadPorts-1:0][Width-1:0] pop_data,
+    input logic [NumFifos-1:0] pop_empty,
+
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_initial_pop,
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_withhold_pop,
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_available_pop,
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_count_pop,
+
+    input logic [NumFifos-1:0] dealloc_valid,
+    input logic [NumFifos-1:0][AddrWidth-1:0] dealloc_entry_id,
+
+    input logic [NumReadPorts-1:0] data_ram_rd_addr_valid,
+    input logic [NumReadPorts-1:0][AddrWidth-1:0] data_ram_rd_addr,
+    input logic [NumReadPorts-1:0] data_ram_rd_data_valid,
+    input logic [NumReadPorts-1:0][Width-1:0] data_ram_rd_data
+);
+  localparam int MaxPending = Depth + PopMaxCredits + (NumReadPorts * (RamReadLatency + 1));
+
+  logic [NumFifos-1:0] head_hs;
+  logic [NumReadPorts-1:0][FifoIdWidth-1:0] rd_fifo_id;
+  logic [FifoIdWidth-1:0] fv_fifo_id;
+  // Symbolically select one physical read/pop port for the single-port data-order scoreboard.
+  logic [ReadPortIdWidth-1:0] fv_read_port_id;
+  logic [NumReadPorts-1:0] fv_rsp_valid;
+  logic [NumReadPorts-1:0] fv_pop_rsp_valid;
+
+  `BR_ASSUME(fv_read_port_id_range_a, $stable(fv_read_port_id) && fv_read_port_id < NumReadPorts)
+
+  br_fifo_shared_pop_ctrl_common_fpv_checker #(
+      .NumReadPorts(NumReadPorts),
+      .NumFifos(NumFifos),
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterDeallocation(RegisterDeallocation),
+      .RamReadLatency(RamReadLatency)
+  ) common_checker (
+      .clk,
+      .rst,
+      .fv_fifo_id,
+      .head_hs,
+      .rd_fifo_id,
+      .fv_rsp_valid,
+      .head_valid,
+      .head_ready,
+      .head,
+      .ram_empty,
+      .dealloc_valid,
+      .dealloc_entry_id,
+      .data_ram_rd_addr_valid,
+      .data_ram_rd_addr,
+      .data_ram_rd_data_valid
+  );
+
+  for (genvar i = 0; i < NumFifos; i++) begin : gen_fifo
+    logic [NumReadPorts-1:0] fv_pop_valid_for_fifo;
+
+    for (genvar p = 0; p < NumReadPorts; p++) begin : gen_pop_port
+      assign fv_pop_valid_for_fifo[p] = pop_valid[p] && (pop_fifo_id[p] == FifoIdWidth'(i));
+    end
+
+    // The external empty flag must pass through to the per-FIFO pop empty output.
+    `BR_ASSERT(pop_empty_matches_ram_empty_a, pop_empty[i] == ram_empty[i])
+
+    // The head pointer source uses ready/valid semantics, so payload holds under backpressure.
+    fv_valid_ready_check #(
+        .Master(1),
+        .PayloadWidth(AddrWidth)
+    ) fv_head_valid_ready_check (
+        .clk,
+        .rst,
+        .ready  (head_ready[i]),
+        .valid  (head_valid[i]),
+        .payload(head[i])
+    );
+
+    br_pop_credit_fpv_monitor #(
+        .NumPopPorts(NumReadPorts),
+        .MaxCredit  (PopMaxCredits)
+    ) fv_pop_credit (
+        .clk,
+        .rst,
+        .pop_sender_in_reset,
+        .pop_receiver_in_reset,
+        .pop_credit(pop_credit[i]),
+        .pop_valid(fv_pop_valid_for_fifo),
+        .credit_initial_pop(credit_initial_pop[i]),
+        .credit_withhold_pop(credit_withhold_pop[i]),
+        .credit_count_pop(credit_count_pop[i]),
+        .credit_available_pop(credit_available_pop[i])
+    );
+
+    // Exercise the pop interface for every logical FIFO.
+    `BR_COVER(pop_valid_c, |fv_pop_valid_for_fifo)
+  end
+
+  for (genvar p = 0; p < NumReadPorts; p++) begin : gen_read_port_checks
+    assign fv_pop_rsp_valid[p] = pop_valid[p] && (pop_fifo_id[p] == fv_fifo_id);
+
+    // Pop data is a direct pass-through from the RAM response on the same physical port.
+    `BR_ASSERT(pop_data_matches_ram_data_a, pop_valid[p] |-> pop_data[p] == data_ram_rd_data[p])
+
+    // Pop valid is a direct pass-through from the RAM response valid on the same physical port.
+    `BR_ASSERT(pop_valid_matches_ram_valid_a, pop_valid[p] == data_ram_rd_data_valid[p])
+
+    if (RamReadLatency == 0) begin : gen_lat0_fifo_id
+      // Pop FIFO ID must match the same-cycle read request FIFO ID.
+      `BR_ASSERT(pop_fifo_id_matches_read_a, pop_valid[p] |-> pop_fifo_id[p] == rd_fifo_id[p])
+    end else begin : gen_lat_non0_fifo_id
+      // Pop FIFO ID must match the delayed read request FIFO ID.
+      `BR_ASSERT(pop_fifo_id_matches_read_a,
+                 ##1 pop_valid[p] |-> pop_fifo_id[p] == $past(rd_fifo_id[p], RamReadLatency))
+    end
+
+    // Pop FIFO ID must name a legal logical FIFO whenever pop data is valid.
+    `BR_ASSERT(pop_fifo_id_in_range_a, pop_valid[p] |-> pop_fifo_id[p] < NumFifos)
+  end
+
+  // Track one arbitrary physical port for the selected FIFO. Per-port assertions above prove
+  // every pop beat is a direct RAM response pass-through and has the expected FIFO ID; this
+  // symbolic-port scoreboard proves the selected port preserves data order for that FIFO.
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(Width),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(1),
+      .MAX_PENDING(MaxPending)
+  ) scoreboard (
+      .clk(clk),
+      .rstN(!rst),
+      .incoming_vld(fv_rsp_valid[fv_read_port_id]),
+      .incoming_data(data_ram_rd_data[fv_read_port_id]),
+      .outgoing_vld(fv_pop_rsp_valid[fv_read_port_id]),
+      .outgoing_data(pop_data[fv_read_port_id])
+  );
+
+endmodule : br_fifo_shared_pop_ctrl_credit_fpv_checker

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_credit_fpv_monitor.sv
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bind wrapper for the shared multi-FIFO credit pop-controller checker.
+
+module br_fifo_shared_pop_ctrl_credit_fpv_monitor #(
+    parameter int NumReadPorts = 1,
+    parameter int NumFifos = 1,
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter int PopMaxCredits = 1,
+    parameter bit RegisterDeallocation = 0,
+    parameter int RamReadLatency = 0,
+    localparam int AddrWidth = $clog2(Depth),
+    localparam int CreditWidth = $clog2(PopMaxCredits + 1),
+    localparam int FifoIdWidth = (NumFifos <= 1) ? 1 : $clog2(NumFifos)
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [NumFifos-1:0] head_valid,
+    input logic [NumFifos-1:0] head_ready,
+    input logic [NumFifos-1:0][AddrWidth-1:0] head,
+
+    input logic [NumFifos-1:0] ram_empty,
+
+    input logic pop_sender_in_reset,
+    input logic pop_receiver_in_reset,
+    input logic [NumFifos-1:0] pop_credit,
+
+    input logic [NumReadPorts-1:0] pop_valid,
+    input logic [NumReadPorts-1:0][FifoIdWidth-1:0] pop_fifo_id,
+    input logic [NumReadPorts-1:0][Width-1:0] pop_data,
+
+    input logic [NumFifos-1:0] pop_empty,
+
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_initial_pop,
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_withhold_pop,
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_available_pop,
+    input logic [NumFifos-1:0][CreditWidth-1:0] credit_count_pop,
+
+    input logic [NumFifos-1:0] dealloc_valid,
+    input logic [NumFifos-1:0][AddrWidth-1:0] dealloc_entry_id,
+
+    input logic [NumReadPorts-1:0] data_ram_rd_addr_valid,
+    input logic [NumReadPorts-1:0][AddrWidth-1:0] data_ram_rd_addr,
+    input logic [NumReadPorts-1:0] data_ram_rd_data_valid,
+    input logic [NumReadPorts-1:0][Width-1:0] data_ram_rd_data
+);
+
+  br_fifo_shared_pop_ctrl_credit_fpv_checker #(
+      .NumReadPorts(NumReadPorts),
+      .NumFifos(NumFifos),
+      .Depth(Depth),
+      .Width(Width),
+      .PopMaxCredits(PopMaxCredits),
+      .RegisterDeallocation(RegisterDeallocation),
+      .RamReadLatency(RamReadLatency)
+  ) checker_inst (
+      .clk,
+      .rst,
+      .head_valid,
+      .head_ready,
+      .head,
+      .ram_empty,
+      .pop_sender_in_reset,
+      .pop_receiver_in_reset,
+      .pop_credit,
+      .pop_valid,
+      .pop_fifo_id,
+      .pop_data,
+      .pop_empty,
+      .credit_initial_pop,
+      .credit_withhold_pop,
+      .credit_available_pop,
+      .credit_count_pop,
+      .dealloc_valid,
+      .dealloc_entry_id,
+      .data_ram_rd_addr_valid,
+      .data_ram_rd_addr,
+      .data_ram_rd_data_valid,
+      .data_ram_rd_data
+  );
+
+endmodule : br_fifo_shared_pop_ctrl_credit_fpv_monitor
+
+bind br_fifo_shared_pop_ctrl_credit br_fifo_shared_pop_ctrl_credit_fpv_monitor #(
+    .NumReadPorts(NumReadPorts),
+    .NumFifos(NumFifos),
+    .Depth(Depth),
+    .Width(Width),
+    .PopMaxCredits(PopMaxCredits),
+    .RegisterDeallocation(RegisterDeallocation),
+    .RamReadLatency(RamReadLatency)
+) monitor (.*);

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker.sv
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker.sv
@@ -5,7 +5,8 @@
 module br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker #(
     parameter int NumReadPorts = 1,
     parameter int NumFifos = 1,
-    parameter bit ArbiterAlwaysGrants = 1
+    parameter bit ArbiterAlwaysGrants = 1,
+    parameter bit EnableAssertRequestStability = 1
 ) (
     input logic clk,
     input logic rst,
@@ -31,11 +32,15 @@ module br_fifo_shared_pop_ctrl_ext_arbiter_fpv_checker #(
     // The read crossbar is permanently ready to issue RAM reads, so priority updates stay enabled.
     `BR_ASSERT(arb_enable_priority_update_a, arb_enable_priority_update[r])
 
-    for (genvar f = 0; f < NumFifos; f++) begin : gen_fifo
-      // The DUT must hold requests until the external arbiter grants them.
-      `BR_ASSERT(arb_req_hold_until_grant_a,
-                 arb_request[r][f] && !arb_grant[r][f] |=> arb_request[r][f])
+    if (EnableAssertRequestStability) begin : gen_request_stability
+      for (genvar f = 0; f < NumFifos; f++) begin : gen_fifo
+        // The DUT must hold requests until the external arbiter grants them.
+        `BR_ASSERT(arb_req_hold_until_grant_a,
+                   arb_request[r][f] && !arb_grant[r][f] |=> arb_request[r][f])
+      end
+    end
 
+    for (genvar f = 0; f < NumFifos; f++) begin : gen_fifo
       // Prevent an unfair external arbiter model from starving an outstanding request forever.
       `BR_ASSUME(arb_grant_eventually_a, arb_request[r][f] |-> s_eventually arb_grant[r][f])
     end

--- a/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_fpv_checker.sv
+++ b/fifo/fpv/br_fifo_shared_pop_ctrl/br_fifo_shared_pop_ctrl_fpv_checker.sv
@@ -83,30 +83,35 @@ module br_fifo_shared_pop_ctrl_fpv_checker #(
   localparam int MaxPending = Depth + StagingBufferDepth + (NumReadPorts * (RamReadLatency + 1));
 
   logic [NumFifos-1:0] head_hs;
-  logic [NumReadPorts-1:0][FifoIdxWidth-1:0] rd_fifo_id;
   logic [FifoIdxWidth-1:0] fv_fifo_id;
   logic [NumReadPorts-1:0] fv_rsp_valid;
 
-  assign head_hs = head_valid & head_ready;
-
-  always_comb begin
-    rd_fifo_id = '0;
-    for (int p = 0; p < NumReadPorts; p++) begin
-      for (int f = 0; f < NumFifos; f++) begin
-        if (data_ram_rd_addr_valid[p] && head_hs[f] && (data_ram_rd_addr[p] == head[f])) begin
-          rd_fifo_id[p] = FifoIdxWidth'(f);
-        end
-      end
-    end
-  end
-
-  // The symbolic FIFO selection lets one scoreboard prove per-FIFO data ordering.
-  `BR_ASSUME(fv_fifo_id_range_a, $stable(fv_fifo_id) && (fv_fifo_id < NumFifos))
+  br_fifo_shared_pop_ctrl_common_fpv_checker #(
+      .NumReadPorts(NumReadPorts),
+      .NumFifos(NumFifos),
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterDeallocation(RegisterDeallocation),
+      .RamReadLatency(RamReadLatency)
+  ) common_checker (
+      .clk,
+      .rst,
+      .fv_fifo_id,
+      .head_hs,
+      .rd_fifo_id(),
+      .fv_rsp_valid,
+      .head_valid,
+      .head_ready,
+      .head,
+      .ram_empty,
+      .dealloc_valid,
+      .dealloc_entry_id,
+      .data_ram_rd_addr_valid,
+      .data_ram_rd_addr,
+      .data_ram_rd_data_valid
+  );
 
   for (genvar i = 0; i < NumFifos; i++) begin : gen_fifo
-    // Pointer management must not offer a head pointer for an empty logical FIFO.
-    `BR_ASSUME(no_head_when_ram_empty_a, ram_empty[i] |-> !head_valid[i])
-
     // The external item count must stay inside the configured storage capacity.
     `BR_ASSUME(ram_items_in_range_a, ram_items[i] <= CountWidth'(Depth))
 
@@ -164,116 +169,12 @@ module br_fifo_shared_pop_ctrl_fpv_checker #(
 
     // Exercise the pop interface for every logical FIFO.
     `BR_COVER(pop_hsk_c, pop_valid[i] && pop_ready[i])
-
-    // Exercise the deallocation path for every logical FIFO.
-    `BR_COVER(dealloc_valid_c, dealloc_valid[i])
   end
 
   if (!HasStagingBuffer) begin : gen_no_staging_buffer_assumptions
     for (genvar i = 0; i < NumFifos; i++) begin : gen_per_fifo
       // Without a staging buffer, pop_ready feeds the request path and must hold to avoid deadlock.
       `BR_ASSUME(pop_ready_hold_a, pop_ready[i] && !pop_valid[i] |=> pop_ready[i])
-    end
-  end
-
-  for (genvar i = 0; i < NumFifos; i++) begin : gen_unique_heads_i
-    for (genvar j = i + 1; j < NumFifos; j++) begin : gen_unique_heads_j
-      // Shared FIFO storage must not present the same allocated entry as two FIFO heads.
-      `BR_ASSUME(unique_accepted_heads_a, !head_hs[i] || !head_hs[j] || (head[i] != head[j]))
-    end
-  end
-
-  for (genvar p = 0; p < NumReadPorts; p++) begin : gen_read_port_checks
-    logic rd_addr_matches_accepted_head;
-
-    always_comb begin
-      rd_addr_matches_accepted_head = 1'b0;
-      for (int f = 0; f < NumFifos; f++) begin
-        rd_addr_matches_accepted_head |= head_hs[f] && (data_ram_rd_addr[p] == head[f]);
-      end
-    end
-
-    // Each read request must come from a head pointer accepted in the same cycle.
-    `BR_ASSERT(read_addr_from_head_a, data_ram_rd_addr_valid[p] |-> rd_addr_matches_accepted_head)
-
-    // Exercise every shared RAM read port.
-    `BR_COVER(read_port_valid_c, data_ram_rd_addr_valid[p])
-  end
-
-  for (genvar i = 0; i < NumFifos; i++) begin : gen_head_to_read_checks
-    logic head_has_read_addr;
-
-    always_comb begin
-      head_has_read_addr = 1'b0;
-      for (int p = 0; p < NumReadPorts; p++) begin
-        head_has_read_addr |= data_ram_rd_addr_valid[p] && (data_ram_rd_addr[p] == head[i]);
-      end
-    end
-
-    // Every accepted head pointer must issue exactly as a shared RAM read request.
-    `BR_ASSERT(accepted_head_has_read_a, head_hs[i] |-> head_has_read_addr)
-  end
-
-  // The number of accepted heads and read requests must match cycle-by-cycle.
-  `BR_ASSERT(read_count_matches_head_hs_a, $countones(data_ram_rd_addr_valid) == $countones(head_hs
-                                                                                               ))
-
-  // The pop side can accept at most one head per physical read port per cycle.
-  `BR_ASSERT(head_hs_read_port_capacity_a, $countones(head_hs) <= NumReadPorts)
-
-  for (genvar p = 0; p < NumReadPorts; p++) begin : gen_ram_response_assumptions
-    if (RamReadLatency == 0) begin : gen_lat0
-      assign fv_rsp_valid[p] = data_ram_rd_data_valid[p] && (rd_fifo_id[p] == fv_fifo_id);
-
-      // The external RAM response valid must match the same-cycle read request.
-      `BR_ASSUME(ram_response_valid_latency_a,
-                 data_ram_rd_data_valid[p] == data_ram_rd_addr_valid[p])
-    end else begin : gen_lat_non0
-      logic fv_rsp_fifo_match;
-
-      fv_delay #(
-          .Width(1),
-          .NumStages(RamReadLatency)
-      ) fv_delay_rsp_fifo_match (
-          .clk,
-          .rst,
-          .in (rd_fifo_id[p] == fv_fifo_id),
-          .out(fv_rsp_fifo_match)
-      );
-
-      assign fv_rsp_valid[p] = data_ram_rd_data_valid[p] && fv_rsp_fifo_match;
-
-      // No RAM response may appear until a post-reset read can mature.
-      `BR_ASSUME(no_ram_response_after_reset_a,
-                 $fell(rst) |-> !data_ram_rd_data_valid[p] [* RamReadLatency])
-
-      // The external RAM response valid must match the configured delayed read request.
-      `BR_ASSUME(ram_response_valid_latency_a,
-                 ##RamReadLatency data_ram_rd_data_valid[p] == $past(
-                     data_ram_rd_addr_valid[p], RamReadLatency
-                 ))
-    end
-  end
-
-  if (RegisterDeallocation) begin : gen_registered_deallocation_check
-    logic [NumFifos-1:0] expected_dealloc_valid_q;
-
-    `BR_REG(expected_dealloc_valid_q, head_hs)
-
-    // Registered deallocation valid must be the previous accepted-head vector.
-    `BR_ASSERT(dealloc_valid_registered_a, dealloc_valid == expected_dealloc_valid_q)
-
-    for (genvar i = 0; i < NumFifos; i++) begin : gen_dealloc_entry_checks
-      // Registered deallocation entry ID must name the previously accepted head entry.
-      `BR_ASSERT(dealloc_entry_id_a, ##1 dealloc_valid[i] |-> dealloc_entry_id[i] == $past(head[i]))
-    end
-  end else begin : gen_unregistered_deallocation_check
-    // Unregistered deallocation valid must match the accepted-head vector immediately.
-    `BR_ASSERT(dealloc_valid_unregistered_a, dealloc_valid == head_hs)
-
-    for (genvar i = 0; i < NumFifos; i++) begin : gen_dealloc_entry_checks
-      // Unregistered deallocation entry ID must name the same-cycle accepted head entry.
-      `BR_ASSERT(dealloc_entry_id_a, dealloc_valid[i] |-> dealloc_entry_id[i] == head[i])
     end
   end
 
@@ -295,13 +196,5 @@ module br_fifo_shared_pop_ctrl_fpv_checker #(
       .outgoing_vld(pop_valid[fv_fifo_id] && pop_ready[fv_fifo_id]),
       .outgoing_data(pop_data[fv_fifo_id])
   );
-
-  if (NumReadPorts < NumFifos) begin : gen_read_contention_cover
-    // Exercise read-port contention when the configuration has fewer read ports than FIFOs.
-    `BR_COVER(read_contention_c, $countones(head_valid) > NumReadPorts)
-  end
-
-  // Exercise a cycle where the controller uses all available read ports.
-  `BR_COVER(all_read_ports_used_c, &data_ram_rd_addr_valid)
 
 endmodule : br_fifo_shared_pop_ctrl_fpv_checker

--- a/fifo/fpv/br_pop_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_pop_credit_fpv_monitor.sv
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL pop valid/credit FPV checks
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_pop_credit_fpv_monitor #(
+    parameter int NumPopPorts = 1,
+    parameter int MaxCredit = 1,
+    parameter int PopCreditMaxChange = 1,
+    parameter bit EnableCoverCreditWithhold = 1,
+    localparam int CreditWidth = $clog2(MaxCredit + 1),
+    localparam int CreditCalcWidth = CreditWidth + 1,
+    localparam int PopCreditWidth = $clog2(PopCreditMaxChange + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    // Pop-side reset interface.
+    input logic pop_sender_in_reset,
+    input logic pop_receiver_in_reset,
+
+    // Pop-side credit/valid interface.
+    input logic [PopCreditWidth-1:0] pop_credit,
+    input logic [NumPopPorts-1:0] pop_valid,
+
+    // Pop-side credits.
+    input logic [CreditWidth-1:0] credit_initial_pop,
+    input logic [CreditWidth-1:0] credit_withhold_pop,
+    input logic [CreditWidth-1:0] credit_count_pop,
+    input logic [CreditWidth-1:0] credit_available_pop
+);
+  logic fv_rst;
+  logic [CreditWidth-1:0] fv_credit_cnt;
+  logic [CreditCalcWidth-1:0] fv_credit_cnt_next;
+  logic [CreditWidth-1:0] fv_max_credit;
+
+  assign fv_rst = rst || pop_receiver_in_reset;
+  assign fv_credit_cnt_next = fv_credit_cnt + pop_credit - $countones(pop_valid);
+  `BR_REGIX(fv_credit_cnt, fv_credit_cnt_next[CreditWidth-1:0], credit_initial_pop, clk, fv_rst)
+  `BR_REGIX(fv_max_credit, fv_max_credit, credit_initial_pop, clk, fv_rst)
+
+  // ----------FV assumptions----------
+  `BR_ASSUME(credit_initial_pop_a, credit_initial_pop <= MaxCredit)
+  `BR_ASSUME(credit_withhold_pop_a, credit_withhold_pop <= credit_initial_pop)
+  `BR_ASSUME(credit_withhold_liveness_a, s_eventually (credit_withhold_pop < fv_max_credit))
+  `BR_ASSUME(legal_pop_credit_a, pop_credit <= PopCreditMaxChange)
+  `BR_ASSUME(no_spurious_pop_credit_a, fv_max_credit - fv_credit_cnt + $countones(pop_valid)
+             >= pop_credit)
+
+  if (EnableCoverCreditWithhold) begin : gen_withhold
+    `BR_COVER(credit_withhold_nonzero_a, credit_withhold_pop != '0)
+  end else begin : gen_no_withhold
+    `BR_ASSUME(credit_withhold_zero_a, credit_withhold_pop == '0)
+  end
+
+  // ----------FV assertions----------
+  `BR_ASSERT(fv_credit_sanity_a, fv_credit_cnt <= fv_max_credit)
+  `BR_ASSERT(no_spurious_pop_valid_a, fv_credit_cnt + pop_credit == '0 |-> pop_valid == '0)
+
+endmodule : br_pop_credit_fpv_monitor

--- a/fifo/rtl/br_fifo_shared_pop_ctrl_credit_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl_credit_ext_arbiter.sv
@@ -131,7 +131,9 @@ module br_fifo_shared_pop_ctrl_credit_ext_arbiter #(
     logic ram_rd_req_ready;
 
     br_credit_counter #(
-        .MaxValue(PopMaxCredits)
+        .MaxValue(PopMaxCredits),
+        .EnableCoverZeroIncrement(0),
+        .EnableCoverZeroDecrement(0)
     ) br_credit_counter (
         .clk,
         .rst(either_rst),
@@ -152,7 +154,10 @@ module br_fifo_shared_pop_ctrl_credit_ext_arbiter #(
     br_flow_join #(
         .NumFlows(2),
         // ram_rd_req_valid will be 1 at end of sim
-        .EnableAssertFinalNotValid(0)
+        .EnableAssertFinalNotValid(0),
+        // Dynamic credit withholding can withdraw read eligibility before the
+        // request is accepted, so this internal valid is not stable-ready.
+        .EnableAssertPushValidStability(0)
     ) br_flow_join_ram_rd_addr (
         .clk,
         .rst(either_rst),
@@ -176,7 +181,9 @@ module br_fifo_shared_pop_ctrl_credit_ext_arbiter #(
       .Depth(Depth),
       .Width(Width),
       .RamReadLatency(RamReadLatency),
-      .EnableAssertPushValidStability(1),
+      // push_rd_addr_valid comes from the credit-gated join above, so it has
+      // eligibility semantics rather than strict stable-ready semantics.
+      .EnableAssertPushValidStability(0),
       .ArbiterAlwaysGrants(ArbiterAlwaysGrants)
   ) br_fifo_shared_read_xbar (
       .clk,


### PR DESCRIPTION
1. Move shared code for all 4 br_fifo_shared_pop_ctrl variations into br_fifo_shared_pop_ctrl_common_fpv_checker (simply code re-structure, no functional change)
2. Added br_pop_credit_fpv_monitor to monitor pop_valid, pop_credit interface.
3. passed in correct parameter to disable RTL inline assertions.