### PR TITLE
[delay] Add simulation benches for delay variants

### DIFF
--- a/delay/sim/BUILD.bazel
+++ b/delay/sim/BUILD.bazel
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:private"])
+
+verilog_library(
+    name = "br_delay_deskew_tb",
+    srcs = ["br_delay_deskew_tb.sv"],
+    deps = [
+        "//delay/rtl:br_delay_deskew",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_delay_deskew_tb_elab_test",
+    tool = "verific",
+    deps = [":br_delay_deskew_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_delay_deskew_sim_test_tools_suite",
+    params = {
+        "Width": [
+            "1",
+            "8",
+        ],
+    },
+    tools = [
+        "iverilog",
+        "vcs",
+        # TODO(mgottscho): Re-enable Verilator once it accepts the dependent
+        # assertions that use delayed sequence expressions.
+        #"verilator",
+    ],
+    deps = [":br_delay_deskew_tb"],
+)
+
+verilog_library(
+    name = "br_delay_skew_tb",
+    srcs = ["br_delay_skew_tb.sv"],
+    deps = [
+        "//delay/rtl:br_delay_skew",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_delay_skew_tb_elab_test",
+    tool = "verific",
+    deps = [":br_delay_skew_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_delay_skew_sim_test_tools_suite",
+    params = {
+        "Width": [
+            "1",
+            "8",
+        ],
+    },
+    tools = [
+        "iverilog",
+        "vcs",
+        # TODO(mgottscho): Re-enable Verilator once it accepts the dependent
+        # assertions that use delayed sequence expressions.
+        #"verilator",
+    ],
+    deps = [":br_delay_skew_tb"],
+)
+
+verilog_library(
+    name = "br_delay_valid_next_tb",
+    srcs = ["br_delay_valid_next_tb.sv"],
+    deps = [
+        "//delay/rtl:br_delay_valid_next",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_delay_valid_next_tb_elab_test",
+    tool = "verific",
+    deps = [":br_delay_valid_next_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_delay_valid_next_sim_test_tools_suite",
+    params = {
+        "NumStages": [
+            "0",
+            "1",
+            "3",
+        ],
+        "Width": [
+            "1",
+            "8",
+        ],
+    },
+    tools = [
+        "iverilog",
+        "vcs",
+        # TODO(mgottscho): Re-enable Verilator once it accepts the dependent
+        # assertions that use delayed sequence expressions.
+        #"verilator",
+    ],
+    deps = [":br_delay_valid_next_tb"],
+)
+
+verilog_library(
+    name = "br_delay_valid_next_nr_tb",
+    srcs = ["br_delay_valid_next_nr_tb.sv"],
+    deps = [
+        "//delay/rtl:br_delay_valid_next_nr",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_delay_valid_next_nr_tb_elab_test",
+    tool = "verific",
+    deps = [":br_delay_valid_next_nr_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_delay_valid_next_nr_sim_test_tools_suite",
+    params = {
+        "NumStages": [
+            "0",
+            "1",
+            "3",
+        ],
+        "Width": [
+            "1",
+            "8",
+        ],
+    },
+    tools = [
+        "iverilog",
+        "vcs",
+        # TODO(mgottscho): Re-enable Verilator once it accepts the dependent
+        # assertions that use delayed sequence expressions.
+        #"verilator",
+    ],
+    deps = [":br_delay_valid_next_nr_tb"],
+)
+
+verilog_library(
+    name = "br_delay_valid_nr_tb",
+    srcs = ["br_delay_valid_nr_tb.sv"],
+    deps = [
+        "//delay/rtl:br_delay_valid_nr",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_delay_valid_nr_tb_elab_test",
+    tool = "verific",
+    deps = [":br_delay_valid_nr_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_delay_valid_nr_sim_test_tools_suite",
+    params = {
+        "FirstStageUngated": [
+            "0",
+            "1",
+        ],
+        "NumStages": [
+            "0",
+            "1",
+            "3",
+        ],
+        "Width": [
+            "1",
+            "8",
+        ],
+    },
+    tools = [
+        "iverilog",
+        "vcs",
+        # TODO(mgottscho): Re-enable Verilator once it accepts the dependent
+        # assertions that use delayed sequence expressions.
+        #"verilator",
+    ],
+    deps = [":br_delay_valid_nr_tb"],
+)

--- a/delay/sim/br_delay_deskew_tb.sv
+++ b/delay/sim/br_delay_deskew_tb.sv
@@ -32,13 +32,15 @@ module br_delay_deskew_tb;
     end
   endfunction
 
-  task automatic check_aligned_data(input logic expected_valid,
-                                    input logic [Width-1:0] expected_data, input string phase);
-    in = expected_data;
+  task automatic drive_cycle(input logic drive_valid_next, input logic expected_valid,
+                             input logic [Width-1:0] drive_data, input string phase);
+    in_valid_next = drive_valid_next;
+    td.wait_cycles();
+    in = drive_data;
     #1;
     td.check(out_valid === expected_valid, $sformatf("%s: out_valid mismatch", phase));
     if (expected_valid) begin
-      td.check(out === expected_data, $sformatf("%s: out mismatch", phase));
+      td.check(out === drive_data, $sformatf("%s: out mismatch", phase));
     end
   endtask
 
@@ -47,29 +49,13 @@ module br_delay_deskew_tb;
     in = '0;
 
     td.reset_dut();
-    td.wait_cycles();
-    check_aligned_data(1'b0, data_for(-1), "initial idle");
 
-    in_valid_next = 1'b1;
-    in = data_for(-2);
-    td.wait_cycles();
-    check_aligned_data(1'b1, data_for(0), "first valid beat");
-
-    in_valid_next = 1'b1;
-    td.wait_cycles();
-    check_aligned_data(1'b1, data_for(1), "back-to-back beat");
-
-    in_valid_next = 1'b0;
-    td.wait_cycles();
-    check_aligned_data(1'b0, data_for(2), "bubble");
-
-    in_valid_next = 1'b1;
-    td.wait_cycles();
-    check_aligned_data(1'b1, data_for(3), "valid after bubble");
-
-    in_valid_next = 1'b0;
-    td.wait_cycles();
-    check_aligned_data(1'b0, data_for(4), "final idle");
+    drive_cycle(1'b0, 1'b0, data_for(-1), "initial idle");
+    drive_cycle(1'b1, 1'b1, data_for(0), "first valid beat");
+    drive_cycle(1'b1, 1'b1, data_for(1), "back-to-back beat");
+    drive_cycle(1'b0, 1'b0, data_for(2), "bubble");
+    drive_cycle(1'b1, 1'b1, data_for(3), "valid after bubble");
+    drive_cycle(1'b0, 1'b0, data_for(4), "final idle");
 
     td.finish();
   end

--- a/delay/sim/br_delay_deskew_tb.sv
+++ b/delay/sim/br_delay_deskew_tb.sv
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module br_delay_deskew_tb;
+
+  parameter int Width = 8;
+
+  logic clk;
+  logic rst;
+  logic in_valid_next;
+  logic [Width-1:0] in;
+  logic out_valid;
+  logic [Width-1:0] out;
+
+  br_delay_deskew #(
+      .Width(Width)
+  ) dut (
+      .clk,
+      .in_valid_next,
+      .in,
+      .out_valid,
+      .out
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  function automatic logic [Width-1:0] data_for(input int idx);
+    for (int i = 0; i < Width; i++) begin
+      data_for[i] = ((idx + i) % 4) < 2;
+    end
+  endfunction
+
+  task automatic check_aligned_data(input logic expected_valid,
+                                    input logic [Width-1:0] expected_data, input string phase);
+    in = expected_data;
+    #1;
+    td.check(out_valid === expected_valid, $sformatf("%s: out_valid mismatch", phase));
+    if (expected_valid) begin
+      td.check(out === expected_data, $sformatf("%s: out mismatch", phase));
+    end
+  endtask
+
+  initial begin
+    in_valid_next = 1'b0;
+    in = '0;
+
+    td.reset_dut();
+    td.wait_cycles();
+    check_aligned_data(1'b0, data_for(-1), "initial idle");
+
+    in_valid_next = 1'b1;
+    in = data_for(-2);
+    td.wait_cycles();
+    check_aligned_data(1'b1, data_for(0), "first valid beat");
+
+    in_valid_next = 1'b1;
+    td.wait_cycles();
+    check_aligned_data(1'b1, data_for(1), "back-to-back beat");
+
+    in_valid_next = 1'b0;
+    td.wait_cycles();
+    check_aligned_data(1'b0, data_for(2), "bubble");
+
+    in_valid_next = 1'b1;
+    td.wait_cycles();
+    check_aligned_data(1'b1, data_for(3), "valid after bubble");
+
+    in_valid_next = 1'b0;
+    td.wait_cycles();
+    check_aligned_data(1'b0, data_for(4), "final idle");
+
+    td.finish();
+  end
+
+endmodule : br_delay_deskew_tb

--- a/delay/sim/br_delay_skew_tb.sv
+++ b/delay/sim/br_delay_skew_tb.sv
@@ -39,8 +39,7 @@ module br_delay_skew_tb;
     in_valid = drive_valid;
     in = drive_data;
     td.wait_cycles();
-    td.check(out_valid_next === drive_valid,
-             $sformatf("%s: out_valid_next mismatch", phase));
+    td.check(out_valid_next === drive_valid, $sformatf("%s: out_valid_next mismatch", phase));
 
     if (drive_valid) begin
       expected_out = drive_data;

--- a/delay/sim/br_delay_skew_tb.sv
+++ b/delay/sim/br_delay_skew_tb.sv
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module br_delay_skew_tb;
+
+  parameter int Width = 8;
+
+  logic clk;
+  logic rst;
+  logic in_valid;
+  logic [Width-1:0] in;
+  logic out_valid_next;
+  logic [Width-1:0] out;
+  logic [Width-1:0] expected_out;
+  logic expected_out_known;
+
+  br_delay_skew #(
+      .Width(Width)
+  ) dut (
+      .clk,
+      .in_valid,
+      .in,
+      .out_valid_next,
+      .out
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  function automatic logic [Width-1:0] data_for(input int idx);
+    for (int i = 0; i < Width; i++) begin
+      data_for[i] = ((idx + (2 * i)) % 3) != 0;
+    end
+  endfunction
+
+  task automatic drive_cycle(input logic drive_valid, input logic [Width-1:0] drive_data,
+                             input string phase);
+    in_valid = drive_valid;
+    in = drive_data;
+    td.wait_cycles();
+    td.check(out_valid_next === drive_valid,
+             $sformatf("%s: out_valid_next mismatch", phase));
+
+    if (drive_valid) begin
+      expected_out = drive_data;
+      expected_out_known = 1'b1;
+    end
+
+    if (expected_out_known) begin
+      td.check(out === expected_out, $sformatf("%s: out mismatch", phase));
+    end
+  endtask
+
+  initial begin
+    in_valid = 1'b0;
+    in = '0;
+    expected_out = '0;
+    expected_out_known = 1'b0;
+
+    td.reset_dut();
+
+    drive_cycle(1'b1, data_for(0), "first valid beat");
+    drive_cycle(1'b1, data_for(1), "back-to-back beat");
+    drive_cycle(1'b0, data_for(2), "invalid hold");
+    drive_cycle(1'b1, data_for(3), "valid after bubble");
+    drive_cycle(1'b0, data_for(4), "drain");
+    drive_cycle(1'b0, data_for(5), "final idle");
+
+    td.finish();
+  end
+
+endmodule : br_delay_skew_tb

--- a/delay/sim/br_delay_valid_next_nr_tb.sv
+++ b/delay/sim/br_delay_valid_next_nr_tb.sv
@@ -84,15 +84,15 @@ module br_delay_valid_next_nr_tb;
   endtask
 
   task automatic check_model(input string phase);
-    td.check(out_valid_next === model_valid_next[NumStages],
-             $sformatf("%s: out_valid_next mismatch", phase));
-    td.check(out_valid_next_stages === model_valid_next,
-             $sformatf("%s: out_valid_next_stages mismatch", phase));
+    td.check(out_valid_next === model_valid_next[NumStages], $sformatf(
+             "%s: out_valid_next mismatch", phase));
+    td.check(out_valid_next_stages === model_valid_next, $sformatf(
+             "%s: out_valid_next_stages mismatch", phase));
 
     for (int i = 0; i <= NumStages; i++) begin
       if (model_data_valid[i] || (NumStages == 0 && i == 0)) begin
-        td.check(out_stages[i] === model_data[i],
-                 $sformatf("%s: out_stages[%0d] mismatch", phase, i));
+        td.check(out_stages[i] === model_data[i], $sformatf("%s: out_stages[%0d] mismatch", phase, i
+                 ));
       end
     end
 

--- a/delay/sim/br_delay_valid_next_nr_tb.sv
+++ b/delay/sim/br_delay_valid_next_nr_tb.sv
@@ -12,8 +12,6 @@ module br_delay_valid_next_nr_tb;
   logic [Width-1:0] in;
   logic out_valid_next;
   logic [Width-1:0] out;
-  logic [NumStages:0] out_valid_next_stages;
-  logic [NumStages:0][Width-1:0] out_stages;
 
   logic [NumStages:0] model_valid_next;
   logic [NumStages:0] model_data_valid;
@@ -31,8 +29,8 @@ module br_delay_valid_next_nr_tb;
       .in,
       .out_valid_next,
       .out,
-      .out_valid_next_stages,
-      .out_stages
+      .out_valid_next_stages(),
+      .out_stages()
   );
 
   br_test_driver td (
@@ -86,15 +84,6 @@ module br_delay_valid_next_nr_tb;
   task automatic check_model(input string phase);
     td.check(out_valid_next === model_valid_next[NumStages], $sformatf(
              "%s: out_valid_next mismatch", phase));
-    td.check(out_valid_next_stages === model_valid_next, $sformatf(
-             "%s: out_valid_next_stages mismatch", phase));
-
-    for (int i = 0; i <= NumStages; i++) begin
-      if (model_data_valid[i] || (NumStages == 0 && i == 0)) begin
-        td.check(out_stages[i] === model_data[i], $sformatf("%s: out_stages[%0d] mismatch", phase, i
-                 ));
-      end
-    end
 
     if (model_data_valid[NumStages] || NumStages == 0) begin
       td.check(out === model_data[NumStages], $sformatf("%s: out mismatch", phase));

--- a/delay/sim/br_delay_valid_next_nr_tb.sv
+++ b/delay/sim/br_delay_valid_next_nr_tb.sv
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module br_delay_valid_next_nr_tb;
+
+  parameter int Width = 8;
+  parameter int NumStages = 2;
+  parameter int NumTestCycles = 18;
+
+  logic clk;
+  logic rst;
+  logic in_valid_next;
+  logic [Width-1:0] in;
+  logic out_valid_next;
+  logic [Width-1:0] out;
+  logic [NumStages:0] out_valid_next_stages;
+  logic [NumStages:0][Width-1:0] out_stages;
+
+  logic [NumStages:0] model_valid_next;
+  logic [NumStages:0] model_data_valid;
+  logic [NumStages:0][Width-1:0] model_data;
+  logic [NumStages:0] next_valid_next;
+  logic [NumStages:0] next_data_valid;
+  logic [NumStages:0][Width-1:0] next_data;
+
+  br_delay_valid_next_nr #(
+      .Width(Width),
+      .NumStages(NumStages)
+  ) dut (
+      .clk,
+      .in_valid_next,
+      .in,
+      .out_valid_next,
+      .out,
+      .out_valid_next_stages,
+      .out_stages
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  function automatic logic [Width-1:0] data_for(input int idx);
+    for (int i = 0; i < Width; i++) begin
+      data_for[i] = ((idx + (5 * i)) % 7) < 3;
+    end
+  endfunction
+
+  function automatic logic valid_next_for(input int idx);
+    valid_next_for = (idx >= 0) && ((idx % 6) != 2) && ((idx % 6) != 5);
+  endfunction
+
+  function automatic logic [Width-1:0] drive_data_for(input int idx);
+    if (valid_next_for(idx - 1)) begin
+      drive_data_for = data_for(idx - 1);
+    end else begin
+      drive_data_for = data_for(-idx - 1);
+    end
+  endfunction
+
+  task automatic update_model(input logic drive_valid_next, input logic [Width-1:0] drive_data);
+    next_valid_next[0] = drive_valid_next;
+    next_data_valid[0] = model_valid_next[0];
+    next_data[0] = drive_data;
+
+    for (int i = 1; i <= NumStages; i++) begin
+      logic prev_valid_next;
+      logic [Width-1:0] prev_data;
+
+      prev_valid_next = (i == 1) ? drive_valid_next : model_valid_next[i-1];
+      prev_data = (i == 1) ? drive_data : model_data[i-1];
+
+      next_valid_next[i] = prev_valid_next;
+      next_data_valid[i] = model_valid_next[i];
+      next_data[i] = model_data[i];
+      if (model_valid_next[i]) begin
+        next_data[i] = prev_data;
+      end
+    end
+
+    model_valid_next = next_valid_next;
+    model_data_valid = next_data_valid;
+    model_data = next_data;
+  endtask
+
+  task automatic check_model(input string phase);
+    td.check(out_valid_next === model_valid_next[NumStages],
+             $sformatf("%s: out_valid_next mismatch", phase));
+    td.check(out_valid_next_stages === model_valid_next,
+             $sformatf("%s: out_valid_next_stages mismatch", phase));
+
+    for (int i = 0; i <= NumStages; i++) begin
+      if (model_data_valid[i] || (NumStages == 0 && i == 0)) begin
+        td.check(out_stages[i] === model_data[i],
+                 $sformatf("%s: out_stages[%0d] mismatch", phase, i));
+      end
+    end
+
+    if (model_data_valid[NumStages] || NumStages == 0) begin
+      td.check(out === model_data[NumStages], $sformatf("%s: out mismatch", phase));
+    end
+  endtask
+
+  task automatic drive_cycle(input logic drive_valid_next, input logic [Width-1:0] drive_data,
+                             input string phase);
+    in_valid_next = drive_valid_next;
+    in = drive_data;
+    td.wait_cycles();
+    update_model(drive_valid_next, drive_data);
+    check_model(phase);
+  endtask
+
+  initial begin
+    in_valid_next = 1'b0;
+    in = '0;
+    model_valid_next = '0;
+    model_data_valid = '0;
+    model_data = '0;
+    next_valid_next = '0;
+    next_data_valid = '0;
+    next_data = '0;
+
+    td.reset_dut();
+
+    for (int i = 0; i < NumStages + 3; i++) begin
+      in_valid_next = 1'b0;
+      in = data_for(-i - 1);
+      td.wait_cycles();
+    end
+
+    for (int i = 0; i < NumTestCycles; i++) begin
+      drive_cycle(valid_next_for(i), drive_data_for(i), $sformatf("directed cycle %0d", i));
+    end
+
+    for (int i = 0; i < NumStages + 3; i++) begin
+      drive_cycle(1'b0, data_for(NumTestCycles + i), $sformatf("drain cycle %0d", i));
+    end
+
+    td.finish();
+  end
+
+endmodule : br_delay_valid_next_nr_tb

--- a/delay/sim/br_delay_valid_next_tb.sv
+++ b/delay/sim/br_delay_valid_next_tb.sv
@@ -85,15 +85,15 @@ module br_delay_valid_next_tb;
   endtask
 
   task automatic check_model(input string phase);
-    td.check(out_valid_next === model_valid_next[NumStages],
-             $sformatf("%s: out_valid_next mismatch", phase));
-    td.check(out_valid_next_stages === model_valid_next,
-             $sformatf("%s: out_valid_next_stages mismatch", phase));
+    td.check(out_valid_next === model_valid_next[NumStages], $sformatf(
+             "%s: out_valid_next mismatch", phase));
+    td.check(out_valid_next_stages === model_valid_next, $sformatf(
+             "%s: out_valid_next_stages mismatch", phase));
 
     for (int i = 0; i <= NumStages; i++) begin
       if (model_data_valid[i] || (NumStages == 0 && i == 0)) begin
-        td.check(out_stages[i] === model_data[i],
-                 $sformatf("%s: out_stages[%0d] mismatch", phase, i));
+        td.check(out_stages[i] === model_data[i], $sformatf("%s: out_stages[%0d] mismatch", phase, i
+                 ));
       end
     end
 

--- a/delay/sim/br_delay_valid_next_tb.sv
+++ b/delay/sim/br_delay_valid_next_tb.sv
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module br_delay_valid_next_tb;
+
+  parameter int Width = 8;
+  parameter int NumStages = 2;
+  parameter int NumTestCycles = 18;
+
+  logic clk;
+  logic rst;
+  logic in_valid_next;
+  logic [Width-1:0] in;
+  logic out_valid_next;
+  logic [Width-1:0] out;
+  logic [NumStages:0] out_valid_next_stages;
+  logic [NumStages:0][Width-1:0] out_stages;
+
+  logic [NumStages:0] model_valid_next;
+  logic [NumStages:0] model_data_valid;
+  logic [NumStages:0][Width-1:0] model_data;
+  logic [NumStages:0] next_valid_next;
+  logic [NumStages:0] next_data_valid;
+  logic [NumStages:0][Width-1:0] next_data;
+
+  br_delay_valid_next #(
+      .Width(Width),
+      .NumStages(NumStages)
+  ) dut (
+      .clk,
+      .rst,
+      .in_valid_next,
+      .in,
+      .out_valid_next,
+      .out,
+      .out_valid_next_stages,
+      .out_stages
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  function automatic logic [Width-1:0] data_for(input int idx);
+    for (int i = 0; i < Width; i++) begin
+      data_for[i] = ((idx + (5 * i)) % 7) < 3;
+    end
+  endfunction
+
+  function automatic logic valid_next_for(input int idx);
+    valid_next_for = (idx >= 0) && ((idx % 6) != 2) && ((idx % 6) != 5);
+  endfunction
+
+  function automatic logic [Width-1:0] drive_data_for(input int idx);
+    if (valid_next_for(idx - 1)) begin
+      drive_data_for = data_for(idx - 1);
+    end else begin
+      drive_data_for = data_for(-idx - 1);
+    end
+  endfunction
+
+  task automatic update_model(input logic drive_valid_next, input logic [Width-1:0] drive_data);
+    next_valid_next[0] = drive_valid_next;
+    next_data_valid[0] = model_valid_next[0];
+    next_data[0] = drive_data;
+
+    for (int i = 1; i <= NumStages; i++) begin
+      logic prev_valid_next;
+      logic [Width-1:0] prev_data;
+
+      prev_valid_next = (i == 1) ? drive_valid_next : model_valid_next[i-1];
+      prev_data = (i == 1) ? drive_data : model_data[i-1];
+
+      next_valid_next[i] = prev_valid_next;
+      next_data_valid[i] = model_valid_next[i];
+      next_data[i] = model_data[i];
+      if (model_valid_next[i]) begin
+        next_data[i] = prev_data;
+      end
+    end
+
+    model_valid_next = next_valid_next;
+    model_data_valid = next_data_valid;
+    model_data = next_data;
+  endtask
+
+  task automatic check_model(input string phase);
+    td.check(out_valid_next === model_valid_next[NumStages],
+             $sformatf("%s: out_valid_next mismatch", phase));
+    td.check(out_valid_next_stages === model_valid_next,
+             $sformatf("%s: out_valid_next_stages mismatch", phase));
+
+    for (int i = 0; i <= NumStages; i++) begin
+      if (model_data_valid[i] || (NumStages == 0 && i == 0)) begin
+        td.check(out_stages[i] === model_data[i],
+                 $sformatf("%s: out_stages[%0d] mismatch", phase, i));
+      end
+    end
+
+    if (model_data_valid[NumStages] || NumStages == 0) begin
+      td.check(out === model_data[NumStages], $sformatf("%s: out mismatch", phase));
+    end
+  endtask
+
+  task automatic drive_cycle(input logic drive_valid_next, input logic [Width-1:0] drive_data,
+                             input string phase);
+    in_valid_next = drive_valid_next;
+    in = drive_data;
+    td.wait_cycles();
+    update_model(drive_valid_next, drive_data);
+    check_model(phase);
+  endtask
+
+  initial begin
+    in_valid_next = 1'b0;
+    in = '0;
+    model_valid_next = '0;
+    model_data_valid = '0;
+    model_data = '0;
+    next_valid_next = '0;
+    next_data_valid = '0;
+    next_data = '0;
+
+    td.reset_dut();
+    check_model("after reset");
+
+    for (int i = 0; i < NumTestCycles; i++) begin
+      drive_cycle(valid_next_for(i), drive_data_for(i), $sformatf("directed cycle %0d", i));
+    end
+
+    for (int i = 0; i < NumStages + 3; i++) begin
+      drive_cycle(1'b0, data_for(NumTestCycles + i), $sformatf("drain cycle %0d", i));
+    end
+
+    td.finish();
+  end
+
+endmodule : br_delay_valid_next_tb

--- a/delay/sim/br_delay_valid_next_tb.sv
+++ b/delay/sim/br_delay_valid_next_tb.sv
@@ -12,8 +12,6 @@ module br_delay_valid_next_tb;
   logic [Width-1:0] in;
   logic out_valid_next;
   logic [Width-1:0] out;
-  logic [NumStages:0] out_valid_next_stages;
-  logic [NumStages:0][Width-1:0] out_stages;
 
   logic [NumStages:0] model_valid_next;
   logic [NumStages:0] model_data_valid;
@@ -32,8 +30,8 @@ module br_delay_valid_next_tb;
       .in,
       .out_valid_next,
       .out,
-      .out_valid_next_stages,
-      .out_stages
+      .out_valid_next_stages(),
+      .out_stages()
   );
 
   br_test_driver td (
@@ -87,15 +85,6 @@ module br_delay_valid_next_tb;
   task automatic check_model(input string phase);
     td.check(out_valid_next === model_valid_next[NumStages], $sformatf(
              "%s: out_valid_next mismatch", phase));
-    td.check(out_valid_next_stages === model_valid_next, $sformatf(
-             "%s: out_valid_next_stages mismatch", phase));
-
-    for (int i = 0; i <= NumStages; i++) begin
-      if (model_data_valid[i] || (NumStages == 0 && i == 0)) begin
-        td.check(out_stages[i] === model_data[i], $sformatf("%s: out_stages[%0d] mismatch", phase, i
-                 ));
-      end
-    end
 
     if (model_data_valid[NumStages] || NumStages == 0) begin
       td.check(out === model_data[NumStages], $sformatf("%s: out mismatch", phase));

--- a/delay/sim/br_delay_valid_nr_tb.sv
+++ b/delay/sim/br_delay_valid_nr_tb.sv
@@ -59,10 +59,10 @@ module br_delay_valid_nr_tb;
       logic [Width-1:0] prev_data;
 
       prev_valid = (i == 1) ? drive_valid : model_valid[i-1];
-      prev_data  = (i == 1) ? drive_data : model_data[i-1];
+      prev_data = (i == 1) ? drive_data : model_data[i-1];
 
       next_valid[i] = prev_valid;
-      next_data[i]  = model_data[i];
+      next_data[i] = model_data[i];
       if (prev_valid || (FirstStageUngated && i == 1)) begin
         next_data[i] = prev_data;
       end
@@ -73,15 +73,13 @@ module br_delay_valid_nr_tb;
   endtask
 
   task automatic check_model(input string phase);
-    td.check(out_valid === model_valid[NumStages],
-             $sformatf("%s: out_valid mismatch", phase));
-    td.check(out_valid_stages === model_valid,
-             $sformatf("%s: out_valid_stages mismatch", phase));
+    td.check(out_valid === model_valid[NumStages], $sformatf("%s: out_valid mismatch", phase));
+    td.check(out_valid_stages === model_valid, $sformatf("%s: out_valid_stages mismatch", phase));
 
     for (int i = 0; i <= NumStages; i++) begin
       if (model_valid[i]) begin
-        td.check(out_stages[i] === model_data[i],
-                 $sformatf("%s: out_stages[%0d] mismatch", phase, i));
+        td.check(out_stages[i] === model_data[i], $sformatf("%s: out_stages[%0d] mismatch", phase, i
+                 ));
       end
     end
 
@@ -116,8 +114,8 @@ module br_delay_valid_nr_tb;
     end
 
     for (int i = 0; i < NumTestCycles; i++) begin
-      drive_cycle(valid_for(i), valid_for(i) ? data_for(i) : data_for(-i - 1),
-                  $sformatf("directed cycle %0d", i));
+      drive_cycle(valid_for(i), valid_for(i) ? data_for(i) : data_for(-i - 1), $sformatf(
+                  "directed cycle %0d", i));
     end
 
     for (int i = 0; i < NumStages + 2; i++) begin

--- a/delay/sim/br_delay_valid_nr_tb.sv
+++ b/delay/sim/br_delay_valid_nr_tb.sv
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module br_delay_valid_nr_tb;
+
+  parameter int Width = 8;
+  parameter int NumStages = 2;
+  parameter bit FirstStageUngated = 0;
+  parameter int NumTestCycles = 16;
+
+  logic clk;
+  logic rst;
+  logic in_valid;
+  logic [Width-1:0] in;
+  logic out_valid;
+  logic [Width-1:0] out;
+  logic [NumStages:0] out_valid_stages;
+  logic [NumStages:0][Width-1:0] out_stages;
+
+  logic [NumStages:0] model_valid;
+  logic [NumStages:0][Width-1:0] model_data;
+  logic [NumStages:0] next_valid;
+  logic [NumStages:0][Width-1:0] next_data;
+
+  br_delay_valid_nr #(
+      .Width(Width),
+      .NumStages(NumStages),
+      .FirstStageUngated(FirstStageUngated)
+  ) dut (
+      .clk,
+      .in_valid,
+      .in,
+      .out_valid,
+      .out,
+      .out_valid_stages,
+      .out_stages
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  function automatic logic [Width-1:0] data_for(input int idx);
+    for (int i = 0; i < Width; i++) begin
+      data_for[i] = ((idx + (3 * i)) % 5) < 2;
+    end
+  endfunction
+
+  function automatic logic valid_for(input int idx);
+    valid_for = (idx % 5) != 1;
+  endfunction
+
+  task automatic update_model(input logic drive_valid, input logic [Width-1:0] drive_data);
+    next_valid[0] = drive_valid;
+    next_data[0]  = drive_data;
+
+    for (int i = 1; i <= NumStages; i++) begin
+      logic prev_valid;
+      logic [Width-1:0] prev_data;
+
+      prev_valid = (i == 1) ? drive_valid : model_valid[i-1];
+      prev_data  = (i == 1) ? drive_data : model_data[i-1];
+
+      next_valid[i] = prev_valid;
+      next_data[i]  = model_data[i];
+      if (prev_valid || (FirstStageUngated && i == 1)) begin
+        next_data[i] = prev_data;
+      end
+    end
+
+    model_valid = next_valid;
+    model_data  = next_data;
+  endtask
+
+  task automatic check_model(input string phase);
+    td.check(out_valid === model_valid[NumStages],
+             $sformatf("%s: out_valid mismatch", phase));
+    td.check(out_valid_stages === model_valid,
+             $sformatf("%s: out_valid_stages mismatch", phase));
+
+    for (int i = 0; i <= NumStages; i++) begin
+      if (model_valid[i]) begin
+        td.check(out_stages[i] === model_data[i],
+                 $sformatf("%s: out_stages[%0d] mismatch", phase, i));
+      end
+    end
+
+    if (model_valid[NumStages]) begin
+      td.check(out === model_data[NumStages], $sformatf("%s: out mismatch", phase));
+    end
+  endtask
+
+  task automatic drive_cycle(input logic drive_valid, input logic [Width-1:0] drive_data,
+                             input string phase);
+    in_valid = drive_valid;
+    in = drive_data;
+    td.wait_cycles();
+    update_model(drive_valid, drive_data);
+    check_model(phase);
+  endtask
+
+  initial begin
+    in_valid = 1'b0;
+    in = '0;
+    model_valid = '0;
+    model_data = '0;
+    next_valid = '0;
+    next_data = '0;
+
+    td.reset_dut();
+
+    for (int i = 0; i < NumStages + 2; i++) begin
+      in_valid = 1'b0;
+      in = data_for(-i - 1);
+      td.wait_cycles();
+    end
+
+    for (int i = 0; i < NumTestCycles; i++) begin
+      drive_cycle(valid_for(i), valid_for(i) ? data_for(i) : data_for(-i - 1),
+                  $sformatf("directed cycle %0d", i));
+    end
+
+    for (int i = 0; i < NumStages + 2; i++) begin
+      drive_cycle(1'b0, data_for(NumTestCycles + i), $sformatf("drain cycle %0d", i));
+    end
+
+    td.finish();
+  end
+
+endmodule : br_delay_valid_nr_tb

--- a/delay/sim/br_delay_valid_nr_tb.sv
+++ b/delay/sim/br_delay_valid_nr_tb.sv
@@ -13,8 +13,6 @@ module br_delay_valid_nr_tb;
   logic [Width-1:0] in;
   logic out_valid;
   logic [Width-1:0] out;
-  logic [NumStages:0] out_valid_stages;
-  logic [NumStages:0][Width-1:0] out_stages;
 
   logic [NumStages:0] model_valid;
   logic [NumStages:0][Width-1:0] model_data;
@@ -31,8 +29,8 @@ module br_delay_valid_nr_tb;
       .in,
       .out_valid,
       .out,
-      .out_valid_stages,
-      .out_stages
+      .out_valid_stages(),
+      .out_stages()
   );
 
   br_test_driver td (
@@ -74,14 +72,6 @@ module br_delay_valid_nr_tb;
 
   task automatic check_model(input string phase);
     td.check(out_valid === model_valid[NumStages], $sformatf("%s: out_valid mismatch", phase));
-    td.check(out_valid_stages === model_valid, $sformatf("%s: out_valid_stages mismatch", phase));
-
-    for (int i = 0; i <= NumStages; i++) begin
-      if (model_valid[i]) begin
-        td.check(out_stages[i] === model_data[i], $sformatf("%s: out_stages[%0d] mismatch", phase, i
-                 ));
-      end
-    end
 
     if (model_valid[NumStages]) begin
       td.check(out === model_data[NumStages], $sformatf("%s: out mismatch", phase));


### PR DESCRIPTION
# Problem

The `delay` RTL had elaboration and formal coverage, but no dedicated simulation benches for the skew/deskew and valid/valid-next delay variants. That left the module behavior and parameter combinations without direct simulator coverage.

# Solution

- Added `delay/sim` with one `verilog_library` and `verilog_elab_test` per new bench.
- Implemented directed, scoreboard-style benches for:
  - `br_delay_deskew`
  - `br_delay_skew`
  - `br_delay_valid_next`
  - `br_delay_valid_next_nr`
  - `br_delay_valid_nr`
- Covered reset, bubbles, back-to-back valid traffic, drain behavior, and representative parameter sweeps.
- Kept Verilator excluded where the dependent RTL assertions use delayed sequence expressions.
- Added the new sim targets to Bazel so they run under the existing Bedrock sim tooling.

# Testing

- `bazel test //delay/sim/... --test_tag-filters=iverilog`
- `bazel test //delay/sim/... --test_tag-filters=vcs`
- `bazel test //delay/sim:all --test_tag-filters=verific`