### PR TITLE
Support replicated credit sender valid outputs

### DIFF
--- a/credit/rtl/BUILD.bazel
+++ b/credit/rtl/BUILD.bazel
@@ -124,6 +124,10 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
+        "NumPopValidCopies": [
+            "1",
+            "2",
+        ],
     },
     deps = [":br_credit_sender"],
 )

--- a/credit/rtl/br_credit_sender.sv
+++ b/credit/rtl/br_credit_sender.sv
@@ -76,6 +76,9 @@ module br_credit_sender #(
     parameter int PopCreditMaxChange = 1,
     // If 1, add 1 cycle of retiming to pop outputs.
     parameter bit RegisterPopOutputs = 0,
+    // Number of physically replicated pop_valid outputs. All copies are identical.
+    // Must be at least 1.
+    parameter int NumPopValidCopies = 1,
     // If 1, cover that the push side experiences backpressure.
     // If 0, disable backpressure coverage. By default, this also
     // asserts that backpressure is impossible.
@@ -124,7 +127,7 @@ module br_credit_sender #(
     // Synchronous active-high.
     input logic pop_receiver_in_reset,
     input logic [PopCreditWidth-1:0] pop_credit,
-    output logic [NumFlows-1:0] pop_valid,
+    output logic [NumFlows-1:0][NumPopValidCopies-1:0] pop_valid,
     output logic [NumFlows-1:0][Width-1:0] pop_data,
 
     // Reset value for the credit counter
@@ -143,6 +146,7 @@ module br_credit_sender #(
   `BR_ASSERT_STATIC(num_flows_in_range_a, (NumFlows >= 1) && (NumFlows <= MaxCredit))
   `BR_ASSERT_STATIC(width_in_range_a, Width >= 1)
   `BR_ASSERT_STATIC(max_credit_in_range_a, MaxCredit >= 1)
+  `BR_ASSERT_STATIC(num_pop_valid_copies_in_range_a, NumPopValidCopies >= 1)
   `BR_ASSERT_STATIC(pop_credit_max_change_in_range_a,
                     (PopCreditMaxChange >= 1) && (PopCreditMaxChange <= MaxCredit))
 
@@ -266,23 +270,32 @@ module br_credit_sender #(
 
   if (RegisterPopOutputs) begin : gen_reg_pop
     `BR_REGI(pop_sender_in_reset, 1'b0, 1'b1)
