### PR TITLE
Add misc directed tests

### DIFF
--- a/misc/sim/BUILD.bazel
+++ b/misc/sim/BUILD.bazel
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//visibility:private"])
@@ -32,4 +33,102 @@ verilog_elab_test(
     name = "br_test_rate_control_elab_test",
     tool = "verific",
     deps = [":br_test_rate_control"],
+)
+
+verilog_library(
+    name = "br_misc_tieoff_one_tb",
+    srcs = ["br_misc_tieoff_one_tb.sv"],
+    deps = [
+        ":br_test_driver",
+        "//misc/rtl:br_misc_tieoff_one",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_misc_tieoff_one_tb_elab_test",
+    tool = "verific",
+    deps = [":br_misc_tieoff_one_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_misc_tieoff_one_sim_test_tools_suite",
+    params = {"Width": [
+        "1",
+        "2",
+        "17",
+        "32",
+    ]},
+    tools = [
+        "iverilog",
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_misc_tieoff_one_tb"],
+)
+
+verilog_library(
+    name = "br_misc_tieoff_zero_tb",
+    srcs = ["br_misc_tieoff_zero_tb.sv"],
+    deps = [
+        ":br_test_driver",
+        "//misc/rtl:br_misc_tieoff_zero",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_misc_tieoff_zero_tb_elab_test",
+    tool = "verific",
+    deps = [":br_misc_tieoff_zero_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_misc_tieoff_zero_sim_test_tools_suite",
+    params = {"Width": [
+        "1",
+        "2",
+        "17",
+        "32",
+    ]},
+    tools = [
+        "iverilog",
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_misc_tieoff_zero_tb"],
+)
+
+verilog_library(
+    name = "br_misc_unused_tb",
+    srcs = ["br_misc_unused_tb.sv"],
+    deps = [
+        ":br_test_driver",
+        "//misc/rtl:br_misc_unused",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_misc_unused_tb_elab_test",
+    tool = "verific",
+    deps = [":br_misc_unused_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_misc_unused_sim_test_tools_suite",
+    params = {
+        "NumRandomIterations": [
+            "8",
+        ],
+        "Width": [
+            "1",
+            "2",
+            "17",
+            "32",
+        ],
+    },
+    tools = [
+        "iverilog",
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_misc_unused_tb"],
 )

--- a/misc/sim/br_misc_tieoff_one_tb.sv
+++ b/misc/sim/br_misc_tieoff_one_tb.sv
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Testbench for br_misc_tieoff_one.
+ *
+ * Scenarios:
+ * - Reset the no-state DUT through br_test_driver.
+ * - Check that the output port width matches the Width parameter.
+ * - Check that the output is all ones after reset and remains stable.
+ */
+module br_misc_tieoff_one_tb;
+
+  parameter int Width = 1;
+
+  logic clk;
+  logic rst;
+  logic [Width-1:0] out;
+
+  br_misc_tieoff_one #(.Width(Width)) dut (.out);
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  initial begin
+    td.reset_dut();
+    td.wait_cycles(1);
+
+    td.check($bits(out) == Width, $sformatf("expected output width %0d", Width));
+    td.check(out === '1, "out is tied high after reset");
+
+    td.wait_cycles(1);
+    td.check(out === '1, "out remains tied high");
+
+    td.finish();
+  end
+
+endmodule : br_misc_tieoff_one_tb

--- a/misc/sim/br_misc_tieoff_zero_tb.sv
+++ b/misc/sim/br_misc_tieoff_zero_tb.sv
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Testbench for br_misc_tieoff_zero.
+ *
+ * Scenarios:
+ * - Reset the no-state DUT through br_test_driver.
+ * - Check that the output port width matches the Width parameter.
+ * - Check that the output is all zeros after reset and remains stable.
+ */
+module br_misc_tieoff_zero_tb;
+
+  parameter int Width = 1;
+
+  logic clk;
+  logic rst;
+  logic [Width-1:0] out;
+
+  br_misc_tieoff_zero #(.Width(Width)) dut (.out);
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  initial begin
+    td.reset_dut();
+    td.wait_cycles(1);
+
+    td.check($bits(out) == Width, $sformatf("expected output width %0d", Width));
+    td.check(out === '0, "out is tied low after reset");
+
+    td.wait_cycles(1);
+    td.check(out === '0, "out remains tied low");
+
+    td.finish();
+  end
+
+endmodule : br_misc_tieoff_zero_tb

--- a/misc/sim/br_misc_unused_tb.sv
+++ b/misc/sim/br_misc_unused_tb.sv
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Testbench for br_misc_unused.
+ *
+ * Scenarios:
+ * - Reset the no-state DUT through br_test_driver.
+ * - Drive all-zero and all-one inputs.
+ * - Walk a single set bit across every input bit.
+ * - Drive NumRandomIterations pseudo-random input values.
+ * - Check that the internal reduction sink tracks the OR reduction of in.
+ */
+module br_misc_unused_tb;
+
+  parameter int Width = 1;
+  parameter int NumRandomIterations = 8;
+
+  logic clk;
+  logic rst;
+  logic [Width-1:0] in;
+
+  br_misc_unused #(.Width(Width)) dut (.in);
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  task automatic check_sink(input string message);
+    td.wait_cycles(1);
+    td.check(dut.unused === (|in), message);
+  endtask
+
+  initial begin
+    in = '0;
+
+    td.reset_dut();
+
+    check_sink("sink observes all-zero input");
+
+    in = '1;
+    check_sink("sink observes all-one input");
+
+    for (int i = 0; i < Width; i++) begin
+      in = '0;
+      in[i] = 1'b1;
+      check_sink($sformatf("sink observes bit %0d", i));
+    end
+
+    for (int i = 0; i < NumRandomIterations; i++) begin
+      in = $urandom();
+      check_sink($sformatf("sink observes random input %0d", i));
+    end
+
+    td.finish();
+  end
+
+endmodule : br_misc_unused_tb


### PR DESCRIPTION
This PR adds directed tests for the `misc` modules:
* misc/sim/br_misc_tieoff_one_tb.sv
* misc/sim/br_misc_tieoff_zero_tb.sv
* misc/sim/br_misc_unused_tb.sv