### PR TITLE
[Bazel] Avoid zipapp for Verilog runner tests.

### DIFF
--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -110,9 +110,21 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
     data_files = getattr(ctx.files, "data", [])
     runfiles = list(data_files)
     verilog_runner_files_to_run = ctx.attr.verilog_runner_tool[DefaultInfo].files_to_run
-    if test and not verilog_runner_files_to_run.executable:
-        fail("verilog_runner_tool must be an executable target for Verilog tests.")
-    if test or not verilog_runner_files_to_run.executable:
+    verilog_runner_files = ctx.files.verilog_runner_tool
+    verilog_runner_file = None
+
+    # Bazel may expose a single source file or filegroup through files_to_run;
+    # raw runner sources still need to be invoked through Python.
+    if (
+        len(verilog_runner_files) == 1 and
+        verilog_runner_files[0].is_source and
+        verilog_runner_files[0].basename.endswith(".py")
+    ):
+        verilog_runner_file = verilog_runner_files[0]
+        verilog_runner_executable = None
+    else:
+        verilog_runner_executable = verilog_runner_files_to_run.executable
+    if test or not verilog_runner_executable:
         runfiles += ctx.files.verilog_runner_tool
     runfiles += ctx.files.verilog_runner_data
     runfiles += ctx.files.verilog_runner_plugins
