### PR TITLE
Add generated axi2axil testbench

### DIFF
--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -154,6 +154,51 @@ br_verilog_sim_test_tools_suite(
 )
 
 verilog_library(
+    name = "br_amba_axi2axil_tb",
+    srcs = ["br_amba_axi2axil_tb.sv"],
+    deps = [
+        "//amba/rtl:br_amba_axi2axil",
+        "//amba/sim/drivers:br_amba_axi_sim_pkg",
+        "//amba/sim/drivers:br_amba_axi_target_driver",
+        "//amba/sim/drivers:br_amba_axil_sim_pkg",
+        "//amba/sim/drivers:br_amba_axil_target_driver",
+        "//amba/sim/drivers:br_amba_sim_pkg",
+        "//amba/sim/monitors:br_amba_axi_response_monitor",
+        "//amba/sim/monitors:br_amba_axil_request_monitor",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_amba_axi2axil_tb_elab_test",
+    tool = "slang",
+    deps = [":br_amba_axi2axil_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_amba_axi2axil_sim_test_tools_suite",
+    params = {
+        "DataWidth": [
+            "32",
+            "64",
+        ],
+        "MaxOutstandingReqs": [
+            "4",
+            "6",
+        ],
+        "NumRandomTransactions": [
+            "1",
+            "10",
+        ],
+    },
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_amba_axi2axil_tb"],
+)
+
+verilog_library(
     name = "br_amba_axil_timing_slice_tb",
     srcs = ["br_amba_axil_timing_slice_tb.sv"],
     deps = [

--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -171,32 +171,49 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_amba_axi2axil_tb_elab_test",
+    defines = [
+        "BR_AMBA_AXI_SIM_ADDR_WIDTH=12",
+        "BR_AMBA_AXI_SIM_DATA_WIDTH=32",
+        "BR_AMBA_AXI_SIM_ID_WIDTH=3",
+        "BR_AMBA_AXI_SIM_USER_WIDTH=2",
+    ],
     tool = "slang",
     deps = [":br_amba_axi2axil_tb"],
 )
 
-br_verilog_sim_test_tools_suite(
-    name = "br_amba_axi2axil_sim_test_tools_suite",
-    params = {
-        "DataWidth": [
-            "32",
-            "64",
+[
+    br_verilog_sim_test_tools_suite(
+        name = "br_amba_axi2axil_sim_test_tools_suite_dw%s" % data_width,
+        defines = [
+            "BR_ASSERT_ON",
+            "BR_ENABLE_IMPL_CHECKS",
+            "SIMULATION",
+            "BR_AMBA_AXI_SIM_ADDR_WIDTH=12",
+            "BR_AMBA_AXI_SIM_DATA_WIDTH=%s" % data_width,
+            "BR_AMBA_AXI_SIM_ID_WIDTH=3",
+            "BR_AMBA_AXI_SIM_USER_WIDTH=2",
         ],
-        "MaxOutstandingReqs": [
-            "4",
-            "6",
+        params = {
+            "MaxOutstandingReqs": [
+                "4",
+                "6",
+            ],
+            "NumRandomTransactions": [
+                "1",
+                "10",
+            ],
+        },
+        tools = [
+            "vcs",
+            "verilator",
         ],
-        "NumRandomTransactions": [
-            "1",
-            "10",
-        ],
-    },
-    tools = [
-        "vcs",
-        "verilator",
-    ],
-    deps = [":br_amba_axi2axil_tb"],
-)
+        deps = [":br_amba_axi2axil_tb"],
+    )
+    for data_width in [
+        "32",
+        "64",
+    ]
+]
 
 verilog_library(
     name = "br_amba_axil_timing_slice_tb",

--- a/amba/sim/br_amba_axi2axil_tb.sv
+++ b/amba/sim/br_amba_axi2axil_tb.sv
@@ -1,0 +1,910 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_axi_sim_pkg::*;
+import br_amba_axil_sim_pkg::*;
+import br_amba_sim_pkg::*;
+
+// Directed simulation testbench for br_amba_axi2axil.
+//
+// Scope:
+// - checks reset-visible AXI4-Lite request and AXI4 response outputs are idle;
+// - converts single-beat, incrementing, fixed, and wrapping AXI bursts into AXI4-Lite accesses;
+// - verifies write data passthrough, read data passthrough, response user fields, IDs, and RLAST;
+// - checks AXI4 write response propagation returns the first non-OKAY beat response;
+// - separates no-stall stress traffic from directed backpressure scenarios;
+// - sweeps DataWidth, MaxOutstandingReqs, and NumRandomTransactions from Bazel.
+module br_amba_axi2axil_tb;
+  parameter int DataWidth = 32;
+  parameter int MaxOutstandingReqs = 4;
+  parameter int NumRandomTransactions = 1;
+
+  localparam int TimeoutCycles = 100;
+  localparam int AddrWidth = 12;
+  localparam int IdWidth = 3;
+  localparam int AWUserWidth = 2;
+  localparam int ARUserWidth = 2;
+  localparam int WUserWidth = 2;
+  localparam int BUserWidth = 2;
+  localparam int RUserWidth = 2;
+  localparam int StrobeWidth = DataWidth / 8;
+  localparam int AxiSize = $clog2(StrobeWidth);
+  localparam int MaxDirectedBeats = 4;
+  localparam int NumStressTransactions = 100;
+  localparam int NumBackpressureTransactions = MaxOutstandingReqs;
+  localparam int MaxBackpressureStallCycles = 3;
+
+  logic clk;
+  logic rst;
+
+  // AXI4 manager-side signals.
+  logic [AddrWidth-1:0] axi_awaddr;
+  logic [IdWidth-1:0] axi_awid;
+  logic [AxiBurstLenWidth-1:0] axi_awlen;
+  logic [AxiBurstSizeWidth-1:0] axi_awsize;
+  logic [AxiBurstTypeWidth-1:0] axi_awburst;
+  logic [AxiProtWidth-1:0] axi_awprot;
+  logic [AWUserWidth-1:0] axi_awuser;
+  logic axi_awvalid;
+  logic axi_awready;
+  logic [DataWidth-1:0] axi_wdata;
+  logic [StrobeWidth-1:0] axi_wstrb;
+  logic [WUserWidth-1:0] axi_wuser;
+  logic axi_wlast;
+  logic axi_wvalid;
+  logic axi_wready;
+  logic [IdWidth-1:0] axi_bid;
+  logic [BUserWidth-1:0] axi_buser;
+  logic [AxiRespWidth-1:0] axi_bresp;
+  logic axi_bvalid;
+  logic axi_bready;
+  logic [AddrWidth-1:0] axi_araddr;
+  logic [IdWidth-1:0] axi_arid;
+  logic [AxiBurstLenWidth-1:0] axi_arlen;
+  logic [AxiBurstSizeWidth-1:0] axi_arsize;
+  logic [AxiBurstTypeWidth-1:0] axi_arburst;
+  logic [AxiProtWidth-1:0] axi_arprot;
+  logic [ARUserWidth-1:0] axi_aruser;
+  logic axi_arvalid;
+  logic axi_arready;
+  logic [IdWidth-1:0] axi_rid;
+  logic [DataWidth-1:0] axi_rdata;
+  logic [RUserWidth-1:0] axi_ruser;
+  logic [AxiRespWidth-1:0] axi_rresp;
+  logic axi_rlast;
+  logic axi_rvalid;
+  logic axi_rready;
+
+  // AXI4-Lite target-side signals.
+  logic [AddrWidth-1:0] axil_awaddr;
+  logic [AxiProtWidth-1:0] axil_awprot;
+  logic [AWUserWidth-1:0] axil_awuser;
+  logic axil_awvalid;
+  logic axil_awready;
+  logic [DataWidth-1:0] axil_wdata;
+  logic [StrobeWidth-1:0] axil_wstrb;
+  logic [WUserWidth-1:0] axil_wuser;
+  logic axil_wvalid;
+  logic axil_wready;
+  logic [AxiRespWidth-1:0] axil_bresp;
+  logic [BUserWidth-1:0] axil_buser;
+  logic axil_bvalid;
+  logic axil_bready;
+  logic [AddrWidth-1:0] axil_araddr;
+  logic [AxiProtWidth-1:0] axil_arprot;
+  logic [ARUserWidth-1:0] axil_aruser;
+  logic axil_arvalid;
+  logic axil_arready;
+  logic [DataWidth-1:0] axil_rdata;
+  logic [AxiRespWidth-1:0] axil_rresp;
+  logic [RUserWidth-1:0] axil_ruser;
+  logic axil_rvalid;
+  logic axil_rready;
+
+  logic axi_manager_failed;
+  logic axil_target_driver_failed;
+  logic axil_request_monitor_failed;
+  logic response_monitor_failed;
+
+  br_amba_axi2axil #(
+      .AddrWidth(AddrWidth),
+      .DataWidth(DataWidth),
+      .IdWidth(IdWidth),
+      .AWUserWidth(AWUserWidth),
+      .ARUserWidth(ARUserWidth),
+      .WUserWidth(WUserWidth),
+      .BUserWidth(BUserWidth),
+      .RUserWidth(RUserWidth),
+      .MaxOutstandingReqs(MaxOutstandingReqs)
+  ) dut (
+      .clk(clk),
+      .rst(rst),
+      .axi_awaddr(axi_awaddr),
+      .axi_awid(axi_awid),
+      .axi_awlen(axi_awlen),
+      .axi_awsize(axi_awsize),
+      .axi_awburst(axi_awburst),
+      .axi_awprot(axi_awprot),
+      .axi_awuser(axi_awuser),
+      .axi_awvalid(axi_awvalid),
+      .axi_awready(axi_awready),
+      .axi_wdata(axi_wdata),
+      .axi_wstrb(axi_wstrb),
+      .axi_wuser(axi_wuser),
+      .axi_wlast(axi_wlast),
+      .axi_wvalid(axi_wvalid),
+      .axi_wready(axi_wready),
+      .axi_bid(axi_bid),
+      .axi_buser(axi_buser),
+      .axi_bresp(axi_bresp),
+      .axi_bvalid(axi_bvalid),
+      .axi_bready(axi_bready),
+      .axi_araddr(axi_araddr),
+      .axi_arid(axi_arid),
+      .axi_arlen(axi_arlen),
+      .axi_arsize(axi_arsize),
+      .axi_arburst(axi_arburst),
+      .axi_arprot(axi_arprot),
+      .axi_aruser(axi_aruser),
+      .axi_arvalid(axi_arvalid),
+      .axi_arready(axi_arready),
+      .axi_rid(axi_rid),
+      .axi_rdata(axi_rdata),
+      .axi_ruser(axi_ruser),
+      .axi_rresp(axi_rresp),
+      .axi_rlast(axi_rlast),
+      .axi_rvalid(axi_rvalid),
+      .axi_rready(axi_rready),
+      .axil_awaddr(axil_awaddr),
+      .axil_awprot(axil_awprot),
+      .axil_awuser(axil_awuser),
+      .axil_awvalid(axil_awvalid),
+      .axil_awready(axil_awready),
+      .axil_wdata(axil_wdata),
+      .axil_wstrb(axil_wstrb),
+      .axil_wuser(axil_wuser),
+      .axil_wvalid(axil_wvalid),
+      .axil_wready(axil_wready),
+      .axil_bresp(axil_bresp),
+      .axil_buser(axil_buser),
+      .axil_bvalid(axil_bvalid),
+      .axil_bready(axil_bready),
+      .axil_araddr(axil_araddr),
+      .axil_arprot(axil_arprot),
+      .axil_aruser(axil_aruser),
+      .axil_arvalid(axil_arvalid),
+      .axil_arready(axil_arready),
+      .axil_rdata(axil_rdata),
+      .axil_rresp(axil_rresp),
+      .axil_ruser(axil_ruser),
+      .axil_rvalid(axil_rvalid),
+      .axil_rready(axil_rready)
+  );
+
+  br_test_driver #(
+      .ResetCycles(5)
+  ) td (
+      .clk(clk),
+      .rst(rst)
+  );
+
+  br_amba_axi_target_driver #(
+      .AddrWidth(AddrWidth),
+      .DataWidth(DataWidth),
+      .IdWidth(IdWidth),
+      .AWUserWidth(AWUserWidth),
+      .WUserWidth(WUserWidth),
+      .ARUserWidth(ARUserWidth),
+      .TimeoutCycles(TimeoutCycles)
+  ) axi_manager (
+      .clk(clk),
+      .rst(rst),
+      .target_awaddr(axi_awaddr),
+      .target_awid(axi_awid),
+      .target_awlen(axi_awlen),
+      .target_awsize(axi_awsize),
+      .target_awburst(axi_awburst),
+      .target_awprot(axi_awprot),
+      .target_awuser(axi_awuser),
+      .target_awvalid(axi_awvalid),
+      .target_awready(axi_awready),
+      .target_wdata(axi_wdata),
+      .target_wstrb(axi_wstrb),
+      .target_wuser(axi_wuser),
+      .target_wlast(axi_wlast),
+      .target_wvalid(axi_wvalid),
+      .target_wready(axi_wready),
+      .target_bvalid(axi_bvalid),
+      .target_bready(axi_bready),
+      .target_araddr(axi_araddr),
+      .target_arid(axi_arid),
+      .target_arlen(axi_arlen),
+      .target_arsize(axi_arsize),
+      .target_arburst(axi_arburst),
+      .target_arprot(axi_arprot),
+      .target_aruser(axi_aruser),
+      .target_arvalid(axi_arvalid),
+      .target_arready(axi_arready),
+      .target_rvalid(axi_rvalid),
+      .target_rready(axi_rready),
+      .failed(axi_manager_failed)
+  );
+
+  br_amba_axil_target_driver #(
+      .DataWidth(DataWidth),
+      .BUserWidth(BUserWidth),
+      .RUserWidth(RUserWidth),
+      .TimeoutCycles(TimeoutCycles)
+  ) axil_target (
+      .clk(clk),
+      .rst(rst),
+      .axil_awvalid(axil_awvalid),
+      .axil_awready(axil_awready),
+      .axil_wvalid(axil_wvalid),
+      .axil_wready(axil_wready),
+      .axil_bresp(axil_bresp),
+      .axil_buser(axil_buser),
+      .axil_bvalid(axil_bvalid),
+      .axil_bready(axil_bready),
+      .axil_arvalid(axil_arvalid),
+      .axil_arready(axil_arready),
+      .axil_rdata(axil_rdata),
+      .axil_rresp(axil_rresp),
+      .axil_ruser(axil_ruser),
+      .axil_rvalid(axil_rvalid),
+      .axil_rready(axil_rready),
+      .failed(axil_target_driver_failed)
+  );
+
+  br_amba_axil_request_monitor #(
+      .AddrWidth(AddrWidth),
+      .DataWidth(DataWidth),
+      .AWUserWidth(AWUserWidth),
+      .WUserWidth(WUserWidth),
+      .ARUserWidth(ARUserWidth),
+      .TimeoutCycles(TimeoutCycles)
+  ) axil_request_monitor (
+      .clk(clk),
+      .rst(rst),
+      .axil_awaddr(axil_awaddr),
+      .axil_awprot(axil_awprot),
+      .axil_awuser(axil_awuser),
+      .axil_awvalid(axil_awvalid),
+      .axil_awready(axil_awready),
+      .axil_wdata(axil_wdata),
+      .axil_wstrb(axil_wstrb),
+      .axil_wuser(axil_wuser),
+      .axil_wvalid(axil_wvalid),
+      .axil_wready(axil_wready),
+      .axil_araddr(axil_araddr),
+      .axil_arprot(axil_arprot),
+      .axil_aruser(axil_aruser),
+      .axil_arvalid(axil_arvalid),
+      .axil_arready(axil_arready),
+      .failed(axil_request_monitor_failed)
+  );
+
+  br_amba_axi_response_monitor #(
+      .DataWidth(DataWidth),
+      .IdWidth(IdWidth),
+      .BUserWidth(BUserWidth),
+      .RUserWidth(RUserWidth),
+      .TimeoutCycles(TimeoutCycles)
+  ) response_monitor (
+      .clk(clk),
+      .rst(rst),
+      .axi_bid(axi_bid),
+      .axi_buser(axi_buser),
+      .axi_bresp(axi_bresp),
+      .axi_bvalid(axi_bvalid),
+      .axi_bready(axi_bready),
+      .axi_rid(axi_rid),
+      .axi_rdata(axi_rdata),
+      .axi_ruser(axi_ruser),
+      .axi_rresp(axi_rresp),
+      .axi_rlast(axi_rlast),
+      .axi_rvalid(axi_rvalid),
+      .axi_rready(axi_rready),
+      .failed(response_monitor_failed)
+  );
+
+  //----------------------------------------------------------------------------
+  // Checks and test helpers
+  //----------------------------------------------------------------------------
+
+  task automatic check_reset_outputs();
+    td.check(!axil_awvalid, "axil_awvalid asserted after reset");
+    td.check(!axil_wvalid, "axil_wvalid asserted after reset");
+    td.check(!axi_bvalid, "axi_bvalid asserted after reset");
+    td.check(!axil_arvalid, "axil_arvalid asserted after reset");
+    td.check(!axi_rvalid, "axi_rvalid asserted after reset");
+  endtask
+
+  task automatic check_helpers_passed();
+    td.check(!axi_manager_failed, "AXI manager driver reported a failure");
+    td.check(!axil_target_driver_failed, "AXI-Lite target driver reported a failure");
+    td.check(!axil_request_monitor_failed, "AXI-Lite request monitor reported a failure");
+    td.check(!response_monitor_failed, "AXI response monitor reported a failure");
+  endtask
+
+  task automatic init_helpers();
+    axi_manager.init_idle();
+    axil_target.init_idle();
+    axil_request_monitor.init_idle();
+    response_monitor.init_idle();
+  endtask
+
+  task automatic start_test_case();
+    init_helpers();
+    td.reset_dut();
+    td.wait_cycles(2);
+    check_reset_outputs();
+  endtask
+
+  task automatic finish_test_case();
+    check_helpers_passed();
+  endtask
+
+  function automatic logic [DataWidth-1:0] get_random_data();
+    logic [DataWidth-1:0] random_data;
+    logic [31:0] random_word;
+
+    random_data = '0;
+    for (int word = 0; word < (DataWidth + 31) / 32; word++) begin
+      random_word = $urandom();
+      for (int bit_idx = 0; bit_idx < 32; bit_idx++) begin
+        if ((word * 32) + bit_idx < DataWidth) begin
+          random_data[(word*32)+bit_idx] = random_word[bit_idx];
+        end
+      end
+    end
+    get_random_data = random_data;
+  endfunction
+
+  function automatic logic [AddrWidth-1:0] get_random_aligned_addr(
+      input logic [AxiBurstSizeWidth-1:0] size);
+    logic [AddrWidth-1:0] align_mask;
+
+    align_mask = {AddrWidth{1'b1}} << size;
+    get_random_aligned_addr = AddrWidth'($urandom()) & align_mask;
+  endfunction
+
+  //----------------------------------------------------------------------------
+  // Test scenarios
+  //----------------------------------------------------------------------------
+
+  task automatic queue_write_burst(
+      input axi_aw_t request, input logic [WUserWidth-1:0] wuser,
+      input logic [BUserWidth-1:0] buser, input logic [AxiRespWidth-1:0] first_resp,
+      input logic [AxiRespWidth-1:0] later_resp, output int unsigned beats);
+    logic [AxiRespWidth-1:0] resp;
+    logic [ StrobeWidth-1:0] strb;
+
+    beats = int'(request.len) + 1;
+    resp  = response_monitor.predict_axi_write_resp(beats, first_resp, later_resp);
+    strb  = StrobeWidth'($urandom()) | StrobeWidth'(1'b1);
+
+    for (int unsigned beat = 0; beat < beats; beat++) begin
+      logic [AxiRespWidth-1:0] beat_resp;
+      logic [AddrWidth-1:0] expected_addr;
+      logic [DataWidth-1:0] data;
+      logic last;
+
+      data = get_random_data();
+      expected_addr = axil_request_monitor.predict_axi2axil_addr(request.addr, request.size,
+                                                                 request.len, request.burst, beat);
+      last = beat == beats - 1;
+      beat_resp = (beat == 0) ? first_resp : later_resp;
+
+      axi_manager.queue_w_beat('{data: AxiDataWidth'(data), strb: AxiStrobeWidth'(strb),
+                               user: AxiUserWidth'(wuser), last: last});
+      axil_request_monitor.aw_queue.push_back('{addr: AxilAddrWidth'(expected_addr),
+                                              prot: request.prot,
+                                              user: AxilUserWidth'(request.user)});
+      axil_request_monitor.w_queue.push_back('{data: AxilDataWidth'(data),
+                                             strb: AxilStrobeWidth'(strb),
+                                             user: AxilUserWidth'(wuser)});
+      axil_target.queue_b_response('{resp: beat_resp, user: AxilUserWidth'(buser)});
+    end
+    response_monitor.b_queue.push_back('{id: AxiIdWidth'(request.id), user: AxiUserWidth'(buser),
+                                       resp: resp});
+  endtask
+
+  task automatic run_write_burst(
+      input axi_aw_t request, input logic [WUserWidth-1:0] wuser,
+      input logic [BUserWidth-1:0] buser, input logic [AxiRespWidth-1:0] first_resp,
+      input logic [AxiRespWidth-1:0] later_resp, input bit stall_outputs);
+    int unsigned beats;
+    int max_stall_cycles;
+
+    queue_write_burst(request, wuser, buser, first_resp, later_resp, beats);
+    max_stall_cycles = stall_outputs ? 2 : 0;
+
+    fork
+      axi_manager.run_write_burst(request, max_stall_cycles, stall_outputs ? 2 : 0);
+      axil_target.run(beats, 0, max_stall_cycles);
+      axil_request_monitor.run(beats, 0);
+      response_monitor.run(1, 0);
+    join
+  endtask
+
+  task automatic queue_read_burst(input axi_ar_t request, input logic [RUserWidth-1:0] ruser,
+                                  input logic [AxiRespWidth-1:0] resp, output int unsigned beats);
+    beats = int'(request.len) + 1;
+    for (int unsigned beat = 0; beat < beats; beat++) begin
+      logic [AddrWidth-1:0] expected_addr;
+      logic [DataWidth-1:0] data;
+      logic last;
+
+      data = get_random_data();
+      expected_addr = axil_request_monitor.predict_axi2axil_addr(request.addr, request.size,
+                                                                 request.len, request.burst, beat);
+      last = beat == beats - 1;
+
+      axil_request_monitor.ar_queue.push_back('{addr: AxilAddrWidth'(expected_addr),
+                                              prot: request.prot,
+                                              user: AxilUserWidth'(request.user)});
+      axil_target.queue_r_response('{data: AxilDataWidth'(data), resp: resp,
+                                   user: AxilUserWidth'(ruser)});
+      response_monitor.r_queue.push_back('{id: AxiIdWidth'(request.id), data: AxiDataWidth'(data),
+                                         resp: resp, user: AxiUserWidth'(ruser), last: last});
+    end
+  endtask
+
+  task automatic run_read_burst(input axi_ar_t request, input logic [RUserWidth-1:0] ruser,
+                                input logic [AxiRespWidth-1:0] resp, input bit stall_outputs);
+    int unsigned beats;
+    int max_stall_cycles;
+
+    queue_read_burst(request, ruser, resp, beats);
+    max_stall_cycles = stall_outputs ? 2 : 0;
+
+    fork
+      axi_manager.run_read_burst_fields(AddrWidth'(request.addr), IdWidth'(request.id), request.len,
+                                        request.size, request.burst, request.prot,
+                                        ARUserWidth'(request.user), max_stall_cycles);
+      axil_target.run(0, beats, max_stall_cycles);
+      axil_request_monitor.run(0, beats);
+      response_monitor.run(0, beats);
+    join
+  endtask
+
+  task automatic run_parallel_read_write(
+      input axi_aw_t write_request, input logic [WUserWidth-1:0] wuser,
+      input logic [BUserWidth-1:0] buser, input logic [AxiRespWidth-1:0] first_write_resp,
+      input logic [AxiRespWidth-1:0] later_write_resp, input axi_ar_t read_request,
+      input logic [RUserWidth-1:0] ruser, input logic [AxiRespWidth-1:0] read_resp,
+      input bit stall_outputs);
+    int unsigned write_beats;
+    int unsigned read_beats;
+    int max_stall_cycles;
+
+    queue_write_burst(write_request, wuser, buser, first_write_resp, later_write_resp, write_beats);
+    queue_read_burst(read_request, ruser, read_resp, read_beats);
+    max_stall_cycles = stall_outputs ? 3 : 0;
+
+    fork
+      axi_manager.run_write_burst(write_request, max_stall_cycles, stall_outputs ? 3 : 0);
+      axi_manager.run_read_burst_fields(AddrWidth'(read_request.addr), IdWidth'(read_request.id),
+                                        read_request.len, read_request.size, read_request.burst,
+                                        read_request.prot, ARUserWidth'(read_request.user),
+                                        max_stall_cycles);
+      axil_target.run(write_beats, read_beats, max_stall_cycles);
+      axil_request_monitor.run(write_beats, read_beats);
+      response_monitor.run(1, read_beats);
+    join
+  endtask
+
+  task automatic run_parallel_traffic(
+      input int unsigned num_transactions, input int awvalid_max_stall_cycles,
+      input int wvalid_max_stall_cycles, input int bready_max_stall_cycles,
+      input int arvalid_max_stall_cycles, input int rready_max_stall_cycles,
+      input int axil_awready_max_stall_cycles, input int axil_wready_max_stall_cycles,
+      input int axil_bvalid_max_stall_cycles, input int axil_arready_max_stall_cycles,
+      input int axil_rvalid_max_stall_cycles);
+    axi_aw_t write_requests[$];
+    axi_ar_t read_requests[$];
+    int unsigned total_write_beats;
+    int unsigned total_read_beats;
+
+    total_write_beats = 0;
+    total_read_beats  = 0;
+
+    for (int unsigned transaction = 0; transaction < num_transactions; transaction++) begin
+      axi_aw_t write_request;
+      axi_ar_t read_request;
+      int unsigned write_beats;
+      int unsigned read_beats;
+
+      write_beats = $urandom_range(1, MaxDirectedBeats);
+      read_beats = $urandom_range(1, MaxDirectedBeats);
+
+      write_request = '0;
+      write_request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+      write_request.id = IdWidth'($urandom());
+      write_request.len = AxiBurstLenWidth'(write_beats - 1);
+      write_request.size = AxiBurstSizeWidth'(AxiSize);
+      write_request.burst = transaction[0] ? AxiBurstFixed : AxiBurstIncr;
+      write_request.prot = AxiProtWidth'($urandom());
+      write_request.user = AWUserWidth'($urandom());
+
+      read_request = '0;
+      read_request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+      read_request.id = IdWidth'($urandom());
+      read_request.len = AxiBurstLenWidth'(read_beats - 1);
+      read_request.size = AxiBurstSizeWidth'(AxiSize);
+      read_request.burst = transaction[0] ? AxiBurstIncr : AxiBurstFixed;
+      read_request.prot = AxiProtWidth'($urandom());
+      read_request.user = ARUserWidth'($urandom());
+
+      write_requests.push_back(write_request);
+      read_requests.push_back(read_request);
+      queue_write_burst(write_request, WUserWidth'($urandom()), BUserWidth'($urandom()),
+                        AxiRespOkay, transaction[0] ? AxiRespSlverr : AxiRespOkay, write_beats);
+      queue_read_burst(read_request, RUserWidth'($urandom()), AxiRespOkay, read_beats);
+      total_write_beats += write_beats;
+      total_read_beats += read_beats;
+    end
+
+    fork
+      begin
+        while (write_requests.size() > 0) begin
+          axi_manager.wait_cycles(get_random_stall_cycles(awvalid_max_stall_cycles));
+          axi_manager.drive_aw(write_requests.pop_front());
+        end
+      end
+      begin
+        for (int unsigned beat = 0; beat < total_write_beats; beat++) begin
+          axi_manager.drive_queued_w(get_random_stall_cycles(wvalid_max_stall_cycles));
+        end
+      end
+      begin
+        for (int unsigned response = 0; response < num_transactions; response++) begin
+          axi_manager.accept_target_b(get_random_stall_cycles(bready_max_stall_cycles));
+        end
+      end
+      begin
+        while (read_requests.size() > 0) begin
+          axi_manager.wait_cycles(get_random_stall_cycles(arvalid_max_stall_cycles));
+          axi_manager.drive_ar(read_requests.pop_front());
+        end
+      end
+      begin
+        for (int unsigned beat = 0; beat < total_read_beats; beat++) begin
+          axi_manager.accept_target_r(get_random_stall_cycles(rready_max_stall_cycles));
+        end
+      end
+      axil_target.run(total_write_beats, total_read_beats, 0, axil_awready_max_stall_cycles,
+                      axil_wready_max_stall_cycles, axil_bvalid_max_stall_cycles,
+                      axil_arready_max_stall_cycles, axil_rvalid_max_stall_cycles);
+      axil_request_monitor.run(total_write_beats, total_read_beats);
+      response_monitor.run(num_transactions, total_read_beats);
+    join
+  endtask
+
+  task automatic run_parallel_stress(input int unsigned num_transactions);
+    run_parallel_traffic(num_transactions, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  endtask
+
+  task automatic run_parallel_backpressure(
+      input int unsigned num_transactions, input int awvalid_max_stall_cycles,
+      input int wvalid_max_stall_cycles, input int bready_max_stall_cycles,
+      input int arvalid_max_stall_cycles, input int rready_max_stall_cycles,
+      input int axil_awready_max_stall_cycles, input int axil_wready_max_stall_cycles,
+      input int axil_bvalid_max_stall_cycles, input int axil_arready_max_stall_cycles,
+      input int axil_rvalid_max_stall_cycles);
+    run_parallel_traffic(num_transactions, awvalid_max_stall_cycles, wvalid_max_stall_cycles,
+                         bready_max_stall_cycles, arvalid_max_stall_cycles, rready_max_stall_cycles,
+                         axil_awready_max_stall_cycles, axil_wready_max_stall_cycles,
+                         axil_bvalid_max_stall_cycles, axil_arready_max_stall_cycles,
+                         axil_rvalid_max_stall_cycles);
+  endtask
+
+  task automatic test_single_beat_write();
+    axi_aw_t request;
+
+    // Single-beat incrementing burst covers the AXI4 request degenerate case that maps to one
+    // AXI-Lite AW/W/B transaction without multi-beat response propagation.
+    $display("Checking single-beat write conversion");
+    start_test_case();
+    request = '0;
+    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    request.id = IdWidth'($urandom());
+    request.len = '0;
+    request.size = AxiBurstSizeWidth'(AxiSize);
+    request.burst = AxiBurstIncr;
+    request.prot = AxiProtWidth'($urandom());
+    request.user = AWUserWidth'($urandom());
+    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespOkay,
+                    AxiRespOkay, 1'b0);
+    finish_test_case();
+  endtask
+
+  task automatic test_incr_write_response_propagation();
+    axi_aw_t request;
+
+    // Multi-beat incrementing burst checks address stepping, one AXI-Lite write per AXI beat, and
+    // propagation of a later SLVERR into the single AXI4 write response.
+    $display("Checking incrementing write burst with response propagation");
+    start_test_case();
+    request = '0;
+    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    request.id = IdWidth'($urandom());
+    request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
+    request.size = AxiBurstSizeWidth'(AxiSize);
+    request.burst = AxiBurstIncr;
+    request.prot = AxiProtWidth'($urandom());
+    request.user = AWUserWidth'($urandom());
+    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespOkay,
+                    AxiRespSlverr, 1'b1);
+    finish_test_case();
+  endtask
+
+  task automatic test_fixed_write();
+    axi_aw_t request;
+
+    // Fixed burst verifies that every generated AXI-Lite write uses the original address, and that
+    // the first non-OKAY response wins even when following beats return OKAY.
+    $display("Checking fixed write burst");
+    start_test_case();
+    request = '0;
+    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    request.id = IdWidth'($urandom());
+    request.len = AxiBurstLenWidth'(3 - 1);
+    request.size = AxiBurstSizeWidth'(AxiSize);
+    request.burst = AxiBurstFixed;
+    request.prot = AxiProtWidth'($urandom());
+    request.user = AWUserWidth'($urandom());
+    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespDecerr,
+                    AxiRespOkay, 1'b0);
+    finish_test_case();
+  endtask
+
+  task automatic test_first_write_slverr_response_propagation();
+    axi_aw_t request;
+
+    // A first-beat SLVERR must be propagated as the single AXI4 write response, even if the
+    // remaining AXI-Lite write beats complete with OKAY.
+    $display("Checking first-beat SLVERR write response propagation");
+    start_test_case();
+    request = '0;
+    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    request.id = IdWidth'($urandom());
+    request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
+    request.size = AxiBurstSizeWidth'(AxiSize);
+    request.burst = AxiBurstIncr;
+    request.prot = AxiProtWidth'($urandom());
+    request.user = AWUserWidth'($urandom());
+    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespSlverr,
+                    AxiRespOkay, 1'b1);
+    finish_test_case();
+  endtask
+
+  task automatic test_later_write_decerr_response_propagation();
+    axi_aw_t request;
+
+    // A later-beat DECERR must be captured after initial OKAY beats and returned on the single
+    // AXI4 B response.
+    $display("Checking later-beat DECERR write response propagation");
+    start_test_case();
+    request = '0;
+    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    request.id = IdWidth'($urandom());
+    request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
+    request.size = AxiBurstSizeWidth'(AxiSize);
+    request.burst = AxiBurstIncr;
+    request.prot = AxiProtWidth'($urandom());
+    request.user = AWUserWidth'($urandom());
+    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespOkay,
+                    AxiRespDecerr, 1'b1);
+    finish_test_case();
+  endtask
+
+  task automatic test_wrapping_read();
+    axi_ar_t request;
+
+    // Wrapping read burst validates wrap-boundary address generation while response-side stalls
+    // exercise R channel ordering, payload, and RLAST checks.
+    $display("Checking wrapping read burst");
+    start_test_case();
+    request = '0;
+    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    request.id = IdWidth'($urandom());
+    request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
+    request.size = AxiBurstSizeWidth'(AxiSize);
+    request.burst = AxiBurstWrap;
+    request.prot = AxiProtWidth'($urandom());
+    request.user = ARUserWidth'($urandom());
+    run_read_burst(request, RUserWidth'($urandom()), AxiRespOkay, 1'b1);
+    finish_test_case();
+  endtask
+
+  task automatic test_fixed_read();
+    axi_ar_t request;
+
+    // Fixed read burst checks repeated AXI-Lite AR addresses and propagation of a non-OKAY read
+    // response on every returned AXI4 read beat.
+    $display("Checking fixed read burst");
+    start_test_case();
+    request = '0;
+    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    request.id = IdWidth'($urandom());
+    request.len = AxiBurstLenWidth'(3 - 1);
+    request.size = AxiBurstSizeWidth'(AxiSize);
+    request.burst = AxiBurstFixed;
+    request.prot = AxiProtWidth'($urandom());
+    request.user = ARUserWidth'($urandom());
+    run_read_burst(request, RUserWidth'($urandom()), AxiRespSlverr, 1'b0);
+    finish_test_case();
+  endtask
+
+  task automatic test_decerr_read();
+    axi_ar_t request;
+
+    // DECERR on the AXI-Lite R channel must propagate unchanged to every AXI4 read beat while
+    // preserving the read data, ID, user, and RLAST sequence.
+    $display("Checking DECERR read response propagation");
+    start_test_case();
+    request = '0;
+    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    request.id = IdWidth'($urandom());
+    request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
+    request.size = AxiBurstSizeWidth'(AxiSize);
+    request.burst = AxiBurstIncr;
+    request.prot = AxiProtWidth'($urandom());
+    request.user = ARUserWidth'($urandom());
+    run_read_burst(request, RUserWidth'($urandom()), AxiRespDecerr, 1'b1);
+    finish_test_case();
+  endtask
+
+  task automatic test_parallel_read_write();
+    axi_aw_t write_request;
+    axi_ar_t read_request;
+
+    // AXI read and write address/data/response channels are independent. This case launches one
+    // write burst and one read burst together to check that neither path blocks the other.
+    $display("Checking parallel read/write burst conversion");
+    start_test_case();
+    write_request = '0;
+    write_request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    write_request.id = IdWidth'($urandom());
+    write_request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
+    write_request.size = AxiBurstSizeWidth'(AxiSize);
+    write_request.burst = AxiBurstIncr;
+    write_request.prot = AxiProtWidth'($urandom());
+    write_request.user = AWUserWidth'($urandom());
+
+    read_request = '0;
+    read_request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+    read_request.id = IdWidth'($urandom());
+    read_request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
+    read_request.size = AxiBurstSizeWidth'(AxiSize);
+    read_request.burst = AxiBurstIncr;
+    read_request.prot = AxiProtWidth'($urandom());
+    read_request.user = ARUserWidth'($urandom());
+
+    run_parallel_read_write(write_request, WUserWidth'($urandom()), BUserWidth'($urandom()),
+                            AxiRespOkay, AxiRespOkay, read_request, RUserWidth'($urandom()),
+                            AxiRespOkay, 1'b0);
+    finish_test_case();
+  endtask
+
+  task automatic test_parallel_stress();
+    // High-throughput stress keeps all read and write channels active with no intentional stalls.
+    // This pushes the interfaces toward one transfer per cycle over many randomized bursts.
+    $display("Checking no-stall parallel read/write stress");
+    start_test_case();
+    run_parallel_stress(NumStressTransactions);
+    finish_test_case();
+  endtask
+
+  task automatic test_axil_request_backpressure();
+    // AXI-Lite target request backpressure independently stalls AWREADY, WREADY, and ARREADY while
+    // the AXI manager continues issuing read/write bursts.
+    $display("Checking AXI-Lite request-channel backpressure");
+    start_test_case();
+    run_parallel_backpressure(NumBackpressureTransactions, 0, 0, 0, 0, 0,
+                              MaxBackpressureStallCycles, MaxBackpressureStallCycles, 0,
+                              MaxBackpressureStallCycles, 0);
+    finish_test_case();
+  endtask
+
+  task automatic test_axil_response_backpressure();
+    // AXI-Lite target response backpressure delays B and R responses after accepting requests,
+    // which exercises the bridge response trackers while requests keep flowing.
+    $display("Checking AXI-Lite response-channel backpressure");
+    start_test_case();
+    run_parallel_backpressure(NumBackpressureTransactions, 0, 0, 0, 0, 0, 0, 0,
+                              MaxBackpressureStallCycles, 0, MaxBackpressureStallCycles);
+    finish_test_case();
+  endtask
+
+  task automatic test_axi_response_backpressure();
+    // AXI response backpressure stalls BREADY and RREADY. The read side issues the maximum allowed
+    // number of outstanding transactions for this parameterization.
+    $display("Checking AXI response-channel backpressure");
+    start_test_case();
+    run_parallel_backpressure(NumBackpressureTransactions, 0, 0, MaxBackpressureStallCycles, 0,
+                              MaxBackpressureStallCycles, 0, 0, 0, 0, 0);
+    finish_test_case();
+  endtask
+
+  task automatic test_axi_source_channel_stalls();
+    // Source-side stalls pause AXI AW, W, and AR issuance independently. This complements target
+    // backpressure by checking that the bridge accepts the channels whenever they resume.
+    $display("Checking AXI source-channel stalls");
+    start_test_case();
+    run_parallel_backpressure(NumBackpressureTransactions, MaxBackpressureStallCycles,
+                              MaxBackpressureStallCycles, 0, MaxBackpressureStallCycles, 0, 0, 0, 0,
+                              0, 0);
+    finish_test_case();
+  endtask
+
+  task automatic test_random_transaction(input int unsigned transaction);
+    bit is_write;
+    int unsigned beats;
+
+    is_write = $urandom_range(0, 1);
+    beats = $urandom_range(1, MaxDirectedBeats);
+    start_test_case();
+    if (is_write) begin
+      axi_aw_t request;
+
+      request = '0;
+      request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+      request.id = IdWidth'($urandom());
+      request.len = AxiBurstLenWidth'(beats - 1);
+      request.size = AxiBurstSizeWidth'(AxiSize);
+      request.burst = AxiBurstIncr;
+      request.prot = AxiProtWidth'($urandom());
+      request.user = AWUserWidth'($urandom());
+      run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespOkay,
+                      AxiRespOkay, transaction[0]);
+    end else begin
+      axi_ar_t request;
+
+      request = '0;
+      request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
+      request.id = IdWidth'($urandom());
+      request.len = AxiBurstLenWidth'(beats - 1);
+      request.size = AxiBurstSizeWidth'(AxiSize);
+      request.burst = AxiBurstIncr;
+      request.prot = AxiProtWidth'($urandom());
+      request.user = ARUserWidth'($urandom());
+      run_read_burst(request, RUserWidth'($urandom()), AxiRespOkay, transaction[0]);
+    end
+    finish_test_case();
+  endtask
+
+  task automatic test_random_smoke();
+    // Bounded pseudo-random traffic mixes read/write direction, burst length, users, IDs, data, and
+    // optional stalls while keeping addresses aligned for legal full-width transfers.
+    for (int unsigned transaction = 0; transaction < NumRandomTransactions; transaction++) begin
+      test_random_transaction(transaction);
+    end
+  endtask
+
+  initial begin
+    test_single_beat_write();
+    test_incr_write_response_propagation();
+    test_fixed_write();
+    test_first_write_slverr_response_propagation();
+    test_later_write_decerr_response_propagation();
+    test_wrapping_read();
+    test_fixed_read();
+    test_decerr_read();
+    test_parallel_read_write();
+    test_parallel_stress();
+    test_axil_request_backpressure();
+    test_axil_response_backpressure();
+    test_axi_response_backpressure();
+    test_axi_source_channel_stalls();
+    test_random_smoke();
+
+    td.wait_cycles(10);
+    td.finish();
+  end
+
+endmodule : br_amba_axi2axil_tb

--- a/amba/sim/br_amba_axi2axil_tb.sv
+++ b/amba/sim/br_amba_axi2axil_tb.sv
@@ -15,22 +15,13 @@ import br_amba_sim_pkg::*;
 // - verifies write data passthrough, read data passthrough, response user fields, IDs, and RLAST;
 // - checks AXI4 write response propagation returns the first non-OKAY beat response;
 // - separates no-stall stress traffic from directed backpressure scenarios;
-// - sweeps DataWidth, MaxOutstandingReqs, and NumRandomTransactions from Bazel.
+// - sweeps br_amba_axi_sim_pkg widths, MaxOutstandingReqs, and NumRandomTransactions from Bazel.
 module br_amba_axi2axil_tb;
-  parameter int DataWidth = 32;
   parameter int MaxOutstandingReqs = 4;
   parameter int NumRandomTransactions = 1;
 
   localparam int TimeoutCycles = 100;
-  localparam int AddrWidth = 12;
-  localparam int IdWidth = 3;
-  localparam int AWUserWidth = 2;
-  localparam int ARUserWidth = 2;
-  localparam int WUserWidth = 2;
-  localparam int BUserWidth = 2;
-  localparam int RUserWidth = 2;
-  localparam int StrobeWidth = DataWidth / 8;
-  localparam int AxiSize = $clog2(StrobeWidth);
+  localparam int AxiSize = $clog2(AxiStrobeWidth);
   localparam int MaxDirectedBeats = 4;
   localparam int NumStressTransactions = 100;
   localparam int NumBackpressureTransactions = MaxOutstandingReqs;
@@ -40,66 +31,66 @@ module br_amba_axi2axil_tb;
   logic rst;
 
   // AXI4 manager-side signals.
-  logic [AddrWidth-1:0] axi_awaddr;
-  logic [IdWidth-1:0] axi_awid;
+  logic [AxiAddrWidth-1:0] axi_awaddr;
+  logic [AxiIdWidth-1:0] axi_awid;
   logic [AxiBurstLenWidth-1:0] axi_awlen;
   logic [AxiBurstSizeWidth-1:0] axi_awsize;
   logic [AxiBurstTypeWidth-1:0] axi_awburst;
   logic [AxiProtWidth-1:0] axi_awprot;
-  logic [AWUserWidth-1:0] axi_awuser;
+  logic [AxiUserWidth-1:0] axi_awuser;
   logic axi_awvalid;
   logic axi_awready;
-  logic [DataWidth-1:0] axi_wdata;
-  logic [StrobeWidth-1:0] axi_wstrb;
-  logic [WUserWidth-1:0] axi_wuser;
+  logic [AxiDataWidth-1:0] axi_wdata;
+  logic [AxiStrobeWidth-1:0] axi_wstrb;
+  logic [AxiUserWidth-1:0] axi_wuser;
   logic axi_wlast;
   logic axi_wvalid;
   logic axi_wready;
-  logic [IdWidth-1:0] axi_bid;
-  logic [BUserWidth-1:0] axi_buser;
+  logic [AxiIdWidth-1:0] axi_bid;
+  logic [AxiUserWidth-1:0] axi_buser;
   logic [AxiRespWidth-1:0] axi_bresp;
   logic axi_bvalid;
   logic axi_bready;
-  logic [AddrWidth-1:0] axi_araddr;
-  logic [IdWidth-1:0] axi_arid;
+  logic [AxiAddrWidth-1:0] axi_araddr;
+  logic [AxiIdWidth-1:0] axi_arid;
   logic [AxiBurstLenWidth-1:0] axi_arlen;
   logic [AxiBurstSizeWidth-1:0] axi_arsize;
   logic [AxiBurstTypeWidth-1:0] axi_arburst;
   logic [AxiProtWidth-1:0] axi_arprot;
-  logic [ARUserWidth-1:0] axi_aruser;
+  logic [AxiUserWidth-1:0] axi_aruser;
   logic axi_arvalid;
   logic axi_arready;
-  logic [IdWidth-1:0] axi_rid;
-  logic [DataWidth-1:0] axi_rdata;
-  logic [RUserWidth-1:0] axi_ruser;
+  logic [AxiIdWidth-1:0] axi_rid;
+  logic [AxiDataWidth-1:0] axi_rdata;
+  logic [AxiUserWidth-1:0] axi_ruser;
   logic [AxiRespWidth-1:0] axi_rresp;
   logic axi_rlast;
   logic axi_rvalid;
   logic axi_rready;
 
   // AXI4-Lite target-side signals.
-  logic [AddrWidth-1:0] axil_awaddr;
+  logic [AxiAddrWidth-1:0] axil_awaddr;
   logic [AxiProtWidth-1:0] axil_awprot;
-  logic [AWUserWidth-1:0] axil_awuser;
+  logic [AxiUserWidth-1:0] axil_awuser;
   logic axil_awvalid;
   logic axil_awready;
-  logic [DataWidth-1:0] axil_wdata;
-  logic [StrobeWidth-1:0] axil_wstrb;
-  logic [WUserWidth-1:0] axil_wuser;
+  logic [AxiDataWidth-1:0] axil_wdata;
+  logic [AxiStrobeWidth-1:0] axil_wstrb;
+  logic [AxiUserWidth-1:0] axil_wuser;
   logic axil_wvalid;
   logic axil_wready;
   logic [AxiRespWidth-1:0] axil_bresp;
-  logic [BUserWidth-1:0] axil_buser;
+  logic [AxiUserWidth-1:0] axil_buser;
   logic axil_bvalid;
   logic axil_bready;
-  logic [AddrWidth-1:0] axil_araddr;
+  logic [AxiAddrWidth-1:0] axil_araddr;
   logic [AxiProtWidth-1:0] axil_arprot;
-  logic [ARUserWidth-1:0] axil_aruser;
+  logic [AxiUserWidth-1:0] axil_aruser;
   logic axil_arvalid;
   logic axil_arready;
-  logic [DataWidth-1:0] axil_rdata;
+  logic [AxiDataWidth-1:0] axil_rdata;
   logic [AxiRespWidth-1:0] axil_rresp;
-  logic [RUserWidth-1:0] axil_ruser;
+  logic [AxiUserWidth-1:0] axil_ruser;
   logic axil_rvalid;
   logic axil_rready;
 
@@ -109,14 +100,14 @@ module br_amba_axi2axil_tb;
   logic response_monitor_failed;
 
   br_amba_axi2axil #(
-      .AddrWidth(AddrWidth),
-      .DataWidth(DataWidth),
-      .IdWidth(IdWidth),
-      .AWUserWidth(AWUserWidth),
-      .ARUserWidth(ARUserWidth),
-      .WUserWidth(WUserWidth),
-      .BUserWidth(BUserWidth),
-      .RUserWidth(RUserWidth),
+      .AddrWidth(AxiAddrWidth),
+      .DataWidth(AxiDataWidth),
+      .IdWidth(AxiIdWidth),
+      .AWUserWidth(AxiUserWidth),
+      .ARUserWidth(AxiUserWidth),
+      .WUserWidth(AxiUserWidth),
+      .BUserWidth(AxiUserWidth),
+      .RUserWidth(AxiUserWidth),
       .MaxOutstandingReqs(MaxOutstandingReqs)
   ) dut (
       .clk(clk),
@@ -191,12 +182,6 @@ module br_amba_axi2axil_tb;
   );
 
   br_amba_axi_target_driver #(
-      .AddrWidth(AddrWidth),
-      .DataWidth(DataWidth),
-      .IdWidth(IdWidth),
-      .AWUserWidth(AWUserWidth),
-      .WUserWidth(WUserWidth),
-      .ARUserWidth(ARUserWidth),
       .TimeoutCycles(TimeoutCycles)
   ) axi_manager (
       .clk(clk),
@@ -233,9 +218,9 @@ module br_amba_axi2axil_tb;
   );
 
   br_amba_axil_target_driver #(
-      .DataWidth(DataWidth),
-      .BUserWidth(BUserWidth),
-      .RUserWidth(RUserWidth),
+      .DataWidth(AxiDataWidth),
+      .BUserWidth(AxiUserWidth),
+      .RUserWidth(AxiUserWidth),
       .TimeoutCycles(TimeoutCycles)
   ) axil_target (
       .clk(clk),
@@ -259,11 +244,11 @@ module br_amba_axi2axil_tb;
   );
 
   br_amba_axil_request_monitor #(
-      .AddrWidth(AddrWidth),
-      .DataWidth(DataWidth),
-      .AWUserWidth(AWUserWidth),
-      .WUserWidth(WUserWidth),
-      .ARUserWidth(ARUserWidth),
+      .AddrWidth(AxiAddrWidth),
+      .DataWidth(AxiDataWidth),
+      .AWUserWidth(AxiUserWidth),
+      .WUserWidth(AxiUserWidth),
+      .ARUserWidth(AxiUserWidth),
       .TimeoutCycles(TimeoutCycles)
   ) axil_request_monitor (
       .clk(clk),
@@ -287,10 +272,10 @@ module br_amba_axi2axil_tb;
   );
 
   br_amba_axi_response_monitor #(
-      .DataWidth(DataWidth),
-      .IdWidth(IdWidth),
-      .BUserWidth(BUserWidth),
-      .RUserWidth(RUserWidth),
+      .DataWidth(AxiDataWidth),
+      .IdWidth(AxiIdWidth),
+      .BUserWidth(AxiUserWidth),
+      .RUserWidth(AxiUserWidth),
       .TimeoutCycles(TimeoutCycles)
   ) response_monitor (
       .clk(clk),
@@ -347,15 +332,15 @@ module br_amba_axi2axil_tb;
     check_helpers_passed();
   endtask
 
-  function automatic logic [DataWidth-1:0] get_random_data();
-    logic [DataWidth-1:0] random_data;
+  function automatic logic [AxiDataWidth-1:0] get_random_data();
+    logic [AxiDataWidth-1:0] random_data;
     logic [31:0] random_word;
 
     random_data = '0;
-    for (int word = 0; word < (DataWidth + 31) / 32; word++) begin
+    for (int word = 0; word < (AxiDataWidth + 31) / 32; word++) begin
       random_word = $urandom();
       for (int bit_idx = 0; bit_idx < 32; bit_idx++) begin
-        if ((word * 32) + bit_idx < DataWidth) begin
+        if ((word * 32) + bit_idx < AxiDataWidth) begin
           random_data[(word*32)+bit_idx] = random_word[bit_idx];
         end
       end
@@ -363,12 +348,12 @@ module br_amba_axi2axil_tb;
     get_random_data = random_data;
   endfunction
 
-  function automatic logic [AddrWidth-1:0] get_random_aligned_addr(
+  function automatic logic [AxiAddrWidth-1:0] get_random_aligned_addr(
       input logic [AxiBurstSizeWidth-1:0] size);
-    logic [AddrWidth-1:0] align_mask;
+    logic [AxiAddrWidth-1:0] align_mask;
 
-    align_mask = {AddrWidth{1'b1}} << size;
-    get_random_aligned_addr = AddrWidth'($urandom()) & align_mask;
+    align_mask = {AxiAddrWidth{1'b1}} << size;
+    get_random_aligned_addr = AxiAddrWidth'($urandom()) & align_mask;
   endfunction
 
   //----------------------------------------------------------------------------
@@ -376,20 +361,20 @@ module br_amba_axi2axil_tb;
   //----------------------------------------------------------------------------
 
   task automatic queue_write_burst(
-      input axi_aw_t request, input logic [WUserWidth-1:0] wuser,
-      input logic [BUserWidth-1:0] buser, input logic [AxiRespWidth-1:0] first_resp,
+      input axi_aw_t request, input logic [AxiUserWidth-1:0] wuser,
+      input logic [AxiUserWidth-1:0] buser, input logic [AxiRespWidth-1:0] first_resp,
       input logic [AxiRespWidth-1:0] later_resp, output int unsigned beats);
-    logic [AxiRespWidth-1:0] resp;
-    logic [ StrobeWidth-1:0] strb;
+    logic [  AxiRespWidth-1:0] resp;
+    logic [AxiStrobeWidth-1:0] strb;
 
     beats = int'(request.len) + 1;
     resp  = response_monitor.predict_axi_write_resp(beats, first_resp, later_resp);
-    strb  = StrobeWidth'($urandom()) | StrobeWidth'(1'b1);
+    strb  = AxiStrobeWidth'($urandom()) | AxiStrobeWidth'(1'b1);
 
     for (int unsigned beat = 0; beat < beats; beat++) begin
       logic [AxiRespWidth-1:0] beat_resp;
-      logic [AddrWidth-1:0] expected_addr;
-      logic [DataWidth-1:0] data;
+      logic [AxiAddrWidth-1:0] expected_addr;
+      logic [AxiDataWidth-1:0] data;
       logic last;
 
       data = get_random_data();
@@ -398,8 +383,8 @@ module br_amba_axi2axil_tb;
       last = beat == beats - 1;
       beat_resp = (beat == 0) ? first_resp : later_resp;
 
-      axi_manager.queue_w_beat('{data: AxiDataWidth'(data), strb: AxiStrobeWidth'(strb),
-                               user: AxiUserWidth'(wuser), last: last});
+      axi_manager.queue_w_beat_fields(AxiDataWidth'(data), AxiStrobeWidth'(strb),
+                                      AxiUserWidth'(wuser), last);
       axil_request_monitor.aw_queue.push_back('{addr: AxilAddrWidth'(expected_addr),
                                               prot: request.prot,
                                               user: AxilUserWidth'(request.user)});
@@ -413,8 +398,8 @@ module br_amba_axi2axil_tb;
   endtask
 
   task automatic run_write_burst(
-      input axi_aw_t request, input logic [WUserWidth-1:0] wuser,
-      input logic [BUserWidth-1:0] buser, input logic [AxiRespWidth-1:0] first_resp,
+      input axi_aw_t request, input logic [AxiUserWidth-1:0] wuser,
+      input logic [AxiUserWidth-1:0] buser, input logic [AxiRespWidth-1:0] first_resp,
       input logic [AxiRespWidth-1:0] later_resp, input bit stall_outputs);
     int unsigned beats;
     int max_stall_cycles;
@@ -423,19 +408,21 @@ module br_amba_axi2axil_tb;
     max_stall_cycles = stall_outputs ? 2 : 0;
 
     fork
-      axi_manager.run_write_burst(request, max_stall_cycles, stall_outputs ? 2 : 0);
+      axi_manager.run_write_burst_fields(request.addr, request.id, request.len, request.size,
+                                         request.burst, request.prot, request.user,
+                                         max_stall_cycles, stall_outputs ? 2 : 0);
       axil_target.run(beats, 0, max_stall_cycles);
       axil_request_monitor.run(beats, 0);
       response_monitor.run(1, 0);
     join
   endtask
 
-  task automatic queue_read_burst(input axi_ar_t request, input logic [RUserWidth-1:0] ruser,
+  task automatic queue_read_burst(input axi_ar_t request, input logic [AxiUserWidth-1:0] ruser,
                                   input logic [AxiRespWidth-1:0] resp, output int unsigned beats);
     beats = int'(request.len) + 1;
     for (int unsigned beat = 0; beat < beats; beat++) begin
-      logic [AddrWidth-1:0] expected_addr;
-      logic [DataWidth-1:0] data;
+      logic [AxiAddrWidth-1:0] expected_addr;
+      logic [AxiDataWidth-1:0] data;
       logic last;
 
       data = get_random_data();
@@ -453,7 +440,7 @@ module br_amba_axi2axil_tb;
     end
   endtask
 
-  task automatic run_read_burst(input axi_ar_t request, input logic [RUserWidth-1:0] ruser,
+  task automatic run_read_burst(input axi_ar_t request, input logic [AxiUserWidth-1:0] ruser,
                                 input logic [AxiRespWidth-1:0] resp, input bit stall_outputs);
     int unsigned beats;
     int max_stall_cycles;
@@ -462,9 +449,9 @@ module br_amba_axi2axil_tb;
     max_stall_cycles = stall_outputs ? 2 : 0;
 
     fork
-      axi_manager.run_read_burst_fields(AddrWidth'(request.addr), IdWidth'(request.id), request.len,
-                                        request.size, request.burst, request.prot,
-                                        ARUserWidth'(request.user), max_stall_cycles);
+      axi_manager.run_read_burst_fields(request.addr, request.id, request.len, request.size,
+                                        request.burst, request.prot, request.user,
+                                        max_stall_cycles);
       axil_target.run(0, beats, max_stall_cycles);
       axil_request_monitor.run(0, beats);
       response_monitor.run(0, beats);
@@ -472,10 +459,10 @@ module br_amba_axi2axil_tb;
   endtask
 
   task automatic run_parallel_read_write(
-      input axi_aw_t write_request, input logic [WUserWidth-1:0] wuser,
-      input logic [BUserWidth-1:0] buser, input logic [AxiRespWidth-1:0] first_write_resp,
+      input axi_aw_t write_request, input logic [AxiUserWidth-1:0] wuser,
+      input logic [AxiUserWidth-1:0] buser, input logic [AxiRespWidth-1:0] first_write_resp,
       input logic [AxiRespWidth-1:0] later_write_resp, input axi_ar_t read_request,
-      input logic [RUserWidth-1:0] ruser, input logic [AxiRespWidth-1:0] read_resp,
+      input logic [AxiUserWidth-1:0] ruser, input logic [AxiRespWidth-1:0] read_resp,
       input bit stall_outputs);
     int unsigned write_beats;
     int unsigned read_beats;
@@ -486,11 +473,13 @@ module br_amba_axi2axil_tb;
     max_stall_cycles = stall_outputs ? 3 : 0;
 
     fork
-      axi_manager.run_write_burst(write_request, max_stall_cycles, stall_outputs ? 3 : 0);
-      axi_manager.run_read_burst_fields(AddrWidth'(read_request.addr), IdWidth'(read_request.id),
-                                        read_request.len, read_request.size, read_request.burst,
-                                        read_request.prot, ARUserWidth'(read_request.user),
-                                        max_stall_cycles);
+      axi_manager.run_write_burst_fields(write_request.addr, write_request.id, write_request.len,
+                                         write_request.size, write_request.burst,
+                                         write_request.prot, write_request.user, max_stall_cycles,
+                                         stall_outputs ? 3 : 0);
+      axi_manager.run_read_burst_fields(read_request.addr, read_request.id, read_request.len,
+                                        read_request.size, read_request.burst, read_request.prot,
+                                        read_request.user, max_stall_cycles);
       axil_target.run(write_beats, read_beats, max_stall_cycles);
       axil_request_monitor.run(write_beats, read_beats);
       response_monitor.run(1, read_beats);
@@ -522,37 +511,42 @@ module br_amba_axi2axil_tb;
       read_beats = $urandom_range(1, MaxDirectedBeats);
 
       write_request = '0;
-      write_request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-      write_request.id = IdWidth'($urandom());
+      write_request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+      write_request.id = AxiIdWidth'($urandom());
       write_request.len = AxiBurstLenWidth'(write_beats - 1);
       write_request.size = AxiBurstSizeWidth'(AxiSize);
       write_request.burst = transaction[0] ? AxiBurstFixed : AxiBurstIncr;
       write_request.prot = AxiProtWidth'($urandom());
-      write_request.user = AWUserWidth'($urandom());
+      write_request.user = AxiUserWidth'($urandom());
 
       read_request = '0;
-      read_request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-      read_request.id = IdWidth'($urandom());
+      read_request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+      read_request.id = AxiIdWidth'($urandom());
       read_request.len = AxiBurstLenWidth'(read_beats - 1);
       read_request.size = AxiBurstSizeWidth'(AxiSize);
       read_request.burst = transaction[0] ? AxiBurstIncr : AxiBurstFixed;
       read_request.prot = AxiProtWidth'($urandom());
-      read_request.user = ARUserWidth'($urandom());
+      read_request.user = AxiUserWidth'($urandom());
 
       write_requests.push_back(write_request);
       read_requests.push_back(read_request);
-      queue_write_burst(write_request, WUserWidth'($urandom()), BUserWidth'($urandom()),
+      queue_write_burst(write_request, AxiUserWidth'($urandom()), AxiUserWidth'($urandom()),
                         AxiRespOkay, transaction[0] ? AxiRespSlverr : AxiRespOkay, write_beats);
-      queue_read_burst(read_request, RUserWidth'($urandom()), AxiRespOkay, read_beats);
+      queue_read_burst(read_request, AxiUserWidth'($urandom()), AxiRespOkay, read_beats);
       total_write_beats += write_beats;
       total_read_beats += read_beats;
     end
 
     fork
       begin
+        axi_aw_t write_request;
+
         while (write_requests.size() > 0) begin
           axi_manager.wait_cycles(get_random_stall_cycles(awvalid_max_stall_cycles));
-          axi_manager.drive_aw(write_requests.pop_front());
+          write_request = write_requests.pop_front();
+          axi_manager.drive_aw_fields(write_request.addr, write_request.id, write_request.len,
+                                      write_request.size, write_request.burst, write_request.prot,
+                                      write_request.user);
         end
       end
       begin
@@ -566,9 +560,14 @@ module br_amba_axi2axil_tb;
         end
       end
       begin
+        axi_ar_t read_request;
+
         while (read_requests.size() > 0) begin
           axi_manager.wait_cycles(get_random_stall_cycles(arvalid_max_stall_cycles));
-          axi_manager.drive_ar(read_requests.pop_front());
+          read_request = read_requests.pop_front();
+          axi_manager.drive_ar_fields(read_request.addr, read_request.id, read_request.len,
+                                      read_request.size, read_request.burst, read_request.prot,
+                                      read_request.user);
         end
       end
       begin
@@ -610,14 +609,14 @@ module br_amba_axi2axil_tb;
     $display("Checking single-beat write conversion");
     start_test_case();
     request = '0;
-    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    request.id = IdWidth'($urandom());
+    request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    request.id = AxiIdWidth'($urandom());
     request.len = '0;
     request.size = AxiBurstSizeWidth'(AxiSize);
     request.burst = AxiBurstIncr;
     request.prot = AxiProtWidth'($urandom());
-    request.user = AWUserWidth'($urandom());
-    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespOkay,
+    request.user = AxiUserWidth'($urandom());
+    run_write_burst(request, AxiUserWidth'($urandom()), AxiUserWidth'($urandom()), AxiRespOkay,
                     AxiRespOkay, 1'b0);
     finish_test_case();
   endtask
@@ -630,14 +629,14 @@ module br_amba_axi2axil_tb;
     $display("Checking incrementing write burst with response propagation");
     start_test_case();
     request = '0;
-    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    request.id = IdWidth'($urandom());
+    request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    request.id = AxiIdWidth'($urandom());
     request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
     request.size = AxiBurstSizeWidth'(AxiSize);
     request.burst = AxiBurstIncr;
     request.prot = AxiProtWidth'($urandom());
-    request.user = AWUserWidth'($urandom());
-    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespOkay,
+    request.user = AxiUserWidth'($urandom());
+    run_write_burst(request, AxiUserWidth'($urandom()), AxiUserWidth'($urandom()), AxiRespOkay,
                     AxiRespSlverr, 1'b1);
     finish_test_case();
   endtask
@@ -650,14 +649,14 @@ module br_amba_axi2axil_tb;
     $display("Checking fixed write burst");
     start_test_case();
     request = '0;
-    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    request.id = IdWidth'($urandom());
+    request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    request.id = AxiIdWidth'($urandom());
     request.len = AxiBurstLenWidth'(3 - 1);
     request.size = AxiBurstSizeWidth'(AxiSize);
     request.burst = AxiBurstFixed;
     request.prot = AxiProtWidth'($urandom());
-    request.user = AWUserWidth'($urandom());
-    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespDecerr,
+    request.user = AxiUserWidth'($urandom());
+    run_write_burst(request, AxiUserWidth'($urandom()), AxiUserWidth'($urandom()), AxiRespDecerr,
                     AxiRespOkay, 1'b0);
     finish_test_case();
   endtask
@@ -670,14 +669,14 @@ module br_amba_axi2axil_tb;
     $display("Checking first-beat SLVERR write response propagation");
     start_test_case();
     request = '0;
-    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    request.id = IdWidth'($urandom());
+    request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    request.id = AxiIdWidth'($urandom());
     request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
     request.size = AxiBurstSizeWidth'(AxiSize);
     request.burst = AxiBurstIncr;
     request.prot = AxiProtWidth'($urandom());
-    request.user = AWUserWidth'($urandom());
-    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespSlverr,
+    request.user = AxiUserWidth'($urandom());
+    run_write_burst(request, AxiUserWidth'($urandom()), AxiUserWidth'($urandom()), AxiRespSlverr,
                     AxiRespOkay, 1'b1);
     finish_test_case();
   endtask
@@ -690,14 +689,14 @@ module br_amba_axi2axil_tb;
     $display("Checking later-beat DECERR write response propagation");
     start_test_case();
     request = '0;
-    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    request.id = IdWidth'($urandom());
+    request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    request.id = AxiIdWidth'($urandom());
     request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
     request.size = AxiBurstSizeWidth'(AxiSize);
     request.burst = AxiBurstIncr;
     request.prot = AxiProtWidth'($urandom());
-    request.user = AWUserWidth'($urandom());
-    run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespOkay,
+    request.user = AxiUserWidth'($urandom());
+    run_write_burst(request, AxiUserWidth'($urandom()), AxiUserWidth'($urandom()), AxiRespOkay,
                     AxiRespDecerr, 1'b1);
     finish_test_case();
   endtask
@@ -710,14 +709,14 @@ module br_amba_axi2axil_tb;
     $display("Checking wrapping read burst");
     start_test_case();
     request = '0;
-    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    request.id = IdWidth'($urandom());
+    request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    request.id = AxiIdWidth'($urandom());
     request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
     request.size = AxiBurstSizeWidth'(AxiSize);
     request.burst = AxiBurstWrap;
     request.prot = AxiProtWidth'($urandom());
-    request.user = ARUserWidth'($urandom());
-    run_read_burst(request, RUserWidth'($urandom()), AxiRespOkay, 1'b1);
+    request.user = AxiUserWidth'($urandom());
+    run_read_burst(request, AxiUserWidth'($urandom()), AxiRespOkay, 1'b1);
     finish_test_case();
   endtask
 
@@ -729,14 +728,14 @@ module br_amba_axi2axil_tb;
     $display("Checking fixed read burst");
     start_test_case();
     request = '0;
-    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    request.id = IdWidth'($urandom());
+    request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    request.id = AxiIdWidth'($urandom());
     request.len = AxiBurstLenWidth'(3 - 1);
     request.size = AxiBurstSizeWidth'(AxiSize);
     request.burst = AxiBurstFixed;
     request.prot = AxiProtWidth'($urandom());
-    request.user = ARUserWidth'($urandom());
-    run_read_burst(request, RUserWidth'($urandom()), AxiRespSlverr, 1'b0);
+    request.user = AxiUserWidth'($urandom());
+    run_read_burst(request, AxiUserWidth'($urandom()), AxiRespSlverr, 1'b0);
     finish_test_case();
   endtask
 
@@ -748,14 +747,14 @@ module br_amba_axi2axil_tb;
     $display("Checking DECERR read response propagation");
     start_test_case();
     request = '0;
-    request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    request.id = IdWidth'($urandom());
+    request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    request.id = AxiIdWidth'($urandom());
     request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
     request.size = AxiBurstSizeWidth'(AxiSize);
     request.burst = AxiBurstIncr;
     request.prot = AxiProtWidth'($urandom());
-    request.user = ARUserWidth'($urandom());
-    run_read_burst(request, RUserWidth'($urandom()), AxiRespDecerr, 1'b1);
+    request.user = AxiUserWidth'($urandom());
+    run_read_burst(request, AxiUserWidth'($urandom()), AxiRespDecerr, 1'b1);
     finish_test_case();
   endtask
 
@@ -768,25 +767,25 @@ module br_amba_axi2axil_tb;
     $display("Checking parallel read/write burst conversion");
     start_test_case();
     write_request = '0;
-    write_request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    write_request.id = IdWidth'($urandom());
+    write_request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    write_request.id = AxiIdWidth'($urandom());
     write_request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
     write_request.size = AxiBurstSizeWidth'(AxiSize);
     write_request.burst = AxiBurstIncr;
     write_request.prot = AxiProtWidth'($urandom());
-    write_request.user = AWUserWidth'($urandom());
+    write_request.user = AxiUserWidth'($urandom());
 
     read_request = '0;
-    read_request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-    read_request.id = IdWidth'($urandom());
+    read_request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+    read_request.id = AxiIdWidth'($urandom());
     read_request.len = AxiBurstLenWidth'(MaxDirectedBeats - 1);
     read_request.size = AxiBurstSizeWidth'(AxiSize);
     read_request.burst = AxiBurstIncr;
     read_request.prot = AxiProtWidth'($urandom());
-    read_request.user = ARUserWidth'($urandom());
+    read_request.user = AxiUserWidth'($urandom());
 
-    run_parallel_read_write(write_request, WUserWidth'($urandom()), BUserWidth'($urandom()),
-                            AxiRespOkay, AxiRespOkay, read_request, RUserWidth'($urandom()),
+    run_parallel_read_write(write_request, AxiUserWidth'($urandom()), AxiUserWidth'($urandom()),
+                            AxiRespOkay, AxiRespOkay, read_request, AxiUserWidth'($urandom()),
                             AxiRespOkay, 1'b0);
     finish_test_case();
   endtask
@@ -846,34 +845,34 @@ module br_amba_axi2axil_tb;
     bit is_write;
     int unsigned beats;
 
-    is_write = $urandom_range(0, 1);
+    is_write = bit'($urandom_range(0, 1));
     beats = $urandom_range(1, MaxDirectedBeats);
     start_test_case();
     if (is_write) begin
       axi_aw_t request;
 
       request = '0;
-      request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-      request.id = IdWidth'($urandom());
+      request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+      request.id = AxiIdWidth'($urandom());
       request.len = AxiBurstLenWidth'(beats - 1);
       request.size = AxiBurstSizeWidth'(AxiSize);
       request.burst = AxiBurstIncr;
       request.prot = AxiProtWidth'($urandom());
-      request.user = AWUserWidth'($urandom());
-      run_write_burst(request, WUserWidth'($urandom()), BUserWidth'($urandom()), AxiRespOkay,
+      request.user = AxiUserWidth'($urandom());
+      run_write_burst(request, AxiUserWidth'($urandom()), AxiUserWidth'($urandom()), AxiRespOkay,
                       AxiRespOkay, transaction[0]);
     end else begin
       axi_ar_t request;
 
       request = '0;
-      request.addr = get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize));
-      request.id = IdWidth'($urandom());
+      request.addr = AxiAddrWidth'(get_random_aligned_addr(AxiBurstSizeWidth'(AxiSize)));
+      request.id = AxiIdWidth'($urandom());
       request.len = AxiBurstLenWidth'(beats - 1);
       request.size = AxiBurstSizeWidth'(AxiSize);
       request.burst = AxiBurstIncr;
       request.prot = AxiProtWidth'($urandom());
-      request.user = ARUserWidth'($urandom());
-      run_read_burst(request, RUserWidth'($urandom()), AxiRespOkay, transaction[0]);
+      request.user = AxiUserWidth'($urandom());
+      run_read_burst(request, AxiUserWidth'($urandom()), AxiRespOkay, transaction[0]);
     end
     finish_test_case();
   endtask

--- a/amba/sim/br_amba_axi_default_target_tb.sv
+++ b/amba/sim/br_amba_axi_default_target_tb.sv
@@ -4,6 +4,7 @@
 
 import br_amba::*;
 import br_amba_axi_sim_pkg::*;
+import br_amba_sim_pkg::*;
 
 typedef enum int {
   AxiDefaultResponseKindOkay   = 0,
@@ -209,19 +210,48 @@ module br_amba_axi_default_target_tb;
       .failed(monitor_failed)
   );
 
+  function automatic axi_aw_t get_aw_input(input int index);
+    get_aw_input = '0;
+    get_aw_input.addr = AxiAddrWidth'($urandom());
+    get_aw_input.id = AxiIdWidth'($urandom());
+    get_aw_input.len = get_axi_default_target_aw_len(index, SingleBeat, MaxReadLen);
+    get_aw_input.size = AxiBurstSizeWidth'($clog2(DriverStrobeWidth));
+    get_aw_input.burst = AxiBurstIncr;
+    get_aw_input.prot = AxiProtWidth'($urandom());
+    get_aw_input.user = AxiUserWidth'($urandom());
+  endfunction
+
+  function automatic axi_w_t get_w_input();
+    get_w_input = '0;
+    for (int word = 0; word < DriverDataWidth / 32; word++) begin
+      get_w_input.data[word*32+:32] = $urandom();
+    end
+    get_w_input.strb = AxiStrobeWidth'($urandom()) | AxiStrobeWidth'(1'b1);
+    get_w_input.user = AxiUserWidth'($urandom());
+    get_w_input.last = 1'b1;
+  endfunction
+
+  function automatic axi_ar_t get_ar_input(input int index);
+    get_ar_input = '0;
+    get_ar_input.addr = AxiAddrWidth'($urandom());
+    get_ar_input.id = AxiIdWidth'($urandom());
+    get_ar_input.len = get_axi_default_target_ar_len(index, SingleBeat, MaxReadLen);
+    get_ar_input.size = AxiBurstSizeWidth'($clog2(DriverStrobeWidth));
+    get_ar_input.burst = AxiBurstIncr;
+    get_ar_input.prot = AxiProtWidth'($urandom());
+    get_ar_input.user = AxiUserWidth'($urandom());
+  endfunction
+
   task automatic test_write_address_before_data();
     axi_default_delays_t delays;
 
     delays = '{default: 0};
     delays.wvalid = ChannelSkewCycles;
     fork
-      axi_driver.run(
-          .num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
-          .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid),
-          .max_stall_cycles(MaxReadyStallCycles),
-          .aw_input(get_axi_default_target_aw_input(0, SingleBeat, MaxReadLen, DriverStrobeWidth)),
-          .w_input(get_axi_default_target_w_input(0)), .vary_burst_len(!SingleBeat),
-          .vary_wlast(1'b0));
+      axi_driver.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
+                     .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid),
+                     .max_stall_cycles(MaxReadyStallCycles), .aw_input(get_aw_input(0)),
+                     .w_input(get_w_input()), .vary_burst_len(!SingleBeat), .vary_wlast(1'b0));
       axi_monitor.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
                       .wvalid_delay(delays.wvalid));
     join
@@ -233,13 +263,10 @@ module br_amba_axi_default_target_tb;
     delays = '{default: 0};
     delays.awvalid = ChannelSkewCycles;
     fork
-      axi_driver.run(
-          .num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
-          .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid),
-          .max_stall_cycles(MaxReadyStallCycles),
-          .aw_input(get_axi_default_target_aw_input(0, SingleBeat, MaxReadLen, DriverStrobeWidth)),
-          .w_input(get_axi_default_target_w_input(0)), .vary_burst_len(!SingleBeat),
-          .vary_wlast(1'b0));
+      axi_driver.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
+                     .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid),
+                     .max_stall_cycles(MaxReadyStallCycles), .aw_input(get_aw_input(0)),
+                     .w_input(get_w_input()), .vary_burst_len(!SingleBeat), .vary_wlast(1'b0));
       axi_monitor.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
                       .wvalid_delay(delays.wvalid));
     join
@@ -250,11 +277,10 @@ module br_amba_axi_default_target_tb;
 
     delays = '{default: 0};
     fork
-      axi_driver.run(
-          .num_reads(NumTransactions), .awvalid_delay(delays.awvalid), .wvalid_delay(delays.wvalid),
-          .arvalid_delay(delays.arvalid), .max_stall_cycles(MaxReadyStallCycles),
-          .ar_input(get_axi_default_target_ar_input(0, SingleBeat, MaxReadLen, DriverStrobeWidth)),
-          .accept_r_burst_len(1'b1), .vary_burst_len(!SingleBeat));
+      axi_driver.run(.num_reads(NumTransactions), .awvalid_delay(delays.awvalid),
+                     .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid),
+                     .max_stall_cycles(MaxReadyStallCycles), .ar_input(get_ar_input(0)),
+                     .accept_r_burst_len(1'b1), .vary_burst_len(!SingleBeat));
       axi_monitor.run(.num_reads(NumTransactions), .awvalid_delay(delays.awvalid),
                       .wvalid_delay(delays.wvalid));
     join

--- a/amba/sim/br_amba_axi_default_target_tb.sv
+++ b/amba/sim/br_amba_axi_default_target_tb.sv
@@ -35,10 +35,6 @@ module br_amba_axi_default_target_tb;
   localparam int TimeoutCycles = (NumTransactions * 80) + 200;
   localparam int ChannelSkewCycles = 3;
   localparam int MaxReadyStallCycles = 9;
-  localparam int DriverAddrWidth = 12;
-  localparam int DriverDataWidth = 32;
-  localparam int DriverUserWidth = 1;
-  localparam int DriverStrobeWidth = DriverDataWidth / 8;
   localparam int MaxReadLen = 3;
   localparam logic [63:0] DefaultReadDataFull = 64'hc001_d00d_f00d_5eed;
   localparam logic [DataWidth-1:0] DefaultReadData = DefaultReadDataFull[DataWidth-1:0];
@@ -75,23 +71,27 @@ module br_amba_axi_default_target_tb;
   logic target_rlast;
   logic driver_failed;
   logic monitor_failed;
-  logic [DriverAddrWidth-1:0] unused_awaddr;
+  logic [br_amba_axi_sim_pkg::AxiAddrWidth-1:0] unused_awaddr;
+  logic [br_amba_axi_sim_pkg::AxiIdWidth-1:0] driver_awid;
   logic [AxiBurstLenWidth-1:0] full_awlen;
   logic [AxiBurstSizeWidth-1:0] unused_awsize;
   logic [AxiBurstTypeWidth-1:0] unused_awburst;
   logic [AxiProtWidth-1:0] unused_awprot;
-  logic [DriverUserWidth-1:0] unused_awuser;
-  logic [DriverDataWidth-1:0] unused_wdata;
-  logic [DriverStrobeWidth-1:0] unused_wstrb;
-  logic [DriverUserWidth-1:0] unused_wuser;
-  logic [DriverAddrWidth-1:0] unused_araddr;
+  logic [br_amba_axi_sim_pkg::AxiUserWidth-1:0] unused_awuser;
+  logic [br_amba_axi_sim_pkg::AxiDataWidth-1:0] unused_wdata;
+  logic [br_amba_axi_sim_pkg::AxiStrobeWidth-1:0] unused_wstrb;
+  logic [br_amba_axi_sim_pkg::AxiUserWidth-1:0] unused_wuser;
+  logic [br_amba_axi_sim_pkg::AxiAddrWidth-1:0] unused_araddr;
+  logic [br_amba_axi_sim_pkg::AxiIdWidth-1:0] driver_arid;
   logic [AxiBurstLenWidth-1:0] full_arlen;
   logic [AxiBurstSizeWidth-1:0] unused_arsize;
   logic [AxiBurstTypeWidth-1:0] unused_arburst;
   logic [AxiProtWidth-1:0] unused_arprot;
-  logic [DriverUserWidth-1:0] unused_aruser;
+  logic [br_amba_axi_sim_pkg::AxiUserWidth-1:0] unused_aruser;
 
+  assign target_awid  = AxiIdWidth'(driver_awid);
   assign target_awlen = AxiLenWidth'(full_awlen);
+  assign target_arid  = AxiIdWidth'(driver_arid);
   assign target_arlen = AxiLenWidth'(full_arlen);
 
   br_test_driver #(
@@ -135,12 +135,6 @@ module br_amba_axi_default_target_tb;
   );
 
   br_amba_axi_target_driver #(
-      .AddrWidth(DriverAddrWidth),
-      .DataWidth(DriverDataWidth),
-      .IdWidth(AxiIdWidth),
-      .AWUserWidth(DriverUserWidth),
-      .WUserWidth(DriverUserWidth),
-      .ARUserWidth(DriverUserWidth),
       .TimeoutCycles(TimeoutCycles)
   ) axi_driver (
       .clk,
@@ -148,7 +142,7 @@ module br_amba_axi_default_target_tb;
       .target_awaddr(unused_awaddr),
       .target_awvalid,
       .target_awready,
-      .target_awid,
+      .target_awid(driver_awid),
       .target_awlen(full_awlen),
       .target_awsize(unused_awsize),
       .target_awburst(unused_awburst),
@@ -165,7 +159,7 @@ module br_amba_axi_default_target_tb;
       .target_araddr(unused_araddr),
       .target_arvalid,
       .target_arready,
-      .target_arid,
+      .target_arid(driver_arid),
       .target_arlen(full_arlen),
       .target_arsize(unused_arsize),
       .target_arburst(unused_arburst),
@@ -213,9 +207,9 @@ module br_amba_axi_default_target_tb;
   function automatic axi_aw_t get_aw_input(input int index);
     get_aw_input = '0;
     get_aw_input.addr = AxiAddrWidth'($urandom());
-    get_aw_input.id = AxiIdWidth'($urandom());
+    get_aw_input.id = br_amba_axi_sim_pkg::AxiIdWidth'(AxiIdWidth'($urandom()));
     get_aw_input.len = get_axi_default_target_aw_len(index, SingleBeat, MaxReadLen);
-    get_aw_input.size = AxiBurstSizeWidth'($clog2(DriverStrobeWidth));
+    get_aw_input.size = AxiBurstSizeWidth'($clog2(br_amba_axi_sim_pkg::AxiStrobeWidth));
     get_aw_input.burst = AxiBurstIncr;
     get_aw_input.prot = AxiProtWidth'($urandom());
     get_aw_input.user = AxiUserWidth'($urandom());
@@ -223,7 +217,7 @@ module br_amba_axi_default_target_tb;
 
   function automatic axi_w_t get_w_input();
     get_w_input = '0;
-    for (int word = 0; word < DriverDataWidth / 32; word++) begin
+    for (int word = 0; word < br_amba_axi_sim_pkg::AxiDataWidth / 32; word++) begin
       get_w_input.data[word*32+:32] = $urandom();
     end
     get_w_input.strb = AxiStrobeWidth'($urandom()) | AxiStrobeWidth'(1'b1);
@@ -234,9 +228,9 @@ module br_amba_axi_default_target_tb;
   function automatic axi_ar_t get_ar_input(input int index);
     get_ar_input = '0;
     get_ar_input.addr = AxiAddrWidth'($urandom());
-    get_ar_input.id = AxiIdWidth'($urandom());
+    get_ar_input.id = br_amba_axi_sim_pkg::AxiIdWidth'(AxiIdWidth'($urandom()));
     get_ar_input.len = get_axi_default_target_ar_len(index, SingleBeat, MaxReadLen);
-    get_ar_input.size = AxiBurstSizeWidth'($clog2(DriverStrobeWidth));
+    get_ar_input.size = AxiBurstSizeWidth'($clog2(br_amba_axi_sim_pkg::AxiStrobeWidth));
     get_ar_input.burst = AxiBurstIncr;
     get_ar_input.prot = AxiProtWidth'($urandom());
     get_ar_input.user = AxiUserWidth'($urandom());
@@ -244,14 +238,21 @@ module br_amba_axi_default_target_tb;
 
   task automatic test_write_address_before_data();
     axi_default_delays_t delays;
+    axi_aw_t aw_input;
+    axi_w_t w_input;
 
     delays = '{default: 0};
     delays.wvalid = ChannelSkewCycles;
+    aw_input = get_aw_input(0);
+    w_input = get_w_input();
     fork
       axi_driver.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
                      .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid),
-                     .max_stall_cycles(MaxReadyStallCycles), .aw_input(get_aw_input(0)),
-                     .w_input(get_w_input()), .vary_burst_len(!SingleBeat), .vary_wlast(1'b0));
+                     .max_stall_cycles(MaxReadyStallCycles), .awaddr(aw_input.addr),
+                     .awid(aw_input.id), .awlen(aw_input.len), .awsize(aw_input.size),
+                     .awburst(aw_input.burst), .awprot(aw_input.prot), .awuser(aw_input.user),
+                     .wdata(w_input.data), .wstrb(w_input.strb), .wuser(w_input.user),
+                     .wlast(w_input.last), .vary_burst_len(!SingleBeat), .vary_wlast(1'b0));
       axi_monitor.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
                       .wvalid_delay(delays.wvalid));
     join
@@ -259,14 +260,21 @@ module br_amba_axi_default_target_tb;
 
   task automatic test_write_data_before_address();
     axi_default_delays_t delays;
+    axi_aw_t aw_input;
+    axi_w_t w_input;
 
     delays = '{default: 0};
     delays.awvalid = ChannelSkewCycles;
+    aw_input = get_aw_input(0);
+    w_input = get_w_input();
     fork
       axi_driver.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
                      .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid),
-                     .max_stall_cycles(MaxReadyStallCycles), .aw_input(get_aw_input(0)),
-                     .w_input(get_w_input()), .vary_burst_len(!SingleBeat), .vary_wlast(1'b0));
+                     .max_stall_cycles(MaxReadyStallCycles), .awaddr(aw_input.addr),
+                     .awid(aw_input.id), .awlen(aw_input.len), .awsize(aw_input.size),
+                     .awburst(aw_input.burst), .awprot(aw_input.prot), .awuser(aw_input.user),
+                     .wdata(w_input.data), .wstrb(w_input.strb), .wuser(w_input.user),
+                     .wlast(w_input.last), .vary_burst_len(!SingleBeat), .vary_wlast(1'b0));
       axi_monitor.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
                       .wvalid_delay(delays.wvalid));
     join
@@ -274,12 +282,16 @@ module br_amba_axi_default_target_tb;
 
   task automatic test_read_backpressure();
     axi_default_delays_t delays;
+    axi_ar_t ar_input;
 
-    delays = '{default: 0};
+    delays   = '{default: 0};
+    ar_input = get_ar_input(0);
     fork
       axi_driver.run(.num_reads(NumTransactions), .awvalid_delay(delays.awvalid),
                      .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid),
-                     .max_stall_cycles(MaxReadyStallCycles), .ar_input(get_ar_input(0)),
+                     .max_stall_cycles(MaxReadyStallCycles), .araddr(ar_input.addr),
+                     .arid(ar_input.id), .arlen(ar_input.len), .arsize(ar_input.size),
+                     .arburst(ar_input.burst), .arprot(ar_input.prot), .aruser(ar_input.user),
                      .accept_r_burst_len(1'b1), .vary_burst_len(!SingleBeat));
       axi_monitor.run(.num_reads(NumTransactions), .awvalid_delay(delays.awvalid),
                       .wvalid_delay(delays.wvalid));

--- a/amba/sim/br_amba_axi_timing_slice_tb.sv
+++ b/amba/sim/br_amba_axi_timing_slice_tb.sv
@@ -4,6 +4,7 @@
 
 import br_amba::*;
 import br_amba_axi_sim_pkg::*;
+import br_amba_sim_pkg::*;
 
 typedef struct {
   int num_writes;
@@ -50,8 +51,6 @@ module br_amba_axi_timing_slice_tb;
   // The directed phase covers reverse-W backpressure without relying on a
   // multi-transfer source/sink pattern that can deadlock a registered-ready slice.
   localparam int MultiNumTransactions = (EffectiveWSliceType == 1) ? 1 : NumTransactions;
-  localparam int PayloadSeed = 32'h1357_2468;
-
   logic clk;
   logic rst;
   logic driver_failed;
@@ -394,23 +393,53 @@ module br_amba_axi_timing_slice_tb;
   );
 
   function automatic axi_aw_t get_aw_input(input int index);
-    get_aw_input = get_axi_timing_slice_aw_input(index, StrobeWidth, PayloadSeed);
+    get_aw_input = '0;
+    get_aw_input.addr = AxiAddrWidth'($urandom());
+    get_aw_input.id = AxiIdWidth'($urandom());
+    get_aw_input.len = AxiBurstLenWidth'(index);
+    get_aw_input.size = AxiBurstSizeWidth'($clog2(StrobeWidth));
+    get_aw_input.burst = AxiBurstIncr;
+    get_aw_input.prot = AxiProtWidth'($urandom());
+    get_aw_input.user = AxiUserWidth'($urandom());
   endfunction
 
-  function automatic axi_w_t get_w_input(input int index);
-    get_w_input = get_axi_timing_slice_w_input(index, PayloadSeed);
+  function automatic axi_w_t get_w_input();
+    get_w_input = '0;
+    for (int word = 0; word < DataWidth / 32; word++) begin
+      get_w_input.data[word*32+:32] = $urandom();
+    end
+    get_w_input.strb = AxiStrobeWidth'($urandom()) | AxiStrobeWidth'(1'b1);
+    get_w_input.user = AxiUserWidth'($urandom());
+    get_w_input.last = logic'($urandom_range(0, 1));
   endfunction
 
   function automatic axi_ar_t get_ar_input(input int index);
-    get_ar_input = get_axi_timing_slice_ar_input(index, StrobeWidth, PayloadSeed);
+    get_ar_input = '0;
+    get_ar_input.addr = AxiAddrWidth'($urandom());
+    get_ar_input.id = AxiIdWidth'($urandom());
+    get_ar_input.len = AxiBurstLenWidth'(index + 1);
+    get_ar_input.size = AxiBurstSizeWidth'($clog2(StrobeWidth));
+    get_ar_input.burst = AxiBurstWrap;
+    get_ar_input.prot = AxiProtWidth'($urandom());
+    get_ar_input.user = AxiUserWidth'($urandom());
   endfunction
 
-  function automatic axi_b_t get_b_input(input int index);
-    get_b_input = get_axi_timing_slice_b_input(index, PayloadSeed);
+  function automatic axi_b_t get_b_input();
+    get_b_input = '0;
+    get_b_input.id = AxiIdWidth'($urandom());
+    get_b_input.user = AxiUserWidth'($urandom());
+    get_b_input.resp = AxiRespWidth'($urandom());
   endfunction
 
-  function automatic axi_r_t get_r_input(input int index);
-    get_r_input = get_axi_timing_slice_r_input(index, PayloadSeed);
+  function automatic axi_r_t get_r_input();
+    get_r_input = '0;
+    get_r_input.id = AxiIdWidth'($urandom());
+    for (int word = 0; word < DataWidth / 32; word++) begin
+      get_r_input.data[word*32+:32] = $urandom();
+    end
+    get_r_input.resp = AxiRespWidth'($urandom());
+    get_r_input.user = AxiUserWidth'($urandom());
+    get_r_input.last = logic'($urandom_range(0, 1));
   endfunction
 
   task automatic run_timing_slice_test(input axi_timing_slice_controls_t controls);
@@ -421,10 +450,10 @@ module br_amba_axi_timing_slice_tb;
     axi_r_t  r_input;
 
     aw_input = get_aw_input(0);
-    w_input  = get_w_input(0);
+    w_input  = get_w_input();
     ar_input = get_ar_input(0);
-    b_input  = get_b_input(0);
-    r_input  = get_r_input(0);
+    b_input  = get_b_input();
+    r_input  = get_r_input();
 
     axi_target_driver.init_idle();
     axi_initiator_driver.init_idle();

--- a/amba/sim/br_amba_axil_timing_slice_tb.sv
+++ b/amba/sim/br_amba_axil_timing_slice_tb.sv
@@ -4,6 +4,7 @@
 
 import br_amba::*;
 import br_amba_axil_sim_pkg::*;
+import br_amba_sim_pkg::*;
 
 typedef struct {
   int num_writes;
@@ -35,7 +36,6 @@ module br_amba_axil_timing_slice_tb;
   localparam int DirectedStallCycles = 3;
   localparam int RandomizedValidGapCycles = 1;
   localparam int RandomizedStallCycles = 0;
-  localparam int PayloadSeed = 32'h2468_1357;
 
   logic clk;
   logic rst;
@@ -272,51 +272,39 @@ module br_amba_axil_timing_slice_tb;
       .failed(monitor_failed)
   );
 
-  function automatic logic [255:0] payload_pattern(input int index, input int salt);
-    for (int word = 0; word < 8; word++) begin
-      payload_pattern[word*32+:32] = 32'((index + 1) * (salt + (word * 19)) ^
-                                         (PayloadSeed >> (word % 7)) ^
-                                         (32'h2040_8102 << (word % 5)));
+  function automatic axil_aw_t get_aw_input();
+    get_aw_input.addr = AddrWidth'($urandom());
+    get_aw_input.prot = AxiProtWidth'($urandom());
+    get_aw_input.user = AWUserWidth'($urandom());
+  endfunction
+
+  function automatic axil_w_t get_w_input();
+    get_w_input.data = '0;
+    for (int word = 0; word < DataWidth / 32; word++) begin
+      get_w_input.data[word*32+:32] = $urandom();
     end
+    get_w_input.strb = StrobeWidth'($urandom()) | StrobeWidth'(1'b1);
+    get_w_input.user = WUserWidth'($urandom());
   endfunction
 
-  function automatic axil_aw_t get_aw_input(input int index);
-    logic [255:0] payload;
-    payload = payload_pattern(index, 11);
-    get_aw_input.addr = payload[AddrWidth-1:0];
-    get_aw_input.prot = payload[64+:AxiProtWidth];
-    get_aw_input.user = payload[96+:AWUserWidth];
-  endfunction
-
-  function automatic axil_w_t get_w_input(input int index);
-    logic [255:0] payload;
-    payload = payload_pattern(index, 23);
-    get_w_input.data = payload[DataWidth-1:0];
-    get_w_input.strb = StrobeWidth'(payload[128+:StrobeWidth]) | StrobeWidth'(1'b1);
-    get_w_input.user = payload[160+:WUserWidth];
-  endfunction
-
-  function automatic axil_ar_t get_ar_input(input int index);
-    logic [255:0] payload;
-    payload = payload_pattern(index, 37);
-    get_ar_input.addr = payload[AddrWidth-1:0];
-    get_ar_input.prot = payload[64+:AxiProtWidth];
-    get_ar_input.user = payload[96+:ARUserWidth];
+  function automatic axil_ar_t get_ar_input();
+    get_ar_input.addr = AddrWidth'($urandom());
+    get_ar_input.prot = AxiProtWidth'($urandom());
+    get_ar_input.user = ARUserWidth'($urandom());
   endfunction
 
   function automatic axil_b_t get_b_input(input int index);
-    logic [255:0] payload;
-    payload = payload_pattern(index, 47);
     get_b_input.resp = AxiRespWidth'(index);
-    get_b_input.user = payload[32+:BUserWidth];
+    get_b_input.user = BUserWidth'($urandom());
   endfunction
 
   function automatic axil_r_t get_r_input(input int index);
-    logic [255:0] payload;
-    payload = payload_pattern(index, 59);
-    get_r_input.data = payload[DataWidth-1:0];
+    get_r_input.data = '0;
+    for (int word = 0; word < DataWidth / 32; word++) begin
+      get_r_input.data[word*32+:32] = $urandom();
+    end
     get_r_input.resp = AxiRespWidth'(index + 1);
-    get_r_input.user = payload[160+:RUserWidth];
+    get_r_input.user = RUserWidth'($urandom());
   endfunction
 
   task automatic run_timing_slice_test(input axil_timing_slice_controls_t controls);
@@ -326,9 +314,9 @@ module br_amba_axil_timing_slice_tb;
     axil_b_t  b_input;
     axil_r_t  r_input;
 
-    aw_input = get_aw_input(0);
-    w_input  = get_w_input(0);
-    ar_input = get_ar_input(0);
+    aw_input = get_aw_input();
+    w_input  = get_w_input();
+    ar_input = get_ar_input();
     b_input  = get_b_input(0);
     r_input  = get_r_input(0);
 

--- a/amba/sim/drivers/BUILD.bazel
+++ b/amba/sim/drivers/BUILD.bazel
@@ -7,6 +7,7 @@ verilog_library(
     srcs = ["br_amba_apb_sim_pkg.sv"],
     visibility = ["//visibility:public"],
     deps = [
+        ":br_amba_sim_pkg",
         "//amba/rtl:br_amba_pkg",
     ],
 )
@@ -27,6 +28,12 @@ verilog_library(
     deps = [
         "//amba/rtl:br_amba_pkg",
     ],
+)
+
+verilog_library(
+    name = "br_amba_sim_pkg",
+    srcs = ["br_amba_sim_pkg.sv"],
+    visibility = ["//visibility:public"],
 )
 
 verilog_library(
@@ -53,6 +60,7 @@ verilog_library(
     visibility = ["//visibility:public"],
     deps = [
         ":br_amba_axi_sim_pkg",
+        ":br_amba_sim_pkg",
     ],
 )
 
@@ -62,6 +70,17 @@ verilog_library(
     visibility = ["//visibility:public"],
     deps = [
         ":br_amba_axil_sim_pkg",
+        ":br_amba_sim_pkg",
+    ],
+)
+
+verilog_library(
+    name = "br_amba_axil_target_driver",
+    srcs = ["br_amba_axil_target_driver.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":br_amba_axil_sim_pkg",
+        ":br_amba_sim_pkg",
     ],
 )
 
@@ -72,5 +91,6 @@ verilog_library(
     deps = [
         ":br_amba_axi_sim_pkg",
         ":br_amba_axi_target_driver",
+        ":br_amba_sim_pkg",
     ],
 )

--- a/amba/sim/drivers/BUILD.bazel
+++ b/amba/sim/drivers/BUILD.bazel
@@ -33,6 +33,7 @@ verilog_library(
 verilog_library(
     name = "br_amba_sim_pkg",
     srcs = ["br_amba_sim_pkg.sv"],
+    hdrs = ["br_amba_sim_macros.svh"],
     visibility = ["//visibility:public"],
 )
 

--- a/amba/sim/drivers/br_amba_axi_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_axi_sim_pkg.sv
@@ -5,11 +5,27 @@
 package br_amba_axi_sim_pkg;
   import br_amba::*;
 
-  localparam int AxiAddrWidth = 64;
-  localparam int AxiDataWidth = 1024;
-  localparam int AxiIdWidth = 16;
-  localparam int AxiUserWidth = 64;
-  localparam int AxiStrobeWidth = AxiDataWidth / 8;
+`ifndef BR_AMBA_AXI_SIM_ADDR_WIDTH
+  `define BR_AMBA_AXI_SIM_ADDR_WIDTH 64
+`endif
+
+`ifndef BR_AMBA_AXI_SIM_DATA_WIDTH
+  `define BR_AMBA_AXI_SIM_DATA_WIDTH 1024
+`endif
+
+`ifndef BR_AMBA_AXI_SIM_ID_WIDTH
+  `define BR_AMBA_AXI_SIM_ID_WIDTH 16
+`endif
+
+`ifndef BR_AMBA_AXI_SIM_USER_WIDTH
+  `define BR_AMBA_AXI_SIM_USER_WIDTH 64
+`endif
+
+  parameter int AxiAddrWidth = `BR_AMBA_AXI_SIM_ADDR_WIDTH;
+  parameter int AxiDataWidth = `BR_AMBA_AXI_SIM_DATA_WIDTH;
+  parameter int AxiIdWidth = `BR_AMBA_AXI_SIM_ID_WIDTH;
+  parameter int AxiUserWidth = `BR_AMBA_AXI_SIM_USER_WIDTH;
+  parameter int AxiStrobeWidth = AxiDataWidth / 8;
 
   typedef struct packed {
     logic [AxiAddrWidth-1:0] addr;
@@ -51,6 +67,21 @@ package br_amba_axi_sim_pkg;
     logic [AxiUserWidth-1:0] user;
     logic last;
   } axi_r_t;
+
+  typedef struct packed {
+    axi_aw_t payload;
+    logic valid;
+  } axi_aw_source_t;
+
+  typedef struct packed {
+    axi_w_t payload;
+    logic   valid;
+  } axi_w_source_t;
+
+  typedef struct packed {
+    axi_ar_t payload;
+    logic valid;
+  } axi_ar_source_t;
 
   function automatic logic [AxiBurstLenWidth-1:0] get_axi_default_target_aw_len(
       input int index, input bit single_beat, input int max_len);

--- a/amba/sim/drivers/br_amba_axi_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_axi_sim_pkg.sv
@@ -52,15 +52,6 @@ package br_amba_axi_sim_pkg;
     logic last;
   } axi_r_t;
 
-  function automatic logic [255:0] get_axi_payload_pattern(input int index, input int salt,
-                                                           input logic [31:0] payload_seed);
-    for (int word = 0; word < 8; word++) begin
-      get_axi_payload_pattern[word*32+:32] = 32'((index + 1) * (salt + (word * 17)) ^
-                                                 (payload_seed >> (word % 7)) ^
-                                                 (32'h1020_4081 << (word % 5)));
-    end
-  endfunction
-
   function automatic logic [AxiBurstLenWidth-1:0] get_axi_default_target_aw_len(
       input int index, input bit single_beat, input int max_len);
     if (single_beat) begin
@@ -77,98 +68,6 @@ package br_amba_axi_sim_pkg;
     end else begin
       get_axi_default_target_ar_len = AxiBurstLenWidth'((index % max_len) + 1);
     end
-  endfunction
-
-  function automatic axi_aw_t get_axi_default_target_aw_input(
-      input int index, input bit single_beat, input int max_len, input int strobe_width);
-    get_axi_default_target_aw_input = '0;
-    get_axi_default_target_aw_input.addr = AxiAddrWidth'(32'h1000 + index);
-    get_axi_default_target_aw_input.id = AxiIdWidth'(index + 1);
-    get_axi_default_target_aw_input.len =
-        get_axi_default_target_aw_len(index, single_beat, max_len);
-    get_axi_default_target_aw_input.size = AxiBurstSizeWidth'($clog2(strobe_width));
-    get_axi_default_target_aw_input.burst = AxiBurstIncr;
-  endfunction
-
-  function automatic axi_w_t get_axi_default_target_w_input(input int index);
-    get_axi_default_target_w_input = '0;
-    get_axi_default_target_w_input.data = AxiDataWidth'(32'hcafe_0000 + index);
-    get_axi_default_target_w_input.strb = '1;
-    get_axi_default_target_w_input.last = 1'b1;
-  endfunction
-
-  function automatic axi_ar_t get_axi_default_target_ar_input(
-      input int index, input bit single_beat, input int max_len, input int strobe_width);
-    get_axi_default_target_ar_input = '0;
-    get_axi_default_target_ar_input.addr = AxiAddrWidth'(32'h2000 + index);
-    get_axi_default_target_ar_input.id = AxiIdWidth'(index + 1);
-    get_axi_default_target_ar_input.len =
-        get_axi_default_target_ar_len(index, single_beat, max_len);
-    get_axi_default_target_ar_input.size = AxiBurstSizeWidth'($clog2(strobe_width));
-    get_axi_default_target_ar_input.burst = AxiBurstIncr;
-  endfunction
-
-  function automatic axi_aw_t get_axi_timing_slice_aw_input(input int index, input int strobe_width,
-                                                            input logic [31:0] payload_seed);
-    logic [255:0] payload;
-
-    payload = get_axi_payload_pattern(index, 11, payload_seed);
-    get_axi_timing_slice_aw_input.addr  = payload[AxiAddrWidth-1:0];
-    get_axi_timing_slice_aw_input.id    = payload[32+:AxiIdWidth];
-    get_axi_timing_slice_aw_input.len   = AxiBurstLenWidth'(index);
-    get_axi_timing_slice_aw_input.size  = AxiBurstSizeWidth'($clog2(strobe_width));
-    get_axi_timing_slice_aw_input.burst = AxiBurstIncr;
-    get_axi_timing_slice_aw_input.prot  = payload[64+:AxiProtWidth];
-    get_axi_timing_slice_aw_input.user  = payload[96+:AxiUserWidth];
-  endfunction
-
-  function automatic axi_w_t get_axi_timing_slice_w_input(input int index,
-                                                          input logic [31:0] payload_seed);
-    logic [255:0] payload;
-
-    payload = get_axi_payload_pattern(index, 23, payload_seed);
-    get_axi_timing_slice_w_input.data = '0;
-    get_axi_timing_slice_w_input.data[255:0] = payload;
-    get_axi_timing_slice_w_input.strb = payload[128+:AxiStrobeWidth] | AxiStrobeWidth'(1'b1);
-    get_axi_timing_slice_w_input.user = payload[160+:AxiUserWidth];
-    get_axi_timing_slice_w_input.last = index[0];
-  endfunction
-
-  function automatic axi_ar_t get_axi_timing_slice_ar_input(input int index, input int strobe_width,
-                                                            input logic [31:0] payload_seed);
-    logic [255:0] payload;
-
-    payload = get_axi_payload_pattern(index, 37, payload_seed);
-    get_axi_timing_slice_ar_input.addr  = payload[AxiAddrWidth-1:0];
-    get_axi_timing_slice_ar_input.id    = payload[32+:AxiIdWidth];
-    get_axi_timing_slice_ar_input.len   = AxiBurstLenWidth'(index + 1);
-    get_axi_timing_slice_ar_input.size  = AxiBurstSizeWidth'($clog2(strobe_width));
-    get_axi_timing_slice_ar_input.burst = AxiBurstWrap;
-    get_axi_timing_slice_ar_input.prot  = payload[64+:AxiProtWidth];
-    get_axi_timing_slice_ar_input.user  = payload[96+:AxiUserWidth];
-  endfunction
-
-  function automatic axi_b_t get_axi_timing_slice_b_input(input int index,
-                                                          input logic [31:0] payload_seed);
-    logic [255:0] payload;
-
-    payload = get_axi_payload_pattern(index, 47, payload_seed);
-    get_axi_timing_slice_b_input.id = payload[AxiIdWidth-1:0];
-    get_axi_timing_slice_b_input.user = payload[32+:AxiUserWidth];
-    get_axi_timing_slice_b_input.resp = AxiRespWidth'(index);
-  endfunction
-
-  function automatic axi_r_t get_axi_timing_slice_r_input(input int index,
-                                                          input logic [31:0] payload_seed);
-    logic [255:0] payload;
-
-    payload = get_axi_payload_pattern(index, 59, payload_seed);
-    get_axi_timing_slice_r_input.id = payload[AxiIdWidth-1:0];
-    get_axi_timing_slice_r_input.data = '0;
-    get_axi_timing_slice_r_input.data[255:0] = payload;
-    get_axi_timing_slice_r_input.resp = AxiRespWidth'(index + 1);
-    get_axi_timing_slice_r_input.user = payload[160+:AxiUserWidth];
-    get_axi_timing_slice_r_input.last = !index[0];
   endfunction
 
 endpackage : br_amba_axi_sim_pkg

--- a/amba/sim/drivers/br_amba_axi_target_driver.sv
+++ b/amba/sim/drivers/br_amba_axi_target_driver.sv
@@ -4,6 +4,7 @@
 
 import br_amba::*;
 import br_amba_axi_sim_pkg::*;
+import br_amba_sim_pkg::*;
 
 // Configurable AXI target-side stimulus driver.
 //
@@ -80,8 +81,23 @@ module br_amba_axi_target_driver #(
   axi_aw_source_t target_aw_drive;
   axi_w_source_t target_w_drive;
   axi_ar_source_t target_ar_drive;
+  axi_w_t queued_w_beats[$];
   logic target_bready_drive;
   logic target_rready_drive;
+
+  clocking cb @(posedge clk);
+    default input #1step;
+    input target_awvalid;
+    input target_awready;
+    input target_wvalid;
+    input target_wready;
+    input target_arvalid;
+    input target_arready;
+    input target_bvalid;
+    input target_bready;
+    input target_rvalid;
+    input target_rready;
+  endclocking
 
   assign target_awaddr  = AddrWidth'(target_aw_drive.payload.addr);
   assign target_awid    = IdWidth'(target_aw_drive.payload.id);
@@ -108,13 +124,14 @@ module br_amba_axi_target_driver #(
   assign target_rready  = target_rready_drive;
 
   task automatic init_idle();
-    failed              = 1'b0;
+    failed          = 1'b0;
 
-    target_aw_drive     = '0;
-    target_w_drive      = '0;
-    target_ar_drive     = '0;
-    target_bready_drive = 1'b0;
-    target_rready_drive = 1'b0;
+    target_aw_drive = '0;
+    target_w_drive  = '0;
+    target_ar_drive = '0;
+    queued_w_beats.delete();
+    target_bready_drive = 1'b1;
+    target_rready_drive = 1'b1;
   endtask
 
   task automatic check(input logic condition, input string message);
@@ -128,36 +145,40 @@ module br_amba_axi_target_driver #(
     repeat (cycles) @(negedge clk);
   endtask
 
-  function automatic int get_stall_cycles(input int index, input int max_stall_cycles,
-                                          input int salt);
-    if (max_stall_cycles == 0) begin
-      return 0;
-    end
-    return (((index + 1) * salt) ^ (salt >> 1)) % (max_stall_cycles + 1);
-  endfunction
-
   function automatic logic is_wait_condition_met(input wait_condition_e condition);
     case (condition)
-      WaitTargetAw: is_wait_condition_met = target_awvalid && target_awready;
-      WaitTargetW:  is_wait_condition_met = target_wvalid && target_wready;
-      WaitTargetAr: is_wait_condition_met = target_arvalid && target_arready;
-      WaitTargetB:  is_wait_condition_met = target_bvalid && target_bready;
-      WaitTargetR:  is_wait_condition_met = target_rvalid && target_rready;
+      WaitTargetAw: is_wait_condition_met = cb.target_awvalid && cb.target_awready;
+      WaitTargetW:  is_wait_condition_met = cb.target_wvalid && cb.target_wready;
+      WaitTargetAr: is_wait_condition_met = cb.target_arvalid && cb.target_arready;
+      WaitTargetB:  is_wait_condition_met = cb.target_bvalid && cb.target_bready;
+      WaitTargetR:  is_wait_condition_met = cb.target_rvalid && cb.target_rready;
       default:      is_wait_condition_met = 1'b0;
     endcase
   endfunction
 
-  task automatic wait_for(input wait_condition_e condition, input string timeout_message);
+  function automatic string wait_condition_name(input wait_condition_e condition);
+    case (condition)
+      WaitTargetAw: wait_condition_name = "target AW";
+      WaitTargetW:  wait_condition_name = "target W";
+      WaitTargetAr: wait_condition_name = "target AR";
+      WaitTargetB:  wait_condition_name = "target B";
+      WaitTargetR:  wait_condition_name = "target R";
+      default:      wait_condition_name = "unknown AXI";
+    endcase
+  endfunction
+
+  task automatic wait_for(input wait_condition_e condition);
     int timeout;
 
     timeout = TimeoutCycles;
-    while (!is_wait_condition_met(
-        condition
-    ) && timeout > 0) begin
-      @(posedge clk);
+    do begin
+      @cb;
       timeout--;
-    end
-    check(is_wait_condition_met(condition), timeout_message);
+    end while (!is_wait_condition_met(
+        condition
+    ) && timeout >= 0);
+    check(is_wait_condition_met(condition), {
+          "Timeout waiting for ", wait_condition_name(condition), " handshake"});
   endtask
 
   function automatic axi_aw_t get_aw_transaction(input axi_aw_t base, input int index,
@@ -204,7 +225,27 @@ module br_amba_axi_target_driver #(
     @(negedge clk);
     target_aw_drive.payload = aw_input;
     target_aw_drive.valid   = 1'b1;
-    wait_for(WaitTargetAw, "Timeout waiting for target AW handshake");
+    wait_for(WaitTargetAw);
+    @(negedge clk);
+    target_aw_drive.valid = 1'b0;
+  endtask
+
+  task automatic drive_aw_fields(
+      input logic [AddrWidth-1:0] addr, input logic [IdWidth-1:0] id,
+      input logic [AxiBurstLenWidth-1:0] len, input logic [AxiBurstSizeWidth-1:0] size,
+      input logic [AxiBurstTypeWidth-1:0] burst, input logic [AxiProtWidth-1:0] prot,
+      input logic [AWUserWidth-1:0] user);
+    @(negedge clk);
+    target_aw_drive.payload       = '0;
+    target_aw_drive.payload.addr  = addr;
+    target_aw_drive.payload.id    = id;
+    target_aw_drive.payload.len   = len;
+    target_aw_drive.payload.size  = size;
+    target_aw_drive.payload.burst = burst;
+    target_aw_drive.payload.prot  = prot;
+    target_aw_drive.payload.user  = user;
+    target_aw_drive.valid         = 1'b1;
+    wait_for(WaitTargetAw);
     @(negedge clk);
     target_aw_drive.valid = 1'b0;
   endtask
@@ -213,7 +254,37 @@ module br_amba_axi_target_driver #(
     @(negedge clk);
     target_w_drive.payload = w_input;
     target_w_drive.valid   = 1'b1;
-    wait_for(WaitTargetW, "Timeout waiting for target W handshake");
+    wait_for(WaitTargetW);
+    @(negedge clk);
+    target_w_drive.valid = 1'b0;
+  endtask
+
+  task automatic queue_w_beat(input axi_w_t w_input);
+    queued_w_beats.push_back(w_input);
+  endtask
+
+  task automatic drive_queued_w(input int stall_cycles);
+    axi_w_t w_input;
+
+    wait_cycles(stall_cycles);
+    check(queued_w_beats.size() > 0, "No queued AXI W beat available");
+    if (queued_w_beats.size() > 0) begin
+      w_input = queued_w_beats.pop_front();
+      drive_w(w_input);
+    end
+  endtask
+
+  task automatic drive_w_fields(input logic [DataWidth-1:0] data,
+                                input logic [StrobeWidth-1:0] strb,
+                                input logic [WUserWidth-1:0] user, input logic last);
+    @(negedge clk);
+    target_w_drive.payload      = '0;
+    target_w_drive.payload.data = data;
+    target_w_drive.payload.strb = strb;
+    target_w_drive.payload.user = user;
+    target_w_drive.payload.last = last;
+    target_w_drive.valid        = 1'b1;
+    wait_for(WaitTargetW);
     @(negedge clk);
     target_w_drive.valid = 1'b0;
   endtask
@@ -222,27 +293,82 @@ module br_amba_axi_target_driver #(
     @(negedge clk);
     target_ar_drive.payload = ar_input;
     target_ar_drive.valid   = 1'b1;
-    wait_for(WaitTargetAr, "Timeout waiting for target AR handshake");
+    wait_for(WaitTargetAr);
+    @(negedge clk);
+    target_ar_drive.valid = 1'b0;
+  endtask
+
+  task automatic drive_ar_fields(
+      input logic [AddrWidth-1:0] addr, input logic [IdWidth-1:0] id,
+      input logic [AxiBurstLenWidth-1:0] len, input logic [AxiBurstSizeWidth-1:0] size,
+      input logic [AxiBurstTypeWidth-1:0] burst, input logic [AxiProtWidth-1:0] prot,
+      input logic [ARUserWidth-1:0] user);
+    @(negedge clk);
+    target_ar_drive.payload       = '0;
+    target_ar_drive.payload.addr  = addr;
+    target_ar_drive.payload.id    = id;
+    target_ar_drive.payload.len   = len;
+    target_ar_drive.payload.size  = size;
+    target_ar_drive.payload.burst = burst;
+    target_ar_drive.payload.prot  = prot;
+    target_ar_drive.payload.user  = user;
+    target_ar_drive.valid         = 1'b1;
+    wait_for(WaitTargetAr);
     @(negedge clk);
     target_ar_drive.valid = 1'b0;
   endtask
 
   task automatic accept_target_b(input int stall_cycles);
-    target_bready_drive = 1'b0;
-    wait_cycles(stall_cycles);
+    if (stall_cycles > 0) begin
+      target_bready_drive = 1'b0;
+      wait_cycles(stall_cycles);
+    end
     target_bready_drive = 1'b1;
-    wait_for(WaitTargetB, "Timeout waiting for target B handshake");
-    @(negedge clk);
-    target_bready_drive = 1'b0;
+    wait_for(WaitTargetB);
   endtask
 
   task automatic accept_target_r(input int stall_cycles);
-    target_rready_drive = 1'b0;
-    wait_cycles(stall_cycles);
+    if (stall_cycles > 0) begin
+      target_rready_drive = 1'b0;
+      wait_cycles(stall_cycles);
+    end
     target_rready_drive = 1'b1;
-    wait_for(WaitTargetR, "Timeout waiting for target R handshake");
-    @(negedge clk);
-    target_rready_drive = 1'b0;
+    wait_for(WaitTargetR);
+  endtask
+
+  task automatic run_write_burst(input axi_aw_t aw_input, input int max_stall_cycles,
+                                 input int response_stall_cycles);
+    int unsigned beats;
+
+    beats = int'(aw_input.len) + 1;
+    check(queued_w_beats.size() >= beats, "Too few queued AXI W beats for write burst");
+    fork
+      drive_aw(aw_input);
+      begin
+        for (int unsigned beat = 0; beat < beats; beat++) begin
+          drive_queued_w(get_random_stall_cycles(max_stall_cycles));
+        end
+      end
+      accept_target_b(response_stall_cycles);
+    join
+  endtask
+
+  task automatic run_read_burst_fields(
+      input logic [AddrWidth-1:0] addr, input logic [IdWidth-1:0] id,
+      input logic [AxiBurstLenWidth-1:0] len, input logic [AxiBurstSizeWidth-1:0] size,
+      input logic [AxiBurstTypeWidth-1:0] burst, input logic [AxiProtWidth-1:0] prot,
+      input logic [ARUserWidth-1:0] aruser, input int max_stall_cycles);
+    int unsigned beats;
+
+    beats = int'(len) + 1;
+    fork
+      drive_ar_fields(addr, id, len, size, burst, prot, aruser);
+      begin
+        for (int unsigned beat = 0; beat < beats; beat++) begin
+          accept_target_r(get_random_stall_cycles(max_stall_cycles));
+        end
+      end
+    join
   endtask
 
   task automatic issue_write_transactions(
@@ -266,7 +392,7 @@ module br_amba_axi_target_driver #(
       end
       begin
         for (int i = 0; i < num_transactions; i++) begin
-          accept_target_b(get_stall_cycles(i, max_stall_cycles, 109));
+          accept_target_b(get_random_stall_cycles(max_stall_cycles));
         end
       end
     join
@@ -304,7 +430,7 @@ module br_amba_axi_target_driver #(
               );
               beat++
           ) begin
-            accept_target_r(get_stall_cycles(i + beat, max_stall_cycles, 113));
+            accept_target_r(get_random_stall_cycles(max_stall_cycles));
           end
         end
       end

--- a/amba/sim/drivers/br_amba_axi_target_driver.sv
+++ b/amba/sim/drivers/br_amba_axi_target_driver.sv
@@ -6,47 +6,40 @@ import br_amba::*;
 import br_amba_axi_sim_pkg::*;
 import br_amba_sim_pkg::*;
 
-// Configurable AXI target-side stimulus driver.
+// AXI target-side stimulus driver.
 //
 // This is not a generic AXI master. It owns AXI target-side AW/W/AR
 // valid/payload signals and B/R ready signals for directed simulation benches.
 module br_amba_axi_target_driver #(
-    parameter int AddrWidth = 12,
-    parameter int DataWidth = 32,
-    parameter int IdWidth = 2,
-    parameter int AWUserWidth = 2,
-    parameter int WUserWidth = 2,
-    parameter int ARUserWidth = 2,
-    parameter int TimeoutCycles = 100,
-    localparam int StrobeWidth = DataWidth / 8
+    parameter int TimeoutCycles = 100
 ) (
     input logic clk,
     input logic rst,
 
-    output logic [AddrWidth-1:0] target_awaddr,
-    output logic [IdWidth-1:0] target_awid,
+    output logic [AxiAddrWidth-1:0] target_awaddr,
+    output logic [AxiIdWidth-1:0] target_awid,
     output logic [AxiBurstLenWidth-1:0] target_awlen,
     output logic [AxiBurstSizeWidth-1:0] target_awsize,
     output logic [AxiBurstTypeWidth-1:0] target_awburst,
     output logic [AxiProtWidth-1:0] target_awprot,
-    output logic [AWUserWidth-1:0] target_awuser,
+    output logic [AxiUserWidth-1:0] target_awuser,
     output logic target_awvalid,
     input logic target_awready,
-    output logic [DataWidth-1:0] target_wdata,
-    output logic [StrobeWidth-1:0] target_wstrb,
-    output logic [WUserWidth-1:0] target_wuser,
+    output logic [AxiDataWidth-1:0] target_wdata,
+    output logic [AxiStrobeWidth-1:0] target_wstrb,
+    output logic [AxiUserWidth-1:0] target_wuser,
     output logic target_wlast,
     output logic target_wvalid,
     input logic target_wready,
     input logic target_bvalid,
     output logic target_bready,
-    output logic [AddrWidth-1:0] target_araddr,
-    output logic [IdWidth-1:0] target_arid,
+    output logic [AxiAddrWidth-1:0] target_araddr,
+    output logic [AxiIdWidth-1:0] target_arid,
     output logic [AxiBurstLenWidth-1:0] target_arlen,
     output logic [AxiBurstSizeWidth-1:0] target_arsize,
     output logic [AxiBurstTypeWidth-1:0] target_arburst,
     output logic [AxiProtWidth-1:0] target_arprot,
-    output logic [ARUserWidth-1:0] target_aruser,
+    output logic [AxiUserWidth-1:0] target_aruser,
     output logic target_arvalid,
     input logic target_arready,
     input logic target_rvalid,
@@ -62,21 +55,6 @@ module br_amba_axi_target_driver #(
     WaitTargetB,
     WaitTargetR
   } wait_condition_e;
-
-  typedef struct packed {
-    axi_aw_t payload;
-    logic valid;
-  } axi_aw_source_t;
-
-  typedef struct packed {
-    axi_w_t payload;
-    logic   valid;
-  } axi_w_source_t;
-
-  typedef struct packed {
-    axi_ar_t payload;
-    logic valid;
-  } axi_ar_source_t;
 
   axi_aw_source_t target_aw_drive;
   axi_w_source_t target_w_drive;
@@ -99,35 +77,35 @@ module br_amba_axi_target_driver #(
     input target_rready;
   endclocking
 
-  assign target_awaddr  = AddrWidth'(target_aw_drive.payload.addr);
-  assign target_awid    = IdWidth'(target_aw_drive.payload.id);
+  assign target_awaddr  = target_aw_drive.payload.addr;
+  assign target_awid    = target_aw_drive.payload.id;
   assign target_awlen   = target_aw_drive.payload.len;
   assign target_awsize  = target_aw_drive.payload.size;
   assign target_awburst = target_aw_drive.payload.burst;
   assign target_awprot  = target_aw_drive.payload.prot;
-  assign target_awuser  = AWUserWidth'(target_aw_drive.payload.user);
+  assign target_awuser  = target_aw_drive.payload.user;
   assign target_awvalid = target_aw_drive.valid;
-  assign target_wdata   = DataWidth'(target_w_drive.payload.data);
-  assign target_wstrb   = StrobeWidth'(target_w_drive.payload.strb);
-  assign target_wuser   = WUserWidth'(target_w_drive.payload.user);
+  assign target_wdata   = target_w_drive.payload.data;
+  assign target_wstrb   = target_w_drive.payload.strb;
+  assign target_wuser   = target_w_drive.payload.user;
   assign target_wlast   = target_w_drive.payload.last;
   assign target_wvalid  = target_w_drive.valid;
   assign target_bready  = target_bready_drive;
-  assign target_araddr  = AddrWidth'(target_ar_drive.payload.addr);
-  assign target_arid    = IdWidth'(target_ar_drive.payload.id);
+  assign target_araddr  = target_ar_drive.payload.addr;
+  assign target_arid    = target_ar_drive.payload.id;
   assign target_arlen   = target_ar_drive.payload.len;
   assign target_arsize  = target_ar_drive.payload.size;
   assign target_arburst = target_ar_drive.payload.burst;
   assign target_arprot  = target_ar_drive.payload.prot;
-  assign target_aruser  = ARUserWidth'(target_ar_drive.payload.user);
+  assign target_aruser  = target_ar_drive.payload.user;
   assign target_arvalid = target_ar_drive.valid;
   assign target_rready  = target_rready_drive;
 
   task automatic init_idle();
-    failed          = 1'b0;
+    failed = 1'b0;
 
     target_aw_drive = '0;
-    target_w_drive  = '0;
+    target_w_drive = '0;
     target_ar_drive = '0;
     queued_w_beats.delete();
     target_bready_drive = 1'b1;
@@ -184,19 +162,19 @@ module br_amba_axi_target_driver #(
   function automatic axi_aw_t get_aw_transaction(input axi_aw_t base, input int index,
                                                  input bit vary_burst_len);
     get_aw_transaction = base;
-    get_aw_transaction.addr[AddrWidth-1:0] = base.addr[AddrWidth-1:0] + AddrWidth'(index);
-    get_aw_transaction.id[IdWidth-1:0] = base.id[IdWidth-1:0] + IdWidth'(index);
+    get_aw_transaction.addr = AxiAddrWidth'(base.addr + AxiAddrWidth'(index));
+    get_aw_transaction.id = AxiIdWidth'(base.id + AxiIdWidth'(index));
     if (vary_burst_len) begin
       get_aw_transaction.len = base.len + AxiBurstLenWidth'(index);
     end
-    get_aw_transaction.user[AWUserWidth-1:0] = base.user[AWUserWidth-1:0] + AWUserWidth'(index);
+    get_aw_transaction.user = AxiUserWidth'(base.user + AxiUserWidth'(index));
   endfunction
 
   function automatic axi_w_t get_w_transaction(input axi_w_t base, input int index,
                                                input bit vary_wlast);
     get_w_transaction = base;
-    get_w_transaction.data[DataWidth-1:0] = base.data[DataWidth-1:0] + DataWidth'(index);
-    get_w_transaction.user[WUserWidth-1:0] = base.user[WUserWidth-1:0] + WUserWidth'(index);
+    get_w_transaction.data = AxiDataWidth'(base.data + AxiDataWidth'(index));
+    get_w_transaction.user = AxiUserWidth'(base.user + AxiUserWidth'(index));
     if (vary_wlast) begin
       get_w_transaction.last = base.last ^ index[0];
     end
@@ -205,12 +183,12 @@ module br_amba_axi_target_driver #(
   function automatic axi_ar_t get_ar_transaction(input axi_ar_t base, input int index,
                                                  input bit vary_burst_len);
     get_ar_transaction = base;
-    get_ar_transaction.addr[AddrWidth-1:0] = base.addr[AddrWidth-1:0] + AddrWidth'(index);
-    get_ar_transaction.id[IdWidth-1:0] = base.id[IdWidth-1:0] + IdWidth'(index);
+    get_ar_transaction.addr = AxiAddrWidth'(base.addr + AxiAddrWidth'(index));
+    get_ar_transaction.id = AxiIdWidth'(base.id + AxiIdWidth'(index));
     if (vary_burst_len) begin
       get_ar_transaction.len = base.len + AxiBurstLenWidth'(index);
     end
-    get_ar_transaction.user[ARUserWidth-1:0] = base.user[ARUserWidth-1:0] + ARUserWidth'(index);
+    get_ar_transaction.user = AxiUserWidth'(base.user + AxiUserWidth'(index));
   endfunction
 
   function automatic int get_transaction_index(input int index, input bit vary_transactions);
@@ -231,10 +209,10 @@ module br_amba_axi_target_driver #(
   endtask
 
   task automatic drive_aw_fields(
-      input logic [AddrWidth-1:0] addr, input logic [IdWidth-1:0] id,
+      input logic [AxiAddrWidth-1:0] addr, input logic [AxiIdWidth-1:0] id,
       input logic [AxiBurstLenWidth-1:0] len, input logic [AxiBurstSizeWidth-1:0] size,
       input logic [AxiBurstTypeWidth-1:0] burst, input logic [AxiProtWidth-1:0] prot,
-      input logic [AWUserWidth-1:0] user);
+      input logic [AxiUserWidth-1:0] user);
     @(negedge clk);
     target_aw_drive.payload       = '0;
     target_aw_drive.payload.addr  = addr;
@@ -263,6 +241,12 @@ module br_amba_axi_target_driver #(
     queued_w_beats.push_back(w_input);
   endtask
 
+  task automatic queue_w_beat_fields(input logic [AxiDataWidth-1:0] data,
+                                     input logic [AxiStrobeWidth-1:0] strb,
+                                     input logic [AxiUserWidth-1:0] user, input logic last);
+    queued_w_beats.push_back('{data: data, strb: strb, user: user, last: last});
+  endtask
+
   task automatic drive_queued_w(input int stall_cycles);
     axi_w_t w_input;
 
@@ -274,9 +258,9 @@ module br_amba_axi_target_driver #(
     end
   endtask
 
-  task automatic drive_w_fields(input logic [DataWidth-1:0] data,
-                                input logic [StrobeWidth-1:0] strb,
-                                input logic [WUserWidth-1:0] user, input logic last);
+  task automatic drive_w_fields(input logic [AxiDataWidth-1:0] data,
+                                input logic [AxiStrobeWidth-1:0] strb,
+                                input logic [AxiUserWidth-1:0] user, input logic last);
     @(negedge clk);
     target_w_drive.payload      = '0;
     target_w_drive.payload.data = data;
@@ -299,10 +283,10 @@ module br_amba_axi_target_driver #(
   endtask
 
   task automatic drive_ar_fields(
-      input logic [AddrWidth-1:0] addr, input logic [IdWidth-1:0] id,
+      input logic [AxiAddrWidth-1:0] addr, input logic [AxiIdWidth-1:0] id,
       input logic [AxiBurstLenWidth-1:0] len, input logic [AxiBurstSizeWidth-1:0] size,
       input logic [AxiBurstTypeWidth-1:0] burst, input logic [AxiProtWidth-1:0] prot,
-      input logic [ARUserWidth-1:0] user);
+      input logic [AxiUserWidth-1:0] user);
     @(negedge clk);
     target_ar_drive.payload       = '0;
     target_ar_drive.payload.addr  = addr;
@@ -353,11 +337,22 @@ module br_amba_axi_target_driver #(
     join
   endtask
 
-  task automatic run_read_burst_fields(
-      input logic [AddrWidth-1:0] addr, input logic [IdWidth-1:0] id,
+  task automatic run_write_burst_fields(
+      input logic [AxiAddrWidth-1:0] addr, input logic [AxiIdWidth-1:0] id,
       input logic [AxiBurstLenWidth-1:0] len, input logic [AxiBurstSizeWidth-1:0] size,
       input logic [AxiBurstTypeWidth-1:0] burst, input logic [AxiProtWidth-1:0] prot,
-      input logic [ARUserWidth-1:0] aruser, input int max_stall_cycles);
+      input logic [AxiUserWidth-1:0] awuser, input int max_stall_cycles,
+      input int response_stall_cycles);
+    run_write_burst(
+        '{addr: addr, id: id, len: len, size: size, burst: burst, prot: prot, user: awuser},
+        max_stall_cycles, response_stall_cycles);
+  endtask
+
+  task automatic run_read_burst_fields(
+      input logic [AxiAddrWidth-1:0] addr, input logic [AxiIdWidth-1:0] id,
+      input logic [AxiBurstLenWidth-1:0] len, input logic [AxiBurstSizeWidth-1:0] size,
+      input logic [AxiBurstTypeWidth-1:0] burst, input logic [AxiProtWidth-1:0] prot,
+      input logic [AxiUserWidth-1:0] aruser, input int max_stall_cycles);
     int unsigned beats;
 
     beats = int'(len) + 1;
@@ -437,12 +432,45 @@ module br_amba_axi_target_driver #(
     join
   endtask
 
-  task automatic run(input int num_writes = 0, input int num_reads = 0, input int awvalid_delay = 0,
-                     input int wvalid_delay = 0, input int arvalid_delay = 0,
-                     input int max_stall_cycles = 0, input axi_aw_t aw_input = '0,
-                     input axi_w_t w_input = '0, input axi_ar_t ar_input = '0,
-                     input bit accept_r_burst_len = 0, input bit vary_transactions = 1,
-                     input bit vary_burst_len = 1, input bit vary_wlast = 1);
+  task automatic run(
+      input int num_writes = 0, input int num_reads = 0, input int awvalid_delay = 0,
+      input int wvalid_delay = 0, input int arvalid_delay = 0, input int max_stall_cycles = 0,
+      input logic [AxiAddrWidth-1:0] awaddr = '0, input logic [AxiIdWidth-1:0] awid = '0,
+      input logic [AxiBurstLenWidth-1:0] awlen = '0,
+      input logic [AxiBurstSizeWidth-1:0] awsize = '0,
+      input logic [AxiBurstTypeWidth-1:0] awburst = '0, input logic [AxiProtWidth-1:0] awprot = '0,
+      input logic [AxiUserWidth-1:0] awuser = '0, input logic [AxiDataWidth-1:0] wdata = '0,
+      input logic [AxiStrobeWidth-1:0] wstrb = '0, input logic [AxiUserWidth-1:0] wuser = '0,
+      input logic wlast = '0, input logic [AxiAddrWidth-1:0] araddr = '0,
+      input logic [AxiIdWidth-1:0] arid = '0, input logic [AxiBurstLenWidth-1:0] arlen = '0,
+      input logic [AxiBurstSizeWidth-1:0] arsize = '0,
+      input logic [AxiBurstTypeWidth-1:0] arburst = '0, input logic [AxiProtWidth-1:0] arprot = '0,
+      input logic [AxiUserWidth-1:0] aruser = '0, input bit accept_r_burst_len = 0,
+      input bit vary_transactions = 1, input bit vary_burst_len = 1, input bit vary_wlast = 1);
+    axi_aw_t aw_input;
+    axi_w_t  w_input;
+    axi_ar_t ar_input;
+
+    aw_input = '{
+        addr: awaddr,
+        id: awid,
+        len: awlen,
+        size: awsize,
+        burst: awburst,
+        prot: awprot,
+        user: awuser
+    };
+    w_input = '{data: wdata, strb: wstrb, user: wuser, last: wlast};
+    ar_input = '{
+        addr: araddr,
+        id: arid,
+        len: arlen,
+        size: arsize,
+        burst: arburst,
+        prot: arprot,
+        user: aruser
+    };
+
     fork
       begin
         if (num_writes > 0) begin

--- a/amba/sim/drivers/br_amba_axi_timing_slice_driver.sv
+++ b/amba/sim/drivers/br_amba_axi_timing_slice_driver.sv
@@ -4,6 +4,7 @@
 
 import br_amba::*;
 import br_amba_axi_sim_pkg::*;
+import br_amba_sim_pkg::*;
 
 // AXI timing-slice target-interface stimulus driver.
 //
@@ -206,14 +207,6 @@ module br_amba_axi_timing_slice_initiator_driver #(
     repeat (cycles) @(negedge clk);
   endtask
 
-  function automatic int get_stall_cycles(input int index, input int max_stall_cycles,
-                                          input int salt);
-    if (max_stall_cycles == 0) begin
-      return 0;
-    end
-    return (((index + 1) * salt) ^ (salt >> 1)) % (max_stall_cycles + 1);
-  endfunction
-
   function automatic logic is_wait_condition_met(input wait_condition_e condition);
     case (condition)
       WaitInitAw: is_wait_condition_met = init_awvalid && init_awready;
@@ -308,12 +301,12 @@ module br_amba_axi_timing_slice_initiator_driver #(
       end
       begin
         for (int i = 0; i < num_transactions; i++) begin
-          accept_init_aw(get_stall_cycles(i, max_stall_cycles, 101));
+          accept_init_aw(get_random_stall_cycles(max_stall_cycles));
         end
       end
       begin
         for (int i = 0; i < num_transactions; i++) begin
-          accept_init_w(get_stall_cycles(i, max_stall_cycles, 103));
+          accept_init_w(get_random_stall_cycles(max_stall_cycles));
         end
       end
     join
@@ -330,7 +323,7 @@ module br_amba_axi_timing_slice_initiator_driver #(
       end
       begin
         for (int i = 0; i < num_transactions; i++) begin
-          accept_init_ar(get_stall_cycles(i, max_stall_cycles, 107));
+          accept_init_ar(get_random_stall_cycles(max_stall_cycles));
         end
       end
     join

--- a/amba/sim/drivers/br_amba_axi_timing_slice_driver.sv
+++ b/amba/sim/drivers/br_amba_axi_timing_slice_driver.sv
@@ -55,41 +55,55 @@ module br_amba_axi_timing_slice_driver #(
     output logic failed
 );
 
+  logic [AxiAddrWidth-1:0] target_driver_awaddr;
+  logic [AxiIdWidth-1:0] target_driver_awid;
+  logic [AxiUserWidth-1:0] target_driver_awuser;
+  logic [AxiDataWidth-1:0] target_driver_wdata;
+  logic [AxiStrobeWidth-1:0] target_driver_wstrb;
+  logic [AxiUserWidth-1:0] target_driver_wuser;
+  logic [AxiAddrWidth-1:0] target_driver_araddr;
+  logic [AxiIdWidth-1:0] target_driver_arid;
+  logic [AxiUserWidth-1:0] target_driver_aruser;
+
+  assign target_awaddr = AddrWidth'(target_driver_awaddr);
+  assign target_awid   = IdWidth'(target_driver_awid);
+  assign target_awuser = AWUserWidth'(target_driver_awuser);
+  assign target_wdata  = DataWidth'(target_driver_wdata);
+  assign target_wstrb  = StrobeWidth'(target_driver_wstrb);
+  assign target_wuser  = WUserWidth'(target_driver_wuser);
+  assign target_araddr = AddrWidth'(target_driver_araddr);
+  assign target_arid   = IdWidth'(target_driver_arid);
+  assign target_aruser = ARUserWidth'(target_driver_aruser);
+
   br_amba_axi_target_driver #(
-      .AddrWidth(AddrWidth),
-      .DataWidth(DataWidth),
-      .IdWidth(IdWidth),
-      .AWUserWidth(AWUserWidth),
-      .WUserWidth(WUserWidth),
-      .ARUserWidth(ARUserWidth),
       .TimeoutCycles(TimeoutCycles)
   ) target_driver (
       .clk,
       .rst,
-      .target_awaddr,
-      .target_awid,
+      .target_awaddr(target_driver_awaddr),
+      .target_awid  (target_driver_awid),
       .target_awlen,
       .target_awsize,
       .target_awburst,
       .target_awprot,
-      .target_awuser,
+      .target_awuser(target_driver_awuser),
       .target_awvalid,
       .target_awready,
-      .target_wdata,
-      .target_wstrb,
-      .target_wuser,
+      .target_wdata (target_driver_wdata),
+      .target_wstrb (target_driver_wstrb),
+      .target_wuser (target_driver_wuser),
       .target_wlast,
       .target_wvalid,
       .target_wready,
       .target_bvalid,
       .target_bready,
-      .target_araddr,
-      .target_arid,
+      .target_araddr(target_driver_araddr),
+      .target_arid  (target_driver_arid),
       .target_arlen,
       .target_arsize,
       .target_arburst,
       .target_arprot,
-      .target_aruser,
+      .target_aruser(target_driver_aruser),
       .target_arvalid,
       .target_arready,
       .target_rvalid,
@@ -107,7 +121,12 @@ module br_amba_axi_timing_slice_driver #(
     target_driver.run(.num_writes(num_writes), .num_reads(num_reads),
                       .awvalid_delay(valid_gap_cycles), .wvalid_delay(valid_gap_cycles + 1),
                       .arvalid_delay(valid_gap_cycles + 2), .max_stall_cycles(max_stall_cycles),
-                      .aw_input(aw_input), .w_input(w_input), .ar_input(ar_input));
+                      .awaddr(aw_input.addr), .awid(aw_input.id), .awlen(aw_input.len),
+                      .awsize(aw_input.size), .awburst(aw_input.burst), .awprot(aw_input.prot),
+                      .awuser(aw_input.user), .wdata(w_input.data), .wstrb(w_input.strb),
+                      .wuser(w_input.user), .wlast(w_input.last), .araddr(ar_input.addr),
+                      .arid(ar_input.id), .arlen(ar_input.len), .arsize(ar_input.size),
+                      .arburst(ar_input.burst), .arprot(ar_input.prot), .aruser(ar_input.user));
   endtask
 
 endmodule : br_amba_axi_timing_slice_driver
@@ -232,16 +251,16 @@ module br_amba_axi_timing_slice_initiator_driver #(
   endtask
 
   function automatic axi_b_t get_b_transaction(input axi_b_t base, input int index);
-    get_b_transaction.id   = base.id + IdWidth'(index);
-    get_b_transaction.user = base.user + BUserWidth'(index);
+    get_b_transaction.id   = base.id + br_amba_axi_sim_pkg::AxiIdWidth'(IdWidth'(index));
+    get_b_transaction.user = base.user + br_amba_axi_sim_pkg::AxiUserWidth'(BUserWidth'(index));
     get_b_transaction.resp = base.resp + AxiRespWidth'(index);
   endfunction
 
   function automatic axi_r_t get_r_transaction(input axi_r_t base, input int index);
-    get_r_transaction.id   = base.id + IdWidth'(index);
-    get_r_transaction.data = base.data + DataWidth'(index);
+    get_r_transaction.id   = base.id + br_amba_axi_sim_pkg::AxiIdWidth'(IdWidth'(index));
+    get_r_transaction.data = base.data + br_amba_axi_sim_pkg::AxiDataWidth'(DataWidth'(index));
     get_r_transaction.resp = base.resp + AxiRespWidth'(index);
-    get_r_transaction.user = base.user + RUserWidth'(index);
+    get_r_transaction.user = base.user + br_amba_axi_sim_pkg::AxiUserWidth'(RUserWidth'(index));
     get_r_transaction.last = base.last ^ index[0];
   endfunction
 

--- a/amba/sim/drivers/br_amba_axil_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_axil_sim_pkg.sv
@@ -39,4 +39,10 @@ package br_amba_axil_sim_pkg;
     logic [AxilUserWidth-1:0] user;
   } axil_r_t;
 
+  typedef enum int {
+    AxilRequestAw,
+    AxilRequestW,
+    AxilRequestAr
+  } axil_request_channel_t;
+
 endpackage : br_amba_axil_sim_pkg

--- a/amba/sim/drivers/br_amba_axil_target_driver.sv
+++ b/amba/sim/drivers/br_amba_axil_target_driver.sv
@@ -6,6 +6,8 @@ import br_amba::*;
 import br_amba_axil_sim_pkg::*;
 import br_amba_sim_pkg::*;
 
+`include "br_amba_sim_macros.svh"
+
 // AXI-Lite target-side Bus Functional Model.
 //
 // The driver owns only AXI-Lite target inputs: AWREADY, WREADY, B payload/valid, ARREADY, and R
@@ -95,8 +97,8 @@ module br_amba_axil_target_driver #(
       @cb;
       timeout--;
     end while (!(cb.axil_awvalid && cb.axil_awready) && timeout >= 0);
-    check_eq(cb.axil_awvalid && cb.axil_awready, 1'b1, "Timeout waiting for AXI-Lite AW handshake",
-             failed);
+    `BR_AMBA_SIM_CHECK_EQ(cb.axil_awvalid && cb.axil_awready, 1'b1,
+                          "Timeout waiting for AXI-Lite AW handshake", failed);
   endtask
 
   task automatic wait_w_handshake();
@@ -107,8 +109,8 @@ module br_amba_axil_target_driver #(
       @cb;
       timeout--;
     end while (!(cb.axil_wvalid && cb.axil_wready) && timeout >= 0);
-    check_eq(cb.axil_wvalid && cb.axil_wready, 1'b1, "Timeout waiting for AXI-Lite W handshake",
-             failed);
+    `BR_AMBA_SIM_CHECK_EQ(cb.axil_wvalid && cb.axil_wready, 1'b1,
+                          "Timeout waiting for AXI-Lite W handshake", failed);
   endtask
 
   task automatic wait_b_handshake();
@@ -119,8 +121,8 @@ module br_amba_axil_target_driver #(
       @cb;
       timeout--;
     end while (!(cb.axil_bvalid && cb.axil_bready) && timeout >= 0);
-    check_eq(cb.axil_bvalid && cb.axil_bready, 1'b1, "Timeout waiting for AXI-Lite B handshake",
-             failed);
+    `BR_AMBA_SIM_CHECK_EQ(cb.axil_bvalid && cb.axil_bready, 1'b1,
+                          "Timeout waiting for AXI-Lite B handshake", failed);
   endtask
 
   task automatic wait_ar_handshake();
@@ -131,8 +133,8 @@ module br_amba_axil_target_driver #(
       @cb;
       timeout--;
     end while (!(cb.axil_arvalid && cb.axil_arready) && timeout >= 0);
-    check_eq(cb.axil_arvalid && cb.axil_arready, 1'b1, "Timeout waiting for AXI-Lite AR handshake",
-             failed);
+    `BR_AMBA_SIM_CHECK_EQ(cb.axil_arvalid && cb.axil_arready, 1'b1,
+                          "Timeout waiting for AXI-Lite AR handshake", failed);
   endtask
 
   task automatic wait_r_handshake();
@@ -143,8 +145,8 @@ module br_amba_axil_target_driver #(
       @cb;
       timeout--;
     end while (!(cb.axil_rvalid && cb.axil_rready) && timeout >= 0);
-    check_eq(cb.axil_rvalid && cb.axil_rready, 1'b1, "Timeout waiting for AXI-Lite R handshake",
-             failed);
+    `BR_AMBA_SIM_CHECK_EQ(cb.axil_rvalid && cb.axil_rready, 1'b1,
+                          "Timeout waiting for AXI-Lite R handshake", failed);
   endtask
 
   task automatic queue_b_response(input axil_b_t b);
@@ -201,8 +203,8 @@ module br_amba_axil_target_driver #(
     join_any
     disable fork;
 
-    check_eq(accepted_aw_count > request_index && accepted_w_count > request_index, 1'b1,
-             "Timeout waiting for AXI-Lite write request", failed);
+    `BR_AMBA_SIM_CHECK_EQ(accepted_aw_count > request_index && accepted_w_count > request_index,
+                          1'b1, "Timeout waiting for AXI-Lite write request", failed);
   endtask
 
   task automatic wait_read_request_accepted(input int unsigned request_index);
@@ -212,15 +214,15 @@ module br_amba_axil_target_driver #(
     join_any
     disable fork;
 
-    check_eq(accepted_ar_count > request_index, 1'b1, "Timeout waiting for AXI-Lite read request",
-             failed);
+    `BR_AMBA_SIM_CHECK_EQ(accepted_ar_count > request_index, 1'b1,
+                          "Timeout waiting for AXI-Lite read request", failed);
   endtask
 
   task automatic drive_next_b(input int stall_cycles);
     axil_b_t b;
 
     wait_cycles(stall_cycles);
-    check_eq(b_queue.size() > 0, 1'b1, "AXI-Lite B response queue empty", failed);
+    `BR_AMBA_SIM_CHECK_EQ(b_queue.size() > 0, 1'b1, "AXI-Lite B response queue empty", failed);
     if (b_queue.size() > 0) begin
       b = b_queue.pop_front();
     end else begin
@@ -242,7 +244,7 @@ module br_amba_axil_target_driver #(
     axil_r_t r;
 
     wait_cycles(stall_cycles);
-    check_eq(r_queue.size() > 0, 1'b1, "AXI-Lite R response queue empty", failed);
+    `BR_AMBA_SIM_CHECK_EQ(r_queue.size() > 0, 1'b1, "AXI-Lite R response queue empty", failed);
     if (r_queue.size() > 0) begin
       r = r_queue.pop_front();
     end else begin
@@ -299,8 +301,8 @@ module br_amba_axil_target_driver #(
       end
     join
 
-    check_eq(b_queue.size(), 0, "AXI-Lite B response queue not empty", failed);
-    check_eq(r_queue.size(), 0, "AXI-Lite R response queue not empty", failed);
+    `BR_AMBA_SIM_CHECK_EQ(b_queue.size(), 0, "AXI-Lite B response queue not empty", failed);
+    `BR_AMBA_SIM_CHECK_EQ(r_queue.size(), 0, "AXI-Lite R response queue not empty", failed);
   endtask
 
 endmodule : br_amba_axil_target_driver

--- a/amba/sim/drivers/br_amba_axil_target_driver.sv
+++ b/amba/sim/drivers/br_amba_axil_target_driver.sv
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_axil_sim_pkg::*;
+import br_amba_sim_pkg::*;
+
+// AXI-Lite target-side Bus Functional Model.
+//
+// The driver owns only AXI-Lite target inputs: AWREADY, WREADY, B payload/valid, ARREADY, and R
+// payload/valid. It accepts request channels and returns queued responses. Payload checking belongs
+// in monitors or scoreboards.
+module br_amba_axil_target_driver #(
+    parameter int DataWidth = 32,
+    parameter int BUserWidth = 2,
+    parameter int RUserWidth = 2,
+    parameter int TimeoutCycles = 100
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic axil_awvalid,
+    output logic axil_awready,
+    input logic axil_wvalid,
+    output logic axil_wready,
+    output logic [AxiRespWidth-1:0] axil_bresp,
+    output logic [BUserWidth-1:0] axil_buser,
+    output logic axil_bvalid,
+    input logic axil_bready,
+    input logic axil_arvalid,
+    output logic axil_arready,
+    output logic [DataWidth-1:0] axil_rdata,
+    output logic [AxiRespWidth-1:0] axil_rresp,
+    output logic [RUserWidth-1:0] axil_ruser,
+    output logic axil_rvalid,
+    input logic axil_rready,
+
+    output logic failed
+);
+
+  axil_b_t b_queue[$];
+  axil_r_t r_queue[$];
+  int unsigned accepted_aw_count;
+  int unsigned accepted_w_count;
+  int unsigned accepted_ar_count;
+  event posedge_clk;
+
+  clocking cb @(posedge clk);
+    default input #1step;
+    input axil_awvalid;
+    input axil_awready;
+    input axil_wvalid;
+    input axil_wready;
+    input axil_bvalid;
+    input axil_bready;
+    input axil_arvalid;
+    input axil_arready;
+    input axil_rvalid;
+    input axil_rready;
+  endclocking
+
+  always @(posedge clk) begin
+    ->posedge_clk;
+  end
+
+  task automatic init_idle();
+    failed       = 1'b0;
+    axil_awready = 1'b0;
+    axil_wready  = 1'b0;
+    axil_bresp   = '0;
+    axil_buser   = '0;
+    axil_bvalid  = 1'b0;
+    axil_arready = 1'b0;
+    axil_rdata   = '0;
+    axil_rresp   = '0;
+    axil_ruser   = '0;
+    axil_rvalid  = 1'b0;
+    b_queue.delete();
+    r_queue.delete();
+    accepted_aw_count = 0;
+    accepted_w_count  = 0;
+    accepted_ar_count = 0;
+  endtask
+
+  task automatic wait_cycles(input int cycles = 1);
+    repeat (cycles) @(negedge clk);
+  endtask
+
+  task automatic wait_aw_handshake();
+    int timeout;
+
+    timeout = TimeoutCycles;
+    do begin
+      @cb;
+      timeout--;
+    end while (!(cb.axil_awvalid && cb.axil_awready) && timeout >= 0);
+    check_eq(cb.axil_awvalid && cb.axil_awready, 1'b1, "Timeout waiting for AXI-Lite AW handshake",
+             failed);
+  endtask
+
+  task automatic wait_w_handshake();
+    int timeout;
+
+    timeout = TimeoutCycles;
+    do begin
+      @cb;
+      timeout--;
+    end while (!(cb.axil_wvalid && cb.axil_wready) && timeout >= 0);
+    check_eq(cb.axil_wvalid && cb.axil_wready, 1'b1, "Timeout waiting for AXI-Lite W handshake",
+             failed);
+  endtask
+
+  task automatic wait_b_handshake();
+    int timeout;
+
+    timeout = TimeoutCycles;
+    do begin
+      @cb;
+      timeout--;
+    end while (!(cb.axil_bvalid && cb.axil_bready) && timeout >= 0);
+    check_eq(cb.axil_bvalid && cb.axil_bready, 1'b1, "Timeout waiting for AXI-Lite B handshake",
+             failed);
+  endtask
+
+  task automatic wait_ar_handshake();
+    int timeout;
+
+    timeout = TimeoutCycles;
+    do begin
+      @cb;
+      timeout--;
+    end while (!(cb.axil_arvalid && cb.axil_arready) && timeout >= 0);
+    check_eq(cb.axil_arvalid && cb.axil_arready, 1'b1, "Timeout waiting for AXI-Lite AR handshake",
+             failed);
+  endtask
+
+  task automatic wait_r_handshake();
+    int timeout;
+
+    timeout = TimeoutCycles;
+    do begin
+      @cb;
+      timeout--;
+    end while (!(cb.axil_rvalid && cb.axil_rready) && timeout >= 0);
+    check_eq(cb.axil_rvalid && cb.axil_rready, 1'b1, "Timeout waiting for AXI-Lite R handshake",
+             failed);
+  endtask
+
+  task automatic queue_b_response(input axil_b_t b);
+    b_queue.push_back(b);
+  endtask
+
+  task automatic queue_r_response(input axil_r_t r);
+    r_queue.push_back(r);
+  endtask
+
+  function automatic int get_channel_stall_cycles(input int channel_max_stall_cycles,
+                                                  input int default_max_stall_cycles);
+    int max_stall_cycles;
+
+    max_stall_cycles = (channel_max_stall_cycles >= 0) ? channel_max_stall_cycles :
+        default_max_stall_cycles;
+    return get_random_stall_cycles(max_stall_cycles);
+  endfunction
+
+  task automatic accept_aw(input int stall_cycles);
+    if (stall_cycles > 0) begin
+      axil_awready = 1'b0;
+      wait_cycles(stall_cycles);
+    end
+    axil_awready = 1'b1;
+    wait_aw_handshake();
+    accepted_aw_count++;
+  endtask
+
+  task automatic accept_w(input int stall_cycles);
+    if (stall_cycles > 0) begin
+      axil_wready = 1'b0;
+      wait_cycles(stall_cycles);
+    end
+    axil_wready = 1'b1;
+    wait_w_handshake();
+    accepted_w_count++;
+  endtask
+
+  task automatic accept_ar(input int stall_cycles);
+    if (stall_cycles > 0) begin
+      axil_arready = 1'b0;
+      wait_cycles(stall_cycles);
+    end
+    axil_arready = 1'b1;
+    wait_ar_handshake();
+    accepted_ar_count++;
+  endtask
+
+  task automatic wait_write_request_accepted(input int unsigned request_index);
+    fork
+      while (!(accepted_aw_count > request_index && accepted_w_count > request_index)) @posedge_clk;
+      timeout(posedge_clk, TimeoutCycles, "Timeout waiting for AXI-Lite write request", failed);
+    join_any
+    disable fork;
+
+    check_eq(accepted_aw_count > request_index && accepted_w_count > request_index, 1'b1,
+             "Timeout waiting for AXI-Lite write request", failed);
+  endtask
+
+  task automatic wait_read_request_accepted(input int unsigned request_index);
+    fork
+      while (!(accepted_ar_count > request_index)) @posedge_clk;
+      timeout(posedge_clk, TimeoutCycles, "Timeout waiting for AXI-Lite read request", failed);
+    join_any
+    disable fork;
+
+    check_eq(accepted_ar_count > request_index, 1'b1, "Timeout waiting for AXI-Lite read request",
+             failed);
+  endtask
+
+  task automatic drive_next_b(input int stall_cycles);
+    axil_b_t b;
+
+    wait_cycles(stall_cycles);
+    check_eq(b_queue.size() > 0, 1'b1, "AXI-Lite B response queue empty", failed);
+    if (b_queue.size() > 0) begin
+      b = b_queue.pop_front();
+    end else begin
+      b = '0;
+    end
+
+    @(negedge clk);
+    axil_bresp  = b.resp;
+    axil_buser  = BUserWidth'(b.user);
+    axil_bvalid = 1'b1;
+    wait_b_handshake();
+    @(negedge clk);
+    axil_bvalid = 1'b0;
+    axil_bresp  = '0;
+    axil_buser  = '0;
+  endtask
+
+  task automatic drive_next_r(input int stall_cycles);
+    axil_r_t r;
+
+    wait_cycles(stall_cycles);
+    check_eq(r_queue.size() > 0, 1'b1, "AXI-Lite R response queue empty", failed);
+    if (r_queue.size() > 0) begin
+      r = r_queue.pop_front();
+    end else begin
+      r = '0;
+    end
+
+    @(negedge clk);
+    axil_rdata  = DataWidth'(r.data);
+    axil_rresp  = r.resp;
+    axil_ruser  = RUserWidth'(r.user);
+    axil_rvalid = 1'b1;
+    wait_r_handshake();
+    @(negedge clk);
+    axil_rvalid = 1'b0;
+    axil_rdata  = '0;
+    axil_rresp  = '0;
+    axil_ruser  = '0;
+  endtask
+
+  task automatic run(input int num_write_requests, input int num_read_requests,
+                     input int max_stall_cycles, input int awready_max_stall_cycles = -1,
+                     input int wready_max_stall_cycles = -1, input int bvalid_max_stall_cycles = -1,
+                     input int arready_max_stall_cycles = -1,
+                     input int rvalid_max_stall_cycles = -1);
+    wait_cycles();
+
+    fork
+      begin
+        for (int i = 0; i < num_write_requests; i++) begin
+          accept_aw(get_channel_stall_cycles(awready_max_stall_cycles, max_stall_cycles));
+        end
+      end
+      begin
+        for (int i = 0; i < num_write_requests; i++) begin
+          accept_w(get_channel_stall_cycles(wready_max_stall_cycles, max_stall_cycles));
+        end
+      end
+      begin
+        for (int i = 0; i < num_write_requests; i++) begin
+          wait_write_request_accepted(i);
+          drive_next_b(get_channel_stall_cycles(bvalid_max_stall_cycles, max_stall_cycles));
+        end
+      end
+      begin
+        for (int i = 0; i < num_read_requests; i++) begin
+          accept_ar(get_channel_stall_cycles(arready_max_stall_cycles, max_stall_cycles));
+        end
+      end
+      begin
+        for (int i = 0; i < num_read_requests; i++) begin
+          wait_read_request_accepted(i);
+          drive_next_r(get_channel_stall_cycles(rvalid_max_stall_cycles, max_stall_cycles));
+        end
+      end
+    join
+
+    check_eq(b_queue.size(), 0, "AXI-Lite B response queue not empty", failed);
+    check_eq(r_queue.size(), 0, "AXI-Lite R response queue not empty", failed);
+  endtask
+
+endmodule : br_amba_axil_target_driver

--- a/amba/sim/drivers/br_amba_axil_timing_slice_driver.sv
+++ b/amba/sim/drivers/br_amba_axil_timing_slice_driver.sv
@@ -4,6 +4,7 @@
 
 import br_amba::*;
 import br_amba_axil_sim_pkg::*;
+import br_amba_sim_pkg::*;
 
 // AXI-Lite timing-slice stimulus driver.
 //
@@ -163,14 +164,6 @@ module br_amba_axil_timing_slice_driver #(
   task automatic wait_cycles(input int cycles = 1);
     repeat (cycles) @(negedge clk);
   endtask
-
-  function automatic int get_stall_cycles(input int index, input int max_stall_cycles,
-                                          input int salt);
-    if (max_stall_cycles == 0) begin
-      return 0;
-    end
-    return (((index + 1) * salt) ^ (salt >> 1)) % (max_stall_cycles + 1);
-  endfunction
 
   function automatic logic is_wait_condition_met(input wait_condition_e condition);
     case (condition)
@@ -344,17 +337,17 @@ module br_amba_axil_timing_slice_driver #(
       end
       begin
         for (int i = 0; i < num_transactions; i++) begin
-          accept_init_aw(get_stall_cycles(i, max_stall_cycles, 101));
+          accept_init_aw(get_random_stall_cycles(max_stall_cycles));
         end
       end
       begin
         for (int i = 0; i < num_transactions; i++) begin
-          accept_init_w(get_stall_cycles(i, max_stall_cycles, 103));
+          accept_init_w(get_random_stall_cycles(max_stall_cycles));
         end
       end
       begin
         for (int i = 0; i < num_transactions; i++) begin
-          accept_target_b(get_stall_cycles(i, max_stall_cycles, 109));
+          accept_target_b(get_random_stall_cycles(max_stall_cycles));
         end
       end
     join
@@ -378,12 +371,12 @@ module br_amba_axil_timing_slice_driver #(
       end
       begin
         for (int i = 0; i < num_transactions; i++) begin
-          accept_init_ar(get_stall_cycles(i, max_stall_cycles, 107));
+          accept_init_ar(get_random_stall_cycles(max_stall_cycles));
         end
       end
       begin
         for (int i = 0; i < num_transactions; i++) begin
-          accept_target_r(get_stall_cycles(i, max_stall_cycles, 113));
+          accept_target_r(get_random_stall_cycles(max_stall_cycles));
         end
       end
     join

--- a/amba/sim/drivers/br_amba_sim_macros.svh
+++ b/amba/sim/drivers/br_amba_sim_macros.svh
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef BR_AMBA_SIM_MACROS_SVH
+`define BR_AMBA_SIM_MACROS_SVH
+
+`define BR_AMBA_SIM_CHECK_EQ(actual, expected, message, failed) \
+  do begin \
+    if ((actual) !== (expected)) begin \
+      report_error($sformatf("%s: expected 0x%0h got 0x%0h", message, expected, actual), failed); \
+    end \
+  end while (0)
+
+`endif  // BR_AMBA_SIM_MACROS_SVH

--- a/amba/sim/drivers/br_amba_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_sim_pkg.sv
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+package br_amba_sim_pkg;
+  localparam int BrAmbaSimMaxCheckWidth = 1024;
+
+  task automatic check_eq(input logic [BrAmbaSimMaxCheckWidth-1:0] actual,
+                          input logic [BrAmbaSimMaxCheckWidth-1:0] expected, input string message,
+                          ref logic failed);
+    if (actual !== expected) begin
+      failed = 1'b1;
+      $error("%s: expected 0x%0h got 0x%0h", message, expected, actual);
+    end
+  endtask
+
+  task automatic timeout(input event tick, input int cycles, input string message,
+                         ref logic failed);
+    repeat (cycles) @tick;
+    failed = 1'b1;
+    $error("%s", message);
+  endtask
+
+  function automatic int get_random_stall_cycles(input int max_stall_cycles);
+    if (max_stall_cycles == 0) begin
+      return 0;
+    end
+    return int'($urandom_range(max_stall_cycles, 0));
+  endfunction
+
+endpackage : br_amba_sim_pkg

--- a/amba/sim/drivers/br_amba_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_sim_pkg.sv
@@ -3,22 +3,15 @@
 `timescale 1ns / 1ps
 
 package br_amba_sim_pkg;
-  localparam int BrAmbaSimMaxCheckWidth = 1024;
-
-  task automatic check_eq(input logic [BrAmbaSimMaxCheckWidth-1:0] actual,
-                          input logic [BrAmbaSimMaxCheckWidth-1:0] expected, input string message,
-                          ref logic failed);
-    if (actual !== expected) begin
-      failed = 1'b1;
-      $error("%s: expected 0x%0h got 0x%0h", message, expected, actual);
-    end
+  task automatic report_error(input string message, ref logic failed);
+    failed = 1'b1;
+    $error("%s", message);
   endtask
 
   task automatic timeout(input event tick, input int cycles, input string message,
                          ref logic failed);
     repeat (cycles) @tick;
-    failed = 1'b1;
-    $error("%s", message);
+    report_error(message, failed);
   endtask
 
   function automatic int get_random_stall_cycles(input int max_stall_cycles);

--- a/amba/sim/monitors/BUILD.bazel
+++ b/amba/sim/monitors/BUILD.bazel
@@ -41,6 +41,29 @@ verilog_library(
 )
 
 verilog_library(
+    name = "br_amba_axil_request_monitor",
+    srcs = ["br_amba_axil_request_monitor.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//amba/rtl:br_amba_pkg",
+        "//amba/sim/drivers:br_amba_axi_sim_pkg",
+        "//amba/sim/drivers:br_amba_axil_sim_pkg",
+        "//amba/sim/drivers:br_amba_sim_pkg",
+    ],
+)
+
+verilog_library(
+    name = "br_amba_axi_response_monitor",
+    srcs = ["br_amba_axi_response_monitor.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//amba/rtl:br_amba_pkg",
+        "//amba/sim/drivers:br_amba_axi_sim_pkg",
+        "//amba/sim/drivers:br_amba_sim_pkg",
+    ],
+)
+
+verilog_library(
     name = "br_amba_axi_timing_slice_monitor",
     srcs = ["br_amba_axi_timing_slice_monitor.sv"],
     visibility = ["//visibility:public"],

--- a/amba/sim/monitors/br_amba_axi_response_monitor.sv
+++ b/amba/sim/monitors/br_amba_axi_response_monitor.sv
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_axi_sim_pkg::*;
+import br_amba_sim_pkg::*;
+
+// AXI response-channel payload monitor.
+//
+// This monitor observes B/R handshakes, compares each sampled payload against queued expected
+// transactions, and leaves BREADY/RREADY driving to a separate bus functional model.
+module br_amba_axi_response_monitor #(
+    parameter int DataWidth = 32,
+    parameter int IdWidth = 3,
+    parameter int BUserWidth = 2,
+    parameter int RUserWidth = 2,
+    parameter int TimeoutCycles = 100
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [IdWidth-1:0] axi_bid,
+    input logic [BUserWidth-1:0] axi_buser,
+    input logic [AxiRespWidth-1:0] axi_bresp,
+    input logic axi_bvalid,
+    input logic axi_bready,
+    input logic [IdWidth-1:0] axi_rid,
+    input logic [DataWidth-1:0] axi_rdata,
+    input logic [RUserWidth-1:0] axi_ruser,
+    input logic [AxiRespWidth-1:0] axi_rresp,
+    input logic axi_rlast,
+    input logic axi_rvalid,
+    input logic axi_rready,
+
+    output logic failed
+);
+
+  axi_b_t b_queue[$];
+  axi_r_t r_queue[$];
+  event posedge_clk;
+
+  clocking cb @(posedge clk);
+    default input #1step;
+    input axi_bid;
+    input axi_buser;
+    input axi_bresp;
+    input axi_bvalid;
+    input axi_bready;
+    input axi_rid;
+    input axi_rdata;
+    input axi_ruser;
+    input axi_rresp;
+    input axi_rlast;
+    input axi_rvalid;
+    input axi_rready;
+  endclocking
+
+  always @(posedge clk) begin
+    ->posedge_clk;
+  end
+
+  task automatic init_idle();
+    failed = 1'b0;
+    b_queue.delete();
+    r_queue.delete();
+  endtask
+
+  function automatic logic [AxiRespWidth-1:0] predict_axi_write_resp(
+      input int unsigned beats, input logic [AxiRespWidth-1:0] first_resp,
+      input logic [AxiRespWidth-1:0] later_resp);
+    if (beats == 0) begin
+      predict_axi_write_resp = AxiRespOkay;
+    end else if (first_resp != AxiRespOkay || beats == 1) begin
+      predict_axi_write_resp = first_resp;
+    end else begin
+      predict_axi_write_resp = later_resp;
+    end
+  endfunction
+
+  task automatic monitor_b(input int num_transactions);
+    axi_b_t expected;
+    int observed;
+
+    observed = 0;
+    while (observed < num_transactions) begin
+      @cb;
+      if (cb.axi_bvalid && cb.axi_bready) begin
+        check_eq(b_queue.size() > 0, 1'b1, "AXI B expected queue empty", failed);
+        if (b_queue.size() > 0) begin
+          expected = b_queue.pop_front();
+          check_eq(cb.axi_bid, IdWidth'(expected.id), "AXI B id mismatch", failed);
+          check_eq(cb.axi_bresp, expected.resp, "AXI B resp mismatch", failed);
+          check_eq(cb.axi_buser, BUserWidth'(expected.user), "AXI B user mismatch", failed);
+        end
+        observed++;
+      end
+    end
+  endtask
+
+  task automatic monitor_r(input int num_transactions);
+    axi_r_t expected;
+    int observed;
+
+    observed = 0;
+    while (observed < num_transactions) begin
+      @cb;
+      if (cb.axi_rvalid && cb.axi_rready) begin
+        check_eq(r_queue.size() > 0, 1'b1, "AXI R expected queue empty", failed);
+        if (r_queue.size() > 0) begin
+          expected = r_queue.pop_front();
+          check_eq(cb.axi_rid, IdWidth'(expected.id), "AXI R id mismatch", failed);
+          check_eq(cb.axi_rdata, DataWidth'(expected.data), "AXI R data mismatch", failed);
+          check_eq(cb.axi_rresp, expected.resp, "AXI R resp mismatch", failed);
+          check_eq(cb.axi_ruser, RUserWidth'(expected.user), "AXI R user mismatch", failed);
+          check_eq(cb.axi_rlast, expected.last, "AXI R last mismatch", failed);
+        end
+        observed++;
+      end
+    end
+  endtask
+
+  task automatic monitor_b_channel(input int num_transactions);
+    fork
+      monitor_b(num_transactions);
+      timeout(posedge_clk, TimeoutCycles * (num_transactions + 1),
+              "Timeout waiting for AXI B transfers", failed);
+    join_any
+    disable fork;
+  endtask
+
+  task automatic monitor_r_channel(input int num_transactions);
+    fork
+      monitor_r(num_transactions);
+      timeout(posedge_clk, TimeoutCycles * (num_transactions + 1),
+              "Timeout waiting for AXI R transfers", failed);
+    join_any
+    disable fork;
+  endtask
+
+  task automatic run(input int num_writes, input int num_reads);
+    fork
+      monitor_b_channel(num_writes);
+      monitor_r_channel(num_reads);
+    join
+
+    check_eq(b_queue.size(), 0, "AXI B expected queue not empty", failed);
+    check_eq(r_queue.size(), 0, "AXI R expected queue not empty", failed);
+  endtask
+
+endmodule : br_amba_axi_response_monitor

--- a/amba/sim/monitors/br_amba_axi_response_monitor.sv
+++ b/amba/sim/monitors/br_amba_axi_response_monitor.sv
@@ -6,6 +6,8 @@ import br_amba::*;
 import br_amba_axi_sim_pkg::*;
 import br_amba_sim_pkg::*;
 
+`include "br_amba_sim_macros.svh"
+
 // AXI response-channel payload monitor.
 //
 // This monitor observes B/R handshakes, compares each sampled payload against queued expected
@@ -86,12 +88,13 @@ module br_amba_axi_response_monitor #(
     while (observed < num_transactions) begin
       @cb;
       if (cb.axi_bvalid && cb.axi_bready) begin
-        check_eq(b_queue.size() > 0, 1'b1, "AXI B expected queue empty", failed);
+        `BR_AMBA_SIM_CHECK_EQ(b_queue.size() > 0, 1'b1, "AXI B expected queue empty", failed);
         if (b_queue.size() > 0) begin
           expected = b_queue.pop_front();
-          check_eq(cb.axi_bid, IdWidth'(expected.id), "AXI B id mismatch", failed);
-          check_eq(cb.axi_bresp, expected.resp, "AXI B resp mismatch", failed);
-          check_eq(cb.axi_buser, BUserWidth'(expected.user), "AXI B user mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axi_bid, IdWidth'(expected.id), "AXI B id mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axi_bresp, expected.resp, "AXI B resp mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axi_buser, BUserWidth'(expected.user), "AXI B user mismatch",
+                                failed);
         end
         observed++;
       end
@@ -106,14 +109,16 @@ module br_amba_axi_response_monitor #(
     while (observed < num_transactions) begin
       @cb;
       if (cb.axi_rvalid && cb.axi_rready) begin
-        check_eq(r_queue.size() > 0, 1'b1, "AXI R expected queue empty", failed);
+        `BR_AMBA_SIM_CHECK_EQ(r_queue.size() > 0, 1'b1, "AXI R expected queue empty", failed);
         if (r_queue.size() > 0) begin
           expected = r_queue.pop_front();
-          check_eq(cb.axi_rid, IdWidth'(expected.id), "AXI R id mismatch", failed);
-          check_eq(cb.axi_rdata, DataWidth'(expected.data), "AXI R data mismatch", failed);
-          check_eq(cb.axi_rresp, expected.resp, "AXI R resp mismatch", failed);
-          check_eq(cb.axi_ruser, RUserWidth'(expected.user), "AXI R user mismatch", failed);
-          check_eq(cb.axi_rlast, expected.last, "AXI R last mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axi_rid, IdWidth'(expected.id), "AXI R id mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axi_rdata, DataWidth'(expected.data), "AXI R data mismatch",
+                                failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axi_rresp, expected.resp, "AXI R resp mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axi_ruser, RUserWidth'(expected.user), "AXI R user mismatch",
+                                failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axi_rlast, expected.last, "AXI R last mismatch", failed);
         end
         observed++;
       end
@@ -144,8 +149,8 @@ module br_amba_axi_response_monitor #(
       monitor_r_channel(num_reads);
     join
 
-    check_eq(b_queue.size(), 0, "AXI B expected queue not empty", failed);
-    check_eq(r_queue.size(), 0, "AXI R expected queue not empty", failed);
+    `BR_AMBA_SIM_CHECK_EQ(b_queue.size(), 0, "AXI B expected queue not empty", failed);
+    `BR_AMBA_SIM_CHECK_EQ(r_queue.size(), 0, "AXI R expected queue not empty", failed);
   endtask
 
 endmodule : br_amba_axi_response_monitor

--- a/amba/sim/monitors/br_amba_axi_timing_slice_monitor.sv
+++ b/amba/sim/monitors/br_amba_axi_timing_slice_monitor.sv
@@ -149,84 +149,84 @@ module br_amba_axi_timing_slice_monitor #(
   endtask
 
   function automatic axi_aw_t get_target_aw();
-    get_target_aw.addr  = target_awaddr;
-    get_target_aw.id    = target_awid;
+    get_target_aw.addr  = br_amba_axi_sim_pkg::AxiAddrWidth'(target_awaddr);
+    get_target_aw.id    = br_amba_axi_sim_pkg::AxiIdWidth'(target_awid);
     get_target_aw.len   = target_awlen;
     get_target_aw.size  = target_awsize;
     get_target_aw.burst = target_awburst;
     get_target_aw.prot  = target_awprot;
-    get_target_aw.user  = target_awuser;
+    get_target_aw.user  = br_amba_axi_sim_pkg::AxiUserWidth'(target_awuser);
   endfunction
 
   function automatic axi_aw_t get_init_aw();
-    get_init_aw.addr  = init_awaddr;
-    get_init_aw.id    = init_awid;
+    get_init_aw.addr  = br_amba_axi_sim_pkg::AxiAddrWidth'(init_awaddr);
+    get_init_aw.id    = br_amba_axi_sim_pkg::AxiIdWidth'(init_awid);
     get_init_aw.len   = init_awlen;
     get_init_aw.size  = init_awsize;
     get_init_aw.burst = init_awburst;
     get_init_aw.prot  = init_awprot;
-    get_init_aw.user  = init_awuser;
+    get_init_aw.user  = br_amba_axi_sim_pkg::AxiUserWidth'(init_awuser);
   endfunction
 
   function automatic axi_w_t get_target_w();
-    get_target_w.data = target_wdata;
-    get_target_w.strb = target_wstrb;
-    get_target_w.user = target_wuser;
+    get_target_w.data = br_amba_axi_sim_pkg::AxiDataWidth'(target_wdata);
+    get_target_w.strb = br_amba_axi_sim_pkg::AxiStrobeWidth'(target_wstrb);
+    get_target_w.user = br_amba_axi_sim_pkg::AxiUserWidth'(target_wuser);
     get_target_w.last = target_wlast;
   endfunction
 
   function automatic axi_w_t get_init_w();
-    get_init_w.data = init_wdata;
-    get_init_w.strb = init_wstrb;
-    get_init_w.user = init_wuser;
+    get_init_w.data = br_amba_axi_sim_pkg::AxiDataWidth'(init_wdata);
+    get_init_w.strb = br_amba_axi_sim_pkg::AxiStrobeWidth'(init_wstrb);
+    get_init_w.user = br_amba_axi_sim_pkg::AxiUserWidth'(init_wuser);
     get_init_w.last = init_wlast;
   endfunction
 
   function automatic axi_ar_t get_target_ar();
-    get_target_ar.addr  = target_araddr;
-    get_target_ar.id    = target_arid;
+    get_target_ar.addr  = br_amba_axi_sim_pkg::AxiAddrWidth'(target_araddr);
+    get_target_ar.id    = br_amba_axi_sim_pkg::AxiIdWidth'(target_arid);
     get_target_ar.len   = target_arlen;
     get_target_ar.size  = target_arsize;
     get_target_ar.burst = target_arburst;
     get_target_ar.prot  = target_arprot;
-    get_target_ar.user  = target_aruser;
+    get_target_ar.user  = br_amba_axi_sim_pkg::AxiUserWidth'(target_aruser);
   endfunction
 
   function automatic axi_ar_t get_init_ar();
-    get_init_ar.addr  = init_araddr;
-    get_init_ar.id    = init_arid;
+    get_init_ar.addr  = br_amba_axi_sim_pkg::AxiAddrWidth'(init_araddr);
+    get_init_ar.id    = br_amba_axi_sim_pkg::AxiIdWidth'(init_arid);
     get_init_ar.len   = init_arlen;
     get_init_ar.size  = init_arsize;
     get_init_ar.burst = init_arburst;
     get_init_ar.prot  = init_arprot;
-    get_init_ar.user  = init_aruser;
+    get_init_ar.user  = br_amba_axi_sim_pkg::AxiUserWidth'(init_aruser);
   endfunction
 
   function automatic axi_b_t get_init_b();
-    get_init_b.id   = init_bid;
-    get_init_b.user = init_buser;
+    get_init_b.id   = br_amba_axi_sim_pkg::AxiIdWidth'(init_bid);
+    get_init_b.user = br_amba_axi_sim_pkg::AxiUserWidth'(init_buser);
     get_init_b.resp = init_bresp;
   endfunction
 
   function automatic axi_b_t get_target_b();
-    get_target_b.id   = target_bid;
-    get_target_b.user = target_buser;
+    get_target_b.id   = br_amba_axi_sim_pkg::AxiIdWidth'(target_bid);
+    get_target_b.user = br_amba_axi_sim_pkg::AxiUserWidth'(target_buser);
     get_target_b.resp = target_bresp;
   endfunction
 
   function automatic axi_r_t get_init_r();
-    get_init_r.id   = init_rid;
-    get_init_r.data = init_rdata;
+    get_init_r.id   = br_amba_axi_sim_pkg::AxiIdWidth'(init_rid);
+    get_init_r.data = br_amba_axi_sim_pkg::AxiDataWidth'(init_rdata);
     get_init_r.resp = init_rresp;
-    get_init_r.user = init_ruser;
+    get_init_r.user = br_amba_axi_sim_pkg::AxiUserWidth'(init_ruser);
     get_init_r.last = init_rlast;
   endfunction
 
   function automatic axi_r_t get_target_r();
-    get_target_r.id   = target_rid;
-    get_target_r.data = target_rdata;
+    get_target_r.id   = br_amba_axi_sim_pkg::AxiIdWidth'(target_rid);
+    get_target_r.data = br_amba_axi_sim_pkg::AxiDataWidth'(target_rdata);
     get_target_r.resp = target_rresp;
-    get_target_r.user = target_ruser;
+    get_target_r.user = br_amba_axi_sim_pkg::AxiUserWidth'(target_ruser);
     get_target_r.last = target_rlast;
   endfunction
 

--- a/amba/sim/monitors/br_amba_axil_request_monitor.sv
+++ b/amba/sim/monitors/br_amba_axil_request_monitor.sv
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_axi_sim_pkg::*;
+import br_amba_axil_sim_pkg::*;
+import br_amba_sim_pkg::*;
+
+// AXI-Lite request-channel payload monitor.
+//
+// This monitor observes AW/W/AR handshakes, compares each sampled payload against queued expected
+// transactions, and leaves all ready/valid driving to separate bus functional models.
+module br_amba_axil_request_monitor #(
+    parameter int AddrWidth = 12,
+    parameter int DataWidth = 32,
+    parameter int AWUserWidth = 2,
+    parameter int WUserWidth = 2,
+    parameter int ARUserWidth = 2,
+    parameter int TimeoutCycles = 100,
+    localparam int StrobeWidth = DataWidth / 8
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [AddrWidth-1:0] axil_awaddr,
+    input logic [AxiProtWidth-1:0] axil_awprot,
+    input logic [AWUserWidth-1:0] axil_awuser,
+    input logic axil_awvalid,
+    input logic axil_awready,
+    input logic [DataWidth-1:0] axil_wdata,
+    input logic [StrobeWidth-1:0] axil_wstrb,
+    input logic [WUserWidth-1:0] axil_wuser,
+    input logic axil_wvalid,
+    input logic axil_wready,
+    input logic [AddrWidth-1:0] axil_araddr,
+    input logic [AxiProtWidth-1:0] axil_arprot,
+    input logic [ARUserWidth-1:0] axil_aruser,
+    input logic axil_arvalid,
+    input logic axil_arready,
+
+    output logic failed
+);
+
+  axil_aw_t aw_queue[$];
+  axil_w_t w_queue[$];
+  axil_ar_t ar_queue[$];
+  event posedge_clk;
+
+  clocking cb @(posedge clk);
+    default input #1step;
+    input axil_awaddr;
+    input axil_awprot;
+    input axil_awuser;
+    input axil_awvalid;
+    input axil_awready;
+    input axil_wdata;
+    input axil_wstrb;
+    input axil_wuser;
+    input axil_wvalid;
+    input axil_wready;
+    input axil_araddr;
+    input axil_arprot;
+    input axil_aruser;
+    input axil_arvalid;
+    input axil_arready;
+  endclocking
+
+  always @(posedge clk) begin
+    ->posedge_clk;
+  end
+
+  task automatic init_idle();
+    failed = 1'b0;
+    aw_queue.delete();
+    w_queue.delete();
+    ar_queue.delete();
+  endtask
+
+  function automatic logic [AddrWidth-1:0] predict_axi2axil_addr(
+      input logic [AxiAddrWidth-1:0] start_addr, input logic [AxiBurstSizeWidth-1:0] size,
+      input logic [AxiBurstLenWidth-1:0] len, input logic [AxiBurstTypeWidth-1:0] burst,
+      input int unsigned beat);
+    logic [AddrWidth-1:0] incr_addr;
+    logic [AddrWidth-1:0] align_mask;
+    logic [AddrWidth-1:0] base_addr;
+    logic [AddrWidth-1:0] wrap_mask;
+
+    incr_addr = AddrWidth'(start_addr) + (AddrWidth'(beat) << size);
+    unique case (axi_burst_type_t'(burst))
+      AxiBurstFixed: predict_axi2axil_addr = AddrWidth'(start_addr);
+      AxiBurstIncr: begin
+        align_mask = {AddrWidth{1'b1}} << size;
+        predict_axi2axil_addr = (beat == 0) ? AddrWidth'(start_addr) : (incr_addr & align_mask);
+      end
+      AxiBurstWrap: begin
+        wrap_mask = ((AddrWidth'(len) + 1'b1) << size) - 1'b1;
+        base_addr = AddrWidth'(start_addr) & ~wrap_mask;
+        predict_axi2axil_addr = base_addr | (incr_addr & wrap_mask);
+      end
+      default: predict_axi2axil_addr = AddrWidth'(start_addr);
+    endcase
+  endfunction
+
+  function automatic string channel_name(input axil_request_channel_t channel);
+    case (channel)
+      AxilRequestAw: channel_name = "AW";
+      AxilRequestW:  channel_name = "W";
+      AxilRequestAr: channel_name = "AR";
+      default:       channel_name = "unknown";
+    endcase
+  endfunction
+
+  task automatic monitor_aw(input int num_transactions);
+    axil_aw_t expected;
+    int observed;
+
+    observed = 0;
+    while (observed < num_transactions) begin
+      @cb;
+      if (cb.axil_awvalid && cb.axil_awready) begin
+        check_eq(aw_queue.size() > 0, 1'b1, "AXI-Lite AW expected queue empty", failed);
+        if (aw_queue.size() > 0) begin
+          expected = aw_queue.pop_front();
+          check_eq(cb.axil_awaddr, AddrWidth'(expected.addr), "AXI-Lite AW address mismatch",
+                   failed);
+          check_eq(cb.axil_awprot, expected.prot, "AXI-Lite AW prot mismatch", failed);
+          check_eq(cb.axil_awuser, AWUserWidth'(expected.user), "AXI-Lite AW user mismatch",
+                   failed);
+        end
+        observed++;
+      end
+    end
+  endtask
+
+  task automatic monitor_w(input int num_transactions);
+    axil_w_t expected;
+    int observed;
+
+    observed = 0;
+    while (observed < num_transactions) begin
+      @cb;
+      if (cb.axil_wvalid && cb.axil_wready) begin
+        check_eq(w_queue.size() > 0, 1'b1, "AXI-Lite W expected queue empty", failed);
+        if (w_queue.size() > 0) begin
+          expected = w_queue.pop_front();
+          check_eq(cb.axil_wdata, DataWidth'(expected.data), "AXI-Lite W data mismatch", failed);
+          check_eq(cb.axil_wstrb, StrobeWidth'(expected.strb), "AXI-Lite W strobe mismatch",
+                   failed);
+          check_eq(cb.axil_wuser, WUserWidth'(expected.user), "AXI-Lite W user mismatch", failed);
+        end
+        observed++;
+      end
+    end
+  endtask
+
+  task automatic monitor_ar(input int num_transactions);
+    axil_ar_t expected;
+    int observed;
+
+    observed = 0;
+    while (observed < num_transactions) begin
+      @cb;
+      if (cb.axil_arvalid && cb.axil_arready) begin
+        check_eq(ar_queue.size() > 0, 1'b1, "AXI-Lite AR expected queue empty", failed);
+        if (ar_queue.size() > 0) begin
+          expected = ar_queue.pop_front();
+          check_eq(cb.axil_araddr, AddrWidth'(expected.addr), "AXI-Lite AR address mismatch",
+                   failed);
+          check_eq(cb.axil_arprot, expected.prot, "AXI-Lite AR prot mismatch", failed);
+          check_eq(cb.axil_aruser, ARUserWidth'(expected.user), "AXI-Lite AR user mismatch",
+                   failed);
+        end
+        observed++;
+      end
+    end
+  endtask
+
+  task automatic monitor_channel(input axil_request_channel_t channel, input int num_transactions);
+    fork
+      case (channel)
+        AxilRequestAw: monitor_aw(num_transactions);
+        AxilRequestW:  monitor_w(num_transactions);
+        AxilRequestAr: monitor_ar(num_transactions);
+        default:       check_eq(1'b0, 1'b1, "Unknown AXI-Lite request channel", failed);
+      endcase
+      timeout(posedge_clk, TimeoutCycles * (num_transactions + 1), {
+              "Timeout waiting for AXI-Lite ", channel_name(channel), " transfers"}, failed);
+    join_any
+    disable fork;
+  endtask
+
+  task automatic run(input int num_writes, input int num_reads);
+    fork
+      monitor_channel(AxilRequestAw, num_writes);
+      monitor_channel(AxilRequestW, num_writes);
+      monitor_channel(AxilRequestAr, num_reads);
+    join
+
+    check_eq(aw_queue.size(), 0, "AXI-Lite AW expected queue not empty", failed);
+    check_eq(w_queue.size(), 0, "AXI-Lite W expected queue not empty", failed);
+    check_eq(ar_queue.size(), 0, "AXI-Lite AR expected queue not empty", failed);
+  endtask
+
+endmodule : br_amba_axil_request_monitor

--- a/amba/sim/monitors/br_amba_axil_request_monitor.sv
+++ b/amba/sim/monitors/br_amba_axil_request_monitor.sv
@@ -7,6 +7,8 @@ import br_amba_axi_sim_pkg::*;
 import br_amba_axil_sim_pkg::*;
 import br_amba_sim_pkg::*;
 
+`include "br_amba_sim_macros.svh"
+
 // AXI-Lite request-channel payload monitor.
 //
 // This monitor observes AW/W/AR handshakes, compares each sampled payload against queued expected
@@ -119,14 +121,15 @@ module br_amba_axil_request_monitor #(
     while (observed < num_transactions) begin
       @cb;
       if (cb.axil_awvalid && cb.axil_awready) begin
-        check_eq(aw_queue.size() > 0, 1'b1, "AXI-Lite AW expected queue empty", failed);
+        `BR_AMBA_SIM_CHECK_EQ(aw_queue.size() > 0, 1'b1, "AXI-Lite AW expected queue empty",
+                              failed);
         if (aw_queue.size() > 0) begin
           expected = aw_queue.pop_front();
-          check_eq(cb.axil_awaddr, AddrWidth'(expected.addr), "AXI-Lite AW address mismatch",
-                   failed);
-          check_eq(cb.axil_awprot, expected.prot, "AXI-Lite AW prot mismatch", failed);
-          check_eq(cb.axil_awuser, AWUserWidth'(expected.user), "AXI-Lite AW user mismatch",
-                   failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axil_awaddr, AddrWidth'(expected.addr),
+                                "AXI-Lite AW address mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axil_awprot, expected.prot, "AXI-Lite AW prot mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axil_awuser, AWUserWidth'(expected.user),
+                                "AXI-Lite AW user mismatch", failed);
         end
         observed++;
       end
@@ -141,13 +144,15 @@ module br_amba_axil_request_monitor #(
     while (observed < num_transactions) begin
       @cb;
       if (cb.axil_wvalid && cb.axil_wready) begin
-        check_eq(w_queue.size() > 0, 1'b1, "AXI-Lite W expected queue empty", failed);
+        `BR_AMBA_SIM_CHECK_EQ(w_queue.size() > 0, 1'b1, "AXI-Lite W expected queue empty", failed);
         if (w_queue.size() > 0) begin
           expected = w_queue.pop_front();
-          check_eq(cb.axil_wdata, DataWidth'(expected.data), "AXI-Lite W data mismatch", failed);
-          check_eq(cb.axil_wstrb, StrobeWidth'(expected.strb), "AXI-Lite W strobe mismatch",
-                   failed);
-          check_eq(cb.axil_wuser, WUserWidth'(expected.user), "AXI-Lite W user mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axil_wdata, DataWidth'(expected.data),
+                                "AXI-Lite W data mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axil_wstrb, StrobeWidth'(expected.strb),
+                                "AXI-Lite W strobe mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axil_wuser, WUserWidth'(expected.user),
+                                "AXI-Lite W user mismatch", failed);
         end
         observed++;
       end
@@ -162,14 +167,15 @@ module br_amba_axil_request_monitor #(
     while (observed < num_transactions) begin
       @cb;
       if (cb.axil_arvalid && cb.axil_arready) begin
-        check_eq(ar_queue.size() > 0, 1'b1, "AXI-Lite AR expected queue empty", failed);
+        `BR_AMBA_SIM_CHECK_EQ(ar_queue.size() > 0, 1'b1, "AXI-Lite AR expected queue empty",
+                              failed);
         if (ar_queue.size() > 0) begin
           expected = ar_queue.pop_front();
-          check_eq(cb.axil_araddr, AddrWidth'(expected.addr), "AXI-Lite AR address mismatch",
-                   failed);
-          check_eq(cb.axil_arprot, expected.prot, "AXI-Lite AR prot mismatch", failed);
-          check_eq(cb.axil_aruser, ARUserWidth'(expected.user), "AXI-Lite AR user mismatch",
-                   failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axil_araddr, AddrWidth'(expected.addr),
+                                "AXI-Lite AR address mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axil_arprot, expected.prot, "AXI-Lite AR prot mismatch", failed);
+          `BR_AMBA_SIM_CHECK_EQ(cb.axil_aruser, ARUserWidth'(expected.user),
+                                "AXI-Lite AR user mismatch", failed);
         end
         observed++;
       end
@@ -180,9 +186,9 @@ module br_amba_axil_request_monitor #(
     fork
       case (channel)
         AxilRequestAw: monitor_aw(num_transactions);
-        AxilRequestW:  monitor_w(num_transactions);
+        AxilRequestW: monitor_w(num_transactions);
         AxilRequestAr: monitor_ar(num_transactions);
-        default:       check_eq(1'b0, 1'b1, "Unknown AXI-Lite request channel", failed);
+        default: report_error("Unknown AXI-Lite request channel", failed);
       endcase
       timeout(posedge_clk, TimeoutCycles * (num_transactions + 1), {
               "Timeout waiting for AXI-Lite ", channel_name(channel), " transfers"}, failed);
@@ -197,9 +203,9 @@ module br_amba_axil_request_monitor #(
       monitor_channel(AxilRequestAr, num_reads);
     join
 
-    check_eq(aw_queue.size(), 0, "AXI-Lite AW expected queue not empty", failed);
-    check_eq(w_queue.size(), 0, "AXI-Lite W expected queue not empty", failed);
-    check_eq(ar_queue.size(), 0, "AXI-Lite AR expected queue not empty", failed);
+    `BR_AMBA_SIM_CHECK_EQ(aw_queue.size(), 0, "AXI-Lite AW expected queue not empty", failed);
+    `BR_AMBA_SIM_CHECK_EQ(w_queue.size(), 0, "AXI-Lite W expected queue not empty", failed);
+    `BR_AMBA_SIM_CHECK_EQ(ar_queue.size(), 0, "AXI-Lite AR expected queue not empty", failed);
   endtask
 
 endmodule : br_amba_axil_request_monitor


### PR DESCRIPTION
Thip PR adds a directed simulation testbench for `br_amba_axi2axil` and reusable AMBA simulation helpers for AXI/AXI-Lite transaction driving and monitoring.

- Adds reusable AXI/AXI-Lite helper collateral:
  - common simulation check/timeout helpers,
  - AXI target driver extensions,
  - AXI-Lite target driver,
  - AXI response monitor,
  - AXI-Lite request monitor.
- Refactors existing AMBA timing/default-target tests to reuse the common helper package where needed.