### PR TITLE
[codex] Update simulation testbench skill

### DIFF
--- a/.codex/skills/write-sim-testbench/SKILL.md
+++ b/.codex/skills/write-sim-testbench/SKILL.md
@@ -13,8 +13,13 @@ description: Write or update one Bedrock-RTL SystemVerilog simulation testbench 
    - Single-clock state/protocol: scenario tasks plus a small scoreboard and timeout.
    - Ready/valid or credit/valid: reuse `br_test_driver`, `br_test_rate_control`, `br_flow_test_driver`, `br_flow_test_sink`, FIFO harnesses, or an existing local harness before inventing a new driver.
    - Protocol-heavy modules: write task-based transactions and response checkers.
-3. Add a parameterized `*_tb.sv` module and a `BUILD.bazel` entry. Keep VCS as the minimum simulator target; include Verilator and Icarus only when the bench and dependent RTL actually work with them.
-4. Run the narrowest relevant Bazel target when the environment supports it. If EDA tools are unavailable, at least verify labels/deps with `bazel query` or report that simulation could not be run.
+3. Decide DUT ownership before sharing code:
+   - Use one bench per distinct DUT behavior or arbitration policy. Do not instantiate unrelated variants together merely to reduce duplication.
+   - Reuse a bench for a thin wrapper only when the wrapper is genuinely a base parameterization of the same behavior and the resulting test remains clear.
+   - Share small helpers only when they make each bench easier to read; accept modest duplication over preprocessor or generic-harness complexity.
+4. Add a `*_tb.sv` module and a `BUILD.bazel` entry. Expose a testbench parameter only when changing it changes stimulus or expected coverage; otherwise make it a `localparam`. Sweep important parameters from Bazel using string values.
+5. Keep VCS as the minimum simulator target; include Verilator and Icarus only when the bench and dependent RTL actually work with them.
+6. Run formatting/lint, the narrowest relevant elaboration and simulation targets, the area simulation regression, and `python/sim_tb_coverage_inventory.py` when adding direct DUT coverage. If EDA tools are unavailable, at least verify labels/deps with `bazel query` or report that simulation could not be run.
 
 Read `references/repo-patterns.md` when you need concrete examples, a BUILD skeleton, or simulator compatibility notes.
 
@@ -24,17 +29,22 @@ Use the existing Bedrock simulation utilities by default:
 
 - Instantiate `br_test_driver td` for single-clock benches. Drive `logic clk, rst`; call `td.reset_dut()`, `td.wait_cycles()`, `td.check()`, `td.check_integer()`, and `td.finish()`.
 - Use a no-port module named after the file, usually `br_<module>_tb`; instantiate the DUT as `dut` unless a local pattern does otherwise.
-- Put tunable knobs in `parameter` declarations and derive widths/latencies with `localparam`. Sweep important parameters from Bazel using string values.
+- Put genuinely swept knobs in `parameter` declarations and derive widths/latencies with `localparam`. If the stimulus or expected results assume a fixed value, use a `localparam` instead of advertising an override that the test does not cover.
 - Prefer deterministic directed phases plus a bounded pseudo-random phase over a large random-only test. Include boundary cases: reset, idle, min/max sizes, full/empty or no-credit states, backpressure/stalls, bypass/cut-through paths, and drain/quiesce.
+- Use existing random drivers for ordinary ready/valid traffic; write manual drivers only when a directed timing or protocol scenario needs precise control.
+- Check data integrity for every accepted transfer, not only handshake/control behavior. Also check documented latency and output stability through stalls when applicable.
 - Use scoreboards for ordering/data checks. Keep them simple: arrays for fixed-depth structures, queues for per-flow/per-VC expected data when supported by the selected tools.
 - Add timeouts around every wait loop. Never rely on an unbounded `forever` or `while` in the main test flow without an external bounded completion check.
 - Prefer `td.check*` and `$error` over SVA in simulation testbenches. Do not add `assert property` just to test behavior; internal RTL assertions and formal collateral carry the deeper proof load.
+- Do not add `initial` parameter-validity checks to a bench. The DUT owns legal-parameter checks through `BR_ASSERT_STATIC`.
 
 ## Portability Rules
 
 Target VCS first. Add Verilator and Icarus opportunistically:
 
 - Verilator often fails on dependent Bedrock internal SVA that uses multi-cycle sequence constructs, especially delayed sequence expressions with logical not. If those assertions are in the dependency closure, comment out `"verilator"` with a TODO explaining the unsupported construct.
