### PR TITLE
Extend timeout to observe dst_pulse

### DIFF
--- a/cdc/sim/BUILD.bazel
+++ b/cdc/sim/BUILD.bazel
@@ -197,12 +197,9 @@ verilog_elab_test(
             "+cdc_delay_mode=" + cdc_delay_mode,
         ],
         tags = ["no-sandbox"],
-        # TODO(mgottscho): Enable Verilator once it supports
-        # `process::self().srandom(new_seed)` in `br_cdc_bit_toggle` during CDC
-        # delay modeling.
         tools = [
             "vcs",
-            #"verilator",
+            "verilator",
         ],
         deps = [":br_cdc_bit_pulse_tb"],
     )

--- a/cdc/sim/br_cdc_bit_pulse_tb.sv
+++ b/cdc/sim/br_cdc_bit_pulse_tb.sv
@@ -16,9 +16,12 @@ module br_cdc_bit_pulse_tb;
   localparam int DstClkHalfPeriod = DstClkPeriod / 2;
   localparam int MinSrcCycleSpacing = br_math::ceil_div(2 * DstClkPeriod, SrcClkPeriod);
   localparam int MaxSrcCycleSpacing = MinSrcCycleSpacing + 4;
+  localparam int SrcPulseLaunchCycles = 1;
+  localparam int MaxCdcDelayModelDstCycles = 1;
+  localparam int DstPulseObservationCycles = 1;
   localparam int DstTimeoutCycles = br_math::ceil_div(
-      MaxSrcCycleSpacing * SrcClkPeriod, DstClkPeriod
-  ) + NumStages + RegisterOutput;
+      (MaxSrcCycleSpacing + SrcPulseLaunchCycles) * SrcClkPeriod, DstClkPeriod
+  ) + NumStages + RegisterOutput + MaxCdcDelayModelDstCycles + DstPulseObservationCycles;
 
   logic src_clk;
   logic src_rst;


### PR DESCRIPTION
This extension of the timeout is required, because some combinations of parameters can create a condition where observing dst_pulse timeouts prematurely. For example,
```
src_reset_cycles=[          6]
dst_reset_cycles=[          9]
src_delay=[          4]
```
was a failing test case (now fixed). It was not observed in proprietary runs, because this behavior depends on the random number generators - and even if you pass the same seed to 2 simulators, the conditions will differ.

