### PR TITLE
Add demux tests

### DIFF
--- a/LIBRARIES.adoc
+++ b/LIBRARIES.adoc
@@ -291,11 +291,11 @@ The verification-artifact column reports repository evidence, not a promise that
 
 | `br_demux_bin`
 | Routes input data to one output selected by a binary index.
-| Elab/lint.
+| Elab/lint, Sim
 
 | `br_demux_onehot`
 | Routes input data to outputs selected by a one-hot mask.
-| Elab/lint.
+| Elab/lint, Sim
 
 |===
 

--- a/demux/sim/BUILD.bazel
+++ b/demux/sim/BUILD.bazel
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:private"])
+
+verilog_library(
+    name = "br_demux_tb",
+    srcs = ["br_demux_tb.sv"],
+    deps = [
+        "//demux/rtl:br_demux_bin",
+        "//demux/rtl:br_demux_onehot",
+        "//misc/sim:br_test_driver",
+        "//pkg:br_math_pkg",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_demux_tb_elab_test",
+    tool = "verific",
+    deps = [":br_demux_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_demux_sim_test_tools_suite",
+    params = {
+        "NumSymbolsOut": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "7",
+        ],
+        "SymbolWidth": [
+            "1",
+            "8",
+        ],
+    },
+    tools = [
+        "iverilog",
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_demux_tb"],
+)

--- a/demux/sim/br_demux_tb.sv
+++ b/demux/sim/br_demux_tb.sv
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module br_demux_tb;
+
+  parameter int NumSymbolsOut = 2;
+  parameter int SymbolWidth = 8;
+
+  localparam int SelectWidth = br_math::clamped_clog2(NumSymbolsOut);
+
+  logic clk;
+  logic rst;
+
+  logic [SelectWidth-1:0] bin_select;
+  logic [NumSymbolsOut-1:0] onehot_select;
+  logic in_valid;
+  logic [SymbolWidth-1:0] in;
+
+  logic [NumSymbolsOut-1:0] bin_out_valid;
+  logic [NumSymbolsOut-1:0][SymbolWidth-1:0] bin_out;
+  logic [NumSymbolsOut-1:0] onehot_out_valid;
+  logic [NumSymbolsOut-1:0][SymbolWidth-1:0] onehot_out;
+
+  br_demux_bin #(
+      .NumSymbolsOut(NumSymbolsOut),
+      .SymbolWidth(SymbolWidth),
+      .EnableAssertFinalNotValid(1'b0)
+  ) dut_bin (
+      .select(bin_select),
+      .in_valid,
+      .in,
+      .out_valid(bin_out_valid),
+      .out(bin_out)
+  );
+
+  br_demux_onehot #(
+      .NumSymbolsOut(NumSymbolsOut),
+      .SymbolWidth(SymbolWidth),
+      .EnableAssertFinalNotValid(1'b0)
+  ) dut_onehot (
+      .select(onehot_select),
+      .in_valid,
+      .in,
+      .out_valid(onehot_out_valid),
+      .out(onehot_out)
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  function automatic logic [SymbolWidth-1:0] data_pattern(input int seed);
+    logic [SymbolWidth-1:0] pattern;
+
+    for (int i = 0; i < SymbolWidth; i++) begin
+      pattern[i] = ((seed + i) % 3) == 0;
+    end
+    return pattern;
+  endfunction
+
+  task automatic check_replicated_data(input string test_name);
+    for (int i = 0; i < NumSymbolsOut; i++) begin
+      td.check(bin_out[i] === in, $sformatf("%s: bin out[%0d] data mismatch", test_name, i));
+      td.check(onehot_out[i] === in,
+               $sformatf("%s: onehot out[%0d] data mismatch", test_name, i));
+    end
+  endtask
+
+  task automatic check_bin(input logic [NumSymbolsOut-1:0] expected_valid, input string test_name);
+    td.check(bin_out_valid === expected_valid, $sformatf("%s: bin valid mismatch", test_name));
+  endtask
+
+  task automatic check_onehot(input logic [NumSymbolsOut-1:0] expected_valid,
+                              input string test_name);
+    td.check(onehot_out_valid === expected_valid,
+             $sformatf("%s: onehot valid mismatch", test_name));
+  endtask
+
+  initial begin
+    logic [NumSymbolsOut-1:0] expected_valid;
+
+    bin_select = '0;
+    onehot_select = '0;
+    in_valid = 1'b0;
+    in = '0;
+
+    td.reset_dut();
+    td.wait_cycles(1);
+
+    check_bin('0, "reset idle");
+    check_onehot('0, "reset idle");
+    check_replicated_data("reset idle");
+
+    in = '1;
+    in_valid = 1'b0;
+    for (int select_idx = 0; select_idx < NumSymbolsOut; select_idx++) begin
+      bin_select = select_idx[SelectWidth-1:0];
+      onehot_select = '0;
+      onehot_select[select_idx] = 1'b1;
+      td.wait_cycles(1);
+      check_bin('0, $sformatf("invalid bin select %0d", select_idx));
+      check_onehot('0, $sformatf("invalid onehot select %0d", select_idx));
+      check_replicated_data($sformatf("invalid select %0d", select_idx));
+    end
+
+    in_valid = 1'b1;
+    for (int select_idx = 0; select_idx < NumSymbolsOut; select_idx++) begin
+      in = data_pattern(select_idx);
+      expected_valid = '0;
+      expected_valid[select_idx] = 1'b1;
+
+      bin_select = select_idx[SelectWidth-1:0];
+      onehot_select = '0;
+      onehot_select[select_idx] = 1'b1;
+      td.wait_cycles(1);
+      check_bin(expected_valid, $sformatf("valid bin select %0d", select_idx));
+      check_onehot(expected_valid, $sformatf("valid onehot select %0d", select_idx));
+      check_replicated_data($sformatf("valid select %0d", select_idx));
+    end
+
+    onehot_select = '0;
+    in = '0;
+    td.wait_cycles(1);
+    check_onehot('0, "valid with no onehot select");
+    check_replicated_data("valid with no onehot select");
+
+    in_valid = 1'b0;
+    td.wait_cycles(1);
+
+    td.finish();
+  end
+
+endmodule : br_demux_tb

--- a/demux/sim/br_demux_tb.sv
+++ b/demux/sim/br_demux_tb.sv
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//
+// Bedrock-RTL-Eval One-Hot and Binary Select Demultiplexer Testbench
+
 module br_demux_tb;
 
   parameter int NumSymbolsOut = 2;
   parameter int SymbolWidth = 8;
+  parameter int DRAIN_TIME_CYCLES = 10;  // Time to observe all results in ns
 
   localparam int SelectWidth = br_math::clamped_clog2(NumSymbolsOut);
 
@@ -49,20 +53,10 @@ module br_demux_tb;
       .rst
   );
 
-  function automatic logic [SymbolWidth-1:0] data_pattern(input int seed);
-    logic [SymbolWidth-1:0] pattern;
-
-    for (int i = 0; i < SymbolWidth; i++) begin
-      pattern[i] = ((seed + i) % 3) == 0;
-    end
-    return pattern;
-  endfunction
-
   task automatic check_replicated_data(input string test_name);
     for (int i = 0; i < NumSymbolsOut; i++) begin
       td.check(bin_out[i] === in, $sformatf("%s: bin out[%0d] data mismatch", test_name, i));
-      td.check(onehot_out[i] === in,
-               $sformatf("%s: onehot out[%0d] data mismatch", test_name, i));
+      td.check(onehot_out[i] === in, $sformatf("%s: onehot out[%0d] data mismatch", test_name, i));
     end
   endtask
 
@@ -72,8 +66,8 @@ module br_demux_tb;
 
   task automatic check_onehot(input logic [NumSymbolsOut-1:0] expected_valid,
                               input string test_name);
-    td.check(onehot_out_valid === expected_valid,
-             $sformatf("%s: onehot valid mismatch", test_name));
+    td.check(onehot_out_valid === expected_valid, $sformatf("%s: onehot valid mismatch", test_name
+             ));
   endtask
 
   initial begin
@@ -91,6 +85,7 @@ module br_demux_tb;
     check_onehot('0, "reset idle");
     check_replicated_data("reset idle");
 
+    // Input data is invalid
     in = '1;
     in_valid = 1'b0;
     for (int select_idx = 0; select_idx < NumSymbolsOut; select_idx++) begin
@@ -103,9 +98,11 @@ module br_demux_tb;
       check_replicated_data($sformatf("invalid select %0d", select_idx));
     end
 
+    // Valid input data and test both demultiplexers
     in_valid = 1'b1;
     for (int select_idx = 0; select_idx < NumSymbolsOut; select_idx++) begin
-      in = data_pattern(select_idx);
+      in = SymbolWidth'($urandom_range(0, (2 ** SymbolWidth) - 1));
+
       expected_valid = '0;
       expected_valid[select_idx] = 1'b1;
 
@@ -118,6 +115,7 @@ module br_demux_tb;
       check_replicated_data($sformatf("valid select %0d", select_idx));
     end
 
+    // Test only the binary select demultiplexer
     onehot_select = '0;
     in = '0;
     td.wait_cycles(1);
@@ -127,7 +125,7 @@ module br_demux_tb;
     in_valid = 1'b0;
     td.wait_cycles(1);
 
-    td.finish();
+    td.finish(DRAIN_TIME_CYCLES);
   end
 
 endmodule : br_demux_tb

--- a/misc/sim/br_test_driver.sv
+++ b/misc/sim/br_test_driver.sv
@@ -49,11 +49,11 @@ module br_test_driver #(
     end
   endtask
 
-  task automatic finish();
+  task automatic finish(input int cycles = 100);
     // Wait some cycles for things to drain, then finish simulation.
     // Cannot catch assertion failures here, so we rely on the test runner to report them.
     // This means it's possible to have "TEST PASSED" and also have assertions that failed.
-    wait_cycles(100);
+    wait_cycles(cycles);
     if (error_count == 0) begin
       $display("TEST PASSED");
     end else begin


### PR DESCRIPTION
This PR adds the following:

- Generated tests for the demux IP
- Modify the testbench to add comments describing the purpose of each test
- Parameterize timeout, and drain time
- Enable waveform dumping for demux test
- Randomize the `in` input