### PR TITLE
[fv] Update LFSR FPV to handle different advance steps

### DIFF
--- a/lfsr/fpv/BUILD.bazel
+++ b/lfsr/fpv/BUILD.bazel
@@ -50,7 +50,6 @@ br_verilog_fpv_test_tools_suite(
 br_verilog_fpv_test_tools_suite(
     name = "br_lfsr_initial_state_test_suite",
     elab_opts = ["-parameter Width 4"],
-    gui = True,
     params = {
         "EnableAssertInitialStateNonZero": [
             "0",

--- a/lfsr/fpv/BUILD.bazel
+++ b/lfsr/fpv/BUILD.bazel
@@ -33,3 +33,16 @@ br_verilog_fpv_test_tools_suite(
     top = "br_lfsr",
     deps = [":br_lfsr_fpv_monitor"],
 )
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_lfsr_advance_steps_test_suite",
+    elab_opts = ["-parameter Width 4"],
+    params = {
+        "AdvanceSteps": [str(advance_steps) for advance_steps in range(2, 15)],
+    },
+    tools = {
+        "jg": "br_lfsr_fpv.jg.tcl",
+    },
+    top = "br_lfsr",
+    deps = [":br_lfsr_fpv_monitor"],
+)

--- a/lfsr/fpv/BUILD.bazel
+++ b/lfsr/fpv/BUILD.bazel
@@ -46,3 +46,20 @@ br_verilog_fpv_test_tools_suite(
     top = "br_lfsr",
     deps = [":br_lfsr_fpv_monitor"],
 )
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_lfsr_initial_state_test_suite",
+    elab_opts = ["-parameter Width 4"],
+    gui = True,
+    params = {
+        "EnableAssertInitialStateNonZero": [
+            "0",
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_lfsr_fpv.jg.tcl",
+    },
+    top = "br_lfsr",
+    deps = [":br_lfsr_fpv_monitor"],
+)

--- a/lfsr/fpv/br_lfsr_fpv.jg.tcl
+++ b/lfsr/fpv/br_lfsr_fpv.jg.tcl
@@ -10,15 +10,27 @@ assume -name deassert_rst {##1 !rst}
 assume -name initial_state_non_zero_during_reset {rst |-> initial_state != '0}
 get_design_info
 array set param_list [get_design_info -list parameter]
-set PeriodMinusOne [expr {2 ** $param_list(Width) - 2}]
+set Period [expr {2 ** $param_list(Width) - 1}]
+set GcdA $param_list(AdvanceSteps)
+set GcdB $Period
+while {$GcdB != 0} {
+    set Remainder [expr {$GcdA % $GcdB}]
+    set GcdA $GcdB
+    set GcdB $Remainder
+}
+set EffectivePeriod [expr {$Period / $GcdA}]
+set EffectivePeriodMinusOne [expr {$EffectivePeriod - 1}]
 
 # abstract flop state, so DUT can start from any state
 abstract -reset state
 abstract -reset monitor.period_count
 abstract -reset monitor.period_done
 assume -name state_is_legal_after_reset {$fell(rst) |-> state != '0}
-assume -name period_count_matches_state_after_reset {$fell(rst) |-> monitor.period_count == state}
-assume -name period_done_matches_count_after_reset "\$fell(rst) |-> monitor.period_done == (monitor.period_count == $PeriodMinusOne)"
+# The monitor counts positions in the AdvanceSteps effective cycle, not the full
+# raw LFSR period. After reset abstraction, period_count must therefore start at
+# one of those effective-step positions.
+assume -name period_count_in_range_after_reset "\$fell(rst) |-> monitor.period_count < $EffectivePeriod"
+assume -name period_done_matches_count_after_reset "\$fell(rst) |-> monitor.period_done == (monitor.period_count == $EffectivePeriodMinusOne)"
 
 # FV won't be able to converge within 30m when width >= 9
 set_prove_time_limit 30m

--- a/lfsr/fpv/br_lfsr_fpv.jg.tcl
+++ b/lfsr/fpv/br_lfsr_fpv.jg.tcl
@@ -7,7 +7,6 @@ reset -none
 assume -reset -name set_rst_during_reset {rst}
 assume -bound 1 -name lfsr_rst {rst}
 assume -name deassert_rst {##1 !rst}
-assume -name initial_state_non_zero_during_reset {rst |-> initial_state != '0}
 get_design_info
 array set param_list [get_design_info -list parameter]
 set Period [expr {2 ** $param_list(Width) - 1}]
@@ -20,17 +19,24 @@ while {$GcdB != 0} {
 }
 set EffectivePeriod [expr {$Period / $GcdA}]
 set EffectivePeriodMinusOne [expr {$EffectivePeriod - 1}]
+set EnableAssertInitialStateNonZero [expr {$param_list(EnableAssertInitialStateNonZero) == "1" || $param_list(EnableAssertInitialStateNonZero) == "1'b1"}]
 
 # abstract flop state, so DUT can start from any state
 abstract -reset state
 abstract -reset monitor.period_count
 abstract -reset monitor.period_done
-assume -name state_is_legal_after_reset {$fell(rst) |-> state != '0}
-# The monitor counts positions in the AdvanceSteps effective cycle, not the full
-# raw LFSR period. After reset abstraction, period_count must therefore start at
-# one of those effective-step positions.
-assume -name period_count_in_range_after_reset "\$fell(rst) |-> monitor.period_count < $EffectivePeriod"
-assume -name period_done_matches_count_after_reset "\$fell(rst) |-> monitor.period_done == (monitor.period_count == $EffectivePeriodMinusOne)"
+if {$EnableAssertInitialStateNonZero} {
+    assume -name initial_state_non_zero_during_reset {rst |-> initial_state != '0}
+    assume -name state_is_legal_after_reset {$fell(rst) |-> state != '0}
+    # The monitor counts positions in the AdvanceSteps effective cycle, not the full
+    # raw LFSR period. After reset abstraction, period_count must therefore start at
+    # one of those effective-step positions.
+    assume -name period_count_in_range_after_reset "\$fell(rst) |-> monitor.period_count < $EffectivePeriod"
+    assume -name period_done_matches_count_after_reset "\$fell(rst) |-> monitor.period_done == (monitor.period_count == $EffectivePeriodMinusOne)"
+} else {
+    assume -name initial_state_zero_during_reset {rst |-> initial_state == '0}
+    assume -name state_is_zero_after_reset {$fell(rst) |-> state == '0}
+}
 
 # FV won't be able to converge within 30m when width >= 9
 set_prove_time_limit 30m

--- a/lfsr/fpv/br_lfsr_fpv_monitor.sv
+++ b/lfsr/fpv/br_lfsr_fpv_monitor.sv
@@ -5,7 +5,7 @@
 //
 // This monitor checks that a configured maximum-length LFSR stays out of the
 // all-zero lock-up state, preserves state while stalled, reloads initial_state
-// on reinit, and does not repeat an out_state value within one expected period.
+// on reinit, and does not repeat an out_state value within one effective period.
 // The period check constrains taps to the known-good table values for the
 // selected Width and compares two arbitrary positions in the cycle.
 
@@ -15,10 +15,9 @@
 
 module br_lfsr_fpv_monitor #(
     parameter int Width = 2,
+    parameter int AdvanceSteps = 1,
     parameter bit EnableAssertTapsMsbIsSet = 1,
-    parameter bit EnableAssertInitialStateNonZero = 1,
-    localparam int Period = (2 ** Width) - 1,
-    localparam int PeriodCounterWidth = $clog2(Period)
+    parameter bit EnableAssertInitialStateNonZero = 1
 ) (
     input logic             clk,
     input logic             rst,
@@ -29,9 +28,35 @@ module br_lfsr_fpv_monitor #(
     input logic             out,
     input logic [Width-1:0] out_state
 );
+  localparam int Period = (2 ** Width) - 1;
 
   `BR_ASSERT_STATIC(width_gte_two_a, Width >= 2)
   `BR_ASSERT_STATIC(width_supported_a, Width <= 16)
+
+  // Euclidean algorithm for the greatest common divisor. This is used only in
+  // constant parameter math to determine how AdvanceSteps maps onto the LFSR period.
+  function automatic int get_gcd(input int value_a, input int value_b);
+    int a;
+    int b;
+    int remainder;
+
+    a = value_a;
+    b = value_b;
+    while (b != 0) begin
+      remainder = a % b;
+      a = b;
+      b = remainder;
+    end
+    return a;
+  endfunction
+
+  // Advancing by N steps walks the period-sized state cycle in strides of N.
+  // If the stride shares a factor with Period, only Period / gcd(N, Period)
+  // unique states are visited before repeating.
+  localparam int EffectivePeriod = Period / get_gcd(AdvanceSteps, Period);
+  localparam int PeriodCounterWidth = (EffectivePeriod > 1) ? $clog2(EffectivePeriod) : 1;
+
+  `BR_ASSERT_STATIC(effective_period_gt_one_a, EffectivePeriod > 1)
 
   function automatic logic [Width-1:0] get_expected_taps();
     if (Width == 2) begin
@@ -86,7 +111,7 @@ module br_lfsr_fpv_monitor #(
   `BR_ASSERT(reinit_loads_initial_state_a, reinit |=> out_state == $past(initial_state))
 
   //------------------------------------------
-  // Full-period checks
+  // Effective-period checks
   //------------------------------------------
 
   logic [PeriodCounterWidth-1:0] period_count;
@@ -96,10 +121,10 @@ module br_lfsr_fpv_monitor #(
   logic                          out_state_a_valid;
   logic [             Width-1:0] out_state_a;
 
-  `BR_FV_2RAND_IDX(state_a, state_b, Period)
+  `BR_FV_2RAND_IDX(state_a, state_b, EffectivePeriod)
   `BR_ASSUME(state_a_lt_state_b_a, state_a < state_b)
 
-  // Pick two arbitrary positions in the expected period. Capture the out_state
+  // Pick two arbitrary positions in the effective period. Capture the out_state
   // at the earlier position and check that the later position differs.
   always_ff @(posedge clk) begin
     if (rst || reinit) begin
@@ -114,7 +139,7 @@ module br_lfsr_fpv_monitor #(
       end
 
       if (advance) begin
-        if (period_count == PeriodCounterWidth'(Period - 1)) begin
+        if (period_count == PeriodCounterWidth'(EffectivePeriod - 1)) begin
           period_count <= '0;
           period_done  <= 1'b1;
         end else begin
@@ -124,8 +149,8 @@ module br_lfsr_fpv_monitor #(
     end
   end
 
-  // Since state_a and state_b are arbitrary distinct period positions, this
-  // proves any two positions in the period produce different LFSR states.
+  // Since state_a and state_b are arbitrary distinct effective-period positions,
+  // this proves any two positions in the effective period produce different LFSR states.
   `BR_ASSERT(no_duplicate_states_a,
              out_state_a_valid && (period_count == state_b) |-> out_state_a != out_state)
 
@@ -135,6 +160,7 @@ endmodule : br_lfsr_fpv_monitor
 
 bind br_lfsr br_lfsr_fpv_monitor #(
     .Width(Width),
+    .AdvanceSteps(AdvanceSteps),
     .EnableAssertTapsMsbIsSet(EnableAssertTapsMsbIsSet),
     .EnableAssertInitialStateNonZero(EnableAssertInitialStateNonZero)
 ) monitor (.*);

--- a/lfsr/fpv/br_lfsr_fpv_monitor.sv
+++ b/lfsr/fpv/br_lfsr_fpv_monitor.sv
@@ -96,7 +96,11 @@ module br_lfsr_fpv_monitor #(
   // Assumptions
   //------------------------------------------
 
-  `BR_ASSUME(initial_state_non_zero_a, initial_state != '0)
+  if (EnableAssertInitialStateNonZero) begin : gen_initial_state_check
+    `BR_ASSUME(initial_state_non_zero_a, initial_state != '0)
+  end else begin : gen_initial_state_zero_check
+    `BR_ASSUME(initial_state_zero_a, initial_state == '0)
+  end
   `BR_ASSUME(initial_state_stable_a, $stable(initial_state))
   `BR_ASSUME(taps_known_good_a, taps == get_expected_taps())
   `BR_ASSUME(taps_stable_a, $stable(taps))
@@ -106,7 +110,11 @@ module br_lfsr_fpv_monitor #(
   //------------------------------------------
 
   `BR_ASSERT(out_check_a, out == out_state[0])
-  `BR_ASSERT(out_state_non_zero_a, out_state != '0)
+  if (EnableAssertInitialStateNonZero) begin : gen_out_state_non_zero_check
+    `BR_ASSERT(out_state_non_zero_a, out_state != '0)
+  end else begin : gen_out_state_zero_check
+    `BR_ASSERT(out_state_zero_a, out_state == '0)
+  end
   `BR_ASSERT(no_advance_holds_a, !advance && !reinit |=> out_state == $past(out_state))
   `BR_ASSERT(reinit_loads_initial_state_a, reinit |=> out_state == $past(initial_state))
 
@@ -151,8 +159,10 @@ module br_lfsr_fpv_monitor #(
 
   // Since state_a and state_b are arbitrary distinct effective-period positions,
   // this proves any two positions in the effective period produce different LFSR states.
-  `BR_ASSERT(no_duplicate_states_a,
-             out_state_a_valid && (period_count == state_b) |-> out_state_a != out_state)
+  if (EnableAssertInitialStateNonZero) begin : gen_no_duplicate_states_check
+    `BR_ASSERT(no_duplicate_states_a,
+               out_state_a_valid && (period_count == state_b) |-> out_state_a != out_state)
+  end
 
   `BR_COVER(full_period_done_c, period_done)
 

--- a/lfsr/rtl/br_lfsr.sv
+++ b/lfsr/rtl/br_lfsr.sv
@@ -107,9 +107,13 @@ module br_lfsr #(
   //------------------------------------------
 
   // Value
-  `BR_ASSERT_IMPL(out_state_non_zero_a, out_state != '0)
-  // Assumes AdvanceSteps is not equal to the LFSR period.
-  `BR_ASSERT_IMPL(advance_changes_a, advance && !reinit |=> out_state != $past(out_state))
+  if (EnableAssertInitialStateNonZero) begin : gen_out_state_non_zero_check
+    `BR_ASSERT_IMPL(out_state_non_zero_a, out_state != '0)
+    // Assumes AdvanceSteps is not equal to the LFSR period.
+    `BR_ASSERT_IMPL(advance_changes_a, advance && !reinit |=> out_state != $past(out_state))
+  end else begin : gen_out_state_zero_check
+    `BR_ASSERT_IMPL(out_state_zero_a, out_state == '0)
+  end
   `BR_ASSERT_IMPL(no_advance_holds_a, !advance && !reinit |=> (out_state == $past(out_state)
                                       ) && (out == $past(out)))
 


### PR DESCRIPTION
This PR updates the LFSR FPV coverage for the new AdvanceSteps parameter. #1104 

Added effective-period checking in the FPV monitor:
1. The expected period is now Period / gcd(AdvanceSteps, Period) instead of the full period.
2. This handles non-coprime AdvanceSteps values, where the LFSR intentionally visits a shorter cycle before repeating.

Added an FPV sweep for AdvanceSteps with Width = 4:
1. Sweeps legal AdvanceSteps values from 2 through (2 ** Width) - 2.

Added FPV coverage for EnableAssertInitialStateNonZero = 0:
1. This mode represents disabling the LFSR by allowing initial_state == 0.
2. The FPV monitor now checks that out_state remains stuck at 0 in that configuration.
3. RTL inline assertions are also guarded by this parameter.