### PR TITLE
[fv] add knob param sweep for br_credit_counter

### DIFF
--- a/credit/fpv/BUILD.bazel
+++ b/credit/fpv/BUILD.bazel
@@ -56,6 +56,57 @@ br_verilog_fpv_test_tools_suite(
 )
 
 br_verilog_fpv_test_tools_suite(
+    name = "br_credit_counter_param_knobs_test_suite",
+    elab_opts = [
+        "-parameter MaxValue 5",
+        "-parameter MaxChange 3",
+    ],
+    illegal_param_combinations = {
+        (
+            "EnableCoverZeroDecrement",
+            "MaxDecrement",
+        ): [
+            ("1", "1"),
+        ],
+    },
+    params = {
+        "MaxDecrement": [
+            "1",
+            "3",
+        ],
+        "MaxIncrement": [
+            "1",
+            "3",
+        ],
+        "EnableAssertAlwaysDecr": [
+            "0",
+            "1",
+        ],
+        "EnableCoverDecrementBackpressure": [
+            "0",
+            "1",
+        ],
+        "EnableCoverWithhold": [
+            "0",
+            "1",
+        ],
+        "EnableCoverZeroDecrement": [
+            "0",
+            "1",
+        ],
+        "EnableCoverZeroIncrement": [
+            "0",
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_credit_counter_fpv.jg.tcl",
+    },
+    top = "br_credit_counter",
+    deps = [":br_credit_counter_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
     name = "br_credit_counter_test_max",
     elab_opts = [
         "-parameter MaxValue 4294967295",

--- a/credit/fpv/BUILD.bazel
+++ b/credit/fpv/BUILD.bazel
@@ -68,6 +68,12 @@ br_verilog_fpv_test_tools_suite(
         ): [
             ("1", "1"),
         ],
+        (
+            "EnableAssertNoDecrementBackpressure",
+            "EnableCoverDecrementBackpressure",
+        ): [
+            ("1", "1"),
+        ],
     },
     params = {
         "MaxDecrement": [
@@ -79,6 +85,10 @@ br_verilog_fpv_test_tools_suite(
             "3",
         ],
         "EnableAssertAlwaysDecr": [
+            "0",
+            "1",
+        ],
+        "EnableAssertNoDecrementBackpressure": [
             "0",
             "1",
         ],

--- a/credit/fpv/br_credit_counter_fpv_monitor.sv
+++ b/credit/fpv/br_credit_counter_fpv_monitor.sv
@@ -19,6 +19,7 @@ module br_credit_counter_fpv_monitor #(
     parameter bit EnableCoverDecrementBackpressure = 1,
     parameter bit EnableCoverWithhold = 1,
     parameter bit EnableAssertAlwaysDecr = 0,
+    parameter bit EnableAssertNoDecrementBackpressure = !EnableCoverDecrementBackpressure,
     parameter bit EnableAssertFinalNotValid = 1,
     localparam int MaxValueP1Width = MaxValueWidth + 1,
     localparam int MaxChangeP1Width = MaxChangeWidth + 1,
@@ -74,7 +75,7 @@ module br_credit_counter_fpv_monitor #(
   end
   if (EnableCoverDecrementBackpressure) begin : gen_cover_decrement_backpressure
     `BR_COVER(decrement_backpressure_c, decr_valid && decr > fv_available)
-  end else begin : gen_assume_no_decrement_backpressure
+  end else if (EnableAssertNoDecrementBackpressure) begin : gen_assume_no_decrement_backpressure
     `BR_ASSUME(no_decrement_backpressure_a, decr_valid |-> decr <= fv_available)
   end
   if (EnableCoverWithhold) begin : gen_assume_withhold_liveness
@@ -89,9 +90,10 @@ module br_credit_counter_fpv_monitor #(
   end
 
   // ----------FV assertions----------
-  // Always-decrement with no backpressure requires each decrement to be immediately serviceable,
-  // so the counter cannot be empty without an increment to replenish available credit.
-  if (!(EnableAssertAlwaysDecr && !EnableCoverDecrementBackpressure)) begin : gen_decr_ready_sanity
+  // Always-decrement with no backpressure requires each nonzero decrement to be immediately
+  // serviceable, so the empty/no-increment antecedent is unreachable unless decr can be zero.
+  if (!(EnableAssertAlwaysDecr && EnableAssertNoDecrementBackpressure &&
+        !EnableCoverZeroDecrement)) begin : gen_decr_ready_sanity
     `BR_ASSERT(decr_ready_sanity_a, (fv_credit_cnt == 'd0) && (fv_incr == 'd0) |-> fv_decr == 'd0)
   end
   // Cover the ready contract for all serviceable decrement requests, including decr == 0.
@@ -114,5 +116,6 @@ bind br_credit_counter br_credit_counter_fpv_monitor #(
     .EnableCoverDecrementBackpressure(EnableCoverDecrementBackpressure),
     .EnableCoverWithhold(EnableCoverWithhold),
     .EnableAssertAlwaysDecr(EnableAssertAlwaysDecr),
+    .EnableAssertNoDecrementBackpressure(EnableAssertNoDecrementBackpressure),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
 ) monitor (.*);

--- a/credit/fpv/br_credit_counter_fpv_monitor.sv
+++ b/credit/fpv/br_credit_counter_fpv_monitor.sv
@@ -83,6 +83,10 @@ module br_credit_counter_fpv_monitor #(
   end else begin : gen_assume_no_withhold
     `BR_ASSUME(no_withhold_a, withhold == 'd0)
   end
+  if (EnableAssertAlwaysDecr && EnableAssertNoDecrementBackpressure &&
+      !EnableCoverZeroDecrement && MaxIncrement == 1) begin : gen_assume_withhold_lte_value
+    `BR_ASSUME(withhold_lte_value_a, withhold <= value)
+  end
   if (EnableAssertAlwaysDecr) begin : gen_assume_always_decr
     `BR_ASSUME(always_decr_a, decr_valid)
   end else begin : gen_cover_no_decr

--- a/credit/fpv/br_credit_counter_fpv_monitor.sv
+++ b/credit/fpv/br_credit_counter_fpv_monitor.sv
@@ -12,6 +12,13 @@ module br_credit_counter_fpv_monitor #(
     parameter int MaxChangeWidth = 32,
     parameter logic [MaxValueWidth-1:0] MaxValue = 1,
     parameter logic [MaxChangeWidth-1:0] MaxChange = 1,
+    parameter logic [MaxChangeWidth-1:0] MaxIncrement = MaxChange,
+    parameter logic [MaxChangeWidth-1:0] MaxDecrement = MaxChange,
+    parameter bit EnableCoverZeroIncrement = 1,
+    parameter bit EnableCoverZeroDecrement = MaxDecrement > 1,
+    parameter bit EnableCoverDecrementBackpressure = 1,
+    parameter bit EnableCoverWithhold = 1,
+    parameter bit EnableAssertAlwaysDecr = 0,
     parameter bit EnableAssertFinalNotValid = 1,
     localparam int MaxValueP1Width = MaxValueWidth + 1,
     localparam int MaxChangeP1Width = MaxChangeWidth + 1,
@@ -51,15 +58,44 @@ module br_credit_counter_fpv_monitor #(
 
   // ----------FV assumptions----------
   `BR_ASSUME(withhold_a, withhold <= MaxValue)
-  `BR_ASSUME(incr_a, incr_valid |-> incr <= MaxChange)
-  `BR_ASSUME(decr_a, decr_valid |-> decr <= MaxChange)
-  `BR_ASSUME(no_spurious_incr_valid_a, (fv_credit_cnt + incr - fv_decr) > MaxValue |-> !incr_valid)
-  `BR_ASSUME(withold_liveness_a, s_eventually withhold < fv_initial_value)
+  `BR_ASSUME(incr_a, incr_valid |-> incr <= MaxIncrement)
+  `BR_ASSUME(decr_a, decr_valid |-> decr <= MaxDecrement)
+  `BR_ASSUME(no_spurious_incr_valid_a,
+             incr_valid |-> (fv_credit_cnt + fv_incr - fv_decr) <= MaxValue)
+  if (EnableCoverZeroIncrement) begin : gen_assume_zero_increment_ok
+    `BR_COVER(zero_increment_c, incr_valid && incr == 'd0)
+  end else begin : gen_assume_nonzero_increment
+    `BR_ASSUME(nonzero_increment_a, incr_valid |-> incr != 'd0)
+  end
+  if (EnableCoverZeroDecrement) begin : gen_assume_zero_decrement_ok
+    `BR_COVER(zero_decrement_c, decr_valid && decr == 'd0)
+  end else begin : gen_assume_nonzero_decrement
+    `BR_ASSUME(nonzero_decrement_a, decr_valid |-> decr != 'd0)
+  end
+  if (EnableCoverDecrementBackpressure) begin : gen_cover_decrement_backpressure
+    `BR_COVER(decrement_backpressure_c, decr_valid && decr > fv_available)
+  end else begin : gen_assume_no_decrement_backpressure
+    `BR_ASSUME(no_decrement_backpressure_a, decr_valid |-> decr <= fv_available)
+  end
+  if (EnableCoverWithhold) begin : gen_assume_withhold_liveness
+    `BR_ASSUME(withold_liveness_a, s_eventually withhold < fv_initial_value)
+  end else begin : gen_assume_no_withhold
+    `BR_ASSUME(no_withhold_a, withhold == 'd0)
+  end
+  if (EnableAssertAlwaysDecr) begin : gen_assume_always_decr
+    `BR_ASSUME(always_decr_a, decr_valid)
+  end else begin : gen_cover_no_decr
+    `BR_COVER(no_decr_c, !decr_valid)
+  end
 
   // ----------FV assertions----------
-  `BR_ASSERT(decr_ready_sanity_a, (fv_credit_cnt == 'd0) && (fv_incr == 'd0) |-> fv_decr == 'd0)
-  `BR_ASSERT(decr_ready_forward_progress_a,
-             (decr_valid && fv_available >= decr && fv_available != 'd0) |-> decr_ready)
+  // Always-decrement with no backpressure requires each decrement to be immediately serviceable,
+  // so the counter cannot be empty without an increment to replenish available credit.
+  if (!(EnableAssertAlwaysDecr && !EnableCoverDecrementBackpressure)) begin : gen_decr_ready_sanity
+    `BR_ASSERT(decr_ready_sanity_a, (fv_credit_cnt == 'd0) && (fv_incr == 'd0) |-> fv_decr == 'd0)
+  end
+  // Cover the ready contract for all serviceable decrement requests, including decr == 0.
+  `BR_ASSERT(decr_ready_forward_progress_a, decr_valid && decr <= fv_available |-> decr_ready)
   `BR_ASSERT(value_a, fv_value == value)
   `BR_ASSERT(available_a, fv_available == available)
   `BR_ASSERT(available_liveness_a, (fv_decr != 'd0) |-> s_eventually (fv_available != 'd0))
@@ -71,5 +107,12 @@ bind br_credit_counter br_credit_counter_fpv_monitor #(
     .MaxChangeWidth(MaxChangeWidth),
     .MaxValue(MaxValue),
     .MaxChange(MaxChange),
+    .MaxIncrement(MaxIncrement),
+    .MaxDecrement(MaxDecrement),
+    .EnableCoverZeroIncrement(EnableCoverZeroIncrement),
+    .EnableCoverZeroDecrement(EnableCoverZeroDecrement),
+    .EnableCoverDecrementBackpressure(EnableCoverDecrementBackpressure),
+    .EnableCoverWithhold(EnableCoverWithhold),
+    .EnableAssertAlwaysDecr(EnableAssertAlwaysDecr),
     .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
 ) monitor (.*);

--- a/credit/rtl/br_credit_counter.sv
+++ b/credit/rtl/br_credit_counter.sv
@@ -275,9 +275,10 @@ module br_credit_counter #(
   `BR_COVER_IMPL(value_lt_available_c, value < available)
   if (EnableCoverWithhold) begin : gen_cover_withhold_gt_value
     `BR_COVER_IMPL(value_gt_available_c, value > available)
-    // Always-decrement with no backpressure requires each decrement to be immediately
-    // serviceable, so withhold cannot be driven above the stored value in that environment.
-    if (!(EnableAssertAlwaysDecr && EnableAssertNoDecrementBackpressure)) begin : gen_wh_gt_value
+    // If every cycle must decrement with no backpressure, zero decrements are disallowed,
+    // and increments are limited to one credit, withhold cannot exceed the stored value.
+    if (!(EnableAssertAlwaysDecr && EnableAssertNoDecrementBackpressure &&
+          !EnableCoverZeroDecrement && MaxIncrement == 1)) begin : gen_wh_gt_value
       `BR_COVER_IMPL(withhold_gt_value_c, withhold > value)
     end
   end

--- a/credit/rtl/br_credit_counter.sv
+++ b/credit/rtl/br_credit_counter.sv
@@ -191,6 +191,12 @@ module br_credit_counter #(
   end else begin : gen_assert_withhold_zero
     `BR_ASSERT_INTG(withhold_zero_a, withhold == 0)
   end
+  // If every cycle must pop a nonzero credit with no backpressure, withholding more
+  // than the stored pool would force an underflow when increments are limited to one.
+  if (EnableAssertAlwaysDecr && EnableAssertNoDecrementBackpressure &&
+      !EnableCoverZeroDecrement && MaxIncrement == 1) begin : gen_assert_withhold_lte_value
+    `BR_ASSERT_INTG(withhold_lte_value_a, withhold <= value)
+  end
 
   if (EnableCoverDecrementBackpressure) begin : gen_cover_decr_gt_available
     `BR_COVER_INTG(decr_gt_available_c, decr_valid && decr > available)

--- a/credit/rtl/br_credit_counter.sv
+++ b/credit/rtl/br_credit_counter.sv
@@ -275,7 +275,11 @@ module br_credit_counter #(
   `BR_COVER_IMPL(value_lt_available_c, value < available)
   if (EnableCoverWithhold) begin : gen_cover_withhold_gt_value
     `BR_COVER_IMPL(value_gt_available_c, value > available)
-    `BR_COVER_IMPL(withhold_gt_value_c, withhold > value)
+    // Always-decrement with no backpressure requires each decrement to be immediately
+    // serviceable, so withhold cannot be driven above the stored value in that environment.
+    if (!(EnableAssertAlwaysDecr && EnableAssertNoDecrementBackpressure)) begin : gen_wh_gt_value
+      `BR_COVER_IMPL(withhold_gt_value_c, withhold > value)
+    end
   end
 
 endmodule : br_credit_counter


### PR DESCRIPTION
After #1147, I realize FV doesn't have parameter sweep on RTL knobs (we only have parameter sweep on MaxChange and MaxValue). Therefore, I'm adding new parameter sweep except MaxChange and MaxValue.
Everything is clean on TOT.

RTL cover withhold_gt_value_c  was unreachable when:
```
EnableAssertAlwaysDecr == 1
EnableAssertNoDecrementBackpressure == 1
EnableCoverZeroDecrement == 0
MaxIncrement == 1
```
Added RTL INTEG assertion to disallow withhold to be great than value, and disabled this cover under this parameter set up.