### PR TITLE
[ram] Propagate final-not-valid assertion control into write address decode

### DIFF
--- a/ram/rtl/br_ram_flops_tile.sv
+++ b/ram/rtl/br_ram_flops_tile.sv
@@ -260,7 +260,8 @@ module br_ram_flops_tile #(
       // Write address decoding
       for (genvar port = 0; port < NumWritePorts; port++) begin : gen_wr_addr_onehot
         br_enc_bin2onehot #(
-            .NumValues(Depth)
+            .NumValues(Depth),
+            .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
         ) br_enc_bin2onehot_inst (
             .clk(wr_clk),  // ri lint_check_waive SAME_CLOCK_NAME
             .rst(wr_rst),


### PR DESCRIPTION
# Problem

- `br_ram_flops_tile` instantiated `br_enc_bin2onehot` without forwarding `EnableAssertFinalNotValid`.
- That left the write-address decode path inconsistent with the tile-level assertion configuration.

# Solution

- Thread `EnableAssertFinalNotValid` through the `br_enc_bin2onehot` instance used for write address decoding.
- Keep the decoder behavior aligned with the surrounding RAM assertion settings.