### PR TITLE
Allow multiple steps of LFSR state update per advance

### DIFF
--- a/lfsr/rtl/BUILD.bazel
+++ b/lfsr/rtl/BUILD.bazel
@@ -25,8 +25,20 @@ br_verilog_elab_and_lint_test_suite(
             "8",
             "11",
             "16",
+            "55",
         ],
     },
+    deps = [":br_lfsr"],
+)
+
+verilog_elab_test(
+    name = "br_lfsr_advance_limit_elab_test",
+    defines = ["BR_ASSERT_ON"],
+    params = {
+        "AdvanceSteps": "6",
+        "Width": "3",
+    },
+    tool = "verific",
     deps = [":br_lfsr"],
 )
 

--- a/lfsr/rtl/br_lfsr.sv
+++ b/lfsr/rtl/br_lfsr.sv
@@ -28,6 +28,11 @@
 module br_lfsr #(
     // Width of the LFSR state. Must be at least 2.
     parameter int Width = 2,
+    // Number of LFSR state update steps per advance. If AdvanceSteps is relatively
+    // prime to the period of the LFSR, then advancing multiple steps does not change
+    // the period of the resulting LFSR. Higher values of AdvanceSteps result in more
+    // "state mixing" per advance.
+    parameter int AdvanceSteps = 1,
     // Enable check that MSB of taps is set. This is necessary, but not sufficient,
     // for a maximal period LFSR. Disabling this checks allows the LFSR to be used
     // more flexibly (e.g. supporting adjustable period LFSRs by changing the taps).
@@ -60,6 +65,7 @@ module br_lfsr #(
   // Integration checks
   //------------------------------------------
   `BR_ASSERT_STATIC(width_gte_two_a, Width >= 2)
+  `BR_ASSERT_STATIC(advance_steps_gt_zero_a, AdvanceSteps > 0)
   if (EnableAssertTapsMsbIsSet) begin : gen_taps_msb_check
     `BR_ASSERT_INTG(taps_msb_set_a, taps[Width-1] == 1'b1)
   end
@@ -74,9 +80,21 @@ module br_lfsr #(
   logic [Width-1:0] state;
   logic [Width-1:0] next_state;
 
+  function automatic logic [Width-1:0] get_next_state(input logic [Width-1:0] current_state,
+                                                      input logic [Width-1:0] current_taps);
+    logic [Width-1:0] advanced_state;
+
+    advanced_state = current_state;
+    // ri lint_check_waive LOOP_VAR_NOT_USED
+    for (int i = 0; i < AdvanceSteps; i++) begin
+      advanced_state = {advanced_state[Width-2:0], ^(advanced_state & current_taps)};
+    end
+    return advanced_state;
+  endfunction
+
   assign out = state[0];
   assign out_state = state;
-  assign next_state = reinit ? initial_state : {state[Width-2:0], ^(state & taps)};
+  assign next_state = reinit ? initial_state : get_next_state(state, taps);
 
   `BR_REGLI(state, next_state, advance || reinit, initial_state)
 
@@ -86,6 +104,7 @@ module br_lfsr #(
 
   // Value
   `BR_ASSERT_IMPL(out_state_non_zero_a, out_state != '0)
+  // Assumes AdvanceSteps is not equal to the LFSR period.
   `BR_ASSERT_IMPL(advance_changes_a, advance && !reinit |=> out_state != $past(out_state))
   `BR_ASSERT_IMPL(no_advance_holds_a, !advance && !reinit |=> (out_state == $past(out_state)
                                       ) && (out == $past(out)))

--- a/lfsr/rtl/br_lfsr.sv
+++ b/lfsr/rtl/br_lfsr.sv
@@ -64,8 +64,12 @@ module br_lfsr #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  localparam longint AdvanceStepsPlusTwo = (AdvanceSteps > 0) ? longint'(AdvanceSteps) + 2 : 2;
+
   `BR_ASSERT_STATIC(width_gte_two_a, Width >= 2)
   `BR_ASSERT_STATIC(advance_steps_gt_zero_a, AdvanceSteps > 0)
+  // Equivalent to AdvanceSteps < 2**Width - 1, but avoids constructing 2**Width.
+  `BR_ASSERT_STATIC(advance_steps_lt_period_a, $clog2(AdvanceStepsPlusTwo) <= Width)
   if (EnableAssertTapsMsbIsSet) begin : gen_taps_msb_check
     `BR_ASSERT_INTG(taps_msb_set_a, taps[Width-1] == 1'b1)
   end

--- a/lfsr/sim/BUILD.bazel
+++ b/lfsr/sim/BUILD.bazel
@@ -49,3 +49,23 @@ br_verilog_sim_test_tools_suite(
     ],
     deps = [":br_lfsr_tb"],
 )
+
+br_verilog_sim_test_tools_suite(
+    name = "br_lfsr_advance_steps_sim_test_tools_suite",
+    params = {
+        "AdvanceSteps": [
+            "2",
+            "3",
+            "4",
+        ],
+        "Width": [
+            "3",
+            "5",
+        ],
+    },
+    tools = [
+        "iverilog",
+        "vcs",
+    ],
+    deps = [":br_lfsr_tb"],
+)

--- a/lfsr/sim/br_lfsr_tb.sv
+++ b/lfsr/sim/br_lfsr_tb.sv
@@ -5,6 +5,7 @@
 
 module br_lfsr_tb;
   parameter int Width = 2;
+  parameter int AdvanceSteps = 1;
 
   logic clk;
   logic rst;
@@ -50,7 +51,8 @@ module br_lfsr_tb;
   end
 
   br_lfsr #(
-      .Width(Width)
+      .Width(Width),
+      .AdvanceSteps(AdvanceSteps)
   ) dut (
       .clk,
       .rst,
@@ -67,6 +69,17 @@ module br_lfsr_tb;
       .rst
   );
 
+  function automatic logic [Width-1:0] get_next_state(input logic [Width-1:0] current_state,
+                                                      input logic [Width-1:0] current_taps);
+    logic [Width-1:0] advanced_state;
+
+    advanced_state = current_state;
+    for (int i = 0; i < AdvanceSteps; i++) begin
+      advanced_state = {advanced_state[Width-2:0], ^(advanced_state & current_taps)};
+    end
+    return advanced_state;
+  endfunction
+
   initial begin
     initial_state = Width'(1'b1);
     reinit = 0;
@@ -80,13 +93,17 @@ module br_lfsr_tb;
       int ones_count;
       int zeros_count;
       int period;
+      logic [Width-1:0] expected_state;
 
       zeros_count = out == 0;
       ones_count = out == 1;
       period = 1;
+      expected_state = initial_state;
 
       advance = 1;
+      expected_state = get_next_state(expected_state, taps);
       td.wait_cycles();
+      td.check_integer(int'(out_state), int'(expected_state), "State mismatch");
 
       while (out_state != initial_state) begin
         zeros_count += (out == 0);
@@ -98,7 +115,9 @@ module br_lfsr_tb;
         td.wait_cycles($urandom() % 3);
 
         advance = 1;
+        expected_state = get_next_state(expected_state, taps);
         td.wait_cycles();
+        td.check_integer(int'(out_state), int'(expected_state), "State mismatch");
       end
 
       td.check_integer(period, 2 ** Width - 1, "Period mismatch");


### PR DESCRIPTION
Verified that `bazel test //lfsr/...` passes (except for some timeouts for FPV tests with widest LFSRs).