### PR TITLE
[ram] Merge partial-write mock RAM bypass data

### DIFF
--- a/ram/rtl/br_ram_flops_1r1w_mock.sv
+++ b/ram/rtl/br_ram_flops_1r1w_mock.sv
@@ -227,9 +227,32 @@ module br_ram_flops_1r1w_mock #(
   // Read port
   assign mem_rd_data_valid = mem_rd_addr_valid;
   if (TileEnableBypass) begin : gen_bypass
-    // ri lint_check_waive VAR_INDEX_READ
-    assign mem_rd_data =
-      (mem_wr_valid && (mem_wr_addr == mem_rd_addr)) ? mem_wr_data : mem[mem_rd_addr];
+    if (EnablePartialWrite) begin : gen_partial_write_bypass
+      logic [NumWords-1:0][WordWidth-1:0] mem_wr_data_words;
+      logic [NumWords-1:0][WordWidth-1:0] mem_rd_data_words;
+      logic [NumWords-1:0][WordWidth-1:0] mem_rd_bypass_data_words;
+
+      assign mem_wr_data_words = mem_wr_data;
+      // ri lint_check_waive VAR_INDEX_READ
+      assign mem_rd_data_words = mem[mem_rd_addr];
+
+      always_comb begin
+        mem_rd_bypass_data_words = mem_rd_data_words;
+        for (int i = 0; i < NumWords; i++) begin
+          if (wr_word_en[i]) begin
+            mem_rd_bypass_data_words[i] = mem_wr_data_words[i];
+          end
+        end
+      end
+
+      assign mem_rd_data = (mem_wr_valid && (mem_wr_addr == mem_rd_addr)) ?
+                           mem_rd_bypass_data_words :
+                           mem_rd_data_words;
+    end else begin : gen_full_write_bypass
+      // ri lint_check_waive VAR_INDEX_READ
+      assign mem_rd_data =
+        (mem_wr_valid && (mem_wr_addr == mem_rd_addr)) ? mem_wr_data : mem[mem_rd_addr];
+    end
   end else begin : gen_no_bypass
     // ri lint_check_waive VAR_INDEX_READ
     assign mem_rd_data = mem[mem_rd_addr];

--- a/ram/rtl/br_ram_flops_1r1w_mock.sv
+++ b/ram/rtl/br_ram_flops_1r1w_mock.sv
@@ -57,6 +57,7 @@ module br_ram_flops_1r1w_mock #(
     // ri lint_check_waive PARAM_NOT_USED
     localparam int WriteLatency = AddressDepthStages + 1,
     // Read latency in units of rd_clk cycles
+    // ri lint_check_waive PARAM_NOT_USED
     localparam int ReadLatency = AddressDepthStages + ReadDataDepthStages + ReadDataWidthStages
 ) (
     // Write-clock signals
@@ -278,21 +279,52 @@ module br_ram_flops_1r1w_mock #(
   //------------------------------------------
   `BR_ASSERT_CR_IMPL(read_latency_a, rd_addr_valid |-> ##ReadLatency rd_data_valid, rd_clk, rd_rst)
 
+`ifdef BR_ASSERT_ON
+`ifdef BR_ENABLE_IMPL_CHECKS
   if (TileEnableBypass) begin : gen_bypass_checks
-    if (ReadLatency > 0) begin : gen_readlat_gt0
+    localparam int ReadDataLatency = ReadDataDepthStages + ReadDataWidthStages;
+
+    logic [Width-1:0] bypass_check_data;
+
+    if (EnablePartialWrite) begin : gen_partial_write_check_data
+      logic [NumWords-1:0][WordWidth-1:0] bypass_check_data_words;
+      logic [NumWords-1:0][WordWidth-1:0] mem_rd_check_data_words;
+      logic [NumWords-1:0][WordWidth-1:0] mem_wr_check_data_words;
+
+      // ri lint_check_waive VAR_INDEX_READ
+      assign mem_rd_check_data_words = mem[mem_rd_addr];
+      assign mem_wr_check_data_words = mem_wr_data;
+
+      always_comb begin
+        bypass_check_data_words = mem_rd_check_data_words;
+        for (int i = 0; i < NumWords; i++) begin
+          if (wr_word_en[i]) begin
+            bypass_check_data_words[i] = mem_wr_check_data_words[i];
+          end
+        end
+      end
+
+      assign bypass_check_data = bypass_check_data_words;
+    end else begin : gen_full_write_check_data
+      assign bypass_check_data = mem_wr_data;
+    end
+
+    if (ReadDataLatency > 0) begin : gen_readlat_gt0
       `BR_ASSERT_CR_IMPL(read_write_hazard_gets_new_data_a,
-                         wr_valid && rd_addr_valid && (wr_addr == rd_addr) |->
-          ##ReadLatency rd_data_valid && rd_data == $past(
-                             wr_data, ReadLatency
+                         mem_wr_valid && mem_rd_addr_valid && (mem_wr_addr == mem_rd_addr) |->
+          ##ReadDataLatency rd_data_valid && rd_data == $past(
+                             bypass_check_data, ReadDataLatency
                          ),
                          rd_clk, rd_rst)
     end else begin : gen_readlat_eq0
       `BR_ASSERT_CR_IMPL(read_write_hazard_gets_new_data_a,
-                         wr_valid && rd_addr_valid && (wr_addr == rd_addr) |->
-          rd_data_valid && (rd_data == wr_data),
+                         mem_wr_valid && mem_rd_addr_valid && (mem_wr_addr == mem_rd_addr) |->
+          rd_data_valid && (rd_data == bypass_check_data),
                          rd_clk, rd_rst)
     end
   end
+`endif
+`endif
 
   `BR_ASSERT_FINAL(final_not_rd_data_valid_a, !rd_data_valid)
 

--- a/ram/rtl/br_ram_flops_1r1w_mock.sv
+++ b/ram/rtl/br_ram_flops_1r1w_mock.sv
@@ -291,6 +291,8 @@ module br_ram_flops_1r1w_mock #(
       logic [NumWords-1:0][WordWidth-1:0] mem_rd_check_data_words;
       logic [NumWords-1:0][WordWidth-1:0] mem_wr_check_data_words;
 
+      // Mirror the partial-write merge here rather than checking against mem_rd_data, so the
+      // assertion compares the output pipeline against an independent expected value.
       // ri lint_check_waive VAR_INDEX_READ
       assign mem_rd_check_data_words = mem[mem_rd_addr];
       assign mem_wr_check_data_words = mem_wr_data;


### PR DESCRIPTION
# Problem

Issue #1066 showed that `br_ram_flops_1r1w_mock` bypasses a same-address write to a read without respecting partial-write word enables.

# Solution

When both tile bypass and partial writes are enabled, merge bypassed write data per enabled word lane and preserve stored RAM data for disabled word lanes.

Fixes #1066