### PR TITLE
[fv] Disable unreachable covers

### DIFF
--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
@@ -33,6 +33,16 @@ clock -rate {pop_rst \
             pop_ram_rd_data} pop_clk
 
 get_design_info
+array set param_list [get_design_info -list parameter]
+set Depth $param_list(Depth)
+
+# For Depth=6, the generic credit-counter max-increment cover requires the
+# push side to observe a full-depth pop-count delta in one synchronized sample.
+# This cover is reachable in all smaller parameter setups, but becomes
+# undetermined due to complexity for Depth=6.
+if {$Depth == 6} {
+  cover -disable *br_credit_receiver.br_credit_counter.max_incr_c
+}
 
 # primary input control signal should be legal during reset
 assume -name initial_value_during_reset {@(posedge push_clk) \

--- a/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_ctrl_push_pop_1r1w_push_credit_fpv.jg.tcl
@@ -33,6 +33,16 @@ clock -rate {pop_rst \
             pop_ram_rd_data} pop_clk
 
 get_design_info
+array set param_list [get_design_info -list parameter]
+set Depth $param_list(Depth)
+
+# For Depth=6, the generic credit-counter max-increment cover requires the
+# push side to observe a full-depth pop-count delta in one synchronized sample.
+# This cover is reachable in all smaller parameter setups, but becomes
+# undetermined due to complexity for Depth=6.
+if {$Depth == 6} {
+  cover -disable *br_credit_receiver.br_credit_counter.max_incr_c
+}
 
 # primary input control signal should be legal during reset
 assume -name initial_value_during_reset {@(posedge push_clk) \

--- a/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv.jg.tcl
@@ -30,6 +30,16 @@ clock -rate {push_rst \
 clock -rate {pop_rst pop_ready} pop_clk
 
 get_design_info
+array set param_list [get_design_info -list parameter]
+set Depth $param_list(Depth)
+
+# For Depth=6, the generic credit-counter max-increment cover requires the
+# push side to observe a full-depth pop-count delta in one synchronized sample.
+# This cover is reachable in all smaller parameter setups, but becomes
+# undetermined due to complexity for Depth=6.
+if {$Depth == 6} {
+  cover -disable *br_credit_receiver.br_credit_counter.max_incr_c
+}
 
 # primary input control signal should be legal during reset
 assume -name initial_value_during_reset {@(posedge push_clk) \

--- a/credit/fpv/br_credit_sender_vc_fpv.jg.tcl
+++ b/credit/fpv/br_credit_sender_vc_fpv.jg.tcl
@@ -17,17 +17,6 @@ for {set i 0} {$i < $NumVcs} {incr i} {
   assume -name credit_initial_in_range_$i "credit_initial\[$i\] <= MaxCredit"
 }
 
-# When push backpressure coverage and push stability checks are all disabled,
-# the counter decrement-backpressure cover can be unreachable through this
-# wrapper. Keep the RTL default cover enabled, but waive it for this FPV sweep
-# point.
-if {[string equal $param_list(EnableCoverPushBackpressure) "1'b0"] &&
-    [string equal $param_list(EnableAssertPushValidStability) "1'b0"] &&
-    [string equal $param_list(EnableAssertPushDataStability) "1'b0"]} {
-  cover -disable {*gen_cover_decr_gt_available.decr_gt_available_c*}
-  cover -disable {*br_flow_fork_push.br_flow_fork_select_multihot.gen_flow_checks*.pop_valid_unstable_c}
-}
-
 assume -name initial_value_during_reset {rst | pop_receiver_in_reset |-> \
 $stable(credit_initial)}
 assume -name no_pop_credit_during_reset {rst | pop_receiver_in_reset |-> pop_credit == 'd0}

--- a/credit/fpv/br_credit_sender_vc_fpv.jg.tcl
+++ b/credit/fpv/br_credit_sender_vc_fpv.jg.tcl
@@ -25,6 +25,7 @@ if {[string equal $param_list(EnableCoverPushBackpressure) "1'b0"] &&
     [string equal $param_list(EnableAssertPushValidStability) "1'b0"] &&
     [string equal $param_list(EnableAssertPushDataStability) "1'b0"]} {
   cover -disable {*gen_cover_decr_gt_available.decr_gt_available_c*}
+  cover -disable {*br_flow_fork_push.br_flow_fork_select_multihot.gen_flow_checks*.pop_valid_unstable_c}
 }
 
 assume -name initial_value_during_reset {rst | pop_receiver_in_reset |-> \

--- a/credit/rtl/br_credit_sender_vc.sv
+++ b/credit/rtl/br_credit_sender_vc.sv
@@ -35,6 +35,7 @@ module br_credit_sender_vc #(
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, assert that push_data is stable when backpressured.
+    // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
@@ -94,8 +95,8 @@ module br_credit_sender_vc #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(legal_assert_push_data_stability_a,
-                    !(EnableAssertPushDataStability && !EnableAssertPushValidStability))
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_vcs_in_range_a, (NumVcs >= 2))
   `BR_ASSERT_STATIC(pop_credit_max_change_in_range_a, (PopCreditMaxChange <= MaxCredit))
 

--- a/credit/rtl/br_credit_sender_vc.sv
+++ b/credit/rtl/br_credit_sender_vc.sv
@@ -94,10 +94,6 @@ module br_credit_sender_vc #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
-                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
-  `BR_ASSERT_STATIC(legal_assert_push_valid_stability_a,
-                    !(EnableAssertPushValidStability && !EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(legal_assert_push_data_stability_a,
                     !(EnableAssertPushDataStability && !EnableAssertPushValidStability))
   `BR_ASSERT_STATIC(num_vcs_in_range_a, (NumVcs >= 2))

--- a/credit/rtl/br_credit_sender_vc.sv
+++ b/credit/rtl/br_credit_sender_vc.sv
@@ -35,7 +35,6 @@ module br_credit_sender_vc #(
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, assert that push_data is stable when backpressured.
-    // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
@@ -97,6 +96,10 @@ module br_credit_sender_vc #(
   //------------------------------------------
   `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
                     !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+  `BR_ASSERT_STATIC(legal_assert_push_valid_stability_a,
+                    !(EnableAssertPushValidStability && !EnableCoverPushBackpressure))
+  `BR_ASSERT_STATIC(legal_assert_push_data_stability_a,
+                    !(EnableAssertPushDataStability && !EnableAssertPushValidStability))
   `BR_ASSERT_STATIC(num_vcs_in_range_a, (NumVcs >= 2))
   `BR_ASSERT_STATIC(pop_credit_max_change_in_range_a, (PopCreditMaxChange <= MaxCredit))
 
@@ -130,6 +133,7 @@ module br_credit_sender_vc #(
         .MaxDecrement(1),
         .EnableCoverZeroIncrement(0),
         .EnableCoverZeroDecrement(0),
+        .EnableCoverDecrementBackpressure(EnableCoverPushBackpressure),
         .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
         .EnableAssertFinalMaxValue(EnableAssertFinalMaxValue)
     ) br_credit_counter (

--- a/csr/fpv/br_csr_cdc_fpv.jg.tcl
+++ b/csr/fpv/br_csr_cdc_fpv.jg.tcl
@@ -56,9 +56,4 @@ assume -from_assert <embedded>::br_csr_cdc_fpv_monitor.abort_sb.genblk6.core.gen
 # limit run time to 10-mins
 set_prove_time_limit 10m
 
-# The CDC request and response datapaths tie their pop_ready inputs high, so
-# backpressure stability precondition covers in the shared flow checkers are
-# intentionally unreachable.
-cover -disable *valid_data_stable_when_backpressured_a:precondition1
-
 prove -all

--- a/csr/fpv/br_csr_cdc_fpv.jg.tcl
+++ b/csr/fpv/br_csr_cdc_fpv.jg.tcl
@@ -56,4 +56,9 @@ assume -from_assert <embedded>::br_csr_cdc_fpv_monitor.abort_sb.genblk6.core.gen
 # limit run time to 10-mins
 set_prove_time_limit 10m
 
+# The CDC request and response datapaths tie their pop_ready inputs high, so
+# backpressure stability precondition covers in the shared flow checkers are
+# intentionally unreachable.
+cover -disable *valid_data_stable_when_backpressured_a:precondition1
+
 prove -all

--- a/csr/rtl/br_csr_cdc.sv
+++ b/csr/rtl/br_csr_cdc.sv
@@ -96,7 +96,10 @@ module br_csr_cdc #(
       .Width($bits(req_t)),
       .RegisterResetActive(RegisterResetActive),
       .RegisterPopOutputs(RegisterDownstreamReqOutputs),
-      .NumSyncStages(NumSyncStages)
+      .NumSyncStages(NumSyncStages),
+      // CSR CDC ties pop_ready high and asserts no request backpressure, so
+      // br_cdc_reg's push/pop backpressure-stability precondition covers are unreachable.
+      .EnableCoverPushBackpressure(0)
   ) br_cdc_reg_req (
       .push_clk(upstream_clk),  // ri lint_check_waive SAME_CLOCK_NAME
       .push_rst(upstream_rst),
@@ -138,7 +141,10 @@ module br_csr_cdc #(
       .Width($bits(resp_t)),
       .RegisterResetActive(RegisterResetActive),
       .RegisterPopOutputs(RegisterUpstreamRespOutputs),
-      .NumSyncStages(NumSyncStages)
+      .NumSyncStages(NumSyncStages),
+      // CSR CDC ties pop_ready high and asserts no response backpressure, so
+      // br_cdc_reg's push/pop backpressure-stability precondition covers are unreachable.
+      .EnableCoverPushBackpressure(0)
   ) br_cdc_reg_resp (
       .push_clk(downstream_clk),  // ri lint_check_waive SAME_CLOCK_NAME
       .push_rst(downstream_rst),

--- a/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_push_credit_fpv.jg.tcl
@@ -22,9 +22,6 @@ assert -name fv_rst_check_pop_valid {rst | push_sender_in_reset |-> pop_valid ==
 assert -name fv_rst_check_ram_wr_valid {rst | push_sender_in_reset |-> ram_wr_valid == 'd0}
 assert -name fv_rst_check_ram_rd_addr_valid {rst | push_sender_in_reset |-> ram_rd_addr_valid == 'd0}
 
-# The push_ready is tied to 1, so the precondition of the assumption won't be met
-cover -disable *br_fifo_basic_fpv_monitor.gen_push_backpressure_assume.no_push_backpressure*
-
 # limit run time to 10-mins
 set_prove_time_limit 10m
 

--- a/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
@@ -122,7 +122,8 @@ module br_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
       .Depth(Depth),
       .Width(Width),
       .EnableBypass(EnableBypass),
-      .EnableCoverPushBackpressure(0)
+      .EnableCoverPushBackpressure(0),
+      .EnableAssertNoPushBackpressure(0)
   ) br_fifo_basic_fpv_monitor (
       .clk,
       .rst,

--- a/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
+++ b/fifo/fpv/br_fifo/br_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
@@ -123,6 +123,7 @@ module br_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
       .Width(Width),
       .EnableBypass(EnableBypass),
       .EnableCoverPushBackpressure(0),
+      // push_ready is tied high, so do not generate the no-backpressure assumption cover.
       .EnableAssertNoPushBackpressure(0)
   ) br_fifo_basic_fpv_monitor (
       .clk,

--- a/fifo/fpv/br_fifo/br_fifo_flops_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo/br_fifo_flops_push_credit_fpv.jg.tcl
@@ -20,9 +20,6 @@ assume -name no_push_valid_during_reset {rst | push_sender_in_reset |-> push_val
 assert -name fv_rst_check_push_credit {rst | push_sender_in_reset |-> push_credit == 'd0}
 assert -name fv_rst_check_pop_valid {rst | push_sender_in_reset |-> pop_valid == 'd0}
 
-# The push_ready is tied to 1, so the precondition of the assumption won't be met
-cover -disable *br_fifo_basic_fpv_monitor.gen_push_backpressure_assume.no_push_backpressure*
-
 # source ram invariant properties
 array set local_param_list [get_design_info -instance monitor -list local_parameter]
 set WolperColorEn $local_param_list(WolperColorEn)

--- a/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv.jg.tcl
@@ -12,8 +12,6 @@ assume -name no_data_ram_rd_data_valid {rst |-> data_ram_rd_data_valid == 'd0}
 assume -name no_ptr_ram_rd_data_valid {rst |-> ptr_ram_rd_data_valid == 'd0}
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
-set DataRamReadLatency $param_list(DataRamReadLatency)
-set RegisterPopOutputs $param_list(RegisterPopOutputs)
 for {set i 0} {$i < $NumReadPorts} {incr i} {
   assume -name grant_onehot_during_reset_$i "\$onehot0(arb_grant\[$i\])"
 }
@@ -27,27 +25,6 @@ assert -name fv_rst_check_ptr_ram_rd_addr_valid {rst |-> ptr_ram_rd_addr_valid =
 
 # limit run time to 10-mins
 set_prove_time_limit 600s
-
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-
-# With one read port, the FIFO can perform at most one pop/deallocation per
-# cycle. The freelist still has one dealloc port per logical FIFO, so Jasper
-# generates a precondition cover for the multi-dealloc uniqueness assertion even
-# though that precondition is structurally unreachable in this wrapper
-# configuration.
-if {$NumReadPorts == 1} {
-  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
-}
-
-# DataRamReadLatency=0 and RegisterPopOutputs=0 selects the no-staging-buffer
-# path. There, pop_valid is gated by pop_ready through the RAM-read fork, so
-# the internal pop-side backpressure cover is structurally unreachable.
-if {$DataRamReadLatency == 0 && $RegisterPopOutputs eq "1'b0"} {
-  cover -disable *br_flow_fork_head*br_flow_checks_valid_data_impl.gen_backpressure_checks.gen_cover_without_stability.gen_per_flow*0*.backpressure_c
-}
 
 # prove command
 prove -all

--- a/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_ext_arbiter_fpv.jg.tcl
@@ -33,11 +33,20 @@ set_prove_time_limit 600s
 # TODO(zhemao): Find a way to disable in RTL
 cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
 
+# With one read port, the FIFO can perform at most one pop/deallocation per
+# cycle. The freelist still has one dealloc port per logical FIFO, so Jasper
+# generates a precondition cover for the multi-dealloc uniqueness assertion even
+# though that precondition is structurally unreachable in this wrapper
+# configuration.
+if {$NumReadPorts == 1} {
+  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
+}
+
 # DataRamReadLatency=0 and RegisterPopOutputs=0 selects the no-staging-buffer
 # path. There, pop_valid is gated by pop_ready through the RAM-read fork, so
 # the internal pop-side backpressure cover is structurally unreachable.
 if {$DataRamReadLatency == 0 && $RegisterPopOutputs eq "1'b0"} {
-  cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.gen_backpressure_checks.gen_cover_without_stability.gen_per_flow*0*.backpressure_c
+  cover -disable *br_flow_fork_head*br_flow_checks_valid_data_impl.gen_backpressure_checks.gen_cover_without_stability.gen_per_flow*0*.backpressure_c
 }
 
 # prove command

--- a/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_fpv.jg.tcl
@@ -18,8 +18,6 @@ assume -name no_data_ram_rd_data_valid {rst | push_sender_in_reset |-> data_ram_
 assume -name no_ptr_ram_rd_data_valid {rst | push_sender_in_reset |-> ptr_ram_rd_data_valid == 'd0}
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
-set DataRamReadLatency $param_list(DataRamReadLatency)
-set RegisterPopOutputs $param_list(RegisterPopOutputs)
 for {set i 0} {$i < $NumReadPorts} {incr i} {
   assume -name grant_onehot_during_reset_$i "\$onehot0(arb_grant\[$i\])"
 }
@@ -34,27 +32,6 @@ assert -name fv_rst_check_ptr_ram_rd_addr_valid {rst | push_sender_in_reset |-> 
 
 # limit run time to 10-mins
 set_prove_time_limit 600s
-
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-
-# With one read port, the FIFO can perform at most one pop/deallocation per
-# cycle. The freelist still has one dealloc port per logical FIFO, so Jasper
-# generates a precondition cover for the multi-dealloc uniqueness assertion even
-# though that precondition is structurally unreachable in this wrapper
-# configuration.
-if {$NumReadPorts == 1} {
-  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
-}
-
-# DataRamReadLatency=0 and RegisterPopOutputs=0 selects the no-staging-buffer
-# path. There, pop_valid is gated by pop_ready through the RAM-read fork, so
-# the internal pop-side backpressure cover is structurally unreachable.
-if {$DataRamReadLatency == 0 && $RegisterPopOutputs eq "1'b0"} {
-  cover -disable *br_flow_fork_head*br_flow_checks_valid_data_impl.gen_backpressure_checks.gen_cover_without_stability.gen_per_flow*0*.backpressure_c
-}
 
 # prove command
 prove -all

--- a/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_ext_arb/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_fpv.jg.tcl
@@ -40,11 +40,20 @@ set_prove_time_limit 600s
 # TODO(zhemao): Find a way to disable in RTL
 cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
 
+# With one read port, the FIFO can perform at most one pop/deallocation per
+# cycle. The freelist still has one dealloc port per logical FIFO, so Jasper
+# generates a precondition cover for the multi-dealloc uniqueness assertion even
+# though that precondition is structurally unreachable in this wrapper
+# configuration.
+if {$NumReadPorts == 1} {
+  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
+}
+
 # DataRamReadLatency=0 and RegisterPopOutputs=0 selects the no-staging-buffer
 # path. There, pop_valid is gated by pop_ready through the RAM-read fork, so
 # the internal pop-side backpressure cover is structurally unreachable.
 if {$DataRamReadLatency == 0 && $RegisterPopOutputs eq "1'b0"} {
-  cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.gen_backpressure_checks.gen_cover_without_stability.gen_per_flow*0*.backpressure_c
+  cover -disable *br_flow_fork_head*br_flow_checks_valid_data_impl.gen_backpressure_checks.gen_cover_without_stability.gen_per_flow*0*.backpressure_c
 }
 
 # prove command

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv.jg.tcl
@@ -21,26 +21,5 @@ assert -name fv_rst_check_ptr_ram_rd_addr_valid {rst |-> ptr_ram_rd_addr_valid =
 # limit run time to 10-mins
 set_prove_time_limit 10m
 
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-# There are certain cases where the backpressure precondition on these checks are unreachable.
-# Annoying to disable in RTL because only certain output ports are affected.
-# These are redundant with the push integration checks on the muxes, so just disable them all
-# TODO(masai): Figure out a more fine-grained waiver
-array set param_list [get_design_info -list parameter]
-set NumReadPorts $param_list(NumReadPorts)
-set Depth $param_list(Depth)
-# With one read port, the wrapper can only deallocate one FIFO entry per cycle.
-# The freelist has per-FIFO dealloc ports, so its multi-dealloc precondition
-# covers are structurally unreachable in this configuration.
-if {$NumReadPorts == 1} {
-  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
-}
-if {$Depth < 2 * $NumReadPorts} {
-  cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
-}
-
 # prove command
 prove -all

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_fpv.jg.tcl
@@ -32,6 +32,12 @@ cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
 set Depth $param_list(Depth)
+# With one read port, the wrapper can only deallocate one FIFO entry per cycle.
+# The freelist has per-FIFO dealloc ports, so its multi-dealloc precondition
+# covers are structurally unreachable in this configuration.
+if {$NumReadPorts == 1} {
+  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
+}
 if {$Depth < 2 * $NumReadPorts} {
   cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
 }

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl
@@ -28,26 +28,5 @@ assert -name fv_rst_check_ptr_ram_rd_addr_valid {rst | push_sender_in_reset |-> 
 # limit run time to 10-mins
 set_prove_time_limit 10m
 
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-# There are certain cases where the backpressure precondition on these checks are unreachable.
-# Annoying to disable in RTL because only certain output ports are affected.
-# These are redundant with the push integration checks on the muxes, so just disable them all
-# TODO(masai): Figure out a more fine-grained waiver
-array set param_list [get_design_info -list parameter]
-set NumReadPorts $param_list(NumReadPorts)
-set Depth $param_list(Depth)
-# With one read port, the wrapper can only deallocate one FIFO entry per cycle.
-# The freelist has per-FIFO dealloc ports, so its multi-dealloc precondition
-# covers are structurally unreachable in this configuration.
-if {$NumReadPorts == 1} {
-  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
-}
-if {$Depth < 2 * $NumReadPorts} {
-  cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
-}
-
 # prove command
 prove -all

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_ctrl_push_credit_fpv.jg.tcl
@@ -39,6 +39,12 @@ cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
 set Depth $param_list(Depth)
+# With one read port, the wrapper can only deallocate one FIFO entry per cycle.
+# The freelist has per-FIFO dealloc ports, so its multi-dealloc precondition
+# covers are structurally unreachable in this configuration.
+if {$NumReadPorts == 1} {
+  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
+}
 if {$Depth < 2 * $NumReadPorts} {
   cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
 }

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv.jg.tcl
@@ -20,6 +20,12 @@ cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
 set Depth $param_list(Depth)
+# With one read port, the wrapper can only deallocate one FIFO entry per cycle.
+# The freelist has per-FIFO dealloc ports, so its multi-dealloc precondition
+# covers are structurally unreachable in this configuration.
+if {$NumReadPorts == 1} {
+  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
+}
 if {$Depth < 2 * $NumReadPorts} {
   cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
   cover -disable *br_ram_flops_pointer*br_ram_flops_tile.gen_multi_read_checks.all_rd_ports_active_a

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_fpv.jg.tcl
@@ -9,25 +9,10 @@ get_design_info
 # limit run time to 10-mins
 set_prove_time_limit 10m
 
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-# There are certain cases where the backpressure precondition on these checks are unreachable.
-# Annoying to disable in RTL because only certain output ports are affected.
-# These are redundant with the push integration checks on the muxes, so just disable them all
-# TODO(masai): Figure out a more fine-grained waiver
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
 set Depth $param_list(Depth)
-# With one read port, the wrapper can only deallocate one FIFO entry per cycle.
-# The freelist has per-FIFO dealloc ports, so its multi-dealloc precondition
-# covers are structurally unreachable in this configuration.
-if {$NumReadPorts == 1} {
-  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
-}
 if {$Depth < 2 * $NumReadPorts} {
-  cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
   cover -disable *br_ram_flops_pointer*br_ram_flops_tile.gen_multi_read_checks.all_rd_ports_active_a
 }
 

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl
@@ -22,25 +22,10 @@ assert -name fv_rst_check_pop_valid {rst | push_sender_in_reset |-> pop_valid ==
 # limit run time to 10-mins
 set_prove_time_limit 10m
 
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-# There are certain cases where the backpressure precondition on these checks are unreachable.
-# Annoying to disable in RTL because only certain output ports are affected.
-# These are redundant with the push integration checks on the muxes, so just disable them all
-# TODO(masai): Figure out a more fine-grained waiver
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
 set Depth $param_list(Depth)
-# With one read port, the wrapper can only deallocate one FIFO entry per cycle.
-# The freelist has per-FIFO dealloc ports, so its multi-dealloc precondition
-# covers are structurally unreachable in this configuration.
-if {$NumReadPorts == 1} {
-  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
-}
 if {$Depth < 2 * $NumReadPorts} {
-  cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
   cover -disable *br_ram_flops_pointer*br_ram_flops_tile.gen_multi_read_checks.all_rd_ports_active_a
 }
 

--- a/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_dynamic/br_fifo_shared_dynamic_flops_push_credit_fpv.jg.tcl
@@ -33,6 +33,12 @@ cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable
 array set param_list [get_design_info -list parameter]
 set NumReadPorts $param_list(NumReadPorts)
 set Depth $param_list(Depth)
+# With one read port, the wrapper can only deallocate one FIFO entry per cycle.
+# The freelist has per-FIFO dealloc ports, so its multi-dealloc precondition
+# covers are structurally unreachable in this configuration.
+if {$NumReadPorts == 1} {
+  cover -disable *br_tracker_freelist_inst.gen_dealloc_intg_asserts*.gen_unique_dealloc_intg_asserts*.unique_dealloc_entry_id_a:precondition1
+}
 if {$Depth < 2 * $NumReadPorts} {
   cover -disable *br_fifo_shared_read_xbar*br_flow_demux_select_unstable*br_flow_checks_valid_data_impl.*stable*
   cover -disable *br_ram_flops_pointer*br_ram_flops_tile.gen_multi_read_checks.all_rd_ports_active_a

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_ctrl_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_ctrl_fpv.jg.tcl
@@ -11,10 +11,5 @@ assume -name deassert_rst {##1 !rst}
 # limit run time to 10-mins
 set_prove_time_limit 600s
 
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-
 # prove command
 prove -all

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_ctrl_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_ctrl_push_credit_fpv.jg.tcl
@@ -8,11 +8,6 @@ assume -reset -name set_rst_during_reset {rst}
 assume -bound 1 -name delay_rst {rst}
 assume -name deassert_rst {##1 !rst}
 
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-
 # primary input control signal should be legal during reset
 array set param_list [get_design_info -list parameter]
 set NumFifos $param_list(NumFifos)

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_fpv.jg.tcl
@@ -8,11 +8,6 @@ assume -reset -name set_rst_during_reset {rst}
 assume -bound 1 -name delay_rst {rst}
 assume -name deassert_rst {##1 !rst}
 
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-
 # limit run time to 10-mins
 set_prove_time_limit 600s
 

--- a/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_push_credit_fpv.jg.tcl
+++ b/fifo/fpv/br_fifo_shared_pstatic/br_fifo_shared_pstatic_flops_push_credit_fpv.jg.tcl
@@ -15,11 +15,6 @@ for {set i 0} {$i < $NumFifos} {incr i} {
   assume -name initial_value_during_reset_$i "\$stable(credit_initial_push\[$i\])"
 }
 
-# The output of this flow fork will not be unstable because we constrain the
-# ready to hold until valid is asserted.
-# TODO(zhemao): Find a way to disable in RTL
-cover -disable *br_flow_fork_head.br_flow_checks_valid_data_impl.*valid_unstable_c
-
 # limit run time to 10-mins
 set_prove_time_limit 600s
 

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl.sv
@@ -178,7 +178,8 @@ module br_fifo_shared_dynamic_ctrl #(
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertUniqueDeallocEntryId(NumReadPorts > 1)
   ) br_fifo_shared_dynamic_push_ctrl_inst (
       .clk,
       .rst(rst),

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_ext_arbiter.sv
@@ -187,7 +187,8 @@ module br_fifo_shared_dynamic_ctrl_ext_arbiter #(
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertUniqueDeallocEntryId(NumReadPorts > 1)
   ) br_fifo_shared_dynamic_push_ctrl_inst (
       .clk,
       .rst(rst),

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit.sv
@@ -189,7 +189,8 @@ module br_fifo_shared_dynamic_ctrl_push_credit #(
       .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
       .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertUniqueDeallocEntryId(NumReadPorts > 1)
   ) br_fifo_shared_dynamic_push_ctrl_credit_inst (
       .clk,
       .rst(rst),

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter.sv
@@ -198,7 +198,8 @@ module br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter #(
       .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
       .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertUniqueDeallocEntryId(NumReadPorts > 1)
   ) br_fifo_shared_dynamic_push_ctrl_credit_inst (
       .clk,
       .rst(rst),

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit_pop_credit.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit_pop_credit.sv
@@ -195,7 +195,8 @@ module br_fifo_shared_dynamic_ctrl_push_credit_pop_credit #(
       .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
       .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertUniqueDeallocEntryId(NumReadPorts > 1)
   ) br_fifo_shared_dynamic_push_ctrl_credit_inst (
       .clk,
       .rst(push_ctrl_rst),

--- a/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit_pop_credit_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_dynamic_ctrl_push_credit_pop_credit_ext_arbiter.sv
@@ -204,7 +204,8 @@ module br_fifo_shared_dynamic_ctrl_push_credit_pop_credit_ext_arbiter #(
       .EnableCoverCreditWithhold(EnableCoverCreditWithhold),
       .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertUniqueDeallocEntryId(NumReadPorts > 1)
   ) br_fifo_shared_dynamic_push_ctrl_credit_inst (
       .clk,
       .rst(push_ctrl_rst),

--- a/fifo/rtl/br_fifo_shared_pop_ctrl_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl_ext_arbiter.sv
@@ -122,7 +122,10 @@ module br_fifo_shared_pop_ctrl_ext_arbiter #(
   for (genvar i = 0; i < NumFifos; i++) begin : gen_fifo_ram_read
     if (!HasStagingBuffer) begin : gen_no_buffer
       br_flow_fork #(
-          .NumFlows(2)
+          .NumFlows(2),
+          // In the no-buffer path, pop_valid is directly gated by downstream readiness.
+          .EnableCoverPushBackpressure(0),
+          .EnableAssertNoPushBackpressure(0)
       ) br_flow_fork_head (
           .clk,
           .rst,

--- a/fifo/rtl/fifo_codegen/br_fifo_shared.sv.jinja2
+++ b/fifo/rtl/fifo_codegen/br_fifo_shared.sv.jinja2
@@ -573,6 +573,9 @@ module {{ module_name }} #(
 {%-   endif %}
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+{%-   if dynamic %},
+      .EnableAssertUniqueDeallocEntryId(NumReadPorts > 1)
+{%-   endif %}
   ) {{ push_ctrl_module }}_inst (
       .clk,
       .rst({{ push_ctrl_rst }}),

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
@@ -35,6 +35,7 @@ module br_fifo_shared_dynamic_push_ctrl #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    parameter bit EnableAssertUniqueDeallocEntryId = 1,
 
     // If 1, assert that push-side backpressure is impossible.
     // Can only be enabled if EnableCoverPushBackpressure is disabled.
@@ -121,7 +122,8 @@ module br_fifo_shared_dynamic_push_ctrl #(
       .NumEntries(Depth),
       .NumAllocPerCycle(NumWritePorts),
       .NumDeallocPorts(NumFifos),
-      .DeallocCountDelay(DeallocCountDelay)
+      .DeallocCountDelay(DeallocCountDelay),
+      .EnableAssertUniqueDeallocEntryId(EnableAssertUniqueDeallocEntryId)
   ) br_tracker_freelist_inst (
       .clk,
       .rst,

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl_credit.sv
@@ -32,6 +32,7 @@ module br_fifo_shared_dynamic_push_ctrl_credit #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    parameter bit EnableAssertUniqueDeallocEntryId = 1,
 
     localparam int FifoIdWidth = br_math::clamped_clog2(NumFifos),
     localparam int AddrWidth = br_math::clamped_clog2(Depth),
@@ -158,7 +159,7 @@ module br_fifo_shared_dynamic_push_ctrl_credit #(
       .EnableCoverPushBackpressure(0),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
-      .EnableAssertUniqueDeallocEntryId(NumReadPorts > 1)
+      .EnableAssertUniqueDeallocEntryId(EnableAssertUniqueDeallocEntryId)
   ) br_fifo_shared_dynamic_push_ctrl (
       .clk,
       .rst(either_rst),

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl_credit.sv
@@ -157,7 +157,8 @@ module br_fifo_shared_dynamic_push_ctrl_credit #(
       .DeallocCountDelay(2 - RegisterPushOutputs),
       .EnableCoverPushBackpressure(0),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertUniqueDeallocEntryId(NumReadPorts > 1)
   ) br_fifo_shared_dynamic_push_ctrl (
       .clk,
       .rst(either_rst),

--- a/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
+++ b/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
@@ -46,7 +46,14 @@ module br_fifo_shared_read_xbar #(
                     NumReadPorts))
   `BR_ASSERT_STATIC(legal_depth_a, Depth >= NumReadPorts)
 
-  localparam bit EnableCoverDemuxPopBackpressure = Depth >= 2 * NumReadPorts;
+  // Read addresses are demuxed by their low bits, so address N maps to read port
+  // N % NumReadPorts. When Depth is at least 2 * NumReadPorts, every read port owns
+  // at least two entries and can see backpressure from multiple FIFOs targeting it.
+  // For shallower mixed cases, the remainder entries map only to low-indexed ports;
+  // higher-indexed ports own one entry and their backpressure checks are unreachable.
+  localparam int NumDemuxPopBackpressureCheckFlows =
+      (Depth >= 2 * NumReadPorts) ? NumReadPorts : Depth % NumReadPorts;
+  localparam bit EnableCoverDemuxPopBackpressure = NumDemuxPopBackpressureCheckFlows != 0;
   localparam bit EnableAssertDemuxPushValidStability =
       EnableAssertPushValidStability && EnableCoverDemuxPopBackpressure;
 
@@ -72,6 +79,7 @@ module br_fifo_shared_read_xbar #(
           .NumFlows(NumReadPorts),
           .Width(AddrWidth),
           .EnableCoverPushBackpressure(EnableCoverDemuxPopBackpressure),
+          .NumPopBackpressureCheckFlows(NumDemuxPopBackpressureCheckFlows),
           .EnableAssertNoPushBackpressure(0),
           .EnableAssertPushValidStability(EnableAssertDemuxPushValidStability),
           .EnableAssertSelectStability(EnableAssertDemuxPushValidStability)

--- a/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
+++ b/fifo/rtl/internal/br_fifo_shared_read_xbar.sv
@@ -46,6 +46,10 @@ module br_fifo_shared_read_xbar #(
                     NumReadPorts))
   `BR_ASSERT_STATIC(legal_depth_a, Depth >= NumReadPorts)
 
+  localparam bit EnableCoverDemuxPopBackpressure = Depth >= 2 * NumReadPorts;
+  localparam bit EnableAssertDemuxPushValidStability =
+      EnableAssertPushValidStability && EnableCoverDemuxPopBackpressure;
+
   // Read Address Demux per FIFO
 
   logic [NumFifos-1:0][NumReadPorts-1:0] demuxed_rd_addr_valid;
@@ -67,8 +71,10 @@ module br_fifo_shared_read_xbar #(
       br_flow_demux_select_unstable #(
           .NumFlows(NumReadPorts),
           .Width(AddrWidth),
-          .EnableAssertPushValidStability(EnableAssertPushValidStability),
-          .EnableAssertSelectStability(EnableAssertPushValidStability)
+          .EnableCoverPushBackpressure(EnableCoverDemuxPopBackpressure),
+          .EnableAssertNoPushBackpressure(0),
+          .EnableAssertPushValidStability(EnableAssertDemuxPushValidStability),
+          .EnableAssertSelectStability(EnableAssertDemuxPushValidStability)
       ) br_flow_demux_select_unstable_inst (
           .clk,
           .rst,

--- a/flow/rtl/br_flow_demux_select_unstable.sv
+++ b/flow/rtl/br_flow_demux_select_unstable.sv
@@ -30,6 +30,9 @@ module br_flow_demux_select_unstable #(
     // If 0, disable backpressure coverage. By default, this also
     // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
+    // Generate pop-side backpressure covers and stability checks only for this many
+    // low-indexed flows.
+    parameter int NumPopBackpressureCheckFlows = NumFlows,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, assert that push_data is stable when backpressured.
@@ -80,6 +83,8 @@ module br_flow_demux_select_unstable #(
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
   `BR_ASSERT_STATIC(select_stability_implies_valid_stability_a,
                     !(EnableAssertSelectStability && !EnableAssertPushValidStability))
+  `BR_ASSERT_STATIC(legal_num_pop_backpressure_check_flows_a,
+                    NumPopBackpressureCheckFlows <= NumFlows)
 
   br_flow_checks_valid_data_intg #(
       .NumFlows(1),
@@ -158,6 +163,7 @@ module br_flow_demux_select_unstable #(
       .NumFlows(NumFlows),
       .Width(Width),
       .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .NumBackpressureCheckFlows(NumPopBackpressureCheckFlows),
       .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       // Pop valid and data can only be stable if select is stable.
       .EnableAssertValidStability(EnableAssertPushValidStability && EnableAssertSelectStability),

--- a/flow/rtl/br_flow_fork_select_multihot.sv
+++ b/flow/rtl/br_flow_fork_select_multihot.sv
@@ -132,7 +132,10 @@ module br_flow_fork_select_multihot #(
   );
 
   for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks
-    `BR_COVER_IMPL(pop_valid_unstable_c, $stable(push_valid) && $fell(pop_valid_unstable[i]))
+    // With one output flow, no other selected flow can revoke this valid.
+    if (NumFlows > 1) begin : gen_cover_pop_valid_unstable
+      `BR_COVER_IMPL(pop_valid_unstable_c, $stable(push_valid) && $fell(pop_valid_unstable[i]))
+    end
   end
 
 endmodule : br_flow_fork_select_multihot

--- a/flow/rtl/br_flow_fork_select_multihot.sv
+++ b/flow/rtl/br_flow_fork_select_multihot.sv
@@ -132,8 +132,7 @@ module br_flow_fork_select_multihot #(
   );
 
   for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks
-    // With one output flow, no other selected flow can revoke this valid.
-    if (NumFlows > 1) begin : gen_cover_pop_valid_unstable
+    if (NumFlows > 1 && EnableCoverPushBackpressure) begin : gen_cover_pop_valid_unstable
       `BR_COVER_IMPL(pop_valid_unstable_c, $stable(push_valid) && $fell(pop_valid_unstable[i]))
     end
   end

--- a/flow/rtl/internal/br_flow_checks_valid_data_impl.sv
+++ b/flow/rtl/internal/br_flow_checks_valid_data_impl.sv
@@ -23,6 +23,9 @@ module br_flow_checks_valid_data_impl #(
     // asserts that backpressure is impossible.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableCoverBackpressure = 1,
+    // Generate backpressure covers and stability checks only for this many low-indexed flows.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter int NumBackpressureCheckFlows = NumFlows,
     // If 1, assert that valid is stable when backpressured.
     // Can only be enabled if EnableCoverBackpressure is also enabled.
     // ri lint_check_waive PARAM_NOT_USED
@@ -55,6 +58,7 @@ module br_flow_checks_valid_data_impl #(
                     !(EnableAssertDataStability && !EnableAssertValidStability))
   `BR_ASSERT_STATIC(legal_assert_no_backpressure_a,
                     !(EnableAssertNoBackpressure && EnableCoverBackpressure))
+  `BR_ASSERT_STATIC(legal_num_backpressure_check_flows_a, NumBackpressureCheckFlows <= NumFlows)
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
     `BR_ASSERT_FINAL(final_not_valid_a, !valid)
@@ -65,17 +69,21 @@ module br_flow_checks_valid_data_impl #(
   if (EnableCoverBackpressure) begin : gen_backpressure_checks
     if (EnableAssertValidStability) begin : gen_valid_stability_checks
       if (EnableAssertDataStability) begin : gen_valid_data_stability_checks
-        for (genvar i = 0; i < NumFlows; i++) begin : gen_valid_data_stability_per_flow
+        for (
+            genvar i = 0; i < NumBackpressureCheckFlows; i++
+        ) begin : gen_valid_data_stability_per_flow
           `BR_ASSERT_IMPL(valid_data_stable_when_backpressured_a,
                           !ready[i] && valid[i] |=> valid[i] && $stable(data[i]))
         end
       end else begin : gen_valid_only_stability_checks
-        for (genvar i = 0; i < NumFlows; i++) begin : gen_valid_only_stability_per_flow
+        for (
+            genvar i = 0; i < NumBackpressureCheckFlows; i++
+        ) begin : gen_valid_only_stability_per_flow
           `BR_ASSERT_IMPL(valid_stable_when_backpressured_a, !ready[i] && valid[i] |=> valid[i])
         end
       end
     end else begin : gen_cover_without_stability
-      for (genvar i = 0; i < NumFlows; i++) begin : gen_per_flow
+      for (genvar i = 0; i < NumBackpressureCheckFlows; i++) begin : gen_per_flow
         `BR_COVER_IMPL(backpressure_c, !ready[i] && valid[i])
       end
     end

--- a/tracker/rtl/br_tracker_freelist.sv
+++ b/tracker/rtl/br_tracker_freelist.sv
@@ -53,6 +53,7 @@ module br_tracker_freelist #(
     // It is expected that alloc_valid could be 1 at end of the test because it's
     // a natural idle condition for this design.
     parameter bit EnableAssertFinalNotDeallocValid = 1,
+    // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertUniqueDeallocEntryId = 1,
     // If 1, then assert that the number of allocated entries is the same as the number of
     // preallocated entries at the end of the test.

--- a/tracker/rtl/br_tracker_freelist.sv
+++ b/tracker/rtl/br_tracker_freelist.sv
@@ -53,6 +53,7 @@ module br_tracker_freelist #(
     // It is expected that alloc_valid could be 1 at end of the test because it's
     // a natural idle condition for this design.
     parameter bit EnableAssertFinalNotDeallocValid = 1,
+    parameter bit EnableAssertUniqueDeallocEntryId = 1,
     // If 1, then assert that the number of allocated entries is the same as the number of
     // preallocated entries at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
@@ -136,10 +137,12 @@ module br_tracker_freelist #(
     `BR_ASSERT_INTG(dealloc_in_range_a, dealloc_valid[i] |-> dealloc_entry_id[i] < NumEntries)
     `BR_ASSERT_INTG(no_dealloc_unallocated_a,
                     dealloc_valid[i] |-> allocated_entries[dealloc_entry_id[i]])
-    for (genvar j = i + 1; j < NumDeallocPorts; j++) begin : gen_unique_dealloc_intg_asserts
-      `BR_ASSERT_INTG(
-          unique_dealloc_entry_id_a,
-          dealloc_valid[i] && dealloc_valid[j] |-> dealloc_entry_id[i] != dealloc_entry_id[j])
+    if (EnableAssertUniqueDeallocEntryId) begin : gen_unique_dealloc_enabled
+      for (genvar j = i + 1; j < NumDeallocPorts; j++) begin : gen_unique_dealloc_intg_asserts
+        `BR_ASSERT_INTG(
+            unique_dealloc_entry_id_a,
+            dealloc_valid[i] && dealloc_valid[j] |-> dealloc_entry_id[i] != dealloc_entry_id[j])
+      end
     end
   end
 `endif


### PR DESCRIPTION
This PR removes most FIFO FPV cover -disable waivers from Tcl by moving the unreachable-cover control closer to the RTL/monitor instances that generate those properties.

Flow:
1. Re-enabled the disabled FIFO FPV covers locally and reran targeted FPV.
2. Analyzed each unreachable/undetermined cover by parameter combination and RTL structure.
3. Replaced Tcl-level disables with existing RTL/monitor parameters where possible.
4. Added EnableAssertUniqueDeallocEntryId to br_tracker_freelist for FIFO configurations where NumReadPorts == 1, since those wrappers can only deallocate one entry per cycle and the multi-dealloc uniqueness precondition is structurally unreachable.
5. Kept the RAM pointer cover waiver in Tcl, because that cover belongs to generic RAM RTL and the unreachable condition is FIFO-context-specific.

Key changes:
1. Disabled unreachable push/backpressure-related covers through existing EnableCoverPushBackpressure / EnableAssertNoPushBackpressure controls.
2. Gated br_flow_fork_select_multihot.pop_valid_unstable_c so it is only generated when push-backpressure coverage is enabled.
3. Disabled read-xbar demux backpressure/stability coverage for shallow FIFO configurations where Depth < 2 * NumReadPorts.