+- Before adding a Verilator warning waiver, identify the exact RTL construct that triggers it. Scope the waiver to the affected target and leave a comment describing the root cause; do not use a broad unexplained waiver.
+- Treat local compiler/toolchain failures separately from RTL portability. Do not commit simulator or C++ standard fixes solely for a developer-machine issue when the repository CI image already works.
 - Icarus has incomplete SystemVerilog/SVA support and may struggle with richer generated or protocol benches. If it fails for tool limitations, leave it out with a short BUILD comment.
 - Do not make a Verilator-enabled test depend on X-propagation semantics for pass/fail. Verilator is effectively 2-state in many practical cases; checks such as `$isunknown(out)` are usually not portable.
 - Avoid advanced testbench-only constructs unless existing nearby benches already use them with the same tool list: classes, clocking blocks, `process::self().srandom`, DPI, UVM, fork-heavy randomized environments, and complex SVA.
@@ -48,6 +58,8 @@ Use `verilog_library` for the bench, `verilog_elab_test(tool = "verific")` when 
 - Add helper deps explicitly: `//flow/sim:br_flow_test_driver`, `//flow/sim:br_flow_test_sink`, `//fifo/sim:br_fifo_test_harness`, mocks, packages, and macros as needed.
 - Set `top = "..."` when the top cannot be inferred from a single dep or when extra mock deps are present.
 - Use `params = {"Param": ["value0", "value1"]}` for sweeps. Keep sweeps representative, not exhaustive; formal handles broad coverage.
+- Keep `br_verilog_sim_test_tools_suite` when its generated simulation defines are needed, even for a single tool. Split VCS and Verilator suites only when one tool needs scoped options or waivers.
+- Name direct benches and generated sim targets with the DUT stem, normally `br_<dut>_tb` and `br_<dut>_sim_test_tools_suite`, so `python/sim_tb_coverage_inventory.py` recognizes them. Update the inventory's explicit composite aliases only for an intentional shared bench.
 - Use `sim_opts` for plusargs and `tags = ["no-sandbox"]` only when the test needs preserved outputs or follows an existing local pattern.
 
 ## Before Finishing
@@ -55,7 +67,11 @@ Use `verilog_library` for the bench, `verilog_elab_test(tool = "verific")` when 
 Check these before finalizing a new or edited bench:
 
 - The test has a clear pass/fail path and calls `td.finish()` or `$finish` after reporting errors.
+- Every successful transaction checks payload/data integrity, and latency is checked when it is part of the DUT contract.
 - Every wait-for-ready/valid loop has a timeout.
+- Every externally overrideable parameter changes meaningful test coverage; fixed scenario dimensions are `localparam` values.
 - The selected tool list matches the constructs used by the bench and dependent assertions.
+- Every simulator waiver has a narrow scope and a comment naming the RTL root cause.
 - The Bazel deps include the DUT, helper modules, mocks, packages, and macros needed by the testbench.
+- The direct-bench target name is visible to `python/sim_tb_coverage_inventory.py`.
 - New RTL-like helper modules follow repository reset/clock conventions and include static parameter checks where applicable.

