### PR TITLE
`verilog_elab_test`: add support for `tool = "slang"`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,6 +32,8 @@ At minimum, you need to have the following tools installed in your environment.
 Additionally, several tools are needed to build and run all of the tests:
 
 * **Open source**
+  ** Elaboration
+    *** Slang
   ** Linting
     *** Verible
   ** Simulation
@@ -153,6 +155,22 @@ You can set this environment variable in `user.bazelrc` so that it is used in al
 ====
 
 The Bazel test rule implementations at `//bazel:verilog.bzl` shell out the `//python/verilog_runner/verilog_runner.py` tool that presents a generic tool-agnostic API that actually implements the test.
+
+The repository includes a Slang plugin for open-source elaboration tests.
+Select it by setting `tool = "slang"` on a `verilog_elab_test` target:
+
+[source,bazel]
+----
+verilog_elab_test(
+    name = "example_elab_test",
+    tool = "slang",
+    top = "example",
+    deps = [":example"],
+)
+----
+
+Slang performs parsing, semantic analysis, hierarchy elaboration, and type checking.
+The plugin supports source and header dependencies, preprocessor defines, and top-level parameter overrides supplied through the rule.
 
 == Continuous Integration
 

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -375,6 +375,7 @@ rule_verilog_elab_test = rule(
         ),
         "verilog_runner_plugins": attr.label_list(
             default = [
+                "//python/verilog_runner/plugins:slang.py",
                 "//python/verilog_runner/plugins:verilator.py",
             ],
             allow_files = True,

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -79,7 +79,7 @@ Tests that a Verilog or SystemVerilog design elaborates. Needs VERILOG_RUNNER_PL
 | <a id="rule_verilog_elab_test-tool"></a>tool |  Elaboration tool to use.   | String | required |  |
 | <a id="rule_verilog_elab_test-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
 | <a id="rule_verilog_elab_test-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
-| <a id="rule_verilog_elab_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:verilator.py"]`  |
+| <a id="rule_verilog_elab_test-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:slang.py", "@bedrock-rtl//python/verilog_runner/plugins:verilator.py"]`  |
 | <a id="rule_verilog_elab_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
 
 

--- a/bazel/verilog_runner/BUILD.bazel
+++ b/bazel/verilog_runner/BUILD.bazel
@@ -19,6 +19,14 @@ verilog_elab_test(
     deps = [":nonzip_smoke_lib"],
 )
 
+verilog_elab_test(
+    name = "slang_elab_test",
+    params = {"Width": "8"},
+    tool = "slang",
+    top = "nonzip_smoke",
+    deps = [":nonzip_smoke_lib"],
+)
+
 verilog_lint_test(
     name = "nonzip_lint_test",
     tags = ["manual"],

--- a/bazel/verilog_runner/nonzip_smoke.sv
+++ b/bazel/verilog_runner/nonzip_smoke.sv
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-module nonzip_smoke;
+module nonzip_smoke #(
+    parameter int Width = 1
+);
+  logic [Width-1:0] value;
+
   initial begin
+    value = '0;
     $display("TEST PASSED");
     $finish;
   end

--- a/bazel/verilog_runner/nonzip_test.sh
+++ b/bazel/verilog_runner/nonzip_test.sh
@@ -36,6 +36,7 @@ for file in \
   python/verilog_runner/eda_tool.py \
   python/verilog_runner/plugins.py \
   python/verilog_runner/util.py \
+  python/verilog_runner/plugins/slang.py \
   python/verilog_runner/plugins/verilator.py; do
   if [[ ! -f "${repo}/${file}" ]]; then
     echo "missing Verilog runner runfile: ${file}"

--- a/python/verilog_runner/BUILD.bazel
+++ b/python/verilog_runner/BUILD.bazel
@@ -21,6 +21,7 @@ filegroup(
         "eda_tool.py",
         "plugins.py",
         "util.py",
+        "//python/verilog_runner/plugins:slang.py",
         "//python/verilog_runner/plugins:verilator.py",
     ],
 )

--- a/python/verilog_runner/plugins/BUILD.bazel
+++ b/python/verilog_runner/plugins/BUILD.bazel
@@ -3,5 +3,6 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
+    "slang.py",
     "verilator.py",
 ])

