### PR TITLE
Fix demux/sim build file

### DIFF
--- a/demux/sim/BUILD.bazel
+++ b/demux/sim/BUILD.bazel
@@ -19,7 +19,7 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_demux_tb_elab_test",
-    tool = "verific",
+    tool = "slang",
     deps = [":br_demux_tb"],
 )
 
@@ -39,7 +39,6 @@ br_verilog_sim_test_tools_suite(
         ],
     },
     tools = [
-        "iverilog",
         "vcs",
         "verilator",
     ],


### PR DESCRIPTION
Minor change to align with new project requirements:
* primary use slang as the elab tool
* drop Icarus