### PR TITLE
[macros] Fix known-value implementation check guards

### DIFF
--- a/macros/br_asserts_internal.svh
+++ b/macros/br_asserts_internal.svh
@@ -122,7 +122,7 @@
 `endif  // BR_ENABLE_IMPL_CHECKS
 
 // Assert an expression is always known.
-`ifndef BR_ENABLE_IMPL_CHECKS
+`ifdef BR_ENABLE_IMPL_CHECKS
 `define BR_ASSERT_KNOWN_IMPL(__name__, __expr__) \
 `BR_ASSERT_KNOWN(__name__, __expr__)
 `else  // BR_ENABLE_IMPL_CHECKS
@@ -131,7 +131,7 @@
 `endif  // BR_ENABLE_IMPL_CHECKS
 
 // Assert an expression is known whenever a corresponding valid signal is 1.
-`ifndef BR_ENABLE_IMPL_CHECKS
+`ifdef BR_ENABLE_IMPL_CHECKS
 `define BR_ASSERT_KNOWN_VALID_IMPL(__name__, __valid__, __expr__) \
 `BR_ASSERT_KNOWN_VALID(__name__, __valid__, __expr__)
 `else  // BR_ENABLE_IMPL_CHECKS
@@ -140,7 +140,7 @@
 `endif  // BR_ENABLE_IMPL_CHECKS
 
 // More expressive form of BR_ASSERT_KNOWN_IMPL that allows the use of custom clock and reset signal names.
-`ifndef BR_ENABLE_IMPL_CHECKS
+`ifdef BR_ENABLE_IMPL_CHECKS
 `define BR_ASSERT_KNOWN_CR_IMPL(__name__, __expr__, __clk__, __rst__) \
 `BR_ASSERT_KNOWN_CR(__name__, __expr__, __clk__, __rst__)
 `else  // BR_ENABLE_IMPL_CHECKS
@@ -149,7 +149,7 @@
 `endif  // BR_ENABLE_IMPL_CHECKS
 
 // More expressive form of BR_ASSERT_KNOWN_VALID_IMPL that allows the use of custom clock and reset signal names.
-`ifndef BR_ENABLE_IMPL_CHECKS
+`ifdef BR_ENABLE_IMPL_CHECKS
 `define BR_ASSERT_KNOWN_VALID_CR_IMPL(__name__, __valid__, __expr__, __clk__, __rst__) \
 `BR_ASSERT_KNOWN_VALID_CR(__name__, __valid__, __expr__, __clk__, __rst__)
 `else  // BR_ENABLE_IMPL_CHECKS


### PR DESCRIPTION
# Problem

Issue #1063 showed that the internal known-value implementation assertion macros were compiled under the inverse of the intended implementation-check guard.

# Solution

Use `BR_ENABLE_IMPL_CHECKS` for the known-value implementation assertion macro guards so those checks follow the same enable path as other implementation assertions.

Fixes #1063