-    `BR_REG(pop_valid, internal_pop_valid)
     for (genvar i = 0; i < NumFlows; i++) begin : gen_reg_pop_data
+      for (genvar j = 0; j < NumPopValidCopies; j++) begin : gen_reg_pop_valid
+        `BR_REG(pop_valid[i][j], internal_pop_valid[i])
+      end
       `BR_REGL(pop_data[i], push_data[i], internal_pop_valid[i])
     end
   end else begin : gen_passthru_pop
     assign pop_sender_in_reset = rst;
-    assign pop_valid = internal_pop_valid;
+    for (genvar i = 0; i < NumFlows; i++) begin : gen_passthru_pop_valid
+      assign pop_valid[i] = {NumPopValidCopies{internal_pop_valid[i]}};
+    end
     assign pop_data = push_data;
   end
 
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  if (RegisterPopOutputs) begin : gen_reg_pop_check
-    `BR_ASSERT_IMPL(pop_follows_push_a, ##1 (pop_valid == $past(push_valid & push_ready)))
-  end else begin : gen_passthru_pop_check
-    `BR_ASSERT_IMPL(pop_follows_push_a, pop_valid == (push_valid & push_ready))
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_pop_valid_checks
+    for (genvar j = 0; j < NumPopValidCopies; j++) begin : gen_copy
+      if (RegisterPopOutputs) begin : gen_reg_pop_check
+        `BR_ASSERT_IMPL(pop_follows_push_a,
+                        ##1 (pop_valid[i][j] == $past(push_valid[i] & push_ready[i])))
+      end else begin : gen_passthru_pop_check
+        `BR_ASSERT_IMPL(pop_follows_push_a, pop_valid[i][j] == (push_valid[i] & push_ready[i]))
+      end
+    end
   end
 
   `BR_ASSERT_IMPL(

--- a/credit/sim/BUILD.bazel
+++ b/credit/sim/BUILD.bazel
@@ -7,6 +7,44 @@ load("//bazel:verilog.bzl", "verilog_elab_test")
 package(default_visibility = ["//visibility:private"])
 
 verilog_library(
+    name = "br_credit_sender_tb",
+    srcs = ["br_credit_sender_tb.sv"],
+    deps = [
+        "//credit/rtl:br_credit_sender",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_credit_sender_tb_elab_test",
+    tool = "slang",
+    deps = [":br_credit_sender_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_credit_sender_sim_test_tools_suite",
+    params = {
+        "NumPopValidCopies": [
+            "2",
+            "4",
+        ],
+        "NumFlows": [
+            "1",
+            "2",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_credit_sender_tb"],
+)
+
+verilog_library(
     name = "br_credit_receiver_tb",
     srcs = ["br_credit_receiver_tb.sv"],
     deps = [

--- a/credit/sim/br_credit_sender_tb.sv
+++ b/credit/sim/br_credit_sender_tb.sv
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+`timescale 1ns / 1ps
+
+module br_credit_sender_tb;
+
+  parameter int Width = 8;
+  parameter int MaxCredit = 2;
+  parameter int NumFlows = 1;
+  parameter bit RegisterPopOutputs = 0;
+  parameter int NumPopValidCopies = 2;
+
+  localparam int CounterWidth = $clog2(MaxCredit + 1);
+  localparam int PopCreditWidth = $clog2(MaxCredit + 1);
+
+  logic clk;
+  logic rst;
+
+  logic [NumFlows-1:0] push_ready;
+  logic [NumFlows-1:0] push_valid;
+  logic [NumFlows-1:0][Width-1:0] push_data;
+
+  logic pop_sender_in_reset;
+  logic [PopCreditWidth-1:0] pop_credit;
+  logic [NumFlows-1:0][NumPopValidCopies-1:0] pop_valid;
+  logic [NumFlows-1:0][Width-1:0] pop_data;
+
+  logic [CounterWidth-1:0] credit_count;
+  logic [CounterWidth-1:0] credit_available;
+
+  br_credit_sender #(
+      .Width(Width),
+      .MaxCredit(MaxCredit),
+      .NumFlows(NumFlows),
+      .PopCreditMaxChange(MaxCredit),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .NumPopValidCopies(NumPopValidCopies),
+      .EnableCoverCreditWithhold(0),
+      .EnableCoverPopReceiverInReset(0)
+  ) dut (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_sender_in_reset,
+      .pop_receiver_in_reset(1'b0),
+      .pop_credit,
+      .pop_valid,
+      .pop_data,
+      .credit_initial(CounterWidth'(MaxCredit)),
+      .credit_withhold('0),
+      .credit_count,
+      .credit_available
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  task automatic check_pop_valid(input logic [NumFlows-1:0] expected, input string message);
+    for (int i = 0; i < NumFlows; i++) begin
+      for (int j = 0; j < NumPopValidCopies; j++) begin
+        td.check(pop_valid[i][j] === expected[i], $sformatf(
+                 "%s for flow %0d copy %0d", message, i, j));
+      end
+    end
+  endtask
+
+  initial begin
+    push_valid = '0;
+    push_data  = '0;
+    pop_credit = '0;
+
+    td.reset_dut();
+    #1;
+
+    check_pop_valid('0, "pop_valid should be low after reset");
+
+    @(negedge clk);
+    push_valid = '1;
+    for (int i = 0; i < NumFlows; i++) begin
+      push_data[i] = Width'(8'hd3 + i);
+    end
+    #1;
+    td.check(push_ready == '1, "all active pushes should be ready");
+
+    if (RegisterPopOutputs) begin
+      @(negedge clk);
+    end
+
+    check_pop_valid('1, "all pop_valid copies should assert");
+    for (int i = 0; i < NumFlows; i++) begin
+      td.check(pop_data[i] === push_data[i], $sformatf("pop_data mismatch for flow %0d", i));
+    end
+
+    if (!RegisterPopOutputs) begin
+      @(negedge clk);
+    end
+
+    push_valid = '0;
+
+    if (RegisterPopOutputs) begin
+      @(negedge clk);
+    end else begin
+      #1;
+    end
+
+    check_pop_valid('0, "all pop_valid copies should deassert");
+
+    @(negedge clk);
+    pop_credit = PopCreditWidth'(NumFlows);
+    @(negedge clk);
+    pop_credit = '0;
+    #1;
+    td.check_integer(credit_count, MaxCredit, "credit was not replenished");
+
+    td.finish();
+  end
+
+endmodule


### PR DESCRIPTION
Codex is working on behalf of @mgottscho.

# Problem

Wide credit-loop datapaths may need multiple physically replicated copies of `pop_valid` to reduce fanout and align valid distribution with partitioned data pipelines. `br_credit_sender` currently provides only one valid bit per flow.

Fixes #672.

# Solution

Add a backward-compatible `NumPopValidCopies` parameter to `br_credit_sender`, with flow-first indexing and identical valid copies for each flow. When pop outputs are registered, each copy is driven by its own register. Add directed single- and multi-flow simulation coverage for two and four copies with registered and passthrough outputs.

Validated in the public Docker image with eight Verilator simulations, default/all-assert/no-assert Slang elaboration, downstream compatibility elaboration, and pre-commit.
