### PR TITLE
Bump Verilator version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,10 @@ RUN pip3.12 install --require-hashes -r /tmp/requirements_lock_3_12.txt && \
     rm /tmp/requirements_lock_3_12.txt
 
 # Install Verilator
-# v5.048
+# v5.049 - devel
 RUN git clone https://github.com/verilator/verilator && \
     cd verilator && \
-    git checkout d0aa828c217410fffc73d92077b6f4f54830357c && \
+    git checkout def1e2ccbcfc352e37a4245b21086da5cce0e969 && \
     autoconf && \
     CC="clang -fuse-ld=lld" CXX="clang++ -fuse-ld=lld" ./configure && \
     make -j$(nproc) && \


### PR DESCRIPTION
This PR bumps the Verilator version to latest main branch (as of 24 Jun 26). This bump covers many new Verilator features, fixes, most notably: we can run tests with self.process.srandom() like in #1189, use covergroup keywords, better support for `fork` statement etc. 