@@ -161,14 +173,21 @@ def _verilog_base_impl(ctx, subcmd, test = True, extra_args = [], extra_runfiles
     args += extra_args
 
     generator_tools = []
+    if not verilog_runner_executable:
+        if len(verilog_runner_files) != 1:
+            fail("verilog_runner_tool must be an executable target or a single Python source file.")
+        verilog_runner_file = verilog_runner_files[0]
+
     if test:
-        runner_cmd_prefix = [verilog_runner_files_to_run.executable.short_path]
-    elif verilog_runner_files_to_run.executable:
-        runner_cmd_prefix = [verilog_runner_files_to_run.executable.path]
+        if verilog_runner_executable:
+            runner_cmd_prefix = [verilog_runner_executable.short_path]
+        else:
+            runner_cmd_prefix = ["python3", verilog_runner_file.short_path]
+    elif verilog_runner_executable:
+        runner_cmd_prefix = [verilog_runner_executable.path]
         generator_tools = [verilog_runner_files_to_run]
     else:
-        runner_path = ctx.files.verilog_runner_tool[0].path
-        runner_cmd_prefix = ["python3", runner_path]
+        runner_cmd_prefix = ["python3", verilog_runner_file.path]
     plugin_paths = []
     for plugin in ctx.files.verilog_runner_plugins:
         if plugin.dirname not in plugin_paths:
@@ -342,7 +361,7 @@ rule_verilog_elab_test = rule(
         "defines": attr.string_list(doc = "Preprocessor defines to pass to the Verilog compiler."),
         "params": attr.string_dict(doc = "Verilog module parameters to set in the instantiation of the top-level module."),
         "top": attr.string(doc = "The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name."),
-        "verilog_runner_tool": attr.label(doc = "The executable Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner_zipapp", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,
@@ -428,7 +447,7 @@ rule_verilog_lint_test = rule(
             allow_files = True,
             doc = "The lint policy file to use. If not provided, then the default tool policy is used (typically provided through an environment variable).",
         ),
-        "verilog_runner_tool": attr.label(doc = "The executable Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner_zipapp", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,
@@ -517,7 +536,7 @@ rule_verilog_sim_test = rule(
             doc = "Run UVM test.",
             default = False,
         ),
-        "verilog_runner_tool": attr.label(doc = "The executable Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner_zipapp", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,
@@ -634,7 +653,7 @@ rule_verilog_fpv_test = rule(
             doc = "Only run elaboration.",
             default = False,
         ),
-        "verilog_runner_tool": attr.label(doc = "The executable Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner_zipapp", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,
@@ -737,7 +756,7 @@ rule_verilog_fpv_sandbox = rule(
             doc = "Only run elaboration.",
             default = False,
         ),
-        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner", allow_files = True),
+        "verilog_runner_tool": attr.label(doc = "The Verilog Runner tool to use.", default = "//python/verilog_runner:verilog_runner.py", allow_files = True),
         "verilog_runner_data": attr.label_list(
             default = ["//python/verilog_runner:verilog_runner_data"],
             allow_files = True,

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -80,7 +80,7 @@ Tests that a Verilog or SystemVerilog design elaborates. Needs VERILOG_RUNNER_PL
 | <a id="rule_verilog_elab_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_elab_test-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_elab_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py", "@bedrock-rtl//python/verilog_runner/plugins:verilator.py"]`  |
-| <a id="rule_verilog_elab_test-verilog_runner_tool"></a>verilog_runner_tool |  The executable Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner_zipapp"`  |
+| <a id="rule_verilog_elab_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
 
 
 <a id="rule_verilog_fpv_sandbox"></a>
@@ -120,7 +120,7 @@ Writes FPV files and run scripts into a tarball for independent execution outsid
 | <a id="rule_verilog_fpv_sandbox-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_fpv_sandbox-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_fpv_sandbox-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py", "@bedrock-rtl//python/verilog_runner/plugins:verilator.py"]`  |
-| <a id="rule_verilog_fpv_sandbox-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner"`  |
+| <a id="rule_verilog_fpv_sandbox-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
 
 
 <a id="rule_verilog_fpv_test"></a>
@@ -160,7 +160,7 @@ Runs Verilog/SystemVerilog compilation and formal verification in one command. T
 | <a id="rule_verilog_fpv_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_fpv_test-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_fpv_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py", "@bedrock-rtl//python/verilog_runner/plugins:verilator.py"]`  |
-| <a id="rule_verilog_fpv_test-verilog_runner_tool"></a>verilog_runner_tool |  The executable Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner_zipapp"`  |
+| <a id="rule_verilog_fpv_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
 
 
 <a id="rule_verilog_lint_test"></a>
@@ -194,7 +194,7 @@ Tests that a Verilog or SystemVerilog design passes a set of static lint checks.
 | <a id="rule_verilog_lint_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_lint_test-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_lint_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py", "@bedrock-rtl//python/verilog_runner/plugins:verilator.py"]`  |
-| <a id="rule_verilog_lint_test-verilog_runner_tool"></a>verilog_runner_tool |  The executable Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner_zipapp"`  |
+| <a id="rule_verilog_lint_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
 
 
 <a id="rule_verilog_sim_test"></a>
@@ -231,7 +231,7 @@ Runs Verilog/SystemVerilog compilation and simulation in one command. This rule 
 | <a id="rule_verilog_sim_test-uvm"></a>uvm |  Run UVM test.   | Boolean | optional |  `False`  |
 | <a id="rule_verilog_sim_test-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
 | <a id="rule_verilog_sim_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:iverilog.py", "@bedrock-rtl//python/verilog_runner/plugins:verilator.py"]`  |
-| <a id="rule_verilog_sim_test-verilog_runner_tool"></a>verilog_runner_tool |  The executable Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner_zipapp"`  |
+| <a id="rule_verilog_sim_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
 | <a id="rule_verilog_sim_test-waves"></a>waves |  Enable waveform dumping.   | Boolean | optional |  `False`  |
 
 

--- a/bazel/verilog_runner/BUILD.bazel
+++ b/bazel/verilog_runner/BUILD.bazel
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_fpv_test", "verilog_lint_test", "verilog_sim_test")
+
+package(default_visibility = ["//visibility:public"])
+
+verilog_library(
+    name = "nonzip_smoke_lib",
+    srcs = ["nonzip_smoke.sv"],
+)
+
+verilog_elab_test(
+    name = "nonzip_elab_test",
+    tags = ["manual"],
+    tool = "verific",
+    top = "nonzip_smoke",
+    deps = [":nonzip_smoke_lib"],
+)
+
+verilog_lint_test(
+    name = "nonzip_lint_test",
+    tags = ["manual"],
+    tool = "ascentlint",
+    top = "nonzip_smoke",
+    deps = [":nonzip_smoke_lib"],
+)
+
+verilog_sim_test(
+    name = "nonzip_sim_test",
+    tags = ["manual"],
+    tool = "iverilog",
+    top = "nonzip_smoke",
+    deps = [":nonzip_smoke_lib"],
+)
+
+verilog_fpv_test(
+    name = "nonzip_fpv_test",
+    tags = ["manual"],
+    tool = "jg",
+    top = "nonzip_smoke",
+    deps = [":nonzip_smoke_lib"],
+)
+
+sh_test(
+    name = "nonzip_test",
+    srcs = ["nonzip_test.sh"],
+    data = [
+        ":nonzip_elab_test",
+        ":nonzip_fpv_test",
+        ":nonzip_lint_test",
+        ":nonzip_sim_test",
+        "//bazel:verilog.bzl",
+    ],
+)

--- a/bazel/verilog_runner/nonzip_smoke.sv
+++ b/bazel/verilog_runner/nonzip_smoke.sv
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module nonzip_smoke;
+  initial begin
+    $display("TEST PASSED");
+    $finish;
+  end
+endmodule : nonzip_smoke

--- a/bazel/verilog_runner/nonzip_test.sh
+++ b/bazel/verilog_runner/nonzip_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+repo="${TEST_SRCDIR}/${TEST_WORKSPACE}"
+
+if grep -q "verilog_runner_zipapp" "${repo}/bazel/verilog.bzl"; then
+  echo "bazel/verilog.bzl still references verilog_runner_zipapp"
+  exit 1
+fi
+
+for kind in elab lint sim fpv; do
+  wrapper="${repo}/bazel/verilog_runner/nonzip_${kind}_test_runner.sh"
+  if [[ ! -f "${wrapper}" ]]; then
+    echo "missing generated wrapper: ${wrapper}"
+    exit 1
+  fi
+  if ! grep -q "python3 python/verilog_runner/verilog_runner.py" "${wrapper}"; then
+    echo "generated wrapper does not invoke the source runner through python3: ${wrapper}"
+    exit 1
+  fi
+  if grep -q "python/verilog_runner/verilog_runner " "${wrapper}"; then
+    echo "generated wrapper invokes the py_binary runner: ${wrapper}"
+    exit 1
+  fi
+  if grep -q "verilog_runner_zipapp" "${wrapper}"; then
+    echo "generated wrapper still references verilog_runner_zipapp: ${wrapper}"
+    exit 1
+  fi
+done
+
+for file in \
+  python/verilog_runner/verilog_runner.py \
+  python/verilog_runner/cli.py \
+  python/verilog_runner/eda_tool.py \
+  python/verilog_runner/plugins.py \
+  python/verilog_runner/util.py \
+  python/verilog_runner/plugins/iverilog.py \
+  python/verilog_runner/plugins/verilator.py; do
+  if [[ ! -f "${repo}/${file}" ]]; then
+    echo "missing Verilog runner runfile: ${file}"
+    exit 1
+  fi
+done
+
+if find "${TEST_SRCDIR}" -maxdepth 4 -type d -name 'rules_python~~python*' | grep -q .; then
+  echo "Verilog test runfiles include the rules_python interpreter runtime"
+  exit 1
+fi

--- a/python/verilog_runner/BUILD.bazel
+++ b/python/verilog_runner/BUILD.bazel
@@ -5,6 +5,8 @@ load("@rules_python//python/zipapp:py_zipapp_binary.bzl", "py_zipapp_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+# TODO: Use a hermetic Python runner without adding the full Python runtime to
+# every Verilog test runfiles tree.
 exports_files([
     "verilog_runner.py",
     "cli.py",
@@ -20,6 +22,8 @@ filegroup(
         "eda_tool.py",
         "plugins.py",
         "util.py",
+        "//python/verilog_runner/plugins:iverilog.py",
+        "//python/verilog_runner/plugins:verilator.py",
     ],
 )
 


### PR DESCRIPTION
The zipapp/py_binary runner pulls the rules_python interpreter runtime into every generated Verilog test runfiles tree. When Bazel materializes those runfiles under /tmp, that adds avoidable pressure on tmp storage and keeps wrappers tied to the packaged runner.

Default the Verilog test rules to verilog_runner.py instead, teach wrapper generation to invoke raw Python sources through python3, and add a nonzip smoke test that checks the generated wrappers and expected runfiles.