### PR TITLE
Add optimized credit presence output

### DIFF
--- a/credit/rtl/br_credit_counter.sv
+++ b/credit/rtl/br_credit_counter.sv
@@ -215,7 +215,13 @@ module br_credit_counter #(
   assign available = value_plus_incr > withhold ? value_plus_incr - withhold : '0;
 
   if (MaxDecrement == 1) begin : gen_decr_ready_one
-    assign decr_ready = available > '0;
+    if (EnableCoverWithhold) begin : gen_decr_ready_with_withhold
+      assign decr_ready = available > '0;
+    end else if (EnableCoverZeroIncrement) begin : gen_decr_ready_with_zero_increment
+      assign decr_ready = (value != '0) || (incr_valid && incr != '0);
+    end else begin : gen_decr_ready_without_zero_increment
+      assign decr_ready = (value != '0) || incr_valid;
+    end
   end else begin : gen_decr_ready_gt_one
     assign decr_ready = ValueWidth'(decr_internal) <= available;
   end


### PR DESCRIPTION
When withhold is tied '0, there is a trivial credit availability timing optimization on the table. Exposing. 