--- a/.codex/skills/write-sim-testbench/references/repo-patterns.md
+++ b/.codex/skills/write-sim-testbench/references/repo-patterns.md
@@ -78,6 +78,23 @@ br_verilog_sim_test_tools_suite(
 
 If Verilator or Icarus cannot support the bench or dependent RTL, comment out only that tool and leave a short TODO with the reason.
 
+`br_verilog_sim_test_tools_suite` also supplies the repository's standard simulation defines. Keep the wrapper for single-tool targets rather than replacing it with a raw `verilog_sim_test`. When only one tool needs an elaboration option, use a common suite for the unaffected tools and a separate narrowly scoped suite for that tool.
+
+## Bench Boundaries And Naming
+
+- Prefer one testbench file and one DUT instance for each distinct implementation policy. Fixed-priority, round-robin, and LRU variants should normally have separate benches even if their port lists match.
+- A thin wrapper may use the underlying configurable module's bench as a base case when the wrapper adds no behavior and the parameterization remains obvious.
+- Do not build a generic multi-DUT bench whose conditionals obscure the expected behavior. Small duplicated tasks are cheaper than a test harness that is difficult to review.
+- The coverage inventory recognizes sim target names beginning with the DUT stem followed by `_tb`, `_gen_tb`, `_gen_unittest`, or `_sim_test_tools_suite`. Prefer those names. Add an entry to `COMPOSITE_DIRECT_BENCH_PREFIXES` only when sharing a bench is intentional.
+- Repository lint treats `.svh` files as standalone inputs. Do not put module-scope declarations or tasks in a shared header unless the header is also valid when linted independently; use a package/helper module or keep the small helper local.
+
+## Parameterization
+
+- Use a testbench `parameter` only when the test derives its loops, stimulus, expected ordering, widths, and edge cases from that value.
+- If directed behavior assumes exactly three requesters, two outputs, or another fixed shape, declare those values as `localparam` and do not expose a misleading Bazel override.
+- Every Bazel parameter combination is a separate simulation target and typically recompiles in its own sandbox. Keep sweeps representative and make every point earn its compile cost.
+- Do not duplicate DUT parameter legality checks in an `initial` block. RTL modules own them with `BR_ASSERT_STATIC`.
+
 ## Testbench Skeleton
 
 ```systemverilog
@@ -163,6 +180,8 @@ Verilator:
 - Avoid if dependent RTL enables internal assertions with unsupported multi-cycle SVA sequence constructs, especially delayed sequences using logical not.
 - Avoid pass/fail requirements that depend on X detection or X propagation, such as `$isunknown(out)` for an invalid-select case.
 - Existing exclusions appear in counter, FIFO, credit, CDC FIFO, AMBA, and some mux BUILD files.
+- Diagnose warnings from the RTL before waiving them. For example, a packed matrix with disjoint continuously driven and registered bit regions may trigger Verilator's global `BLKANDNBLK` analysis even though the bits do not overlap. Document that exact cause and scope `-Wno-BLKANDNBLK` only to the affected suite.
+- A local Verilator C++ compilation failure may be a host-toolchain problem rather than a repository problem. Verify the configured compiler and CI behavior before changing RTL or shared build rules.
 
 Icarus:
 - Good for simpler procedural benches.
@@ -176,8 +195,21 @@ Simulation tests should be useful smoke/regression tests, not formal replacement
 - Reset and initial state.
 - One or more normal transactions.
 - Backpressure or stall behavior when applicable.
+- Payload/data integrity on every accepted transfer.
+- Contractual latency, cut-through behavior, and output stability while stalled.
+- Every selectable route or requester at least once for routing/arbitration DUTs, plus simultaneous independent routes where the DUT promises parallel throughput.
+- Policy-specific contention and state updates in a bench dedicated to that policy.
 - Boundary values and parameter-sensitive behavior.
 - A short random or permuted phase with a scoreboard for ordering/data integrity.
 - Quiesce/drain at the end.
 
 Leave exhaustive parameter sweeps, full protocol state-space coverage, and liveness/proof obligations to formal collateral.
+
+## Validation Sequence
+
+1. Run `pre-commit` on the changed bench and BUILD files, then `git diff --check`.
+2. Run the bench's Verific elaboration target when present.
+3. Run every generated VCS/Verilator/Icarus target for the changed bench with `--nocache_test_results`.
+4. Run the containing area's simulation regression, for example `bazel test //flow/sim:all --test_tag_filters=sim --nocache_test_results`.
+5. Run `python3 python/sim_tb_coverage_inventory.py` and confirm the intended DUTs are reported as direct benches.
+6. Check `git status` after Bazel runs and discard unrelated generated lockfile churn before committing.


### PR DESCRIPTION
# Problem

The `write-sim-testbench` skill did not capture several Bedrock-specific review lessons that came up while adding broad flow simulation coverage. In particular, it lacked clear guidance on bench boundaries, meaningful parameterization, data and latency checks, coverage-inventory naming, simulator waiver diagnosis, and the expected validation sequence.

# Solution

- Prefer one focused bench per distinct DUT behavior or arbitration policy, while allowing thin wrappers to reuse a genuine base parameterization.
- Require externally overrideable testbench parameters to change meaningful stimulus and expected coverage; otherwise use `localparam`.
- Require payload integrity checks for every accepted transaction, plus latency and stall-stability checks where applicable.
- Prefer existing random ready/valid drivers unless a directed scenario needs precise manual timing.
- Leave parameter legality checks to the DUT's `BR_ASSERT_STATIC` assertions.
- Document direct-bench naming requirements for `python/sim_tb_coverage_inventory.py` and when composite aliases are appropriate.
- Retain `br_verilog_sim_test_tools_suite` for the repository's standard simulation defines, including single-tool targets.
- Require narrowly scoped simulator waivers with comments identifying the RTL root cause, and distinguish local host-toolchain failures from repository portability issues.
- Document the focused-target, area-regression, coverage-inventory, and post-Bazel cleanup sequence.

## Testing

- `python3 /home/mgottscho/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/write-sim-testbench`
- `pre-commit run --files .codex/skills/write-sim-testbench/SKILL.md .codex/skills/write-sim-testbench/references/repo-patterns.md .codex/skills/write-sim-testbench/agents/openai.yaml`
- `git diff --check`
