### PR TITLE
[fv] Add br_ram_flops_1r1w_mock FPV

### DIFF
--- a/ram/fpv/BUILD.bazel
+++ b/ram/fpv/BUILD.bazel
@@ -822,3 +822,107 @@ br_verilog_fpv_test_tools_suite(
     top = "br_ram_flops",
     deps = [":br_ram_flops_fpv_monitor"],
 )
+
+#################################################################
+# Bedrock-RTL Flop-RAM 1R1W Mock
+
+verilog_library(
+    name = "br_ram_flops_1r1w_mock_fpv_monitor",
+    srcs = ["br_ram_flops_1r1w_mock_fpv_monitor.sv"],
+    deps = [
+        ":br_ram_flops_basic_fv_checker",
+        "//ram/rtl:br_ram_flops_1r1w_mock",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_ram_flops_1r1w_mock_fpv_monitor_elab_test",
+    custom_tcl_header = "//:elab_test_jg_custom_header.verific.tcl",
+    tool = "verific",
+    deps = [":br_ram_flops_1r1w_mock_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_ram_flops_1r1w_mock_test_basic",
+    illegal_param_combinations = {
+        (
+            "Width",
+            "WordWidth",
+        ): [
+            ("1", "2"),
+        ],
+    },
+    params = {
+        "Depth": [
+            "4",
+        ],
+        "EnableMemReset": [
+            "0",
+            "1",
+        ],
+        "EnablePartialWrite": [
+            "0",
+            "1",
+        ],
+        "TileEnableBypass": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "6",
+        ],
+        "WordWidth": [
+            "1",
+            "2",
+        ],
+    },
+    tools = {
+        "jg": "br_ram_flops_tile_1clk_fpv.jg.tcl",
+    },
+    top = "br_ram_flops_1r1w_mock",
+    deps = [":br_ram_flops_1r1w_mock_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_ram_flops_1r1w_mock_test_tiles_delay",
+    elab_opts = [
+        "-parameter Depth 6",
+        "-parameter Width 6",
+    ],
+    params = {
+        "AddressDepthStages": [
+            "0",
+            "1",
+        ],
+        "DepthTiles": [
+            "1",
+            "2",
+            "3",
+        ],
+        "ReadDataDepthStages": [
+            "0",
+            "1",
+        ],
+        "ReadDataWidthStages": [
+            "0",
+        ],
+        "TileEnableBypass": [
+            "0",
+            "1",
+        ],
+        "WidthTiles": [
+            "1",
+            "2",
+        ],
+        "WordWidth": [
+            "1",
+            "3",
+        ],
+    },
+    tools = {
+        "jg": "br_ram_flops_tile_1clk_fpv.jg.tcl",
+    },
+    top = "br_ram_flops_1r1w_mock",
+    deps = [":br_ram_flops_1r1w_mock_fpv_monitor"],
+)

--- a/ram/fpv/br_ram_flops_1r1w_mock_fpv_monitor.sv
+++ b/ram/fpv/br_ram_flops_1r1w_mock_fpv_monitor.sv
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_ram_flops_1r1w_mock_fpv_monitor #(
+    parameter int Depth = 2,
+    parameter int Width = 1,
+    parameter int DepthTiles = 1,
+    parameter int WidthTiles = 1,
+    parameter bit EnablePartialWrite = 0,
+    parameter int WordWidth = Width / WidthTiles,
+    parameter int AddressDepthStages = 0,
+    parameter int ReadDataDepthStages = 0,
+    parameter int ReadDataWidthStages = 0,
+    parameter bit TileEnableBypass = 0,
+    parameter bit EnableMemReset = 0,
+    parameter bit EnableAssertFinalNotValid = 1,
+    localparam int AddressWidth = $clog2(Depth),
+    localparam int NumWords = br_math::ceil_div(Width, WordWidth)
+) (
+    input logic                    wr_clk,
+    input logic                    wr_rst,
+    input logic                    wr_valid,
+    input logic [AddressWidth-1:0] wr_addr,
+    input logic [       Width-1:0] wr_data,
+    input logic [    NumWords-1:0] wr_word_en,
+
+    input logic                    rd_clk,
+    input logic                    rd_rst,
+    input logic                    rd_addr_valid,
+    input logic [AddressWidth-1:0] rd_addr,
+    input logic                    rd_data_valid,
+    input logic [       Width-1:0] rd_data
+);
+
+  br_ram_flops_basic_fv_checker #(
+      .Depth(Depth),
+      .Width(Width),
+      .NumWritePorts(1),
+      .NumReadPorts(1),
+      .EnablePartialWrite(EnablePartialWrite),
+      .WordWidth(WordWidth),
+      .EnableBypass(TileEnableBypass),
+      .EnableReset(EnableMemReset),
+      .WriteLatency(AddressDepthStages),
+      .ReadLatency(ReadDataDepthStages + ReadDataWidthStages)
+  ) fv_checker (
+      .wr_clk,
+      .wr_rst,
+      .wr_valid(wr_valid),
+      .wr_addr(wr_addr),
+      .wr_data(wr_data),
+      .wr_word_en(wr_word_en),
+      .rd_clk,
+      .rd_rst,
+      .rd_addr_valid(rd_addr_valid),
+      .rd_addr(rd_addr),
+      .rd_data_valid(rd_data_valid),
+      .rd_data(rd_data)
+  );
+
+endmodule : br_ram_flops_1r1w_mock_fpv_monitor
+
+bind br_ram_flops_1r1w_mock br_ram_flops_1r1w_mock_fpv_monitor #(
+    .Depth(Depth),
+    .Width(Width),
+    .DepthTiles(DepthTiles),
+    .WidthTiles(WidthTiles),
+    .EnablePartialWrite(EnablePartialWrite),
+    .WordWidth(WordWidth),
+    .AddressDepthStages(AddressDepthStages),
+    .ReadDataDepthStages(ReadDataDepthStages),
+    .ReadDataWidthStages(ReadDataWidthStages),
+    .TileEnableBypass(TileEnableBypass),
+    .EnableMemReset(EnableMemReset),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+) monitor (.*);

