### PR TITLE
Support for Unaligned and Narrow Bursts

### DIFF
--- a/amba/rtl/br_amba_axi2axil.sv
+++ b/amba/rtl/br_amba_axi2axil.sv
@@ -7,10 +7,6 @@
 // multiple AXI4-Lite transactions. All write responses will be aggregated into a single AXI4 write
 // response.
 //
-// This does not support narrow transfers with burst length > 1. Single-beat narrow transfers are
-// supported.
-//
-
 `include "br_asserts_internal.svh"
 `include "br_unused.svh"
 

--- a/amba/rtl/internal/br_amba_axi2axil_core.sv
+++ b/amba/rtl/internal/br_amba_axi2axil_core.sv
@@ -107,10 +107,6 @@ module br_amba_axi2axil_core #(
   // We should only get responses when the response FIFO is not empty
   `BR_ASSERT_INTG(resp_fifo_not_empty_when_resp_valid_a, axil_resp_valid |-> resp_fifo_pop_valid)
 
-  // Assert to reject narrow bursts
-  `BR_ASSERT_INTG(reject_narrow_bursts_a, (axi_req_valid && (axi_req_size < $clog2(StrobeWidth)
-                                          )) |-> (axi_req_len == 'd0))
-
   //----------------------------------------------------------------------------
   // Functions
   //----------------------------------------------------------------------------
@@ -124,15 +120,17 @@ module br_amba_axi2axil_core #(
     logic [AddrWidth-1:0] incr_address;
     logic [AddrWidth-1:0] base_address;  // aligned to wrap boundary
     logic [AddrWidth-1:0] wrap_mask;  // mask the wrap boundary
+    logic [AddrWidth-1:0] align_mask;
 
     incr_address = start_addr + (index << size);  // ri lint_check_waive VAR_SHIFT
 
     unique case (br_amba::axi_burst_type_t'(burst_type))
       br_amba::AxiBurstIncr: begin
-        next_address = incr_address;
+        align_mask   = {AddrWidth{1'b1}} << size;  // ri lint_check_waive VAR_SHIFT TRUNC_LSHIFT
+        next_address = (index == 'd0) ? start_addr : (incr_address & align_mask);
       end
       br_amba::AxiBurstWrap: begin
-        wrap_mask = ((burst_len + 1) << size) - 1;  // ri lint_check_waive ARITH_EXTENSION VAR_SHIFT TRUNC_LSHIFT
+        wrap_mask    = ((burst_len + 1) << size) - 1;  // ri lint_check_waive ARITH_EXTENSION VAR_SHIFT TRUNC_LSHIFT
         base_address = start_addr & ~wrap_mask;
         next_address = base_address | (incr_address & wrap_mask);
       end
@@ -147,7 +145,6 @@ module br_amba_axi2axil_core #(
   //----------------------------------------------------------------------------
 
   localparam int RespFifoWidth = (IdWidth + 1);  // 1 bit to indicate if the burst is complete
-  localparam logic [AddrWidth-1:0] AddrAlignMask = {AddrWidth{1'b1}} << $clog2(StrobeWidth);
 
   logic [br_amba::AxiBurstLenWidth-1:0] req_count;
   logic [br_amba::AxiRespWidth-1:0] resp, resp_next;
@@ -161,7 +158,6 @@ module br_amba_axi2axil_core #(
   logic is_last_req_beat;
   logic flow_reg_pop_valid;
   logic flow_reg_pop_ready;
-  logic [AddrWidth-1:0] axi_req_addr_aligned;
   logic [AddrWidth-1:0] axi_req_addr_reg;
   logic [IdWidth-1:0] axi_req_id_reg;
   logic [br_amba::AxiProtWidth-1:0] axi_req_prot_reg;
@@ -181,9 +177,6 @@ module br_amba_axi2axil_core #(
   // Flow Register to Capture the AXI4 Request
   //----------------------------------------------------------------------------
 
-  // Align the AXI4 request address to the bus width
-  assign axi_req_addr_aligned = axi_req_addr & AddrAlignMask;
-
   br_flow_reg_both #(
       .Width(
         AddrWidth +
@@ -200,7 +193,7 @@ module br_amba_axi2axil_core #(
       .push_ready(axi_req_ready),
       .push_valid(axi_req_valid),
       .push_data({
-        axi_req_addr_aligned,
+        axi_req_addr,
         axi_req_id,
         axi_req_len,
         axi_req_size,


### PR DESCRIPTION
# Background
Previously the RTL did not support:
1. bursts that started with unaligned addresses
2. narrow bursts

# Explanation of changes
## Problem 1:
- INCR: we need to pass the unaligned address through unmodified for the first beat of an N-beat burst (where N>=1). 
- WRAP: we need to always align, but should only get aligned addresses in for WRAP.
- FIXED: we need to pass through the address unaligned on every beat.

**_NOTE: when I say "unaligned" I mean without aligning, meaning if the address came in aligned we pass it out aligned too. if the address came in unaligned we do not align it._**

## Problem 2:
we need to increment our beats by the size of the transaction not strobe width, meaning 4B on 4B transactions not strobe width (say 8B) on 4B transactions