### PR TITLE
[tracker] Assert unique freelist dealloc IDs

### DIFF
--- a/tracker/rtl/br_tracker_freelist.sv
+++ b/tracker/rtl/br_tracker_freelist.sv
@@ -136,6 +136,11 @@ module br_tracker_freelist #(
     `BR_ASSERT_INTG(dealloc_in_range_a, dealloc_valid[i] |-> dealloc_entry_id[i] < NumEntries)
     `BR_ASSERT_INTG(no_dealloc_unallocated_a,
                     dealloc_valid[i] |-> allocated_entries[dealloc_entry_id[i]])
+    for (genvar j = i + 1; j < NumDeallocPorts; j++) begin : gen_unique_dealloc_intg_asserts
+      `BR_ASSERT_INTG(
+          unique_dealloc_entry_id_a,
+          dealloc_valid[i] && dealloc_valid[j] |-> dealloc_entry_id[i] != dealloc_entry_id[j])
+    end
   end
 `endif
 `endif


### PR DESCRIPTION
# Problem

Issue #1067 clarified that `br_tracker_freelist` must not accept the same entry ID on more than one deallocation port in the same cycle.

# Solution

Add pairwise integration assertions across the deallocation ports so same-cycle duplicate deallocations of an entry are rejected by the RTL interface contract.

Fixes #1067