### PR TITLE
[arb] Add simulation benches for prioritized and weighted round-robin arbiters

### DIFF
--- a/arb/sim/BUILD.bazel
+++ b/arb/sim/BUILD.bazel
@@ -109,3 +109,83 @@ br_verilog_sim_test_tools_suite(
     ],
     deps = [":br_arb_grant_hold_tb"],
 )
+
+verilog_library(
+    name = "br_arb_pri_rr_tb",
+    srcs = ["br_arb_pri_rr_tb.sv"],
+    deps = [
+        "//arb/rtl:br_arb_pri_rr",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_arb_pri_rr_tb_elab_test",
+    tool = "verific",
+    deps = [":br_arb_pri_rr_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_arb_pri_rr_tb_sim_test_tools_suite",
+    params = {
+        "NumPriorities": [
+            "2",
+            "3",
+        ],
+        "NumRequesters": [
+            "2",
+            "4",
+            "5",
+        ],
+    },
+    # TODO: Does not work with iverilog.
+    # TODO(mgottscho): Re-enable Verilator once it accepts the `br_arb_pri_rr`
+    # assertions that use delayed sequence expressions.
+    tools = [
+        "vcs",
+        #"verilator",
+    ],
+    deps = [":br_arb_pri_rr_tb"],
+)
+
+verilog_library(
+    name = "br_arb_weighted_rr_tb",
+    srcs = ["br_arb_weighted_rr_tb.sv"],
+    deps = [
+        "//arb/rtl:br_arb_weighted_rr",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_arb_weighted_rr_tb_elab_test",
+    tool = "verific",
+    deps = [":br_arb_weighted_rr_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_arb_weighted_rr_tb_sim_test_tools_suite",
+    params = {
+        "MaxAccumulatedWeight": [
+            "3",
+            "8",
+        ],
+        "MaxWeight": [
+            "1",
+            "3",
+        ],
+        "NumRequesters": [
+            "1",
+            "2",
+            "4",
+        ],
+    },
+    # TODO: Does not work with iverilog.
+    # TODO(mgottscho): Re-enable Verilator once it accepts the `br_counter`
+    # assertions that use delayed sequence expressions.
+    tools = [
+        "vcs",
+        #"verilator",
+    ],
+    deps = [":br_arb_weighted_rr_tb"],
+)

--- a/arb/sim/br_arb_pri_rr_tb.sv
+++ b/arb/sim/br_arb_pri_rr_tb.sv
@@ -36,21 +36,19 @@ module br_arb_pri_rr_tb;
   );
 
   function automatic logic [NumRequesters-1:0] expected_grant(
-      input logic [NumRequesters-1:0] req,
-      input logic [NumRequesters-1:0][PriorityWidth-1:0] pri
-  );
+      input logic [NumRequesters-1:0] req, input logic [NumRequesters-1:0][PriorityWidth-1:0] pri);
     logic found_request;
     logic [PriorityWidth-1:0] max_priority;
     int idx;
 
     expected_grant = '0;
-    found_request = 1'b0;
-    max_priority = '0;
+    found_request  = 1'b0;
+    max_priority   = '0;
 
     for (int i = 0; i < NumRequesters; i++) begin
       if (req[i] && (!found_request || (pri[i] > max_priority))) begin
         found_request = 1'b1;
-        max_priority = pri[i];
+        max_priority  = pri[i];
       end
     end
 
@@ -74,12 +72,9 @@ module br_arb_pri_rr_tb;
     end
   endtask
 
-  task automatic drive_and_check(
-      input logic [NumRequesters-1:0] req,
-      input logic [NumRequesters-1:0][PriorityWidth-1:0] pri,
-      input logic enable_update,
-      input string message
-  );
+  task automatic drive_and_check(input logic [NumRequesters-1:0] req,
+                                 input logic [NumRequesters-1:0][PriorityWidth-1:0] pri,
+                                 input logic enable_update, input string message);
     logic [NumRequesters-1:0] grant_expected;
 
     request = req;
@@ -88,9 +83,8 @@ module br_arb_pri_rr_tb;
     #1;
 
     grant_expected = expected_grant(req, pri);
-    td.check(grant === grant_expected,
-             $sformatf("%s: got grant 0x%0h, expected 0x%0h",
-                       message, grant, grant_expected));
+    td.check(grant === grant_expected, $sformatf(
+             "%s: got grant 0x%0h, expected 0x%0h", message, grant, grant_expected));
 
     td.wait_cycles();
     update_model(grant_expected);
@@ -102,18 +96,14 @@ module br_arb_pri_rr_tb;
     end
   endtask
 
-  task automatic set_uniform_priority(
-      output logic [NumRequesters-1:0][PriorityWidth-1:0] pri,
-      input int priority_value
-  );
+  task automatic set_uniform_priority(output logic [NumRequesters-1:0][PriorityWidth-1:0] pri,
+                                      input int priority_value);
     for (int i = 0; i < NumRequesters; i++) begin
       pri[i] = PriorityWidth'(priority_value);
     end
   endtask
 
-  task automatic set_random_priorities(
-      output logic [NumRequesters-1:0][PriorityWidth-1:0] pri
-  );
+  task automatic set_random_priorities(output logic [NumRequesters-1:0][PriorityWidth-1:0] pri);
     for (int i = 0; i < NumRequesters; i++) begin
       pri[i] = PriorityWidth'($urandom_range(0, NumPriorities - 1));
     end

--- a/arb/sim/br_arb_pri_rr_tb.sv
+++ b/arb/sim/br_arb_pri_rr_tb.sv
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module br_arb_pri_rr_tb;
+  timeunit 1ns; timeprecision 100ps;
+
+  parameter int NumRequesters = 4;
+  parameter int NumPriorities = 3;
+  parameter int NumRandomCycles = 100;
+
+  localparam int PriorityWidth = $clog2(NumPriorities);
+
+  logic clk;
+  logic rst;
+  logic enable_priority_update;
+  logic [NumRequesters-1:0] request;
+  logic [NumRequesters-1:0][PriorityWidth-1:0] request_priority;
+  logic [NumRequesters-1:0] grant;
+
+  int rr_ptr;
+
+  br_arb_pri_rr #(
+      .NumRequesters(NumRequesters),
+      .NumPriorities(NumPriorities)
+  ) dut (
+      .clk,
+      .rst,
+      .enable_priority_update,
+      .request,
+      .request_priority,
+      .grant
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  function automatic logic [NumRequesters-1:0] expected_grant(
+      input logic [NumRequesters-1:0] req,
+      input logic [NumRequesters-1:0][PriorityWidth-1:0] pri
+  );
+    logic found_request;
+    logic [PriorityWidth-1:0] max_priority;
+    int idx;
+
+    expected_grant = '0;
+    found_request = 1'b0;
+    max_priority = '0;
+
+    for (int i = 0; i < NumRequesters; i++) begin
+      if (req[i] && (!found_request || (pri[i] > max_priority))) begin
+        found_request = 1'b1;
+        max_priority = pri[i];
+      end
+    end
+
+    if (found_request) begin
+      for (int offset = 0; offset < NumRequesters; offset++) begin
+        idx = (rr_ptr + offset) % NumRequesters;
+        if (req[idx] && (pri[idx] == max_priority) && (expected_grant == '0)) begin
+          expected_grant[idx] = 1'b1;
+        end
+      end
+    end
+  endfunction
+
+  task automatic update_model(input logic [NumRequesters-1:0] grant_model);
+    if (enable_priority_update && |request) begin
+      for (int i = 0; i < NumRequesters; i++) begin
+        if (grant_model[i]) begin
+          rr_ptr = (i + 1) % NumRequesters;
+        end
+      end
+    end
+  endtask
+
+  task automatic drive_and_check(
+      input logic [NumRequesters-1:0] req,
+      input logic [NumRequesters-1:0][PriorityWidth-1:0] pri,
+      input logic enable_update,
+      input string message
+  );
+    logic [NumRequesters-1:0] grant_expected;
+
+    request = req;
+    request_priority = pri;
+    enable_priority_update = enable_update;
+    #1;
+
+    grant_expected = expected_grant(req, pri);
+    td.check(grant === grant_expected,
+             $sformatf("%s: got grant 0x%0h, expected 0x%0h",
+                       message, grant, grant_expected));
+
+    td.wait_cycles();
+    update_model(grant_expected);
+  endtask
+
+  task automatic clear_priorities(output logic [NumRequesters-1:0][PriorityWidth-1:0] pri);
+    for (int i = 0; i < NumRequesters; i++) begin
+      pri[i] = '0;
+    end
+  endtask
+
+  task automatic set_uniform_priority(
+      output logic [NumRequesters-1:0][PriorityWidth-1:0] pri,
+      input int priority_value
+  );
+    for (int i = 0; i < NumRequesters; i++) begin
+      pri[i] = PriorityWidth'(priority_value);
+    end
+  endtask
+
+  task automatic set_random_priorities(
+      output logic [NumRequesters-1:0][PriorityWidth-1:0] pri
+  );
+    for (int i = 0; i < NumRequesters; i++) begin
+      pri[i] = PriorityWidth'($urandom_range(0, NumPriorities - 1));
+    end
+  endtask
+
+  task automatic reset_test;
+    request = '0;
+    request_priority = '0;
+    enable_priority_update = 1'b0;
+    rr_ptr = 0;
+    td.reset_dut();
+    td.wait_cycles();
+  endtask
+
+  initial begin
+    logic [NumRequesters-1:0][PriorityWidth-1:0] pri;
+    logic [NumRequesters-1:0] req;
+
+    reset_test();
+    clear_priorities(pri);
+    drive_and_check('0, pri, 1'b1, "idle grants nothing");
+
+    for (int i = 0; i < NumRequesters; i++) begin
+      req = '0;
+      req[i] = 1'b1;
+      clear_priorities(pri);
+      pri[i] = PriorityWidth'(NumPriorities - 1);
+      drive_and_check(req, pri, 1'b1, $sformatf("single requester %0d", i));
+    end
+
+    reset_test();
+    clear_priorities(pri);
+    req = '0;
+    req[0] = 1'b1;
+    req[NumRequesters-1] = 1'b1;
+    pri[0] = '0;
+    pri[NumRequesters-1] = PriorityWidth'(NumPriorities - 1);
+    drive_and_check(req, pri, 1'b1, "higher priority beats lower RR position");
+
+    reset_test();
+    req = '1;
+    set_uniform_priority(pri, NumPriorities - 1);
+    for (int i = 0; i < (2 * NumRequesters); i++) begin
+      drive_and_check(req, pri, 1'b1, $sformatf("uniform priority rotation %0d", i));
+    end
+
+    reset_test();
+    req = '1;
+    set_uniform_priority(pri, NumPriorities - 1);
+    for (int i = 0; i < NumRequesters; i++) begin
+      drive_and_check(req, pri, 1'b0, $sformatf("priority update disabled %0d", i));
+    end
+    drive_and_check(req, pri, 1'b1, "priority update re-enabled");
+
+    reset_test();
+    for (int cycle = 0; cycle < NumRandomCycles; cycle++) begin
+      req = NumRequesters'($urandom());
+      set_random_priorities(pri);
+      drive_and_check(req, pri, $urandom_range(0, 1), $sformatf("random cycle %0d", cycle));
+    end
+
+    request = '0;
+    enable_priority_update = 1'b0;
+    td.finish();
+  end
+
+endmodule : br_arb_pri_rr_tb

--- a/arb/sim/br_arb_weighted_rr_tb.sv
+++ b/arb/sim/br_arb_weighted_rr_tb.sv
@@ -38,9 +38,7 @@ module br_arb_weighted_rr_tb;
       .rst
   );
 
-  function automatic logic [NumRequesters-1:0] expected_grant(
-      input logic [NumRequesters-1:0] req
-  );
+  function automatic logic [NumRequesters-1:0] expected_grant(input logic [NumRequesters-1:0] req);
     logic [NumRequesters-1:0] high_priority_request;
     logic [NumRequesters-1:0] eligible_request;
     int idx;
@@ -99,12 +97,9 @@ module br_arb_weighted_rr_tb;
     end
   endtask
 
-  task automatic drive_and_check(
-      input logic [NumRequesters-1:0] req,
-      input logic [NumRequesters-1:0][WeightWidth-1:0] weight,
-      input logic enable_update,
-      input string message
-  );
+  task automatic drive_and_check(input logic [NumRequesters-1:0] req,
+                                 input logic [NumRequesters-1:0][WeightWidth-1:0] weight,
+                                 input logic enable_update, input string message);
     logic [NumRequesters-1:0] grant_expected;
 
     request = req;
@@ -113,18 +108,15 @@ module br_arb_weighted_rr_tb;
     #1;
 
     grant_expected = expected_grant(req);
-    td.check(grant === grant_expected,
-             $sformatf("%s: got grant 0x%0h, expected 0x%0h",
-                       message, grant, grant_expected));
+    td.check(grant === grant_expected, $sformatf(
+             "%s: got grant 0x%0h, expected 0x%0h", message, grant, grant_expected));
 
     td.wait_cycles();
     update_model(grant_expected);
   endtask
 
-  task automatic set_uniform_weight(
-      output logic [NumRequesters-1:0][WeightWidth-1:0] weight,
-      input int value
-  );
+  task automatic set_uniform_weight(output logic [NumRequesters-1:0][WeightWidth-1:0] weight,
+                                    input int value);
     for (int i = 0; i < NumRequesters; i++) begin
       weight[i] = WeightWidth'(value);
     end

--- a/arb/sim/br_arb_weighted_rr_tb.sv
+++ b/arb/sim/br_arb_weighted_rr_tb.sv
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module br_arb_weighted_rr_tb;
+  timeunit 1ns; timeprecision 100ps;
+
+  parameter int NumRequesters = 4;
+  parameter int MaxWeight = 4;
+  parameter int MaxAccumulatedWeight = 8;
+  parameter int NumRandomCycles = 120;
+
+  localparam int WeightWidth = $clog2(MaxWeight + 1);
+
+  logic clk;
+  logic rst;
+  logic enable_priority_update;
+  logic [NumRequesters-1:0] request;
+  logic [NumRequesters-1:0][WeightWidth-1:0] request_weight;
+  logic [NumRequesters-1:0] grant;
+
+  int rr_ptr;
+  int unsigned accumulated_weight[NumRequesters];
+
+  br_arb_weighted_rr #(
+      .NumRequesters(NumRequesters),
+      .MaxWeight(MaxWeight),
+      .MaxAccumulatedWeight(MaxAccumulatedWeight)
+  ) dut (
+      .clk,
+      .rst,
+      .enable_priority_update,
+      .request,
+      .request_weight,
+      .grant
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  function automatic logic [NumRequesters-1:0] expected_grant(
+      input logic [NumRequesters-1:0] req
+  );
+    logic [NumRequesters-1:0] high_priority_request;
+    logic [NumRequesters-1:0] eligible_request;
+    int idx;
+
+    expected_grant = '0;
+
+    if (NumRequesters == 1) begin
+      expected_grant = req;
+    end else begin
+      high_priority_request = '0;
+      for (int i = 0; i < NumRequesters; i++) begin
+        high_priority_request[i] = req[i] && (accumulated_weight[i] != 0);
+      end
+
+      eligible_request = |high_priority_request ? high_priority_request : req;
+      for (int offset = 0; offset < NumRequesters; offset++) begin
+        idx = (rr_ptr + offset) % NumRequesters;
+        if (eligible_request[idx] && (expected_grant == '0)) begin
+          expected_grant[idx] = 1'b1;
+        end
+      end
+    end
+  endfunction
+
+  task automatic update_model(input logic [NumRequesters-1:0] grant_model);
+    logic any_high_priority_request;
+    int unsigned next_weight;
+
+    if (enable_priority_update && |request) begin
+      any_high_priority_request = 1'b0;
+      for (int i = 0; i < NumRequesters; i++) begin
+        any_high_priority_request |= request[i] && (accumulated_weight[i] != 0);
+      end
+
+      for (int i = 0; i < NumRequesters; i++) begin
+        next_weight = accumulated_weight[i];
+        if (!any_high_priority_request) begin
+          next_weight += request_weight[i];
+          if (next_weight > MaxAccumulatedWeight) begin
+            next_weight = MaxAccumulatedWeight;
+          end
+        end
+        if (grant_model[i] && (next_weight != 0)) begin
+          next_weight--;
+        end
+        accumulated_weight[i] = next_weight;
+      end
+
+      if (NumRequesters > 1) begin
+        for (int i = 0; i < NumRequesters; i++) begin
+          if (grant_model[i]) begin
+            rr_ptr = (i + 1) % NumRequesters;
+          end
+        end
+      end
+    end
+  endtask
+
+  task automatic drive_and_check(
+      input logic [NumRequesters-1:0] req,
+      input logic [NumRequesters-1:0][WeightWidth-1:0] weight,
+      input logic enable_update,
+      input string message
+  );
+    logic [NumRequesters-1:0] grant_expected;
+
+    request = req;
+    request_weight = weight;
+    enable_priority_update = enable_update;
+    #1;
+
+    grant_expected = expected_grant(req);
+    td.check(grant === grant_expected,
+             $sformatf("%s: got grant 0x%0h, expected 0x%0h",
+                       message, grant, grant_expected));
+
+    td.wait_cycles();
+    update_model(grant_expected);
+  endtask
+
+  task automatic set_uniform_weight(
+      output logic [NumRequesters-1:0][WeightWidth-1:0] weight,
+      input int value
+  );
+    for (int i = 0; i < NumRequesters; i++) begin
+      weight[i] = WeightWidth'(value);
+    end
+  endtask
+
+  task automatic set_indexed_weight(output logic [NumRequesters-1:0][WeightWidth-1:0] weight);
+    for (int i = 0; i < NumRequesters; i++) begin
+      weight[i] = WeightWidth'(1 + (i % MaxWeight));
+    end
+  endtask
+
+  task automatic set_random_weight(output logic [NumRequesters-1:0][WeightWidth-1:0] weight);
+    for (int i = 0; i < NumRequesters; i++) begin
+      weight[i] = WeightWidth'($urandom_range(1, MaxWeight));
+    end
+  endtask
+
+  task automatic reset_test;
+    request = '0;
+    request_weight = '0;
+    enable_priority_update = 1'b0;
+    rr_ptr = 0;
+    for (int i = 0; i < NumRequesters; i++) begin
+      accumulated_weight[i] = 0;
+      request_weight[i] = WeightWidth'(1);
+    end
+    td.reset_dut();
+    td.wait_cycles();
+  endtask
+
+  initial begin
+    logic [NumRequesters-1:0][WeightWidth-1:0] weight;
+    logic [NumRequesters-1:0] req;
+
+    reset_test();
+    set_uniform_weight(weight, 1);
+    drive_and_check('0, weight, 1'b1, "idle grants nothing");
+
+    req = '1;
+    if (NumRequesters == 1) begin
+      drive_and_check(req, weight, 1'b1, "single requester grant");
+    end else begin
+      for (int i = 0; i < (2 * NumRequesters); i++) begin
+        drive_and_check(req, weight, 1'b1, $sformatf("equal weights rotation %0d", i));
+      end
+
+      reset_test();
+      req = '1;
+      set_indexed_weight(weight);
+      for (int i = 0; i < (4 * NumRequesters); i++) begin
+        drive_and_check(req, weight, 1'b1, $sformatf("indexed weights cycle %0d", i));
+      end
+
+      for (int i = 0; i < NumRequesters; i++) begin
+        drive_and_check(req, weight, 1'b0, $sformatf("priority update disabled %0d", i));
+      end
+      drive_and_check(req, weight, 1'b1, "priority update re-enabled");
+    end
+
+    reset_test();
+    for (int cycle = 0; cycle < NumRandomCycles; cycle++) begin
+      req = NumRequesters'($urandom());
+      set_random_weight(weight);
+      drive_and_check(req, weight, $urandom_range(0, 1), $sformatf("random cycle %0d", cycle));
+    end
+
+    request = '0;
+    enable_priority_update = 1'b0;
+    td.finish();
+  end
+
+endmodule : br_arb_weighted_rr_tb


### PR DESCRIPTION
# Problem
- `br_arb_pri_rr` and `br_arb_weighted_rr` had elaboration/lint collateral but no simulation coverage.
- The arbiter behaviors are stateful enough that a small directed smoke bench is useful to catch integration and priority-update regressions.

# Solution
- Added `br_arb_pri_rr_tb.sv` with a compact reference model for max-priority selection plus round-robin tie-breaking.
- Added `br_arb_weighted_rr_tb.sv` with a lightweight accumulator model that mirrors the DUT’s grant/update ordering.
- Registered both benches in `arb/sim/BUILD.bazel` with Verific elab targets and VCS-only simulation suites.
- Kept the benches focused on reset, idle, single-requester, tie-breaking, disabled-update, and bounded randomized coverage.

# Testing
- `bazel build //arb/sim:br_arb_pri_rr_tb //arb/sim:br_arb_weighted_rr_tb`
- `bazel test //arb/sim:br_arb_pri_rr_tb_elab_test`
- `bazel test //arb/sim:br_arb_weighted_rr_tb_elab_test`
- `bazel test` on the new VCS simulation target matrix: all passed
- `pre-commit run --files arb/sim/BUILD.bazel arb/sim/br_arb_pri_rr_tb.sv arb/sim/br_arb_weighted_rr_tb.sv` passed