### PR TITLE
Support depth-one flop FIFOs

### DIFF
--- a/fifo/fpv/br_fifo/BUILD.bazel
+++ b/fifo/fpv/br_fifo/BUILD.bazel
@@ -81,12 +81,21 @@ br_verilog_fpv_test_tools_suite(
             "Depth",
             "RamReadLatency",
         ): [
+            ("1", "1"),
+            ("1", "2"),
             ("2", "1"),
             ("2", "2"),
+        ],
+        (
+            "Depth",
+            "RegisterPopOutputs",
+        ): [
+            ("1", "1"),
         ],
     },
     params = {
         "Depth": [
+            "1",
             "2",
             "5",
         ],
@@ -223,8 +232,17 @@ br_verilog_fpv_test_tools_suite(
 br_verilog_fpv_test_tools_suite(
     name = "br_fifo_flops_test_suite",
     data = ["//fifo/fpv:br_ram_invariant_tcl"],
+    illegal_param_combinations = {
+        (
+            "Depth",
+            "RegisterPopOutputs",
+        ): [
+            ("1", "1"),
+        ],
+    },
     params = {
         "Depth": [
+            "1",
             "2",
             "5",
         ],
@@ -324,12 +342,21 @@ br_verilog_fpv_test_tools_suite(
             "Depth",
             "RamReadLatency",
         ): [
+            ("1", "1"),
+            ("1", "2"),
             ("2", "1"),
             ("2", "2"),
+        ],
+        (
+            "Depth",
+            "RegisterPopOutputs",
+        ): [
+            ("1", "1"),
         ],
     },
     params = {
         "Depth": [
+            "1",
             "2",
             "5",
         ],
@@ -438,8 +465,17 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_fifo_flops_push_credit_test_suite",
     data = ["//fifo/fpv:br_ram_invariant_tcl"],
+    illegal_param_combinations = {
+        (
+            "Depth",
+            "RegisterPopOutputs",
+        ): [
+            ("1", "1"),
+        ],
+    },
     params = {
         "Depth": [
+            "1",
             "2",
             "5",
         ],

--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -403,6 +403,29 @@ br_verilog_elab_and_lint_test_suite(
 )
 
 br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_flops_push_credit_test_suite_depth_1",
+    params = {
+        "Depth": ["1"],
+        "Width": [
+            "1",
+            "8",
+        ],
+        "EnableBypass": [
+            "0",
+            "1",
+        ],
+        "MaxCredit": ["1"],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": ["0"],
+        "FlopRamAddressDepthStages": ["0"],
+    },
+    deps = [":br_fifo_flops_push_credit"],
+)
+
+br_verilog_elab_and_lint_test_suite(
     name = "br_fifo_flops_push_credit_test_suite_nonzero_read_latency",
     params = {
         "Depth": ["4"],

--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -316,6 +316,24 @@ br_verilog_elab_and_lint_test_suite(
 )
 
 br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_flops_test_suite_depth_1",
+    params = {
+        "Depth": ["1"],
+        "Width": [
+            "1",
+            "8",
+        ],
+        "EnableBypass": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": ["0"],
+        "FlopRamAddressDepthStages": ["0"],
+    },
+    deps = [":br_fifo_flops"],
+)
+
+br_verilog_elab_and_lint_test_suite(
     name = "br_fifo_flops_test_suite_nonzero_read_latency",
     params = {
         "Depth": ["4"],

--- a/fifo/rtl/br_fifo_ctrl_1r1w.sv
+++ b/fifo/rtl/br_fifo_ctrl_1r1w.sv
@@ -252,7 +252,9 @@ module br_fifo_ctrl_1r1w #(
   // Flag coherence
   `BR_ASSERT_IMPL(items_plus_slots_a, items + slots == Depth)
   `BR_ASSERT_IMPL(items_next_plus_slots_next_a, items_next + slots_next == Depth)
-  `BR_ASSERT_IMPL(push_and_pop_flags_unchanged_a,
-                  push_beat && pop_beat |-> items_next == items && slots_next == slots)
+  if (Depth > 1 || EnableBypass) begin : gen_push_and_pop_impl_checks
+    `BR_ASSERT_IMPL(push_and_pop_flags_unchanged_a,
+                    push_beat && pop_beat |-> items_next == items && slots_next == slots)
+  end
 
 endmodule : br_fifo_ctrl_1r1w

--- a/fifo/rtl/br_fifo_ctrl_1r1w.sv
+++ b/fifo/rtl/br_fifo_ctrl_1r1w.sv
@@ -50,7 +50,9 @@
 `include "br_asserts_internal.svh"
 
 module br_fifo_ctrl_1r1w #(
-    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    // Number of entries in the FIFO. Must be at least 1. Depth 1 requires
+    // RamReadLatency=0 and RegisterPopOutputs=0.
+    parameter int Depth = 2,
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then bypasses push-to-pop when the FIFO is empty, resulting in
     // a cut-through latency of 0 cycles, but at the cost of worse timing.
@@ -146,6 +148,12 @@ module br_fifo_ctrl_1r1w #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 1)
+  if (Depth == 1) begin : gen_depth_1_checks
+    `BR_ASSERT_STATIC(depth_1_requires_zero_ram_read_latency_a, RamReadLatency == 0)
+    `BR_ASSERT_STATIC(depth_1_requires_unregistered_pop_outputs_a, !RegisterPopOutputs)
+  end
+
   // Rely on submodule integration checks
 
   //------------------------------------------

--- a/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
+++ b/fifo/rtl/br_fifo_ctrl_1r1w_push_credit.sv
@@ -40,7 +40,9 @@
 `include "br_asserts_internal.svh"
 
 module br_fifo_ctrl_1r1w_push_credit #(
-    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    // Number of entries in the FIFO. Must be at least 1. Depth 1 requires
+    // RamReadLatency=0 and RegisterPopOutputs=0.
+    parameter int Depth = 2,
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then bypasses push-to-pop when the FIFO is empty, resulting in
     // a cut-through latency of 0 cycles, but at the cost of worse timing.
@@ -141,6 +143,12 @@ module br_fifo_ctrl_1r1w_push_credit #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 1)
+  if (Depth == 1) begin : gen_depth_1_checks
+    `BR_ASSERT_STATIC(depth_1_requires_zero_ram_read_latency_a, RamReadLatency == 0)
+    `BR_ASSERT_STATIC(depth_1_requires_unregistered_pop_outputs_a, !RegisterPopOutputs)
+  end
+
   // Rely on submodule integration checks
 
   //------------------------------------------

--- a/fifo/rtl/br_fifo_flops.sv
+++ b/fifo/rtl/br_fifo_flops.sv
@@ -36,7 +36,9 @@
 // any use for the status flags.
 
 module br_fifo_flops #(
-    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    // Number of entries in the FIFO. Must be at least 1. Depth 1 requires
+    // RegisterPopOutputs=0 and all FlopRam*Stages parameters to be 0.
+    parameter int Depth = 2,
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then bypasses push-to-pop when the FIFO is empty, resulting in
     // a cut-through latency of 0 cycles, but at the cost of worse timing.

--- a/fifo/rtl/br_fifo_flops_push_credit.sv
+++ b/fifo/rtl/br_fifo_flops_push_credit.sv
@@ -28,7 +28,9 @@
 // It is recommended to disable the bypass only when necessary to close timing.
 
 module br_fifo_flops_push_credit #(
-    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    // Number of entries in the FIFO. Must be at least 1. Depth 1 requires
+    // RegisterPopOutputs=0 and all FlopRam*Stages parameters to be 0.
+    parameter int Depth = 2,
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then bypasses push-to-pop when the FIFO is empty, resulting in
     // a cut-through latency of 0 cycles, but at the cost of worse timing.

--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -116,7 +116,8 @@ module br_fifo_pop_ctrl #(
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
       .EnableWrap(0),
       .EnableCoverZeroChange(0),
-      .EnableCoverReinit(0)
+      .EnableCoverReinit(0),
+      .EnableCoverIncrementAndDecrement(Depth > 1 || EnableBypass)
   ) br_counter_items (
       .clk,
       .rst,
@@ -168,7 +169,9 @@ module br_fifo_pop_ctrl #(
 
   // Flags
   `BR_ASSERT_IMPL(items_in_range_a, items <= Depth)
-  `BR_ASSERT_IMPL(push_and_pop_items_a, push_beat && pop_beat |-> items_next == items)
+  if (Depth > 1 || EnableBypass) begin : gen_push_and_pop_impl_checks
+    `BR_ASSERT_IMPL(push_and_pop_items_a, push_beat && pop_beat |-> items_next == items)
+  end
   `BR_ASSERT_IMPL(push_items_a, push_beat && !pop_beat |-> items_next == items + 1)
   `BR_ASSERT_IMPL(pop_items_a, !push_beat && pop_beat |-> items_next == items - 1)
   `BR_ASSERT_IMPL(empty_a, empty == (items == 0))

--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -58,7 +58,7 @@ module br_fifo_pop_ctrl #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(depth_must_be_at_least_two_a, Depth >= 2)
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 1)
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
 
   `BR_ASSERT_INTG(ram_rd_latency_matches_a,

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -68,7 +68,7 @@ module br_fifo_push_ctrl #(
   //------------------------------------------
   `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
                     !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
-  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 1)
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
 
   `BR_COVER_INTG(full_c, full)

--- a/fifo/rtl/internal/br_fifo_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl.sv
@@ -127,7 +127,8 @@ module br_fifo_push_ctrl #(
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
       .EnableWrap(0),
       .EnableCoverZeroChange(0),
-      .EnableCoverReinit(0)
+      .EnableCoverReinit(0),
+      .EnableCoverIncrementAndDecrement(Depth > 1 || EnableBypass)
   ) br_counter_slots (
       .clk,
       .rst,
@@ -162,7 +163,9 @@ module br_fifo_push_ctrl #(
   // Flags
   `BR_ASSERT_IMPL(slots_in_range_a, slots <= Depth)
   `BR_ASSERT_IMPL(slots_next_a, ##1 slots == $past(slots_next))
-  `BR_ASSERT_IMPL(push_and_pop_slots_a, push_beat && pop_beat |-> slots_next == slots)
+  if (Depth > 1 || EnableBypass) begin : gen_push_and_pop_impl_checks
+    `BR_ASSERT_IMPL(push_and_pop_slots_a, push_beat && pop_beat |-> slots_next == slots)
+  end
   `BR_ASSERT_IMPL(push_slots_a, push_beat && !pop_beat |-> slots_next == slots - 1)
   `BR_ASSERT_IMPL(pop_slots_a, !push_beat && pop_beat |-> slots_next == slots + 1)
   `BR_ASSERT_IMPL(full_a, full == (slots == 0))

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -79,7 +79,7 @@ module br_fifo_push_ctrl_credit #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 2)
+  `BR_ASSERT_STATIC(depth_must_be_at_least_one_a, Depth >= 1)
   `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
   `BR_ASSERT_STATIC(credit_width_a, CreditWidth >= $clog2(Depth + 1))
 

--- a/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
+++ b/fifo/rtl/internal/br_fifo_push_ctrl_credit.sv
@@ -167,7 +167,8 @@ module br_fifo_push_ctrl_credit #(
       .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
       .EnableWrap(0),
       .EnableCoverZeroChange(0),
-      .EnableCoverReinit(0)
+      .EnableCoverReinit(0),
+      .EnableCoverIncrementAndDecrement(Depth > 1 || EnableBypass)
   ) br_counter_slots (
       .clk,
       .rst(either_rst),
@@ -202,8 +203,10 @@ module br_fifo_push_ctrl_credit #(
   // Flags
   `BR_ASSERT_CR_IMPL(slots_in_range_a, slots <= Depth, clk, either_rst)
   `BR_ASSERT_CR_IMPL(slots_next_a, ##1 slots == $past(slots_next), clk, either_rst)
-  `BR_ASSERT_CR_IMPL(push_and_pop_slots_a, push_beat && pop_beat |-> slots_next == slots, clk,
-                     either_rst)
+  if (Depth > 1 || EnableBypass) begin : gen_push_and_pop_impl_checks
+    `BR_ASSERT_CR_IMPL(push_and_pop_slots_a, push_beat && pop_beat |-> slots_next == slots, clk,
+                       either_rst)
+  end
   `BR_ASSERT_CR_IMPL(push_slots_a, push_beat && !pop_beat |-> slots_next == slots - 1, clk,
                      either_rst)
   `BR_ASSERT_CR_IMPL(pop_slots_a, !push_beat && pop_beat |-> slots_next == slots + 1, clk,

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -209,6 +209,22 @@ br_verilog_sim_test_tools_suite(
 )
 
 br_verilog_sim_test_tools_suite(
+    name = "br_fifo_flops_depth_1_sim_test_tools_suite",
+    params = {
+        "Depth": ["1"],
+        "Width": ["8"],
+        "EnableBypass": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": ["0"],
+        "FlopRamAddressDepthStages": ["0"],
+    },
+    tools = ["verilator"],
+    deps = [":br_fifo_flops_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
     name = "br_fifo_flops_sim_test_tools_suite_nonzero_lat",
     params = {
         "Depth": [

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -220,7 +220,10 @@ br_verilog_sim_test_tools_suite(
         "RegisterPopOutputs": ["0"],
         "FlopRamAddressDepthStages": ["0"],
     },
-    tools = ["verilator"],
+    tools = [
+        "vcs",
+        "verilator",
+    ],
     deps = [":br_fifo_flops_tb"],
 )
 
@@ -320,7 +323,10 @@ br_verilog_sim_test_tools_suite(
             "1",
         ],
     },
-    tools = ["verilator"],
+    tools = [
+        "vcs",
+        "verilator",
+    ],
     deps = [":br_fifo_flops_push_credit_tb"],
 )
 

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -305,6 +305,25 @@ br_verilog_sim_test_tools_suite(
     deps = [":br_fifo_flops_push_credit_tb"],
 )
 
+br_verilog_sim_test_tools_suite(
+    name = "br_fifo_flops_push_credit_depth_1_sim_test_tools_suite",
+    params = {
+        "TestDepth": ["1"],
+        "EnableBypass": [
+            "0",
+            "1",
+        ],
+        "RegisterPopOutputs": ["0"],
+        "FlopRamAddressDepthStages": ["0"],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    tools = ["verilator"],
+    deps = [":br_fifo_flops_push_credit_tb"],
+)
+
 verilog_library(
     name = "br_fifo_shared_test_harness",
     srcs = ["br_fifo_shared_test_harness.sv"],

--- a/fifo/sim/br_fifo_flops_push_credit_tb.sv
+++ b/fifo/sim/br_fifo_flops_push_credit_tb.sv
@@ -10,13 +10,16 @@ module br_fifo_flops_push_credit_tb ();
   parameter bit RegisterPopOutputs = 0;
   parameter bit RegisterPushOutputs = 0;
   parameter int FlopRamAddressDepthStages = 0;
+  // If nonzero, override the minimum depth derived from the credit-loop latency.
+  parameter int TestDepth = 0;
 
   localparam int PropDelay = 3;
   localparam int Width = 8;
   localparam int CutThroughLatency =
       PropDelay + (EnableBypass ? 0 : (FlopRamAddressDepthStages + 1)) + 32'(RegisterPopOutputs);
   localparam int BackpressureLatency = PropDelay + 1 + 32'(RegisterPushOutputs);
-  localparam int Depth = CutThroughLatency + BackpressureLatency + 1;
+  localparam int MinimumDepth = CutThroughLatency + BackpressureLatency + 1;
+  localparam int Depth = TestDepth > 0 ? TestDepth : MinimumDepth;
   localparam int NData = 100;
 
   // Inputs

--- a/fifo/sim/br_fifo_test_harness.sv
+++ b/fifo/sim/br_fifo_test_harness.sv
@@ -147,12 +147,8 @@ module br_fifo_test_harness #(
           push_data = i[Width-1:0];
           scoreboard[i] = push_data;
           @(posedge clk);
-          if (push_ready) begin
-            $display("Pushed data: %0h | Items: %0d", push_data, items);
-          end else begin
-            $error("Cannot push data. FIFO Full.");
-            error_count += 1;
-          end
+          while (!push_ready) @(posedge clk);
+          $display("Pushed data: %0h | Items: %0d", push_data, items);
           @(negedge clk);
           push_valid = 1'b0;
         end


### PR DESCRIPTION
Codex is working on behalf of @mgottscho.

# Problem

br_fifo_flops and br_fifo_flops_push_credit rejected Depth=1, preventing use as parameterized one-entry FIFOs or skid-buffer-like stages.

Fixes #1158.

# Solution

Allow Depth=1 in both the ready/valid and push-credit 1R1W FIFO families when RAM read latency is zero and pop outputs are unregistered. Update the controller integration checks and documentation, make the common FIFO test harness hold push_valid while backpressured, and add dedicated depth-one elaboration and Verilator simulation coverage. Coverage includes bypass disabled and enabled for both families, plus registered and unregistered push-credit returns.

Validated in the public Docker image with six focused Verilator simulations, default/all-assert/no-assert Slang elaboration for both FIFO families, both Slang testbench elaborations, and pre-commit.