--- a/ram/fpv/br_ram_flops_basic_fv_checker.sv
+++ b/ram/fpv/br_ram_flops_basic_fv_checker.sv
@@ -161,20 +161,27 @@ module br_ram_flops_basic_fv_checker #(
     localparam int FvLsb = n * WordWidth;
     localparam int FvMsb = (n + 1) * WordWidth;
 
-    // verilog_lint: waive-start line-length
+    /* verilog_format: off */
     if (EnableBypass) begin : gen_bypass
+      // Same-cycle read/write hazards must return the merged memory value for known words.
       `BR_ASSERT_CR(data_integrity_bypass_a,
-                    fv_rd_valid && fv_wr_valid && fv_wr_word_en[n] |-> ##Latency fv_rd_data[FvMsb-1:FvLsb] == fv_mem_nxt_d[FvMsb-1:FvLsb],
+                    fv_rd_valid && fv_wr_valid &&
+                    (fv_wr_word_en[n] || fv_word_written_d[n] || EnableReset) |->
+                    ##Latency fv_rd_data[FvMsb-1:FvLsb] == fv_mem_nxt_d[FvMsb-1:FvLsb],
                     rd_clk, rd_rst)
+      // Reads without a same-cycle write must return the previously stored word.
       `BR_ASSERT_CR(data_integrity_a,
-                    fv_rd_valid && !fv_wr_valid && fv_word_written_d[n] |-> ##Latency fv_rd_data[FvMsb-1:FvLsb] == fv_mem_d[FvMsb-1:FvLsb],
+                    fv_rd_valid && !fv_wr_valid && fv_word_written_d[n] |->
+                    ##Latency fv_rd_data[FvMsb-1:FvLsb] == fv_mem_d[FvMsb-1:FvLsb],
                     rd_clk, rd_rst)
     end else begin : gen_no_bypass
+      // Non-bypass reads must return the previously stored word.
       `BR_ASSERT_CR(data_integrity_a,
-                    fv_rd_valid && fv_word_written_d[n] |-> ##Latency fv_rd_data[FvMsb-1:FvLsb] == fv_mem_d[FvMsb-1:FvLsb],
+                    fv_rd_valid && fv_word_written_d[n] |->
+                    ##Latency fv_rd_data[FvMsb-1:FvLsb] == fv_mem_d[FvMsb-1:FvLsb],
                     rd_clk, rd_rst)
     end
-    // verilog_lint: waive-stop line-length
+    /* verilog_format: on */
   end
 
 endmodule


### PR DESCRIPTION
Although br_ram_flops_1r1w_mock is a mock ram for simulation, FV should verify its functional correctness.
As expected in https://github.com/xlsynth/bedrock-rtl/issues/1066, bypass data integrity is failing.
I ran RAM FPV regression just to double check RTL ram is ok, everything is clean besides these newly added tests.

//ram/fpv:br_ram_flops_1r1w_mock_test_basic_jg_d4_emr0_epw1_teb1_w1_ww1_fpv_test FAILED in 13.0s
//ram/fpv:br_ram_flops_1r1w_mock_test_basic_jg_d4_emr0_epw1_teb1_w6_ww1_fpv_test FAILED in 13.0s
//ram/fpv:br_ram_flops_1r1w_mock_test_basic_jg_d4_emr0_epw1_teb1_w6_ww2_fpv_test FAILED in 13.1s
//ram/fpv:br_ram_flops_1r1w_mock_test_basic_jg_d4_emr1_epw1_teb1_w1_ww1_fpv_test FAILED in 13.4s
//ram/fpv:br_ram_flops_1r1w_mock_test_basic_jg_d4_emr1_epw1_teb1_w6_ww1_fpv_test FAILED in 13.2s
//ram/fpv:br_ram_flops_1r1w_mock_test_basic_jg_d4_emr1_epw1_teb1_w6_ww2_fpv_test FAILED in 13.6s