### PR TITLE
Add a flow valve widget

### DIFF
--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -87,6 +87,16 @@ verilog_library(
 )
 
 verilog_library(
+    name = "br_flow_valve",
+    srcs = ["br_flow_valve.sv"],
+    deps = [
+        "//flow/rtl/internal:br_flow_checks_valid_data_impl",
+        "//flow/rtl/internal:br_flow_checks_valid_data_intg",
+        "//macros:br_asserts_internal",
+    ],
+)
+
+verilog_library(
     name = "br_flow_mux_select",
     srcs = ["br_flow_mux_select.sv"],
     deps = [
@@ -448,6 +458,18 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_flow_join"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_valve_test_suite",
+    params = {
+        "NumFlows": [
+            "1",
+            "2",
+            "3",
+        ],
+    },
+    deps = [":br_flow_valve"],
 )
 
 br_verilog_elab_and_lint_test_suite(

--- a/flow/rtl/br_flow_valve.sv
+++ b/flow/rtl/br_flow_valve.sv
@@ -36,9 +36,9 @@ module br_flow_valve #(
 
     // Pop-side interfaces
     //
-    // pop_valid can be unstable because it falls if en falls.
+    // pop_valid_unstable can be unstable because it falls if en falls.
     input  logic [NumFlows-1:0] pop_ready,
-    output logic [NumFlows-1:0] pop_valid
+    output logic [NumFlows-1:0] pop_valid_unstable
 );
 
   //------------------------------------------
@@ -62,8 +62,8 @@ module br_flow_valve #(
   //------------------------------------------
   // Implementation
   //------------------------------------------
-  assign push_ready = pop_ready & en;
-  assign pop_valid  = push_valid & en;
+  assign push_ready         = pop_ready & en;
+  assign pop_valid_unstable = push_valid & en;
 
   //------------------------------------------
   // Implementation checks
@@ -78,7 +78,7 @@ module br_flow_valve #(
       .clk,
       .rst,
       .ready(pop_ready),
-      .valid(pop_valid),
+      .valid(pop_valid_unstable),
       .data (1'b0)
   );
 

--- a/flow/rtl/br_flow_valve.sv
+++ b/flow/rtl/br_flow_valve.sv
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL Flow Valve
+//
+// Gates a set of data-less ready-valid flows with an enable signal. Uses the
+// AMBA-inspired ready-valid handshake protocol for synchronizing pipeline
+// stages and stalling when encountering backpressure hazards.
+
+`include "br_asserts_internal.svh"
+
+module br_flow_valve #(
+    parameter int NumFlows = 1,  // Must be at least 1
+    // If 1, cover that the pop side experiences backpressure.
+    // If 0, disable pop-side backpressure coverage. By default, this also
+    // asserts that pop-side backpressure is impossible.
+    parameter bit EnableCoverPopBackpressure = 1,
+    // If 1, then assert there are no valid bits asserted at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    parameter bit EnableAssertPushValidStability = 1
+) (
+    // Used only for assertions
+    // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic clk,
+    // Synchronous active-high reset. Used only for assertions.
+    // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic rst,
+
+    input logic [NumFlows-1:0] en,
+
+    // Push-side interfaces
+    output logic [NumFlows-1:0] push_ready,
+    input  logic [NumFlows-1:0] push_valid,
+
+    // Pop-side interfaces
+    //
+    // pop_valid can be unstable because it falls if en falls.
+    input  logic [NumFlows-1:0] pop_ready,
+    output logic [NumFlows-1:0] pop_valid
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
+
+  `BR_ASSERT_KNOWN_INTG(en_known_a, en)
+
+  br_flow_checks_valid_data_intg #(
+      .NumFlows(NumFlows),
+      .Width(1),
+      .EnableCoverBackpressure(1),
+      .EnableAssertValidStability(EnableAssertPushValidStability),
+      // Data is always stable when valid is since it is constant.
+      .EnableAssertDataStability(EnableAssertPushValidStability),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) br_flow_checks_valid_data_intg (
+      .clk,
+      .rst,
+      .ready(push_ready),
+      .valid(push_valid),
+      .data ({NumFlows{1'b0}})
+  );
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  assign push_ready = pop_ready & en;
+  assign pop_valid  = push_valid & en;
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  br_flow_checks_valid_data_impl #(
+      .NumFlows(NumFlows),
+      .Width(1),
+      .EnableCoverBackpressure(EnableCoverPopBackpressure),
+      .EnableAssertValidStability(0),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+  ) br_flow_checks_valid_data_impl (
+      .clk,
+      .rst,
+      .ready(pop_ready),
+      .valid(pop_valid),
+      .data ({NumFlows{1'b0}})
+  );
+
+  `BR_ASSERT_IMPL(push_ready_masks_pop_ready_a, push_ready == (pop_ready & en))
+  `BR_ASSERT_IMPL(pop_valid_masks_push_valid_a, pop_valid == (push_valid & en))
+
+endmodule : br_flow_valve

--- a/flow/rtl/br_flow_valve.sv
+++ b/flow/rtl/br_flow_valve.sv
@@ -14,8 +14,10 @@ module br_flow_valve #(
     // If 0, disable pop-side backpressure coverage. By default, this also
     // asserts that pop-side backpressure is impossible.
     parameter bit EnableCoverPopBackpressure = 1,
-    // If 1, then assert there are no valid bits asserted at the end of the test.
-    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, then assert there are no push-valid bits asserted at the end of the test.
+    parameter bit EnableAssertPushFinalNotValid = 1,
+    // If 1, then assert there are no pop-valid bits asserted at the end of the test.
+    parameter bit EnableAssertPopFinalNotValid = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = 1
 ) (
@@ -42,24 +44,19 @@ module br_flow_valve #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
-
-  `BR_ASSERT_KNOWN_INTG(en_known_a, en)
-
   br_flow_checks_valid_data_intg #(
       .NumFlows(NumFlows),
       .Width(1),
       .EnableCoverBackpressure(1),
       .EnableAssertValidStability(EnableAssertPushValidStability),
-      // Data is always stable when valid is since it is constant.
-      .EnableAssertDataStability(EnableAssertPushValidStability),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertDataStability(1'b0),
+      .EnableAssertFinalNotValid(EnableAssertPushFinalNotValid)
   ) br_flow_checks_valid_data_intg (
       .clk,
       .rst,
       .ready(push_ready),
       .valid(push_valid),
-      .data ({NumFlows{1'b0}})
+      .data (1'b0)
   );
 
   //------------------------------------------
@@ -76,16 +73,13 @@ module br_flow_valve #(
       .Width(1),
       .EnableCoverBackpressure(EnableCoverPopBackpressure),
       .EnableAssertValidStability(0),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertPopFinalNotValid)
   ) br_flow_checks_valid_data_impl (
       .clk,
       .rst,
       .ready(pop_ready),
       .valid(pop_valid),
-      .data ({NumFlows{1'b0}})
+      .data (1'b0)
   );
-
-  `BR_ASSERT_IMPL(push_ready_masks_pop_ready_a, push_ready == (pop_ready & en))
-  `BR_ASSERT_IMPL(pop_valid_masks_push_valid_a, pop_valid == (push_valid & en))
 
 endmodule : br_flow_valve

--- a/flow/rtl/br_flow_valve.sv
+++ b/flow/rtl/br_flow_valve.sv
@@ -49,7 +49,7 @@ module br_flow_valve #(
       .Width(1),
       .EnableCoverBackpressure(1),
       .EnableAssertValidStability(EnableAssertPushValidStability),
-      .EnableAssertDataStability(1'b0),
+      .EnableAssertDataStability(0),
       .EnableAssertFinalNotValid(EnableAssertPushFinalNotValid)
   ) br_flow_checks_valid_data_intg (
       .clk,

--- a/flow/rtl/br_flow_valve.sv
+++ b/flow/rtl/br_flow_valve.sv
@@ -44,6 +44,8 @@ module br_flow_valve #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
+
   br_flow_checks_valid_data_intg #(
       .NumFlows(NumFlows),
       .Width(1),

--- a/flow/rtl/br_flow_valve.sv
+++ b/flow/rtl/br_flow_valve.sv
@@ -58,7 +58,7 @@ module br_flow_valve #(
       .rst,
       .ready(push_ready),
       .valid(push_valid),
-      .data (1'b0)
+      .data ('0)
   );
 
   //------------------------------------------
@@ -81,7 +81,7 @@ module br_flow_valve #(
       .rst,
       .ready(pop_ready),
       .valid(pop_valid_unstable),
-      .data (1'b0)
+      .data ('0)
   );
 
 endmodule : br_flow_valve

--- a/flow/rtl/br_flow_valve.sv
+++ b/flow/rtl/br_flow_valve.sv
@@ -22,7 +22,6 @@ module br_flow_valve #(
     // Can only be enabled if EnableCoverPushBackpressure is disabled.
     parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
     // If 1, assert that pop-side backpressure is impossible.
-    // This disables the pop-side implementation backpressure cover.
     parameter bit EnableAssertNoPopBackpressure = 0
 ) (
     // Used only for assertions
@@ -80,7 +79,7 @@ module br_flow_valve #(
   br_flow_checks_valid_data_impl #(
       .NumFlows(NumFlows),
       .Width(1),
-      .EnableCoverBackpressure(!EnableAssertNoPopBackpressure),
+      .EnableCoverBackpressure(0),
       .EnableAssertNoBackpressure(EnableAssertNoPopBackpressure),
       .EnableAssertValidStability(0),
       .EnableAssertFinalNotValid(0)

--- a/flow/rtl/br_flow_valve.sv
+++ b/flow/rtl/br_flow_valve.sv
@@ -10,16 +10,20 @@
 
 module br_flow_valve #(
     parameter int NumFlows = 1,  // Must be at least 1
-    // If 1, cover that the pop side experiences backpressure.
-    // If 0, disable pop-side backpressure coverage. By default, this also
-    // asserts that pop-side backpressure is impossible.
-    parameter bit EnableCoverPopBackpressure = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_valid is stable when backpressured.
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, then assert there are no push-valid bits asserted at the end of the test.
     parameter bit EnableAssertPushFinalNotValid = 1,
-    // If 1, then assert there are no pop-valid bits asserted at the end of the test.
-    parameter bit EnableAssertPopFinalNotValid = 1,
-    // If 1, assert that push_valid is stable when backpressured.
-    parameter bit EnableAssertPushValidStability = 1
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, assert that pop-side backpressure is impossible.
+    // This disables the pop-side implementation backpressure cover.
+    parameter bit EnableAssertNoPopBackpressure = 0
 ) (
     // Used only for assertions
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
@@ -44,12 +48,15 @@ module br_flow_valve #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
   `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
 
   br_flow_checks_valid_data_intg #(
       .NumFlows(NumFlows),
       .Width(1),
-      .EnableCoverBackpressure(1),
+      .EnableCoverBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPushBackpressure),
       .EnableAssertValidStability(EnableAssertPushValidStability),
       .EnableAssertDataStability(0),
       .EnableAssertFinalNotValid(EnableAssertPushFinalNotValid)
@@ -73,9 +80,10 @@ module br_flow_valve #(
   br_flow_checks_valid_data_impl #(
       .NumFlows(NumFlows),
       .Width(1),
-      .EnableCoverBackpressure(EnableCoverPopBackpressure),
+      .EnableCoverBackpressure(!EnableAssertNoPopBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPopBackpressure),
       .EnableAssertValidStability(0),
-      .EnableAssertFinalNotValid(EnableAssertPopFinalNotValid)
+      .EnableAssertFinalNotValid(0)
   ) br_flow_checks_valid_data_impl (
       .clk,
       .rst,

--- a/flow/sim/BUILD.bazel
+++ b/flow/sim/BUILD.bazel
@@ -194,6 +194,28 @@ br_verilog_sim_test_tools_suite(
 )
 
 verilog_library(
+    name = "br_flow_valve_tb",
+    srcs = ["br_flow_valve_tb.sv"],
+    deps = [
+        "//flow/rtl:br_flow_valve",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_valve_tb_elab_test",
+    tool = "verific",
+    deps = [":br_flow_valve_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_flow_valve_sim_test_tools_suite",
+    params = _FLOW_NUM_FLOWS_SIM_PARAMS,
+    tools = _FLOW_PRIMITIVE_SIM_TOOLS,
+    deps = [":br_flow_valve_tb"],
+)
+
+verilog_library(
     name = "br_flow_mux_select_tb",
     srcs = ["br_flow_mux_select_tb.sv"],
     deps = [

--- a/flow/sim/br_flow_valve_tb.sv
+++ b/flow/sim/br_flow_valve_tb.sv
@@ -15,7 +15,7 @@ module br_flow_valve_tb;
   logic [NumFlows-1:0] push_ready;
   logic [NumFlows-1:0] push_valid;
   logic [NumFlows-1:0] pop_ready;
-  logic [NumFlows-1:0] pop_valid;
+  logic [NumFlows-1:0] pop_valid_unstable;
 
   br_flow_valve #(
       .NumFlows(NumFlows)
@@ -26,7 +26,7 @@ module br_flow_valve_tb;
       .push_ready,
       .push_valid,
       .pop_ready,
-      .pop_valid
+      .pop_valid_unstable
   );
 
   br_test_driver td (
@@ -43,7 +43,7 @@ module br_flow_valve_tb;
     en         = enable;
     #1;
     td.check(push_ready === (ready & enable), "valve push_ready mismatch");
-    td.check(pop_valid === (valid & enable), "valve pop_valid mismatch");
+    td.check(pop_valid_unstable === (valid & enable), "valve pop_valid_unstable mismatch");
     push_valid = '0;
     pop_ready  = '0;
     en         = '0;

--- a/flow/sim/br_flow_valve_tb.sv
+++ b/flow/sim/br_flow_valve_tb.sv
@@ -34,8 +34,7 @@ module br_flow_valve_tb;
       .rst
   );
 
-  task automatic check_pattern(input logic [NumFlows-1:0] valid,
-                               input logic [NumFlows-1:0] ready,
+  task automatic check_pattern(input logic [NumFlows-1:0] valid, input logic [NumFlows-1:0] ready,
                                input logic [NumFlows-1:0] enable);
     @(negedge clk);
     push_valid = valid;

--- a/flow/sim/br_flow_valve_tb.sv
+++ b/flow/sim/br_flow_valve_tb.sv
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL Flow Valve Testbench
+//
+// Test plan: sweep every combination of push-valid, pop-ready, and enable
+// patterns and verify that enable independently gates each flow.
+
+module br_flow_valve_tb;
+  parameter int NumFlows = 3;
+
+  logic clk;
+  logic rst;
+
+  logic [NumFlows-1:0] en;
+  logic [NumFlows-1:0] push_ready;
+  logic [NumFlows-1:0] push_valid;
+  logic [NumFlows-1:0] pop_ready;
+  logic [NumFlows-1:0] pop_valid;
+
+  br_flow_valve #(
+      .NumFlows(NumFlows)
+  ) dut (
+      .clk,
+      .rst,
+      .en,
+      .push_ready,
+      .push_valid,
+      .pop_ready,
+      .pop_valid
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  task automatic check_pattern(input logic [NumFlows-1:0] valid,
+                               input logic [NumFlows-1:0] ready,
+                               input logic [NumFlows-1:0] enable);
+    @(negedge clk);
+    push_valid = valid;
+    pop_ready  = ready;
+    en         = enable;
+    #1;
+    td.check(push_ready === (ready & enable), "valve push_ready mismatch");
+    td.check(pop_valid === (valid & enable), "valve pop_valid mismatch");
+    push_valid = '0;
+    pop_ready  = '0;
+    en         = '0;
+  endtask
+
+  initial begin
+    push_valid = '0;
+    pop_ready  = '0;
+    en         = '0;
+
+    td.reset_dut();
+
+    for (int valid = 0; valid < (1 << NumFlows); valid++) begin
+      for (int ready = 0; ready < (1 << NumFlows); ready++) begin
+        for (int enable = 0; enable < (1 << NumFlows); enable++) begin
+          check_pattern(NumFlows'(valid), NumFlows'(ready), NumFlows'(enable));
+        end
+      end
+    end
+
+    td.finish();
+  end
+
+endmodule : br_flow_valve_tb


### PR DESCRIPTION
This is a trivial widget to stop a flow. Its use would help prevent a class of bugs where a human or agent masks a ready or valid, but does not also mask in reverse. A NumFlows parameter allows it to be composed cleanly with other components like br_flow_join and br_flow_fork