--- a/python/verilog_runner/plugins/slang.py
+++ b/python/verilog_runner/plugins/slang.py
@@ -56,7 +56,7 @@ class Slang(EdaTool):
         """Returns a default shell script to run slang."""
         self.logger.info("Generating shell script.")
         slang_cmd = [
-            "${SLANG_CMD:-slang}",
+            '"${SLANG_PATH}/slang"',
             "--std 1800-2017",
             f"--top {self.top}",
             f"-f {self.filelist}",

--- a/python/verilog_runner/plugins/slang.py
+++ b/python/verilog_runner/plugins/slang.py
@@ -56,7 +56,7 @@ class Slang(EdaTool):
         """Returns a default shell script to run slang."""
         self.logger.info("Generating shell script.")
         slang_cmd = [
-            '"${SLANG_PATH}/slang"',
+            '"${SLANG_PATH}"',
             "--std 1800-2017",
             f"--top {self.top}",
             f"-f {self.filelist}",

--- a/python/verilog_runner/plugins/slang.py
+++ b/python/verilog_runner/plugins/slang.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""slang elaboration plugin for Verilog Runner."""
+
+import argparse
+from dataclasses import dataclass
+from typing import Dict, Type
+
+from cli import Elab, Subcommand, common_args
+from eda_tool import EdaTool
+from util import (
+    gen_file_header,
+    get_class_logger,
+    include_dirs,
+    print_summary,
+    run_shell_script,
+    write_and_dump_file,
+)
+
+PLUGIN_API_VERSION = "2.0.0"
+
+
+@dataclass
+class Slang(EdaTool):
+    subcommand: Type[Subcommand] = Elab
+    tool_name: str = "slang"
+    help: str = "Elaborate a Verilog/SystemVerilog design using slang"
+
+    def __post_init__(self):
+        self.logger = get_class_logger("elab", "slang")
+
+    @classmethod
+    def add_args(cls, parser: argparse.ArgumentParser) -> None:
+        pass
+
+    @classmethod
+    def from_args(cls, args):
+        return cls(**common_args(args))
+
+    def tcl_preamble(self) -> str:
+        return gen_file_header(self.tclfile, "slang")
+
+    def default_tcl_header(self) -> str:
+        return ""
+
+    def tcl_analysis_elaborate(self) -> str:
+        return ""
+
+    def default_tcl_body(self) -> str:
+        return ""
+
+    def tcl_footer(self) -> str:
+        return ""
+
+    def cmd(self) -> str:
+        """Returns a default shell script to run slang."""
+        self.logger.info("Generating shell script.")
+        slang_cmd = [
+            "${SLANG_CMD:-slang}",
+            "--std 1800-2017",
+            f"--top {self.top}",
+            f"-f {self.filelist}",
+        ]
+        slang_cmd += [f"-I{directory}" for directory in include_dirs(self.hdrs)]
+        slang_cmd += [f"-D{define}" for define in self.defines]
+        slang_cmd += [f"-G{key}={value}" for key, value in self.params.items()]
+        slang_cmd += self.opts
+
+        cmd = [
+            "#!/bin/bash",
+            gen_file_header(self.scriptfile, "slang"),
+            "set -e",
+        ]
+        cmd += self.read_env_setup_commands()
+        cmd += ["echo ' '"]
+        cmd += [
+            "echo '----------------------------- slang -----------------------------'"
+        ]
+        cmd += [" ".join(slang_cmd), ""]
+        return "\n".join(cmd)
+
+    def run_cmd(self) -> Dict[str, bool]:
+        """Runs slang and returns its success criteria."""
+        self.logger.info("Running shell script.")
+        self.prepare_files()
+        returncode, shell_output = run_shell_script(self.scriptfile, self.logger)
+        write_and_dump_file(shell_output, self.logfile, logger=self.logger)
+        return {f"Return code {returncode}": returncode == 0}
+
+    def run_test(self) -> bool:
+        """Runs the test and returns True if elaboration succeeded."""
+        self.logger.info("Running test.")
+        step_success = self.run_cmd()
+        success = all(step_success.values())
+        print_summary(
+            success=success,
+            step_success=step_success,
+            report_table="",
+            logger=self.logger,
+        )
+        return success


### PR DESCRIPTION
# Problem

Want to support `slang` as a tool option for `verilog_elab_test`.

# Solution

Add a built-in Slang elaboration plugin for Verilog Runner and package it with `verilog_elab_test`. The plugin passes sources, headers, defines, top-level selection, parameter overrides, and tool options to Slang, and treats a nonzero Slang exit status as an elaboration failure. Add a parameterized smoke test and document the new `tool = "slang"` option.

Validation includes the affected Verilog Runner tests, the Slang smoke elaboration test, generated documentation checks, and pre-commit.
