### PR TITLE
[Docker] Publish the open-source CI image to GitHub container registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,95 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
 
+  docker-image-build:
+    runs-on: ubuntu-24.04
+    outputs:
+      image-tag: ${{ steps.image-metadata.outputs.tag }}
+    permissions:
+      contents: read
+    steps:
+      # actions/checkout v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      # docker/setup-buildx-action v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+      - name: Set YYYY-MM-DD-SHA image tag
+        id: image-metadata
+        run: |
+          # Normalize the commit timestamp to a UTC date so a Git SHA always
+          # maps to the same YYYY-MM-DD-SHA image tag across time zones.
+          commit_timestamp="$(git show --no-patch --format=%ct "${GITHUB_SHA}")"
+          commit_date="$(date --utc --date="@${commit_timestamp}" +%F)"
+          echo "tag=${commit_date}-${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+      - name: Build Docker image
+        # docker/build-push-action v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          # Reuse BuildKit layers stored in the GitHub Actions cache for this image.
+          cache-from: type=gha,scope=bedrock-rtl-docker
+          # Export all intermediate and final layers for subsequent builds.
+          cache-to: type=gha,mode=max,scope=bedrock-rtl-docker
+
+  docker-image-publish:
+    runs-on: ubuntu-24.04
+    needs: docker-image-build
+    # GitHub only permits users with repository write access to use workflow_dispatch.
+    if: >-
+      needs.docker-image-build.result == 'success' &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+    permissions:
+      # Allows checkout to read the repository contents.
+      contents: read
+      # Allows GitHub to issue the OIDC token used to sign the provenance attestation.
+      id-token: write
+      # Allows the job to persist the signed provenance attestation with GitHub.
+      attestations: write
+      # Links the attestation to the image published in GHCR.
+      artifact-metadata: write
+      # Allows the job credential to publish the image to GHCR.
+      packages: write
+    steps:
+      # actions/checkout v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      # docker/setup-buildx-action v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+      - name: Log in to GHCR
+        # docker/login-action v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Publish Docker image
+        id: publish
+        # docker/build-push-action v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          # Attach max-detail BuildKit provenance to the published image.
+          provenance: mode=max
+          tags: ghcr.io/xlsynth/bedrock-rtl:${{ needs.docker-image-build.outputs.image-tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          # Reuse the layers populated by docker-image-build before publishing.
+          cache-from: type=gha,scope=bedrock-rtl-docker
+      - name: Attest Docker image provenance
+        # actions/attest v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        with:
+          subject-name: ghcr.io/xlsynth/bedrock-rtl
+          subject-digest: ${{ steps.publish.outputs.digest }}
+          push-to-registry: true
+
   # Run bazel build and tests in order in one job to avoid parallel jobs that make
   # build logs appear out of sequence across the CI workflow.
   bazel-build-and-test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rockylinux:8.9.20231119@sha256:2d05a9266523bbf24f33ebc3a9832e4d5fd74b973c220f2204ca802286aa275d
+FROM docker.io/library/rockylinux:8.9.20231119@sha256:2d05a9266523bbf24f33ebc3a9832e4d5fd74b973c220f2204ca802286aa275d
 ARG TARGETPLATFORM
-LABEL description="Docker image for building and testing Bedrock-RTL using open source tools."
 WORKDIR /tmp
 COPY requirements_lock_3_12.txt /tmp/requirements_lock_3_12.txt
 
@@ -13,92 +12,89 @@ RUN if [ "${TARGETPLATFORM}" != "linux/amd64" ]; then \
     fi
 
 # Install build-time dependencies and other helpful yum packages.
-RUN yum install -y dnf-plugins-core-4.0.21-25.el8
-RUN yum config-manager --set-enabled \
-    appstream-debuginfo \
-    appstream-source \
-    baseos-debuginfo \
-    baseos-source \
-    plus \
-    powertools \
-    powertools-debuginfo \
-    powertools-source
+RUN yum install -y dnf-plugins-core-4.0.21-25.el8 && \
+    yum config-manager --set-enabled \
+        plus \
+        powertools && \
+    yum install -y \
+        autoconf-2.69-29.el8_10.1 \
+        bison-3.0.4-10.el8 \
+        boost-1.66.0-13.el8 \
+        boost-python3-devel-1.66.0-13.el8 \
+        boost-system-1.66.0-13.el8 \
+        clang-18.1.8-1.module+el8.10.0+1875+4f0b06db \
+        cmake-3.26.5-2.el8 \
+        curl-7.61.1-34.el8_10.3 \
+        eigen3-devel-3.3.4-6.el8 \
+        emacs-26.1-13.el8_10 \
+        flex-2.6.1-9.el8 \
+        gawk-4.2.1-4.el8 \
+        gcc-8.5.0-23.el8_10 \
+        gcc-c++-8.5.0-23.el8_10 \
+        git-2.43.5-2.el8_10 \
+        glibc-2.28-251.el8_10.13 \
+        glibc-devel-2.28-251.el8_10.13 \
+        gmp-6.1.2-12.el8 \
+        gmp-devel-1:6.1.2-12.el8 \
+        gperf-3.1-5.el8 \
+        graphviz-2.40.1-45.el8 \
+        help2man-1.47.6-1.el8 \
+        libatomic-8.5.0-23.el8_10 \
+        libffi-3.1-24.el8 \
+        libffi-devel-3.1-24.el8.x86_64 \
+        libnsl-2.28-251.el8_10.13 \
+        libstdc++-8.5.0-23.el8_10 \
+        libstdc++-devel-8.5.0-23.el8_10 \
+        lld-18.1.8-1.module+el8.10.0+1875+4f0b06db \
+        make-4.2.1-11.el8 \
+        numactl-2.0.16-4.el8 \
+        perl-5.26.3-422.el8 \
+        pkgconf-pkg-config-1.4.2-1.el8 \
+        python3.12-3.12.8-1.el8_10 \
+        python3.12-pip-23.2.1-4.el8 \
+        readline-7.0-10.el8 \
+        readline-devel-7.0-10.el8 \
+        swig-3.0.12-19.module+el8.4.0+385+82b6e804 \
+        tcl-devel-1:8.6.8-2.el8 \
+        vim-enhanced-2:8.0.1763-19.el8_6.4 \
+        zlib-1.2.11-26.el8 \
+        zlib-devel-1.2.11-26.el8 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
-RUN yum install -y autoconf-2.69-29.el8_10.1
-RUN yum install -y bison-3.0.4-10.el8
-RUN yum install -y boost-1.66.0-13.el8
-RUN yum install -y boost-python3-devel-1.66.0-13.el8
-RUN yum install -y boost-system-1.66.0-13.el8
-RUN yum install -y clang-18.1.8-1.module+el8.10.0+1875+4f0b06db
-RUN yum install -y cmake-3.26.5-2.el8
-RUN yum install -y curl-7.61.1-34.el8_10.3
-RUN yum install -y eigen3-devel-3.3.4-6.el8
-RUN yum install -y emacs-26.1-13.el8_10
-RUN yum install -y flex-2.6.1-9.el8
-RUN yum install -y gawk-4.2.1-4.el8
-RUN yum install -y gcc-8.5.0-23.el8_10
-RUN yum install -y gcc-c++-8.5.0-23.el8_10
-RUN yum install -y git-2.43.5-2.el8_10
-RUN yum install -y glibc-2.28-251.el8_10.13
-RUN yum install -y glibc-devel-2.28-251.el8_10.13
-RUN yum install -y gmp-6.1.2-12.el8
-RUN yum install -y gmp-devel-1:6.1.2-12.el8
-RUN yum install -y gperf-3.1-5.el8
-RUN yum install -y graphviz-2.40.1-45.el8
-RUN yum install -y help2man-1.47.6-1.el8
-RUN yum install -y libffi-3.1-24.el8
-RUN yum install -y libffi-devel-3.1-24.el8.x86_64
-RUN yum install -y libatomic-8.5.0-23.el8_10
-RUN yum install -y libnsl-2.28-251.el8_10.13
-RUN yum install -y libstdc++-8.5.0-23.el8_10
-RUN yum install -y libstdc++-devel-8.5.0-23.el8_10
-RUN yum install -y lld-18.1.8-1.module+el8.10.0+1875+4f0b06db
-RUN yum install -y make-4.2.1-11.el8
-RUN yum install -y numactl-2.0.16-4.el8
-RUN yum install -y perl-5.26.3-422.el8
-RUN yum install -y pkgconf-pkg-config-1.4.2-1.el8
-RUN yum install -y python3.12-3.12.8-1.el8_10
-RUN yum install -y python3.12-pip-23.2.1-4.el8
-RUN yum install -y readline-7.0-10.el8
-RUN yum install -y readline-devel-7.0-10.el8
-RUN yum install -y swig-3.0.12-19.module+el8.4.0+385+82b6e804
-RUN yum install -y tcl-devel-1:8.6.8-2.el8
-RUN yum install -y vim-enhanced-2:8.0.1763-19.el8_6.4
-RUN yum install -y zlib-1.2.11-26.el8
-RUN yum install -y zlib-devel-1.2.11-26.el8
-
-RUN pip3.12 install --require-hashes -r /tmp/requirements_lock_3_12.txt
+RUN pip3.12 install --require-hashes -r /tmp/requirements_lock_3_12.txt && \
+    rm /tmp/requirements_lock_3_12.txt
 
 # Install iverilog
 # git SHA from: Jan 3, 2025
-RUN git clone https://github.com/steveicarus/iverilog.git
-RUN cd iverilog && \
+RUN git clone https://github.com/steveicarus/iverilog.git && \
+    cd iverilog && \
     git checkout 14375567c72b6f71cc93bec3b62cf43aaf34942e && \
     sh autoconf.sh && \
     ./configure && \
     make -j$(nproc) && \
     make install && \
     cd .. && \
-    rm -rf iverilog
-RUN iverilog -V
+    rm -rf iverilog && \
+    iverilog -V
 
 # Install Verilator
 # v5.048
-RUN git clone https://github.com/verilator/verilator
-RUN cd verilator && \
+RUN git clone https://github.com/verilator/verilator && \
+    cd verilator && \
     git checkout d0aa828c217410fffc73d92077b6f4f54830357c && \
     autoconf && \
     CC="clang -fuse-ld=lld" CXX="clang++ -fuse-ld=lld" ./configure && \
     make -j$(nproc) && \
     make install && \
     cd .. && \
-    rm -rf verilator
-RUN verilator --version
+    rm -rf verilator && \
+    verilator --version
 
 # Install Verible
-RUN curl -L https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz -o verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz
-RUN echo "30c20385956f52ef892cb58f7f816f9f9a9dc37a0432848a49c6d9aa3a72a8b7  verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz" | sha256sum -c -
-RUN tar -xzf verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz && \
+RUN curl -L https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz -o verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz && \
+    echo "30c20385956f52ef892cb58f7f816f9f9a9dc37a0432848a49c6d9aa3a72a8b7  verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz" | sha256sum -c - && \
+    tar -xzf verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz && \
     cp verible-v0.0-4023-gc1271a00/bin/* /usr/local/bin/ && \
     verible-verilog-lint --version && \
     rm verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz && \
@@ -106,39 +102,27 @@ RUN tar -xzf verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz && \
 
 # Install Yosys
 # v0.51
-RUN git clone https://github.com/YosysHQ/yosys.git
-RUN cd yosys && \
+RUN git clone https://github.com/YosysHQ/yosys.git && \
+    cd yosys && \
     git fetch --all && \
     git checkout c4b5190229616f7ebf8197f43990b4429de3e420 && \
     git submodule update --init --recursive && \
     make -j$(nproc) && \
     make install && \
     cd .. && \
-    rm -rf yosys
-RUN yosys --help
+    rm -rf yosys && \
+    yosys --help
 
 # Install EQY
 # v0.48
-RUN git clone https://github.com/YosysHQ/eqy.git
-RUN cd eqy && \
+RUN git clone https://github.com/YosysHQ/eqy.git && \
+    cd eqy && \
     git checkout 93bf4dfb8b19c0f1e9d472fd8421cdfdc4fe85a0 && \
     make -j$(nproc) && \
     make install && \
     cd .. && \
-    rm -rf eqy
-RUN eqy --help
-
-# Install SBY
-# TODO: debug
-#RUN git clone https://github.com/YosysHQ/sby
-#RUN cd sby && \
-#    # v0.48
-#    git checkout 26b387466d224cd9e83a6f97d0b69d9dd59e56b5 && \
-#    make -j$(nproc) && \
-#    make install && \
-#    cd .. && \
-#    rm -rf sby
-#RUN sby --help
+    rm -rf eqy && \
+    eqy --help
 
 # Install boolector and yices2 to able to run LEC with Yosys
 # TODO: boolector is not able to build..
@@ -159,21 +143,21 @@ RUN eqy --help
 #RUN boolector --version
 
 # Yices-2.6.5
-RUN git clone https://github.com/SRI-CSL/yices2.git
-RUN cd yices2 && \
+RUN git clone https://github.com/SRI-CSL/yices2.git && \
+    cd yices2 && \
     git checkout 8e6297e233299631147f98659224c3118fc6a215 && \
     autoconf && \
     ./configure && \
     make -j$(nproc) && \
     make install && \
     cd .. && \
-    rm -rf yices2
-RUN yices --version
+    rm -rf yices2 && \
+    yices --version
 
 # Necessary for building OpenSTA
-RUN curl -L https://github.com/davidkebo/cudd/raw/c8d587ef3fbcc115977fed48a867aa6664ca11d0/cudd_versions/cudd-3.0.0.tar.gz -o cudd-3.0.0.tar.gz
-RUN echo "b8e966b4562c96a03e7fbea239729587d7b395d53cadcc39a7203b49cf7eeb69  cudd-3.0.0.tar.gz" | sha256sum -c -
-RUN tar -xzf cudd-3.0.0.tar.gz && \
+RUN curl -L https://github.com/davidkebo/cudd/raw/c8d587ef3fbcc115977fed48a867aa6664ca11d0/cudd_versions/cudd-3.0.0.tar.gz -o cudd-3.0.0.tar.gz && \
+    echo "b8e966b4562c96a03e7fbea239729587d7b395d53cadcc39a7203b49cf7eeb69  cudd-3.0.0.tar.gz" | sha256sum -c - && \
+    tar -xzf cudd-3.0.0.tar.gz && \
     cd cudd-3.0.0 && \
     ./configure --prefix=/usr/local && \
     make -j$(nproc) && \
@@ -211,33 +195,33 @@ RUN tar -xzf cudd-3.0.0.tar.gz && \
 # Install Slang. Make sure to tell it to use clang,
 # because our gcc install in this image is too old for C++20 language features.
 # v7.0
-RUN git clone https://github.com/MikePopoloski/slang.git
-RUN cd slang && \
+RUN git clone https://github.com/MikePopoloski/slang.git && \
+    cd slang && \
     git checkout d56a39898b24208871ac936cd535f9daacef36a7 && \
     CC=clang CXX=clang++ cmake -B build && \
     cmake --build build -j$(nproc) && \
     cp build/bin/slang /usr/local/bin/slang && \
-    rm -rf slang
-RUN slang -version
+    cd .. && \
+    rm -rf slang && \
+    slang -version
 
-# Use Bazelisk to manage Bazel versions
-# Makes it easier to upgrade by just changing .bazelversion file in the Bedrock-RTL repo.
-RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64 -o /usr/local/bin/bazelisk
-RUN echo "fd8fdff418a1758887520fa42da7e6ae39aefc788cf5e7f7bb8db6934d279fc4  /usr/local/bin/bazelisk" | sha256sum -c -
-RUN mv /usr/local/bin/bazelisk /usr/local/bin/bazel
-RUN chmod +x /usr/local/bin/bazel
-RUN bazel --version
+# Use Bazelisk to manage Bazel versions.
+# This makes it easier to upgrade by changing .bazelversion in the Bedrock-RTL repo.
+RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-amd64 -o /usr/local/bin/bazelisk && \
+    echo "e1508323f347ad1465a887bc5d2bfb91cffc232d11e8e997b623227c6b32fb76  /usr/local/bin/bazelisk" | sha256sum -c - && \
+    mv /usr/local/bin/bazelisk /usr/local/bin/bazel && \
+    chmod +x /usr/local/bin/bazel
 
 # Clone z3 to use as a verilator solver
 # z3-4.16.0
 RUN git clone https://github.com/Z3Prover/z3.git && \
     cd z3 && \
-    git checkout ddb49568d3520e99799e364fb22f35fc67d887b1
-RUN cd z3 && \
+    git checkout ddb49568d3520e99799e364fb22f35fc67d887b1 && \
     CXX=clang++ CC=clang python3 ./scripts/mk_make.py && \
     cd build && make -j$(nproc) && make install && \
-    cd ../../
-RUN z3 --version
+    cd ../.. && \
+    rm -rf z3 && \
+    z3 --version
 # Export VERILATOR_SOLVER environmental variable to use z3 as a solver
 ENV VERILATOR_SOLVER="z3 --in"
 
@@ -245,4 +229,9 @@ RUN useradd -m user
 USER user
 
 WORKDIR /home/user
+LABEL description="Docker image for building and testing Bedrock-RTL using open source tools." \
+    org.opencontainers.image.title="Bedrock-RTL" \
+    org.opencontainers.image.description="Open source toolchain for building and testing Bedrock-RTL." \
+    org.opencontainers.image.source="https://github.com/xlsynth/bedrock-rtl" \
+    org.opencontainers.image.licenses="Apache-2.0"
 CMD ["/bin/bash"]


### PR DESCRIPTION
Make the public Dockerfile the authoritative open-source toolchain for both end users and the internal CI overlay. Keep fetched tools immutable, update Bazelisk to 1.27.0, remove the unused SymbiYosys setup, and reduce layer count.

Add cached GitHub Actions jobs that build the image on every CI event and publish a deterministic commit-date and full-SHA tag to GHCR only for main pushes or manual runs. Stamp the raw Git SHA as the OCI source revision during the Buildx export without claiming a separate software release version. Attach max-detail BuildKit provenance and sign the pushed digest through GitHub's Sigstore-backed artifact attestation service. Normalize the tag date from the commit timestamp to UTC so it is independent of stored time zones.

Validation:
- Ran the full pre-commit suite.
- Ran a local linux/amd64 Docker image build.
- Ran two cached exports and verified distinct OCI revision labels.
- Ran workflow assertions for conditions, permissions, cache, and publication tag.
- Ran workflow assertions for signed image provenance and artifact linkage.
- Ran image-tag date checks under UTC+14 and UTC-10 environments.
- Ran a Codex security review for best practices; came back clean.