### PR TITLE
[fv] Fix unreachable CSR FPV backpressure covers

### DIFF
--- a/cdc/rtl/br_cdc_reg.sv
+++ b/cdc/rtl/br_cdc_reg.sv
@@ -35,6 +35,10 @@ module br_cdc_reg #(
     // If 0, disable backpressure coverage. By default, this also
     // asserts that backpressure is impossible.
     parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, cover that the pop side experiences backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
+    parameter bit EnableCoverPopBackpressure = 1,
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, assert that push_data is stable when backpressured.
@@ -46,7 +50,10 @@ module br_cdc_reg #(
     parameter bit EnableAssertFinalNotValid = 1,
     // If 1, assert that push-side backpressure is impossible.
     // Can only be enabled if EnableCoverPushBackpressure is disabled.
-    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, assert that pop-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPopBackpressure is disabled.
+    parameter bit EnableAssertNoPopBackpressure = !EnableCoverPopBackpressure
 ) (
     // Push-side interface
     input  logic             push_clk,
@@ -104,7 +111,9 @@ module br_cdc_reg #(
   br_cdc_reg_pop #(
       .Width(Width),
       .RegisterPopOutputs(RegisterPopOutputs),
-      .RegisterResetActive(RegisterResetActive)
+      .RegisterResetActive(RegisterResetActive),
+      .EnableCoverPopBackpressure(EnableCoverPopBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPopBackpressure)
   ) br_cdc_reg_pop (
       .clk(pop_clk),  // ri lint_check_waive SAME_CLOCK_NAME
       .rst(pop_rst),

--- a/cdc/rtl/internal/br_cdc_reg_pop.sv
+++ b/cdc/rtl/internal/br_cdc_reg_pop.sv
@@ -8,7 +8,14 @@
 module br_cdc_reg_pop #(
     parameter int Width = 1,
     parameter bit RegisterPopOutputs = 0,
-    parameter bit RegisterResetActive = 1
+    parameter bit RegisterResetActive = 1,
+    // If 1, cover that the pop side experiences backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
+    parameter bit EnableCoverPopBackpressure = 1,
+    // If 1, assert that pop-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPopBackpressure is disabled.
+    parameter bit EnableAssertNoPopBackpressure = !EnableCoverPopBackpressure
 ) (
     input logic clk,
     input logic rst,
@@ -73,7 +80,11 @@ module br_cdc_reg_pop #(
 
   if (RegisterPopOutputs) begin : gen_reg_out
     br_flow_reg_fwd #(
-        .Width(Width)
+        .Width(Width),
+        .EnableCoverPushBackpressure(EnableCoverPopBackpressure),
+        .EnableAssertNoPushBackpressure(EnableAssertNoPopBackpressure),
+        .EnableCoverPopBackpressure(EnableCoverPopBackpressure),
+        .EnableAssertNoPopBackpressure(EnableAssertNoPopBackpressure)
     ) br_flow_reg_fwd (
         .clk,
         .rst,
@@ -93,7 +104,11 @@ module br_cdc_reg_pop #(
   // Implementation Checks
   br_flow_checks_valid_data_impl #(
       .NumFlows(1),
-      .Width(Width)
+      .Width(Width),
+      .EnableCoverBackpressure(EnableCoverPopBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPopBackpressure),
+      .EnableAssertValidStability(EnableCoverPopBackpressure),
+      .EnableAssertDataStability(EnableCoverPopBackpressure)
   ) br_flow_checks_valid_data_impl (
       .clk,
       .rst,

--- a/csr/fpv/br_csr_axil_widget_fpv_monitor.sv
+++ b/csr/fpv/br_csr_axil_widget_fpv_monitor.sv
@@ -66,7 +66,7 @@ module br_csr_axil_widget_fpv_monitor #(
       .CONFIG_WAIT_FOR_VALID_BEFORE_READY(1),
       // AXI constraints will be applied to wdata, instead of wstrb & wdata
       .CONFIG_WDATA_MASKED(0),
-      .MAX_PENDING(RegisterResponseOutputs ? 3 : 2)
+      .MAX_PENDING(RegisterResponseOutputs ? 2 : 1)
   ) axi4_lite (
       // Global signals
       .aclk    (clk),

--- a/csr/rtl/br_csr_cdc.sv
+++ b/csr/rtl/br_csr_cdc.sv
@@ -99,7 +99,8 @@ module br_csr_cdc #(
       .NumSyncStages(NumSyncStages),
       // CSR CDC ties pop_ready high and asserts no request backpressure, so
       // br_cdc_reg's push/pop backpressure-stability precondition covers are unreachable.
-      .EnableCoverPushBackpressure(0)
+      .EnableCoverPushBackpressure(0),
+      .EnableCoverPopBackpressure(0)
   ) br_cdc_reg_req (
       .push_clk(upstream_clk),  // ri lint_check_waive SAME_CLOCK_NAME
       .push_rst(upstream_rst),
@@ -144,7 +145,8 @@ module br_csr_cdc #(
       .NumSyncStages(NumSyncStages),
       // CSR CDC ties pop_ready high and asserts no response backpressure, so
       // br_cdc_reg's push/pop backpressure-stability precondition covers are unreachable.
-      .EnableCoverPushBackpressure(0)
+      .EnableCoverPushBackpressure(0),
+      .EnableCoverPopBackpressure(0)
   ) br_cdc_reg_resp (
       .push_clk(downstream_clk),  // ri lint_check_waive SAME_CLOCK_NAME
       .push_rst(downstream_rst),

--- a/flow/rtl/br_flow_reg_fwd.sv
+++ b/flow/rtl/br_flow_reg_fwd.sv
@@ -34,11 +34,18 @@ module br_flow_reg_fwd #(
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
     parameter bit EnableAssertPushDataKnown = 1,
+    // If 1, cover that the pop side experiences backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
+    parameter bit EnableCoverPopBackpressure = 1,
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     // If 1, assert that push-side backpressure is impossible.
     // Can only be enabled if EnableCoverPushBackpressure is disabled.
-    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, assert that pop-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPopBackpressure is disabled.
+    parameter bit EnableAssertNoPopBackpressure = !EnableCoverPopBackpressure
 ) (
     input logic clk,
     input logic rst,  // Synchronous active-high
@@ -57,6 +64,8 @@ module br_flow_reg_fwd #(
   //------------------------------------------
   `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
                     !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+  `BR_ASSERT_STATIC(legal_assert_no_pop_backpressure_a,
+                    !(EnableAssertNoPopBackpressure && EnableCoverPopBackpressure))
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
 
   br_flow_checks_valid_data_intg #(
@@ -101,9 +110,10 @@ module br_flow_reg_fwd #(
   br_flow_checks_valid_data_impl #(
       .NumFlows(1),
       .Width(Width),
-      .EnableCoverBackpressure(1),
-      .EnableAssertValidStability(1),
-      .EnableAssertDataStability(1),
+      .EnableCoverBackpressure(EnableCoverPopBackpressure),
+      .EnableAssertNoBackpressure(EnableAssertNoPopBackpressure),
+      .EnableAssertValidStability(EnableCoverPopBackpressure),
+      .EnableAssertDataStability(EnableCoverPopBackpressure),
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
   ) br_flow_checks_valid_data_impl (
       .clk,


### PR DESCRIPTION
This fixes two CSR FPV unreachable-cover issues.

For br_csr_axil_widget, the AXI-Lite VIP MAX_PENDING now matches the widget’s real outstanding transaction depth: 1 without registered response outputs, 2 with registered response outputs.

For br_csr_cdc, add pop-side backpressure cover/assert controls mirroring the existing push-side controls, then disable pop-side backpressure coverage where CSR CDC ties pop_ready high. The no-pop-backpressure assertion remains enabled by default, so the RTL still checks the intended no-backpressure integration contract without generating structurally unreachable cover preconditions.