### PR TITLE
Split CI into public and proprietary Bazel suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,44 +29,93 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
 
-  bazel-oss-tool-test:
+  bazel-oss-tool-test-shard:
+    name: bazel-oss-tool-test-shard (${{ matrix.name }})
     runs-on: ubuntu-24.04
-    outputs:
-      image-tag: ${{ steps.image-metadata.outputs.tag }}
-      python_total_tests: ${{ steps.results.outputs.python_total_tests }}
-      python_passing_tests: ${{ steps.results.outputs.python_passing_tests }}
-      python_exit_code: ${{ steps.results.outputs.python_exit_code }}
-      stardoc_total_tests: ${{ steps.results.outputs.stardoc_total_tests }}
-      stardoc_passing_tests: ${{ steps.results.outputs.stardoc_passing_tests }}
-      stardoc_exit_code: ${{ steps.results.outputs.stardoc_exit_code }}
-      slang_total_tests: ${{ steps.results.outputs.slang_total_tests }}
-      slang_passing_tests: ${{ steps.results.outputs.slang_passing_tests }}
-      slang_exit_code: ${{ steps.results.outputs.slang_exit_code }}
-      verilator_total_tests: ${{ steps.results.outputs.verilator_total_tests }}
-      verilator_passing_tests: ${{ steps.results.outputs.verilator_passing_tests }}
-      verilator_exit_code: ${{ steps.results.outputs.verilator_exit_code }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: python-stardoc
+            suite: python-stardoc
+            shard_index: 0
+            shard_count: 1
+            docker_cache_writer: true
+          - name: slang-1-of-4
+            suite: slang
+            shard_index: 0
+            shard_count: 4
+            docker_cache_writer: false
+          - name: slang-2-of-4
+            suite: slang
+            shard_index: 1
+            shard_count: 4
+            docker_cache_writer: false
+          - name: slang-3-of-4
+            suite: slang
+            shard_index: 2
+            shard_count: 4
+            docker_cache_writer: false
+          - name: slang-4-of-4
+            suite: slang
+            shard_index: 3
+            shard_count: 4
+            docker_cache_writer: false
+          - name: verilator-1-of-8
+            suite: verilator
+            shard_index: 0
+            shard_count: 8
+            docker_cache_writer: false
+          - name: verilator-2-of-8
+            suite: verilator
+            shard_index: 1
+            shard_count: 8
+            docker_cache_writer: false
+          - name: verilator-3-of-8
+            suite: verilator
+            shard_index: 2
+            shard_count: 8
+            docker_cache_writer: false
+          - name: verilator-4-of-8
+            suite: verilator
+            shard_index: 3
+            shard_count: 8
+            docker_cache_writer: false
+          - name: verilator-5-of-8
+            suite: verilator
+            shard_index: 4
+            shard_count: 8
+            docker_cache_writer: false
+          - name: verilator-6-of-8
+            suite: verilator
+            shard_index: 5
+            shard_count: 8
+            docker_cache_writer: false
+          - name: verilator-7-of-8
+            suite: verilator
+            shard_index: 6
+            shard_count: 8
+            docker_cache_writer: false
+          - name: verilator-8-of-8
+            suite: verilator
+            shard_index: 7
+            shard_count: 8
+            docker_cache_writer: false
     steps:
       # actions/checkout v6
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Set YYYY-MM-DD-SHA image tag
-        id: image-metadata
-        run: |
-          # Normalize the commit timestamp to a UTC date so a Git SHA always
-          # maps to the same YYYY-MM-DD-SHA image tag across time zones.
-          commit_timestamp="$(git show --no-patch --format=%ct "${GITHUB_SHA}")"
-          commit_date="$(date --utc --date="@${commit_timestamp}" +%F)"
-          echo "tag=${commit_date}-${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
       # bazel-contrib/setup-bazel v0.19.0
       - name: Set up Bazel caches
         uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
+          # A stable partition gets a stable cache. Including the shard count
+          # prevents incompatible partitions from sharing an Actions cache.
+          disk-cache: ${{ github.workflow }}-oss-${{ matrix.suite }}-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}
           repository-cache: true
-          # PRs restore trusted cache entries but do not publish new artifacts.
-          # This prevents untrusted pull-request code from polluting shared caches.
+          # PRs restore trusted cache entries but cannot pollute shared caches.
           cache-save: ${{ github.event_name != 'pull_request' }}
           output-base: ${{ runner.temp }}/bazel-output
       - name: Configure public Bazel environment
@@ -92,31 +141,30 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: false
-          # Import the Buildx result into this runner's Docker daemon so the
-          # next step can run the exact image built from this checkout.
+          # Every shard tests the exact image built from its checkout.
           load: true
-          # This local tag is the image reference consumed by `docker run`.
           tags: bedrock-rtl-ci:${{ github.sha }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
-          # Reuse BuildKit layers stored in the GitHub Actions cache for this image.
           cache-from: type=gha,scope=bedrock-rtl-docker
-          # Export all intermediate and final layers for subsequent builds.
-          cache-to: type=gha,mode=max,scope=bedrock-rtl-docker
+          # Only one trusted shard updates this shared cache. All other shards
+          # are read-only, avoiding concurrent exports and PR cache pollution.
+          cache-to: ${{ matrix.docker_cache_writer && github.event_name != 'pull_request' && 'type=gha,mode=max,scope=bedrock-rtl-docker' || '' }}
       # Do not use `bazel test //...` with a tag filter here. Bazel would still
       # analyze targets that need proprietary verilog_runner plugins.
-      - name: Run public Bazel test suites
+      - name: Run public Bazel test shard
         continue-on-error: true
         run: |
           # Keep stdin attached so `bash -s` receives the heredoc below. The
           # hosted runner UID is not present in the image's passwd file, so set
-          # USER explicitly for Bazel after retaining that UID for cache writes.
-          # Mount Bazel's default output user root because the container's
-          # /home/runner is root-owned.
+          # USER explicitly while retaining that UID for cache writes.
           docker run --rm -i \
             --user "$(id -u):$(id -g)" \
             --env USER=user \
             --env HOME="${HOME}" \
+            --env CI_SUITE="${{ matrix.suite }}" \
+            --env CI_SHARD_INDEX="${{ matrix.shard_index }}" \
+            --env CI_SHARD_COUNT="${{ matrix.shard_count }}" \
             --workdir "${GITHUB_WORKSPACE}" \
             --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
             --volume "${HOME}/.bazelrc:${HOME}/.bazelrc:ro" \
@@ -128,135 +176,188 @@ jobs:
             bedrock-rtl-ci:${{ github.sha }} \
             bash -s <<'EOF'
           set +e
-          # Pass cache paths explicitly rather than depending on the generated
-          # user bazelrc being discovered inside the container.
           BAZEL_FLAGS=(
             --action_env=PATH
             --noshow_loading_progress
             --disk_cache=/home/runner/.cache/bazel-disk
             --repository_cache=/home/runner/.cache/bazel-repo
+            --experimental_disk_cache_gc_max_size=256M
+            --experimental_disk_cache_gc_max_age=7d
           )
-          RESULTS=.bazel-oss-test-results
-          : > "$RESULTS"
-          failed_suites=()
+          HELPER=python/ci/bazel_oss_sharding.py
+          RESULTS_DIR="bazel-oss-results/${CI_SUITE}-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}"
+          mkdir -p "$RESULTS_DIR"
 
-          write_result() {
+          run_discovered_suite() {
             local suite="$1"
-            local exit_code="$2"
-            local log="$3"
-            local total_tests
-            local passing_tests
-            total_tests="$(grep -Po '(?<=out of )\d+(?= test)' "$log" | tail -n1)"
-            passing_tests="$(grep -Po '\d+(?= test passes?\.| tests pass)' "$log" | tail -n1)"
-            echo "${suite}_total_tests=${total_tests:-0}" >> "$RESULTS"
-            echo "${suite}_passing_tests=${passing_tests:-0}" >> "$RESULTS"
-            echo "${suite}_exit_code=${exit_code}" >> "$RESULTS"
-            if [ "$exit_code" -ne 0 ]; then
-              failed_suites+=("$suite")
+            local shard_index="$2"
+            local shard_count="$3"
+            local discovered="$4"
+            local result="$RESULTS_DIR/result-${suite}-${shard_index}-of-${shard_count}.json"
+            local targets="$RESULTS_DIR/targets-${suite}-${shard_index}-of-${shard_count}.txt"
+            local log="/tmp/bazel-${suite}-${shard_index}-of-${shard_count}.log"
+
+            python3.12 "$HELPER" partition \
+              --suite "$suite" \
+              --shard-index "$shard_index" \
+              --shard-count "$shard_count" \
+              --input "$discovered" \
+              --output-dir "$RESULTS_DIR"
+            local partition_exit_code=$?
+            if [ "$partition_exit_code" -ne 0 ]; then
+              return "$partition_exit_code"
             fi
+
+            # A target-pattern file guarantees one Bazel invocation even when
+            # thousands of labels would exceed the shell argument limit.
+            bazel test "${BAZEL_FLAGS[@]}" \
+              --target_pattern_file="$targets" 2>&1 | tee "$log"
+            local bazel_exit_code=${PIPESTATUS[0]}
+            python3.12 "$HELPER" finalize \
+              --result "$result" \
+              --log "$log" \
+              --exit-code "$bazel_exit_code"
           }
 
-          run_command() {
+          query_and_run_suite() {
             local suite="$1"
-            shift
-            local log=".bazel-test-${suite}.log"
-            "$@" 2>&1 | tee "$log"
-            write_result "$suite" "${PIPESTATUS[0]}" "$log"
+            local shard_index="$2"
+            local shard_count="$3"
+            local query_expression="$4"
+            local discovered="/tmp/discovered-${suite}-${shard_index}-of-${shard_count}.txt"
+            local result="$RESULTS_DIR/result-${suite}-${shard_index}-of-${shard_count}.json"
+
+            bazel query --noshow_progress "$query_expression" > "$discovered"
+            local query_exit_code=$?
+            if [ "$query_exit_code" -ne 0 ]; then
+              python3.12 "$HELPER" partition \
+                --suite "$suite" \
+                --shard-index "$shard_index" \
+                --shard-count "$shard_count" \
+                --input "$discovered" \
+                --output-dir "$RESULTS_DIR"
+              python3.12 "$HELPER" discovery-failure \
+                --result "$result" \
+                --exit-code "$query_exit_code" \
+                --message "Bazel query failed"
+              return "$query_exit_code"
+            fi
+            run_discovered_suite "$suite" "$shard_index" "$shard_count" "$discovered"
           }
 
-          run_target_file() {
-            local suite="$1"
-            local targets="$2"
-            local log=".bazel-test-${suite}.log"
-            # Invoke Bazel once with every selected label so it can schedule
-            # independent test actions concurrently.
-            xargs -r bazel test "${BAZEL_FLAGS[@]}" < "$targets" 2>&1 | tee "$log"
-            write_result "$suite" "${PIPESTATUS[0]}" "$log"
-          }
+          case "$CI_SUITE" in
+            python-stardoc)
+              query_and_run_suite python 0 1 \
+                'tests(//python/...) union tests(//ecc/rtl/secded_codegen/...)'
+              printf '%s\n' \
+                //bazel:verilog_rules_diff_test \
+                //bazel/verilog_runner:nonzip_test \
+                > /tmp/discovered-stardoc.txt
+              run_discovered_suite stardoc 0 1 /tmp/discovered-stardoc.txt
+              ;;
+            slang)
+              query_and_run_suite slang "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
+                '(tests(//...) intersect attr(tags, "slang", //...)) except attr(tags, "manual", //...)'
+              ;;
+            verilator)
+              query_and_run_suite verilator "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
+                'tests(//...) intersect attr(tags, "verilator", //...) intersect attr(tags, "sim", //...)'
+              ;;
+            *)
+              echo "Unknown public suite: $CI_SUITE" >&2
+              exit 4
+              ;;
+          esac
 
-          PYTHON_TARGETS=.bazel-test-python.targets
-          bazel query --noshow_progress \
-            'tests(//python/...) union tests(//ecc/rtl/secded_codegen/...)' \
-            > "$PYTHON_TARGETS"
-          query_exit_code=$?
-          if [ "$query_exit_code" -ne 0 ] || [ ! -s "$PYTHON_TARGETS" ]; then
-            if [ "$query_exit_code" -eq 0 ]; then
-              query_exit_code=4
-            fi
-            echo "::error title=Python test discovery failed::No public Python test targets were selected"
-            : > .bazel-test-python.log
-            write_result python "$query_exit_code" .bazel-test-python.log
+          check_args=(--results-dir "$RESULTS_DIR")
+          if [ "$CI_SUITE" = python-stardoc ]; then
+            check_args+=(--expected-suite python --expected-suite stardoc)
           else
-            run_target_file python "$PYTHON_TARGETS"
+            check_args+=(--expected-suite "$CI_SUITE")
           fi
-
-          run_command stardoc bazel test "${BAZEL_FLAGS[@]}" \
-            //bazel:verilog_rules_diff_test \
-            //bazel/verilog_runner:nonzip_test
-
-          SLANG_TARGETS=.bazel-test-slang.targets
-          bazel query --noshow_progress \
-            '(tests(//...) intersect attr(tags, "slang", //...)) except attr(tags, "manual", //...)' \
-            > "$SLANG_TARGETS"
-          query_exit_code=$?
-          if [ "$query_exit_code" -ne 0 ] || [ ! -s "$SLANG_TARGETS" ]; then
-            if [ "$query_exit_code" -eq 0 ]; then
-              query_exit_code=4
-            fi
-            echo "::error title=Slang test discovery failed::No non-manual Slang test targets were selected"
-            : > .bazel-test-slang.log
-            write_result slang "$query_exit_code" .bazel-test-slang.log
-          else
-            run_target_file slang "$SLANG_TARGETS"
-          fi
-
-          VERILATOR_TARGETS=.bazel-test-verilator.targets
-          bazel query --noshow_progress \
-            'tests(//...) intersect attr(tags, "verilator", //...) intersect attr(tags, "sim", //...)' \
-            > "$VERILATOR_TARGETS"
-          query_exit_code=$?
-          if [ "$query_exit_code" -ne 0 ] || [ ! -s "$VERILATOR_TARGETS" ]; then
-            if [ "$query_exit_code" -eq 0 ]; then
-              query_exit_code=4
-            fi
-            echo "::error title=Verilator test discovery failed::No Verilator simulation test targets were selected"
-            : > .bazel-test-verilator.log
-            write_result verilator "$query_exit_code" .bazel-test-verilator.log
-          else
-            run_target_file verilator "$VERILATOR_TARGETS"
-          fi
-
-          if [ "${#failed_suites[@]}" -ne 0 ]; then
-            echo "Failed Bazel suites: ${failed_suites[*]}"
-            exit 1
-          fi
+          python3.12 "$HELPER" check "${check_args[@]}"
           EOF
-      - name: Export public suite results
-        id: results
+      - name: Upload public shard result
+        if: ${{ always() }}
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: bazel-oss-result-${{ matrix.name }}
+          path: bazel-oss-results/${{ matrix.suite }}-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}
+          if-no-files-found: error
+          retention-days: 1
+      - name: Check public shard result
+        if: ${{ always() }}
         run: |
-          test -s .bazel-oss-test-results
-          cat .bazel-oss-test-results >> "$GITHUB_OUTPUT"
+          check_args=(
+            --results-dir "bazel-oss-results/${{ matrix.suite }}-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}"
+          )
+          if [ "${{ matrix.suite }}" = python-stardoc ]; then
+            check_args+=(--expected-suite python --expected-suite stardoc)
+          else
+            check_args+=(--expected-suite "${{ matrix.suite }}")
+          fi
+          python3.12 python/ci/bazel_oss_sharding.py check "${check_args[@]}"
+
+  # This stable aggregate check is the public branch-protection, badge, and
+  # image-publication interface; individual shards remain visible underneath it.
+  bazel-oss-tool-test:
+    runs-on: ubuntu-24.04
+    needs: bazel-oss-tool-test-shard
+    if: ${{ always() }}
+    permissions:
+      contents: read
+    outputs:
+      image-tag: ${{ steps.image-metadata.outputs.tag }}
+      python_total_tests: ${{ steps.results.outputs.python_total_tests }}
+      python_passing_tests: ${{ steps.results.outputs.python_passing_tests }}
+      python_exit_code: ${{ steps.results.outputs.python_exit_code }}
+      stardoc_total_tests: ${{ steps.results.outputs.stardoc_total_tests }}
+      stardoc_passing_tests: ${{ steps.results.outputs.stardoc_passing_tests }}
+      stardoc_exit_code: ${{ steps.results.outputs.stardoc_exit_code }}
+      slang_total_tests: ${{ steps.results.outputs.slang_total_tests }}
+      slang_passing_tests: ${{ steps.results.outputs.slang_passing_tests }}
+      slang_exit_code: ${{ steps.results.outputs.slang_exit_code }}
+      verilator_total_tests: ${{ steps.results.outputs.verilator_total_tests }}
+      verilator_passing_tests: ${{ steps.results.outputs.verilator_passing_tests }}
+      verilator_exit_code: ${{ steps.results.outputs.verilator_exit_code }}
+    steps:
+      # actions/checkout v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Set YYYY-MM-DD-SHA image tag
+        id: image-metadata
+        run: |
+          commit_timestamp="$(git show --no-patch --format=%ct "${GITHUB_SHA}")"
+          commit_date="$(date --utc --date="@${commit_timestamp}" +%F)"
+          echo "tag=${commit_date}-${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+      - name: Download public shard results
+        continue-on-error: true
+        # actions/download-artifact v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: bazel-oss-result-*
+          path: bazel-oss-aggregate
+          merge-multiple: true
+      - name: Aggregate public shard results
+        id: results
+        continue-on-error: true
+        run: |
+          python3.12 python/ci/bazel_oss_sharding.py aggregate \
+            --results-dir bazel-oss-aggregate \
+            --expected python=1 \
+            --expected stardoc=1 \
+            --expected slang=4 \
+            --expected verilator=8 \
+            --github-output "$GITHUB_OUTPUT" \
+            --step-summary "$GITHUB_STEP_SUMMARY"
       - name: Check public Bazel test suite results
         run: |
-          failed_suites=()
-
-          check_suite() {
-            local suite="$1"
-            local exit_code="$2"
-            if [ "$exit_code" != "0" ]; then
-              echo "::error title=Bazel suite failed::$suite exited with code ${exit_code:-missing}"
-              failed_suites+=("$suite")
-            fi
-          }
-
-          check_suite "python" "${{ steps.results.outputs.python_exit_code }}"
-          check_suite "stardoc" "${{ steps.results.outputs.stardoc_exit_code }}"
-          check_suite "slang" "${{ steps.results.outputs.slang_exit_code }}"
-          check_suite "verilator" "${{ steps.results.outputs.verilator_exit_code }}"
-
-          if [ "${#failed_suites[@]}" -ne 0 ]; then
-            echo "Failed Bazel suites:"
-            printf '  - %s\n' "${failed_suites[@]}"
+          if [ "${{ needs.bazel-oss-tool-test-shard.result }}" != success ]; then
+            echo "::error title=Public Bazel shard failed::One or more matrix jobs failed"
+            exit 1
+          fi
+          if [ "${{ steps.results.outcome }}" != success ]; then
+            echo "::error title=Public Bazel aggregation failed::Shard results were incomplete or failed validation"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,12 @@ jobs:
       - name: Run public Bazel test suites
         continue-on-error: true
         run: |
-          # Keep stdin attached so `bash -s` receives the heredoc below.
+          # Keep stdin attached so `bash -s` receives the heredoc below. The
+          # hosted runner UID is not present in the image's passwd file, so set
+          # USER explicitly for Bazel after retaining that UID for cache writes.
           docker run --rm -i \
             --user "$(id -u):$(id -g)" \
+            --env USER=user \
             --env HOME="${HOME}" \
             --workdir "${GITHUB_WORKSPACE}" \
             --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,27 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
 
-  docker-image-build:
+  bazel-oss-tool-test:
     runs-on: ubuntu-24.04
     outputs:
       image-tag: ${{ steps.image-metadata.outputs.tag }}
+      python_total_tests: ${{ steps.results.outputs.python_total_tests }}
+      python_passing_tests: ${{ steps.results.outputs.python_passing_tests }}
+      python_exit_code: ${{ steps.results.outputs.python_exit_code }}
+      stardoc_total_tests: ${{ steps.results.outputs.stardoc_total_tests }}
+      stardoc_passing_tests: ${{ steps.results.outputs.stardoc_passing_tests }}
+      stardoc_exit_code: ${{ steps.results.outputs.stardoc_exit_code }}
+      slang_total_tests: ${{ steps.results.outputs.slang_total_tests }}
+      slang_passing_tests: ${{ steps.results.outputs.slang_passing_tests }}
+      slang_exit_code: ${{ steps.results.outputs.slang_exit_code }}
+      verilator_total_tests: ${{ steps.results.outputs.verilator_total_tests }}
+      verilator_passing_tests: ${{ steps.results.outputs.verilator_passing_tests }}
+      verilator_exit_code: ${{ steps.results.outputs.verilator_exit_code }}
     permissions:
       contents: read
     steps:
       # actions/checkout v6
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      # docker/setup-buildx-action v4.1.0
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Set YYYY-MM-DD-SHA image tag
         id: image-metadata
         run: |
@@ -48,7 +58,32 @@ jobs:
           commit_timestamp="$(git show --no-patch --format=%ct "${GITHUB_SHA}")"
           commit_date="$(date --utc --date="@${commit_timestamp}" +%F)"
           echo "tag=${commit_date}-${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
-      - name: Build Docker image
+      # bazel-contrib/setup-bazel v0.19.0
+      - name: Set up Bazel caches
+        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+          # PRs restore trusted cache entries but do not publish new artifacts.
+          # This prevents untrusted pull-request code from polluting shared caches.
+          cache-save: ${{ github.event_name != 'pull_request' }}
+          output-base: ${{ runner.temp }}/bazel-output
+      - name: Configure public Bazel environment
+        run: |
+          # setup-bazel restores these paths on a cache hit. Create them on a
+          # miss so Docker can bind-mount the same host paths below.
+          mkdir -p \
+            "${HOME}/.cache/bazelisk" \
+            "${HOME}/.cache/bazel-disk" \
+            "${HOME}/.cache/bazel-repo" \
+            "${RUNNER_TEMP}/bazel-output"
+          # The Slang plugin executes $SLANG_PATH directly rather than looking
+          # up `slang` on PATH. The public Docker image installs it here.
+          echo 'common --action_env=SLANG_PATH=/usr/local/bin/slang' > ci.bazelrc
+      # docker/setup-buildx-action v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+      - name: Build and load public Docker image
         # docker/build-push-action v7.2.0
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
@@ -56,19 +91,166 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: false
+          # Import the Buildx result into this runner's Docker daemon so the
+          # next step can run the exact image built from this checkout.
+          load: true
+          # This local tag is the image reference consumed by `docker run`.
+          tags: bedrock-rtl-ci:${{ github.sha }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
           # Reuse BuildKit layers stored in the GitHub Actions cache for this image.
           cache-from: type=gha,scope=bedrock-rtl-docker
           # Export all intermediate and final layers for subsequent builds.
           cache-to: type=gha,mode=max,scope=bedrock-rtl-docker
+      # Do not use `bazel test //...` with a tag filter here. Bazel would still
+      # analyze targets that need proprietary verilog_runner plugins.
+      - name: Run public Bazel test suites
+        continue-on-error: true
+        run: |
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --env HOME="${HOME}" \
+            --workdir "${GITHUB_WORKSPACE}" \
+            --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+            --volume "${HOME}/.bazelrc:${HOME}/.bazelrc:ro" \
+            --volume "${HOME}/.cache/bazelisk:${HOME}/.cache/bazelisk" \
+            --volume "${HOME}/.cache/bazel-disk:${HOME}/.cache/bazel-disk" \
+            --volume "${HOME}/.cache/bazel-repo:${HOME}/.cache/bazel-repo" \
+            --volume "${RUNNER_TEMP}/bazel-output:${RUNNER_TEMP}/bazel-output" \
+            bedrock-rtl-ci:${{ github.sha }} \
+            bash -s <<'EOF'
+          set +e
+          BAZEL_FLAGS=(--action_env=PATH --noshow_loading_progress)
+          RESULTS=.bazel-oss-test-results
+          : > "$RESULTS"
+          failed_suites=()
+
+          write_result() {
+            local suite="$1"
+            local exit_code="$2"
+            local log="$3"
+            local total_tests
+            local passing_tests
+            total_tests="$(grep -Po '(?<=out of )\d+(?= test)' "$log" | tail -n1)"
+            passing_tests="$(grep -Po '\d+(?= test passes?\.| tests pass)' "$log" | tail -n1)"
+            echo "${suite}_total_tests=${total_tests:-0}" >> "$RESULTS"
+            echo "${suite}_passing_tests=${passing_tests:-0}" >> "$RESULTS"
+            echo "${suite}_exit_code=${exit_code}" >> "$RESULTS"
+            if [ "$exit_code" -ne 0 ]; then
+              failed_suites+=("$suite")
+            fi
+          }
+
+          run_command() {
+            local suite="$1"
+            shift
+            local log=".bazel-test-${suite}.log"
+            "$@" 2>&1 | tee "$log"
+            write_result "$suite" "${PIPESTATUS[0]}" "$log"
+          }
+
+          run_target_file() {
+            local suite="$1"
+            local targets="$2"
+            local log=".bazel-test-${suite}.log"
+            # Invoke Bazel once with every selected label so it can schedule
+            # independent test actions concurrently.
+            xargs -r bazel test "${BAZEL_FLAGS[@]}" < "$targets" 2>&1 | tee "$log"
+            write_result "$suite" "${PIPESTATUS[0]}" "$log"
+          }
+
+          PYTHON_TARGETS=.bazel-test-python.targets
+          bazel query --noshow_progress \
+            'tests(//python/...) union tests(//ecc/rtl/secded_codegen/...)' \
+            > "$PYTHON_TARGETS"
+          query_exit_code=$?
+          if [ "$query_exit_code" -ne 0 ] || [ ! -s "$PYTHON_TARGETS" ]; then
+            if [ "$query_exit_code" -eq 0 ]; then
+              query_exit_code=4
+            fi
+            echo "::error title=Python test discovery failed::No public Python test targets were selected"
+            : > .bazel-test-python.log
+            write_result python "$query_exit_code" .bazel-test-python.log
+          else
+            run_target_file python "$PYTHON_TARGETS"
+          fi
+
+          run_command stardoc bazel test "${BAZEL_FLAGS[@]}" \
+            //bazel:verilog_rules_diff_test \
+            //bazel/verilog_runner:nonzip_test
+
+          SLANG_TARGETS=.bazel-test-slang.targets
+          bazel query --noshow_progress \
+            '(tests(//...) intersect attr(tags, "slang", //...)) except attr(tags, "manual", //...)' \
+            > "$SLANG_TARGETS"
+          query_exit_code=$?
+          if [ "$query_exit_code" -ne 0 ] || [ ! -s "$SLANG_TARGETS" ]; then
+            if [ "$query_exit_code" -eq 0 ]; then
+              query_exit_code=4
+            fi
+            echo "::error title=Slang test discovery failed::No non-manual Slang test targets were selected"
+            : > .bazel-test-slang.log
+            write_result slang "$query_exit_code" .bazel-test-slang.log
+          else
+            run_target_file slang "$SLANG_TARGETS"
+          fi
+
+          VERILATOR_TARGETS=.bazel-test-verilator.targets
+          bazel query --noshow_progress \
+            'tests(//...) intersect attr(tags, "verilator", //...) intersect attr(tags, "sim", //...)' \
+            > "$VERILATOR_TARGETS"
+          query_exit_code=$?
+          if [ "$query_exit_code" -ne 0 ] || [ ! -s "$VERILATOR_TARGETS" ]; then
+            if [ "$query_exit_code" -eq 0 ]; then
+              query_exit_code=4
+            fi
+            echo "::error title=Verilator test discovery failed::No Verilator simulation test targets were selected"
+            : > .bazel-test-verilator.log
+            write_result verilator "$query_exit_code" .bazel-test-verilator.log
+          else
+            run_target_file verilator "$VERILATOR_TARGETS"
+          fi
+
+          if [ "${#failed_suites[@]}" -ne 0 ]; then
+            echo "Failed Bazel suites: ${failed_suites[*]}"
+            exit 1
+          fi
+          EOF
+      - name: Export public suite results
+        id: results
+        run: |
+          test -s .bazel-oss-test-results
+          cat .bazel-oss-test-results >> "$GITHUB_OUTPUT"
+      - name: Check public Bazel test suite results
+        run: |
+          failed_suites=()
+
+          check_suite() {
+            local suite="$1"
+            local exit_code="$2"
+            if [ "$exit_code" != "0" ]; then
+              echo "::error title=Bazel suite failed::$suite exited with code ${exit_code:-missing}"
+              failed_suites+=("$suite")
+            fi
+          }
+
+          check_suite "python" "${{ steps.results.outputs.python_exit_code }}"
+          check_suite "stardoc" "${{ steps.results.outputs.stardoc_exit_code }}"
+          check_suite "slang" "${{ steps.results.outputs.slang_exit_code }}"
+          check_suite "verilator" "${{ steps.results.outputs.verilator_exit_code }}"
+
+          if [ "${#failed_suites[@]}" -ne 0 ]; then
+            echo "Failed Bazel suites:"
+            printf '  - %s\n' "${failed_suites[@]}"
+            exit 1
+          fi
 
   docker-image-publish:
     runs-on: ubuntu-24.04
-    needs: docker-image-build
+    needs: bazel-oss-tool-test
     # GitHub only permits users with repository write access to use workflow_dispatch.
     if: >-
-      needs.docker-image-build.result == 'success' &&
+      needs.bazel-oss-tool-test.result == 'success' &&
       (github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main'))
     permissions:
@@ -105,10 +287,10 @@ jobs:
           push: true
           # Attach max-detail BuildKit provenance to the published image.
           provenance: mode=max
-          tags: ghcr.io/xlsynth/bedrock-rtl:${{ needs.docker-image-build.outputs.image-tag }}
+          tags: ghcr.io/xlsynth/bedrock-rtl:${{ needs.bazel-oss-tool-test.outputs.image-tag }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
-          # Reuse the layers populated by docker-image-build before publishing.
+          # Reuse the layers populated by bazel-oss-tool-test before publishing.
           cache-from: type=gha,scope=bedrock-rtl-docker
       - name: Attest Docker image provenance
         # actions/attest v4.1.0
@@ -118,9 +300,8 @@ jobs:
           subject-digest: ${{ steps.publish.outputs.digest }}
           push-to-registry: true
 
-  # Run bazel build and tests in order in one job to avoid parallel jobs that make
-  # build logs appear out of sequence across the CI workflow.
-  bazel-build-and-test:
+  # Keep proprietary tools and their logs exclusively on the private runner.
+  bazel-build-and-proprietary-tool-test:
     runs-on: self-hosted
     env:
       # TODO(xiyu): Temporary workaround until CI provides a container-local EDA setup script.
@@ -128,27 +309,15 @@ jobs:
       # a sanitized action PATH unless PATH is passed explicitly.
       TMP_HACK_BAZEL_CI_FLAGS: --action_env=PATH
     outputs:
-      python_total_tests: ${{ steps.python.outputs.total_tests }}
-      python_passing_tests: ${{ steps.python.outputs.passing_tests }}
-      python_exit_code: ${{ steps.python.outputs.exit_code }}
-      stardoc_total_tests: ${{ steps.stardoc.outputs.total_tests }}
-      stardoc_passing_tests: ${{ steps.stardoc.outputs.passing_tests }}
-      stardoc_exit_code: ${{ steps.stardoc.outputs.exit_code }}
       verific_total_tests: ${{ steps.verific.outputs.total_tests }}
       verific_passing_tests: ${{ steps.verific.outputs.passing_tests }}
       verific_exit_code: ${{ steps.verific.outputs.exit_code }}
-      slang_total_tests: ${{ steps.slang.outputs.total_tests }}
-      slang_passing_tests: ${{ steps.slang.outputs.passing_tests }}
-      slang_exit_code: ${{ steps.slang.outputs.exit_code }}
       ascentlint_total_tests: ${{ steps.ascentlint.outputs.total_tests }}
       ascentlint_passing_tests: ${{ steps.ascentlint.outputs.passing_tests }}
       ascentlint_exit_code: ${{ steps.ascentlint.outputs.exit_code }}
       vcs_total_tests: ${{ steps.vcs.outputs.total_tests }}
       vcs_passing_tests: ${{ steps.vcs.outputs.passing_tests }}
       vcs_exit_code: ${{ steps.vcs.outputs.exit_code }}
-      verilator_total_tests: ${{ steps.verilator.outputs.total_tests }}
-      verilator_passing_tests: ${{ steps.verilator.outputs.passing_tests }}
-      verilator_exit_code: ${{ steps.verilator.outputs.exit_code }}
     steps:
     # actions/checkout v6
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -158,29 +327,11 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: cp /home/gh-actions/bedrock-infra/ci.bazelrc ci.bazelrc
     - name: Build
-      run: bazel build $TMP_HACK_BAZEL_CI_FLAGS --noshow_loading_progress //...
-    - name: python tests
-      id: python
+      id: build
       run: |
         set +e
-        bazel test $TMP_HACK_BAZEL_CI_FLAGS --noshow_loading_progress //python/... //ecc/rtl/secded_codegen/... 2>&1 | tee .bazel-test-python.log
-        BAZEL_EXIT_CODE=${PIPESTATUS[0]}
-        TOTAL_TESTS=$(grep -Po '(?<=out of )\d+(?= test)' .bazel-test-python.log)
-        PASSING_TESTS=$(grep -Po '\d+(?= test passes?\.| tests pass)' .bazel-test-python.log)
-        echo "total_tests=$TOTAL_TESTS" >> $GITHUB_OUTPUT
-        echo "passing_tests=$PASSING_TESTS" >> $GITHUB_OUTPUT
-        echo "exit_code=$BAZEL_EXIT_CODE" >> $GITHUB_OUTPUT
-    - name: Stardoc tests
-      id: stardoc
-      run: |
-        set +e
-        bazel test $TMP_HACK_BAZEL_CI_FLAGS --noshow_loading_progress //bazel/... 2>&1 | tee .bazel-test-stardoc.log
-        BAZEL_EXIT_CODE=${PIPESTATUS[0]}
-        TOTAL_TESTS=$(grep -Po '(?<=out of )\d+(?= test)' .bazel-test-stardoc.log)
-        PASSING_TESTS=$(grep -Po '\d+(?= test passes?\.| tests pass)' .bazel-test-stardoc.log)
-        echo "total_tests=$TOTAL_TESTS" >> $GITHUB_OUTPUT
-        echo "passing_tests=$PASSING_TESTS" >> $GITHUB_OUTPUT
-        echo "exit_code=$BAZEL_EXIT_CODE" >> $GITHUB_OUTPUT
+        bazel build $TMP_HACK_BAZEL_CI_FLAGS --noshow_loading_progress //...
+        echo "exit_code=$?" >> $GITHUB_OUTPUT
     - name: Verilog elaboration tests (using Verific tclmain)
       id: verific
       # Use --test_output=summary to suppress log output, even on failure (proprietary EDA tool output may be sensitive).
@@ -190,33 +341,6 @@ jobs:
         BAZEL_EXIT_CODE=${PIPESTATUS[0]}
         TOTAL_TESTS=$(grep -Po '(?<=out of )\d+(?= test)' .bazel-test-verific.log)
         PASSING_TESTS=$(grep -Po '\d+(?= test passes?\.| tests pass)' .bazel-test-verific.log)
-        echo "total_tests=$TOTAL_TESTS" >> $GITHUB_OUTPUT
-        echo "passing_tests=$PASSING_TESTS" >> $GITHUB_OUTPUT
-        echo "exit_code=$BAZEL_EXIT_CODE" >> $GITHUB_OUTPUT
-    - name: Verilog elaboration tests (using Slang)
-      id: slang
-      run: |
-        set +e
-        SLANG_TARGETS=.bazel-test-slang.targets
-        bazel query --noshow_progress 'tests(//...) intersect attr(tags, "slang", //...)' > "$SLANG_TARGETS"
-        BAZEL_EXIT_CODE=$?
-        TOTAL_TESTS=0
-        PASSING_TESTS=0
-
-        if [ "$BAZEL_EXIT_CODE" -ne 0 ]; then
-          echo "::error title=Slang test discovery failed::Bazel query exited with code $BAZEL_EXIT_CODE"
-        elif [ ! -s "$SLANG_TARGETS" ]; then
-          echo "::error title=No Slang tests found::The slang tag must select at least one test target"
-          BAZEL_EXIT_CODE=4
-        else
-          NUM_SLANG_TARGETS=$(wc -l < "$SLANG_TARGETS")
-          echo "Running $NUM_SLANG_TARGETS Slang-tagged test targets."
-          bazel test $TMP_HACK_BAZEL_CI_FLAGS --noshow_loading_progress //... --test_tag_filters=slang 2>&1 | tee .bazel-test-slang.log
-          BAZEL_EXIT_CODE=${PIPESTATUS[0]}
-          TOTAL_TESTS=$(grep -Po '(?<=out of )\d+(?= test)' .bazel-test-slang.log)
-          PASSING_TESTS=$(grep -Po '\d+(?= test passes?\.| tests pass)' .bazel-test-slang.log)
-        fi
-
         echo "total_tests=$TOTAL_TESTS" >> $GITHUB_OUTPUT
         echo "passing_tests=$PASSING_TESTS" >> $GITHUB_OUTPUT
         echo "exit_code=$BAZEL_EXIT_CODE" >> $GITHUB_OUTPUT
@@ -245,21 +369,7 @@ jobs:
         echo "total_tests=$TOTAL_TESTS" >> $GITHUB_OUTPUT
         echo "passing_tests=$PASSING_TESTS" >> $GITHUB_OUTPUT
         echo "exit_code=$BAZEL_EXIT_CODE" >> $GITHUB_OUTPUT
-    - name: Verilog sim tests (using Verilator)
-      id: verilator
-      # Don't need --test_output=summary to suppress log output because Verilator is open source.
-      run: |
-        set +e
-        bazel query 'tests(//...) intersect attr(tags, "verilator", //...) intersect attr(tags, "sim", //...)' > .bazel-test-verilator.targets
-        xargs -a .bazel-test-verilator.targets bazel test $TMP_HACK_BAZEL_CI_FLAGS --noshow_loading_progress 2>&1 | tee .bazel-test-verilator.log
-        BAZEL_EXIT_CODE=${PIPESTATUS[0]}
-        TOTAL_TESTS=$(grep -Po '(?<=out of )\d+(?= test)' .bazel-test-verilator.log)
-        PASSING_TESTS=$(grep -Po '\d+(?= test passes?\.| tests pass)' .bazel-test-verilator.log)
-        echo "total_tests=$TOTAL_TESTS" >> $GITHUB_OUTPUT
-        echo "passing_tests=$PASSING_TESTS" >> $GITHUB_OUTPUT
-        echo "exit_code=$BAZEL_EXIT_CODE" >> $GITHUB_OUTPUT
-
-    - name: Check bazel test suite results
+    - name: Check proprietary Bazel build and test suite results
       run: |
         failed_suites=()
 
@@ -272,13 +382,10 @@ jobs:
           fi
         }
 
-        check_suite "python" "${{ steps.python.outputs.exit_code }}"
-        check_suite "stardoc" "${{ steps.stardoc.outputs.exit_code }}"
+        check_suite "build" "${{ steps.build.outputs.exit_code }}"
         check_suite "verific" "${{ steps.verific.outputs.exit_code }}"
-        check_suite "slang" "${{ steps.slang.outputs.exit_code }}"
         check_suite "ascentlint" "${{ steps.ascentlint.outputs.exit_code }}"
         check_suite "vcs" "${{ steps.vcs.outputs.exit_code }}"
-        check_suite "verilator" "${{ steps.verilator.outputs.exit_code }}"
 
         if [ "${#failed_suites[@]}" -ne 0 ]; then
           echo "Failed Bazel suites:"
@@ -320,8 +427,8 @@ jobs:
   python-badge:
     runs-on: ubuntu-24.04
     environment: ci-badge-publishing
-    needs: bazel-build-and-test
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: bazel-oss-tool-test
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Create python badge
       # schneegans/dynamic-badges-action v1.7.0
@@ -331,14 +438,14 @@ jobs:
         gistID: c66dc2ddc0e513ba06ce338620977b26
         filename: python.json
         label: "python"
-        message: ${{ needs.bazel-build-and-test.outputs.python_passing_tests }} of ${{ needs.bazel-build-and-test.outputs.python_total_tests }} passing
-        color: ${{ needs.bazel-build-and-test.outputs.python_exit_code == '0' && 'brightgreen' || 'red' }}
+        message: ${{ needs.bazel-oss-tool-test.outputs.python_passing_tests }} of ${{ needs.bazel-oss-tool-test.outputs.python_total_tests }} passing
+        color: ${{ needs.bazel-oss-tool-test.outputs.python_exit_code == '0' && 'brightgreen' || 'red' }}
 
   stardoc-badge:
     runs-on: ubuntu-24.04
     environment: ci-badge-publishing
-    needs: bazel-build-and-test
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: bazel-oss-tool-test
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Create stardoc badge
       # schneegans/dynamic-badges-action v1.7.0
@@ -348,14 +455,14 @@ jobs:
         gistID: c66dc2ddc0e513ba06ce338620977b26
         filename: stardoc.json
         label: "stardoc"
-        message: ${{ needs.bazel-build-and-test.outputs.stardoc_passing_tests }} of ${{ needs.bazel-build-and-test.outputs.stardoc_total_tests }} passing
-        color: ${{ needs.bazel-build-and-test.outputs.stardoc_exit_code == '0' && 'brightgreen' || 'red' }}
+        message: ${{ needs.bazel-oss-tool-test.outputs.stardoc_passing_tests }} of ${{ needs.bazel-oss-tool-test.outputs.stardoc_total_tests }} passing
+        color: ${{ needs.bazel-oss-tool-test.outputs.stardoc_exit_code == '0' && 'brightgreen' || 'red' }}
 
   verific-badge:
     runs-on: ubuntu-24.04
     environment: ci-badge-publishing
-    needs: bazel-build-and-test
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: bazel-build-and-proprietary-tool-test
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Create verific badge
       # schneegans/dynamic-badges-action v1.7.0
@@ -365,14 +472,14 @@ jobs:
         gistID: c66dc2ddc0e513ba06ce338620977b26
         filename: verific.json
         label: "verific"
-        message: ${{ needs.bazel-build-and-test.outputs.verific_passing_tests }} of ${{ needs.bazel-build-and-test.outputs.verific_total_tests }} passing
-        color: ${{ needs.bazel-build-and-test.outputs.verific_exit_code == '0' && 'brightgreen' || 'red' }}
+        message: ${{ needs.bazel-build-and-proprietary-tool-test.outputs.verific_passing_tests }} of ${{ needs.bazel-build-and-proprietary-tool-test.outputs.verific_total_tests }} passing
+        color: ${{ needs.bazel-build-and-proprietary-tool-test.outputs.verific_exit_code == '0' && 'brightgreen' || 'red' }}
 
   slang-badge:
     runs-on: ubuntu-24.04
     environment: ci-badge-publishing
-    needs: bazel-build-and-test
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: bazel-oss-tool-test
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Create slang badge
       # schneegans/dynamic-badges-action v1.7.0
@@ -382,14 +489,14 @@ jobs:
         gistID: c66dc2ddc0e513ba06ce338620977b26
         filename: slang.json
         label: "slang"
-        message: ${{ needs.bazel-build-and-test.outputs.slang_passing_tests }} of ${{ needs.bazel-build-and-test.outputs.slang_total_tests }} passing
-        color: ${{ needs.bazel-build-and-test.outputs.slang_exit_code == '0' && 'brightgreen' || 'red' }}
+        message: ${{ needs.bazel-oss-tool-test.outputs.slang_passing_tests }} of ${{ needs.bazel-oss-tool-test.outputs.slang_total_tests }} passing
+        color: ${{ needs.bazel-oss-tool-test.outputs.slang_exit_code == '0' && 'brightgreen' || 'red' }}
 
   ascentlint-badge:
     runs-on: ubuntu-24.04
     environment: ci-badge-publishing
-    needs: bazel-build-and-test
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: bazel-build-and-proprietary-tool-test
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Create ascentlint badge
       # schneegans/dynamic-badges-action v1.7.0
@@ -399,14 +506,14 @@ jobs:
         gistID: c66dc2ddc0e513ba06ce338620977b26
         filename: ascentlint.json
         label: "ascentlint"
-        message: ${{ needs.bazel-build-and-test.outputs.ascentlint_passing_tests }} of ${{ needs.bazel-build-and-test.outputs.ascentlint_total_tests }} passing
-        color: ${{ needs.bazel-build-and-test.outputs.ascentlint_exit_code == '0' && 'brightgreen' || 'red' }}
+        message: ${{ needs.bazel-build-and-proprietary-tool-test.outputs.ascentlint_passing_tests }} of ${{ needs.bazel-build-and-proprietary-tool-test.outputs.ascentlint_total_tests }} passing
+        color: ${{ needs.bazel-build-and-proprietary-tool-test.outputs.ascentlint_exit_code == '0' && 'brightgreen' || 'red' }}
 
   vcs-badge:
     runs-on: ubuntu-24.04
     environment: ci-badge-publishing
-    needs: bazel-build-and-test
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: bazel-build-and-proprietary-tool-test
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Create vcs badge
       # schneegans/dynamic-badges-action v1.7.0
@@ -416,14 +523,14 @@ jobs:
         gistID: c66dc2ddc0e513ba06ce338620977b26
         filename: vcs.json
         label: "vcs"
-        message: ${{ needs.bazel-build-and-test.outputs.vcs_passing_tests }} of ${{ needs.bazel-build-and-test.outputs.vcs_total_tests }} passing
-        color: ${{ needs.bazel-build-and-test.outputs.vcs_exit_code == '0' && 'brightgreen' || 'red' }}
+        message: ${{ needs.bazel-build-and-proprietary-tool-test.outputs.vcs_passing_tests }} of ${{ needs.bazel-build-and-proprietary-tool-test.outputs.vcs_total_tests }} passing
+        color: ${{ needs.bazel-build-and-proprietary-tool-test.outputs.vcs_exit_code == '0' && 'brightgreen' || 'red' }}
 
   verilator-badge:
     runs-on: ubuntu-24.04
     environment: ci-badge-publishing
-    needs: bazel-build-and-test
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: bazel-oss-tool-test
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Create verilator badge
       # schneegans/dynamic-badges-action v1.7.0
@@ -433,5 +540,5 @@ jobs:
         gistID: c66dc2ddc0e513ba06ce338620977b26
         filename: verilator.json
         label: "verilator"
-        message: ${{ needs.bazel-build-and-test.outputs.verilator_passing_tests }} of ${{ needs.bazel-build-and-test.outputs.verilator_total_tests }} passing
-        color: ${{ needs.bazel-build-and-test.outputs.verilator_exit_code == '0' && 'brightgreen' || 'red' }}
+        message: ${{ needs.bazel-oss-tool-test.outputs.verilator_passing_tests }} of ${{ needs.bazel-oss-tool-test.outputs.verilator_total_tests }} passing
+        color: ${{ needs.bazel-oss-tool-test.outputs.verilator_exit_code == '0' && 'brightgreen' || 'red' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           # setup-bazel restores these paths on a cache hit. Create them on a
           # miss so Docker can bind-mount the same host paths below.
           mkdir -p \
+            "${HOME}/.cache/bazel" \
             "${HOME}/.cache/bazelisk" \
             "${HOME}/.cache/bazel-disk" \
             "${HOME}/.cache/bazel-repo" \
@@ -110,6 +111,8 @@ jobs:
           # Keep stdin attached so `bash -s` receives the heredoc below. The
           # hosted runner UID is not present in the image's passwd file, so set
           # USER explicitly for Bazel after retaining that UID for cache writes.
+          # Mount Bazel's default output user root because the container's
+          # /home/runner is root-owned.
           docker run --rm -i \
             --user "$(id -u):$(id -g)" \
             --env USER=user \
@@ -117,6 +120,7 @@ jobs:
             --workdir "${GITHUB_WORKSPACE}" \
             --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
             --volume "${HOME}/.bazelrc:${HOME}/.bazelrc:ro" \
+            --volume "${HOME}/.cache/bazel:${HOME}/.cache/bazel" \
             --volume "${HOME}/.cache/bazelisk:${HOME}/.cache/bazelisk" \
             --volume "${HOME}/.cache/bazel-disk:${HOME}/.cache/bazel-disk" \
             --volume "${HOME}/.cache/bazel-repo:${HOME}/.cache/bazel-repo" \
@@ -124,7 +128,14 @@ jobs:
             bedrock-rtl-ci:${{ github.sha }} \
             bash -s <<'EOF'
           set +e
-          BAZEL_FLAGS=(--action_env=PATH --noshow_loading_progress)
+          # Pass cache paths explicitly rather than depending on the generated
+          # user bazelrc being discovered inside the container.
+          BAZEL_FLAGS=(
+            --action_env=PATH
+            --noshow_loading_progress
+            --disk_cache=/home/runner/.cache/bazel-disk
+            --repository_cache=/home/runner/.cache/bazel-repo
+          )
           RESULTS=.bazel-oss-test-results
           : > "$RESULTS"
           failed_suites=()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,8 @@ jobs:
       - name: Run public Bazel test suites
         continue-on-error: true
         run: |
-          docker run --rm \
+          # Keep stdin attached so `bash -s` receives the heredoc below.
+          docker run --rm -i \
             --user "$(id -u):$(id -g)" \
             --env HOME="${HOME}" \
             --workdir "${GITHUB_WORKSPACE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
           BAZEL_FLAGS=(
             --action_env=PATH
             --noshow_loading_progress
+            --test_output=errors
             --disk_cache=/home/runner/.cache/bazel-disk
             --repository_cache=/home/runner/.cache/bazel-repo
             --experimental_disk_cache_gc_max_size=256M

--- a/README.adoc
+++ b/README.adoc
@@ -8,14 +8,15 @@ image:https://img.shields.io/badge/build%20system-Bazel-blue[build system - Baze
 image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/rtl.json[rtl-files]
 
 image:https://img.shields.io/github/check-runs/xlsynth/bedrock-rtl/main?nameFilter=pre-commit&label=pre-commit[pre-commit,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Apre-commit"]
-image:https://img.shields.io/github/check-runs/xlsynth/bedrock-rtl/main?nameFilter=bazel-build&label=build[bazel-build,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-build"]
-image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/python.json[bazel-test-python,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-test-python"]
-image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/stardoc.json[bazel-test-stardoc,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-test-stardoc"]
-image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/verific.json[bazel-test-verific,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-test-verific"]
-image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/slang.json[bazel-test-slang,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-test-slang"]
-image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/ascentlint.json[bazel-test-ascentlint,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-test-ascentlint"]
-image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/vcs.json[bazel-test-vcs,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-test-vcs"]
-image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/verilator.json[bazel-test-verilator,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-test-verilator"]
+image:https://img.shields.io/github/check-runs/xlsynth/bedrock-rtl/main?nameFilter=bazel-oss-tool-test&label=oss%20tools[oss-tools,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-oss-tool-test"]
+image:https://img.shields.io/github/check-runs/xlsynth/bedrock-rtl/main?nameFilter=bazel-build-and-proprietary-tool-test&label=build%20and%20proprietary%20tools[build-and-proprietary-tools,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-build-and-proprietary-tool-test"]
+image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/python.json[bazel-test-python,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-oss-tool-test"]
+image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/stardoc.json[bazel-test-stardoc,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-oss-tool-test"]
+image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/verific.json[bazel-test-verific,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-build-and-proprietary-tool-test"]
+image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/slang.json[bazel-test-slang,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-oss-tool-test"]
+image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/ascentlint.json[bazel-test-ascentlint,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-build-and-proprietary-tool-test"]
+image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/vcs.json[bazel-test-vcs,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-build-and-proprietary-tool-test"]
+image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/verilator.json[bazel-test-verilator,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/ci.yml?query=job%3Abazel-oss-tool-test"]
 image:https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mgottscho/c66dc2ddc0e513ba06ce338620977b26/raw/jg.json[bazel-test-jg,link="https://github.com/xlsynth/bedrock-rtl/actions/workflows/nightly.yml?query=job%3Abazel-test-jg"]
 image:https://img.shields.io/github/issues/xlsynth/bedrock-rtl/bug?label=bugs[open bugs,link="https://github.com/xlsynth/bedrock-rtl/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug"]
 
@@ -99,8 +100,8 @@ Then once inside the container, try `bazel build //... && bazel test //fifo/sim/
 
 === Deploying Docker Images
 
-The `docker-image-build` job in `.github/workflows/ci.yml` builds the image for every pull request, push to `main`, and manual CI run.
-After that build succeeds, the `docker-image-publish` job deploys the image to `ghcr.io/xlsynth/bedrock-rtl` for pushes to `main` and manually dispatched CI runs.
+The `bazel-oss-tool-test` job in `.github/workflows/ci.yml` builds the image for every pull request, push to `main`, and manual CI run, then uses that exact image for the public-tool test suites.
+After those tests succeed, the `docker-image-publish` job deploys the image to `ghcr.io/xlsynth/bedrock-rtl` for pushes to `main` and manually dispatched CI runs.
 Pull requests build the image but do not publish it.
 
 The publish job generates the immutable `YYYY-MM-DD-<full-git-sha>` tag, pushes the `linux/amd64` image, attaches BuildKit provenance, and publishes a signed GitHub artifact attestation for the image digest.
@@ -180,7 +181,8 @@ Run `bazel run //python/ppa:generate_ppa` to refresh link:PPA.md[] from all publ
 == Continuous Integration
 
 We run continuous integration tests with GitHub Actions.
-The main CI workflow currently covers pre-commit, build, Python/ecc codegen tests, Stardoc, Verific, Slang, AscentLint, VCS, and Verilator.
+The GitHub-hosted `bazel-oss-tool-test` job builds the public Docker image and runs Python/ecc codegen, Stardoc, Slang, and Verilator tests with public logs and GitHub Actions caches.
+The self-hosted `bazel-build-and-proprietary-tool-test` job runs `bazel build //...` plus Verific, AscentLint, and VCS tests; it reports private-suite results without emitting proprietary test logs.
 Sampled JasperGold formal tests run in the nightly workflow.
 See `.github/workflows/ci.yml` and `.github/workflows/nightly.yml` for details.
 

--- a/README.adoc
+++ b/README.adoc
@@ -100,9 +100,14 @@ Then once inside the container, try `bazel build //... && bazel test //fifo/sim/
 
 === Deploying Docker Images
 
-The `bazel-oss-tool-test` job in `.github/workflows/ci.yml` builds the image for every pull request, push to `main`, and manual CI run, then uses that exact image for the public-tool test suites.
+The public CI shard jobs in `.github/workflows/ci.yml` build the image for every pull request, push to `main`, and manual CI run, then use that exact image for the public-tool test suites.
+Python/ecc-codegen and Stardoc share one runner, while stable SHA-256 label partitioning distributes Slang across four runners and Verilator across eight runners.
+The `bazel-oss-tool-test` job validates and aggregates every shard into the stable check and badge interface.
 After those tests succeed, the `docker-image-publish` job deploys the image to `ghcr.io/xlsynth/bedrock-rtl` for pushes to `main` and manually dispatched CI runs.
 Pull requests build the image but do not publish it.
+
+All public shards restore the shared Docker layer cache, but only one shard updates it on trusted `main` or manually dispatched runs.
+Bazel disk caches are partitioned with the test shards so repeated runs restore the outputs relevant to the same stable label set; pull requests restore caches without saving them.
 
 The publish job generates the immutable `YYYY-MM-DD-<full-git-sha>` tag, pushes the `linux/amd64` image, attaches BuildKit provenance, and publishes a signed GitHub artifact attestation for the image digest.
 Repository maintainers can deploy an image manually by opening the
@@ -181,7 +186,8 @@ Run `bazel run //python/ppa:generate_ppa` to refresh link:PPA.md[] from all publ
 == Continuous Integration
 
 We run continuous integration tests with GitHub Actions.
-The GitHub-hosted `bazel-oss-tool-test` job builds the public Docker image and runs Python/ecc codegen, Stardoc, Slang, and Verilator tests with public logs and GitHub Actions caches.
+GitHub-hosted shard jobs build the public Docker image and run Python/ecc codegen, Stardoc, Slang, and Verilator tests in parallel with public logs and GitHub Actions caches.
+The stable `bazel-oss-tool-test` check verifies complete, non-overlapping shard coverage and aggregates the results used by the public badges.
 The self-hosted `bazel-build-and-proprietary-tool-test` job runs `bazel build //...` plus Verific, AscentLint, and VCS tests; it reports private-suite results without emitting proprietary test logs.
 Sampled JasperGold formal tests run in the nightly workflow.
 See `.github/workflows/ci.yml` and `.github/workflows/nightly.yml` for details.

--- a/bazel/verilog_runner/nonzip_test.sh
+++ b/bazel/verilog_runner/nonzip_test.sh
@@ -39,6 +39,7 @@ for output in "${synth_sandbox}" "${synth_sandbox_runner}"; do
   fi
 done
 
+archive_contents="$(tar -tzf "${synth_sandbox}")"
 for required in \
   bazel/verilog_runner/nonzip_smoke.sv \
   python/verilog_runner/verilog_runner.py \
@@ -46,13 +47,13 @@ for required in \
   nonzip_synth_sandbox.f \
   nonzip_synth_sandbox.tcl \
   nonzip_synth_sandbox.sh; do
-  if ! tar -tzf "${synth_sandbox}" | grep -qx "${required}"; then
+  if ! grep -Fxq "${required}" <<< "${archive_contents}"; then
     echo "synthesis sandbox is missing ${required}"
     exit 1
   fi
 done
 
-if tar -tzf "${synth_sandbox}" | grep -q '/yosys$'; then
+if grep -Eq '/yosys$' <<< "${archive_contents}"; then
   echo "synthesis sandbox unexpectedly bundles the Yosys executable"
   exit 1
 fi

--- a/python/ci/BUILD.bazel
+++ b/python/ci/BUILD.bazel
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "bazel_oss_sharding_lib",
+    srcs = ["bazel_oss_sharding.py"],
+)
+
+py_binary(
+    name = "bazel_oss_sharding",
+    srcs = ["bazel_oss_sharding.py"],
+    main = "bazel_oss_sharding.py",
+)
+
+py_test(
+    name = "bazel_oss_sharding_test",
+    srcs = ["bazel_oss_sharding_test.py"],
+    deps = [":bazel_oss_sharding_lib"],
+)

--- a/python/ci/bazel_oss_sharding.py
+++ b/python/ci/bazel_oss_sharding.py
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministically partitions and aggregates public Bazel CI test targets."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Iterable
+
+
+SCHEMA_VERSION = 1
+PASSING_TESTS_RE = re.compile(r"(\d+) tests? pass(?:es)?")
+SUITES = ("python", "stardoc", "slang", "verilator")
+
+
+def canonicalize_labels(lines: Iterable[str]) -> list[str]:
+    """Returns sorted, unique Bazel labels after validating their shape."""
+
+    labels = []
+    for line in lines:
+        label = line.strip()
+        if not label:
+            continue
+        if not label.startswith("//") or any(
+            character.isspace() for character in label
+        ):
+            raise ValueError(f"invalid Bazel label: {label!r}")
+        labels.append(label)
+    return sorted(set(labels))
+
+
+def labels_digest(labels: Iterable[str]) -> str:
+    """Returns a stable digest for a canonical label set."""
+
+    canonical = canonicalize_labels(labels)
+    contents = "".join(f"{label}\n" for label in canonical).encode()
+    return hashlib.sha256(contents).hexdigest()
+
+
+def shard_for_label(label: str, shard_count: int) -> int:
+    """Maps a label to a shard without depending on other labels."""
+
+    if shard_count <= 0:
+        raise ValueError("shard count must be positive")
+    digest = hashlib.sha256(label.encode()).digest()
+    return int.from_bytes(digest, byteorder="big") % shard_count
+
+
+def partition_labels(
+    labels: Iterable[str], shard_index: int, shard_count: int
+) -> tuple[list[str], list[str]]:
+    """Returns the canonical discovered and selected label sets."""
+
+    if shard_count <= 0:
+        raise ValueError("shard count must be positive")
+    if shard_index < 0 or shard_index >= shard_count:
+        raise ValueError(f"shard index {shard_index} is outside [0, {shard_count})")
+    discovered = canonicalize_labels(labels)
+    selected = [
+        label
+        for label in discovered
+        if shard_for_label(label, shard_count) == shard_index
+    ]
+    return discovered, selected
+
+
+def result_filename(suite: str, shard_index: int, shard_count: int) -> str:
+    return f"result-{suite}-{shard_index}-of-{shard_count}.json"
+
+
+def targets_filename(suite: str, shard_index: int, shard_count: int) -> str:
+    return f"targets-{suite}-{shard_index}-of-{shard_count}.txt"
+
+
+def prepare_partition(
+    suite: str,
+    shard_index: int,
+    shard_count: int,
+    labels: Iterable[str],
+    output_dir: Path,
+) -> tuple[dict, Path, Path]:
+    """Writes a shard target manifest and initial result record."""
+
+    if suite not in SUITES:
+        raise ValueError(f"unsupported suite: {suite}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    errors = []
+    try:
+        discovered, selected = partition_labels(labels, shard_index, shard_count)
+    except ValueError as error:
+        discovered = []
+        selected = []
+        errors.append(str(error))
+
+    if not discovered:
+        errors.append("test discovery selected no targets")
+    elif not selected:
+        errors.append("shard selected no targets")
+
+    target_path = output_dir / targets_filename(suite, shard_index, shard_count)
+    target_path.write_text(
+        "".join(f"{label}\n" for label in selected), encoding="utf-8"
+    )
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "suite": suite,
+        "shard_index": shard_index,
+        "shard_count": shard_count,
+        "discovered_count": len(discovered),
+        "discovered_sha256": labels_digest(discovered),
+        "selected_count": len(selected),
+        "selected_sha256": labels_digest(selected),
+        "passing_tests": 0,
+        "exit_code": 4 if errors else None,
+        "target_file": target_path.name,
+        "errors": errors,
+    }
+    result_path = output_dir / result_filename(suite, shard_index, shard_count)
+    write_json(result_path, record)
+    return record, result_path, target_path
+
+
+def parse_passing_tests(log: str) -> int | None:
+    matches = PASSING_TESTS_RE.findall(log)
+    return int(matches[-1]) if matches else None
+
+
+def finalize_result(result_path: Path, log_path: Path, exit_code: int) -> dict:
+    """Adds Bazel's outcome to an existing result record."""
+
+    record = read_json(result_path)
+    passing_tests = parse_passing_tests(
+        log_path.read_text(encoding="utf-8", errors="replace")
+    )
+    errors = list(record.get("errors", []))
+    if passing_tests is None:
+        passing_tests = 0
+        if exit_code == 0:
+            errors.append("successful Bazel invocation had no test summary")
+            exit_code = 4
+    if passing_tests > record["selected_count"]:
+        errors.append("Bazel passing count exceeds selected target count")
+        exit_code = 4
+    if exit_code == 0 and passing_tests != record["selected_count"]:
+        errors.append("successful Bazel invocation did not pass every selected target")
+        exit_code = 4
+    record["passing_tests"] = passing_tests
+    record["exit_code"] = exit_code
+    record["errors"] = errors
+    write_json(result_path, record)
+    return record
+
+
+def mark_discovery_failure(result_path: Path, exit_code: int, message: str) -> dict:
+    """Records a query or partition failure without running Bazel."""
+
+    record = read_json(result_path)
+    record["passing_tests"] = 0
+    record["exit_code"] = exit_code if exit_code != 0 else 4
+    record["errors"] = list(record.get("errors", [])) + [message]
+    write_json(result_path, record)
+    return record
+
+
+def aggregate_results(
+    results_dir: Path, expected_shards: dict[str, int]
+) -> tuple[dict[str, dict[str, int]], list[str], list[str]]:
+    """Validates and aggregates shard records.
+
+    Returns suite outputs, validation errors, and Markdown summary rows.
+    """
+
+    records = []
+    errors = []
+    for result_path in sorted(results_dir.rglob("result-*.json")):
+        try:
+            record = read_json(result_path)
+        except (OSError, json.JSONDecodeError) as error:
+            errors.append(f"{result_path.name}: invalid JSON: {error}")
+            continue
+        record["_result_path"] = result_path
+        records.append(record)
+
+    outputs = {}
+    summary_rows = []
+    for suite, shard_count in expected_shards.items():
+        suite_records = [record for record in records if record.get("suite") == suite]
+        suite_errors = []
+        records_by_index = {}
+        for record in suite_records:
+            record_error = validate_record_shape(record, suite, shard_count)
+            if record_error:
+                suite_errors.extend(record_error)
+                continue
+            shard_index = record["shard_index"]
+            if shard_index in records_by_index:
+                suite_errors.append(f"duplicate shard index {shard_index}")
+            else:
+                records_by_index[shard_index] = record
+
+        missing = sorted(set(range(shard_count)) - set(records_by_index))
+        if missing:
+            suite_errors.append(f"missing shard indexes: {missing}")
+
+        valid_records = [records_by_index[index] for index in sorted(records_by_index)]
+        discovered_counts = {record["discovered_count"] for record in valid_records}
+        discovered_digests = {record["discovered_sha256"] for record in valid_records}
+        if len(discovered_counts) > 1:
+            suite_errors.append("shards disagree on discovered target count")
+        if len(discovered_digests) > 1:
+            suite_errors.append("shards disagree on discovered target digest")
+
+        selected_labels = []
+        selected_seen = set()
+        passing_tests = 0
+        for record in valid_records:
+            target_path = record["_result_path"].parent / record["target_file"]
+            try:
+                labels = canonicalize_labels(
+                    target_path.read_text(encoding="utf-8").splitlines()
+                )
+            except (OSError, ValueError) as error:
+                suite_errors.append(
+                    f"shard {record['shard_index']} target manifest is invalid: {error}"
+                )
+                labels = []
+            if len(labels) != record["selected_count"]:
+                suite_errors.append(
+                    f"shard {record['shard_index']} selected count does not match manifest"
+                )
+            if labels_digest(labels) != record["selected_sha256"]:
+                suite_errors.append(
+                    f"shard {record['shard_index']} selected digest does not match manifest"
+                )
+            duplicates = selected_seen.intersection(labels)
+            if duplicates:
+                suite_errors.append(
+                    f"shard {record['shard_index']} overlaps another shard"
+                )
+            selected_seen.update(labels)
+            selected_labels.extend(labels)
+            passing_tests += record["passing_tests"]
+            if record["exit_code"] != 0:
+                suite_errors.append(
+                    f"shard {record['shard_index']} exited with {record['exit_code']}"
+                )
+            suite_errors.extend(
+                f"shard {record['shard_index']}: {message}"
+                for message in record.get("errors", [])
+            )
+
+        # Keep badge outputs deterministic even when inconsistent records make
+        # the suite fail validation.
+        total_tests = max(discovered_counts, default=0)
+        discovered_digest = min(discovered_digests, default=labels_digest([]))
+        if len(selected_labels) != total_tests:
+            suite_errors.append("selected shard union count does not match discovery")
+        if labels_digest(selected_labels) != discovered_digest:
+            suite_errors.append("selected shard union digest does not match discovery")
+        if passing_tests > total_tests:
+            suite_errors.append("aggregate passing count exceeds discovered count")
+
+        exit_code = 1 if suite_errors else 0
+        outputs[suite] = {
+            "total_tests": total_tests,
+            "passing_tests": passing_tests,
+            "exit_code": exit_code,
+        }
+        errors.extend(f"{suite}: {message}" for message in suite_errors)
+        status = "PASS" if exit_code == 0 else "FAIL"
+        summary_rows.append(
+            f"| {suite} | {shard_count} | {passing_tests} / {total_tests} | {status} |"
+        )
+
+    unknown_suites = sorted(
+        {
+            str(record.get("suite"))
+            for record in records
+            if record.get("suite") not in expected_shards
+        }
+    )
+    if unknown_suites:
+        errors.append(f"unexpected suites: {unknown_suites}")
+    return outputs, errors, summary_rows
+
+
+def validate_record_shape(
+    record: dict, expected_suite: str, expected_shard_count: int
+) -> list[str]:
+    errors = []
+    required_types = {
+        "schema_version": int,
+        "suite": str,
+        "shard_index": int,
+        "shard_count": int,
+        "discovered_count": int,
+        "discovered_sha256": str,
+        "selected_count": int,
+        "selected_sha256": str,
+        "passing_tests": int,
+        "exit_code": int,
+        "target_file": str,
+        "errors": list,
+    }
+    for key, expected_type in required_types.items():
+        if type(record.get(key)) is not expected_type:
+            errors.append(f"record has invalid {key}")
+    if errors:
+        return errors
+    if record["schema_version"] != SCHEMA_VERSION:
+        errors.append(f"unsupported schema version {record['schema_version']}")
+    if record["suite"] != expected_suite:
+        errors.append(f"record has unexpected suite {record['suite']}")
+    if record["shard_count"] != expected_shard_count:
+        errors.append(
+            f"shard count {record['shard_count']} does not match {expected_shard_count}"
+        )
+    if record["shard_index"] < 0 or record["shard_index"] >= expected_shard_count:
+        errors.append(f"shard index {record['shard_index']} is out of range")
+    for key in ("discovered_count", "selected_count", "passing_tests", "exit_code"):
+        if record[key] < 0:
+            errors.append(f"record has negative {key}")
+    if record["discovered_count"] == 0:
+        errors.append("record discovered no targets")
+    if record["selected_count"] == 0:
+        errors.append("record selected no targets")
+    for key in ("discovered_sha256", "selected_sha256"):
+        if re.fullmatch(r"[0-9a-f]{64}", record[key]) is None:
+            errors.append(f"record has invalid {key}")
+    if Path(record["target_file"]).name != record["target_file"]:
+        errors.append("target_file must be a basename")
+    if not all(isinstance(message, str) for message in record["errors"]):
+        errors.append("record errors must be strings")
+    return errors
+
+
+def read_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, value: dict) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def parse_expected_shards(values: list[str]) -> dict[str, int]:
+    expected = {}
+    for value in values:
+        suite, separator, count_text = value.partition("=")
+        if not separator or suite not in SUITES:
+            raise ValueError(f"invalid expected shard specification: {value}")
+        count = int(count_text)
+        if count <= 0:
+            raise ValueError(f"invalid expected shard count: {value}")
+        expected[suite] = count
+    if set(expected) != set(SUITES):
+        raise ValueError(f"expected shard specifications for {SUITES}")
+    return expected
+
+
+def command_partition(args: argparse.Namespace) -> int:
+    labels = args.input.read_text(encoding="utf-8").splitlines()
+    record, _, _ = prepare_partition(
+        args.suite, args.shard_index, args.shard_count, labels, args.output_dir
+    )
+    for error in record["errors"]:
+        print(f"ERROR: {error}", file=sys.stderr)
+    return 0 if not record["errors"] else record["exit_code"]
+
+
+def command_finalize(args: argparse.Namespace) -> int:
+    record = finalize_result(args.result, args.log, args.exit_code)
+    for error in record["errors"]:
+        print(f"ERROR: {error}", file=sys.stderr)
+    return 0 if record["exit_code"] == 0 else record["exit_code"]
+
+
+def command_discovery_failure(args: argparse.Namespace) -> int:
+    record = mark_discovery_failure(args.result, args.exit_code, args.message)
+    for error in record["errors"]:
+        print(f"ERROR: {error}", file=sys.stderr)
+    return record["exit_code"]
+
+
+def command_aggregate(args: argparse.Namespace) -> int:
+    expected = parse_expected_shards(args.expected)
+    outputs, errors, rows = aggregate_results(args.results_dir, expected)
+    with args.github_output.open("a", encoding="utf-8") as output:
+        for suite in SUITES:
+            for field in ("total_tests", "passing_tests", "exit_code"):
+                output.write(f"{suite}_{field}={outputs[suite][field]}\n")
+    with args.step_summary.open("a", encoding="utf-8") as summary:
+        summary.write("## Public Bazel test suites\n\n")
+        summary.write("| Suite | Shards | Passing | Status |\n")
+        summary.write("| --- | ---: | ---: | --- |\n")
+        summary.write("\n".join(rows))
+        summary.write("\n")
+        if errors:
+            summary.write("\n### Errors\n\n")
+            summary.writelines(f"- {error}\n" for error in errors)
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+def command_check(args: argparse.Namespace) -> int:
+    expected_suites = set(args.expected_suite)
+    records = []
+    errors = []
+    for result_path in sorted(args.results_dir.glob("result-*.json")):
+        try:
+            record = read_json(result_path)
+        except (OSError, json.JSONDecodeError) as error:
+            errors.append(f"{result_path.name}: invalid JSON: {error}")
+            continue
+        records.append(record)
+        if record.get("suite") not in expected_suites:
+            errors.append(f"{result_path.name}: unexpected suite {record.get('suite')}")
+        if record.get("exit_code") != 0:
+            errors.append(
+                f"{result_path.name}: exited with {record.get('exit_code', 'missing')}"
+            )
+        errors.extend(
+            f"{result_path.name}: {message}" for message in record.get("errors", [])
+        )
+    found_suites = {record.get("suite") for record in records}
+    missing_suites = sorted(expected_suites - found_suites)
+    if missing_suites:
+        errors.append(f"missing suite results: {missing_suites}")
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    partition = subparsers.add_parser("partition")
+    partition.add_argument("--suite", choices=SUITES, required=True)
+    partition.add_argument("--shard-index", type=int, required=True)
+    partition.add_argument("--shard-count", type=int, required=True)
+    partition.add_argument("--input", type=Path, required=True)
+    partition.add_argument("--output-dir", type=Path, required=True)
+    partition.set_defaults(func=command_partition)
+
+    finalize = subparsers.add_parser("finalize")
+    finalize.add_argument("--result", type=Path, required=True)
+    finalize.add_argument("--log", type=Path, required=True)
+    finalize.add_argument("--exit-code", type=int, required=True)
+    finalize.set_defaults(func=command_finalize)
+
+    discovery_failure = subparsers.add_parser("discovery-failure")
+    discovery_failure.add_argument("--result", type=Path, required=True)
+    discovery_failure.add_argument("--exit-code", type=int, required=True)
+    discovery_failure.add_argument("--message", required=True)
+    discovery_failure.set_defaults(func=command_discovery_failure)
+
+    aggregate = subparsers.add_parser("aggregate")
+    aggregate.add_argument("--results-dir", type=Path, required=True)
+    aggregate.add_argument("--expected", action="append", required=True)
+    aggregate.add_argument("--github-output", type=Path, required=True)
+    aggregate.add_argument("--step-summary", type=Path, required=True)
+    aggregate.set_defaults(func=command_aggregate)
+
+    check = subparsers.add_parser("check")
+    check.add_argument("--results-dir", type=Path, required=True)
+    check.add_argument("--expected-suite", action="append", required=True)
+    check.set_defaults(func=command_check)
+    return parser
+
+
+def main() -> int:
+    args = make_parser().parse_args()
+    try:
+        return args.func(args)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 4
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/ci/bazel_oss_sharding_test.py
+++ b/python/ci/bazel_oss_sharding_test.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+from contextlib import redirect_stderr
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from python.ci.bazel_oss_sharding import (
+    aggregate_results,
+    canonicalize_labels,
+    command_check,
+    finalize_result,
+    labels_digest,
+    partition_labels,
+    prepare_partition,
+    shard_for_label,
+)
+
+
+class BazelOssShardingTest(unittest.TestCase):
+    def test_canonicalizes_labels(self):
+        self.assertEqual(
+            canonicalize_labels(["//z:test\n", "", "//a:test", "//z:test"]),
+            ["//a:test", "//z:test"],
+        )
+        with self.assertRaisesRegex(ValueError, "invalid Bazel label"):
+            canonicalize_labels(["not-a-label"])
+
+    def test_partitions_are_disjoint_and_complete(self):
+        labels = [f"//pkg:test_{index}" for index in range(100)]
+        shards = [partition_labels(labels, index, 7)[1] for index in range(7)]
+        flattened = [label for shard in shards for label in shard]
+        self.assertEqual(sorted(flattened), sorted(labels))
+        self.assertEqual(len(flattened), len(set(flattened)))
+
+    def test_adding_label_does_not_move_existing_labels(self):
+        labels = [f"//pkg:test_{index}" for index in range(30)]
+        assignments = {label: shard_for_label(label, 4) for label in labels}
+        labels.append("//pkg:new_test")
+        updated = {label: shard_for_label(label, 4) for label in labels}
+        for label, shard in assignments.items():
+            self.assertEqual(updated[label], shard)
+
+    def test_rejects_invalid_shard_coordinates(self):
+        with self.assertRaisesRegex(ValueError, "positive"):
+            partition_labels(["//pkg:test"], 0, 0)
+        with self.assertRaisesRegex(ValueError, "outside"):
+            partition_labels(["//pkg:test"], 2, 2)
+
+    def test_prepare_rejects_empty_discovery_and_empty_shard(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output_dir = Path(temporary)
+            empty, _, _ = prepare_partition("slang", 0, 1, [], output_dir)
+            self.assertNotEqual(empty["exit_code"], 0)
+            self.assertIn("test discovery selected no targets", empty["errors"])
+
+            label = "//pkg:single_test"
+            selected_index = shard_for_label(label, 2)
+            empty_index = 1 - selected_index
+            record, _, _ = prepare_partition(
+                "slang", empty_index, 2, [label], output_dir
+            )
+            self.assertIn("shard selected no targets", record["errors"])
+
+    def test_finalize_parses_success_and_rejects_missing_summary(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output_dir = Path(temporary)
+            _, result_path, _ = prepare_partition(
+                "python", 0, 1, ["//python:test"], output_dir
+            )
+            log_path = output_dir / "bazel.log"
+            log_path.write_text("Executed 1 out of 1 test: 1 test passes.\n")
+            record = finalize_result(result_path, log_path, 0)
+            self.assertEqual(record["passing_tests"], 1)
+            self.assertEqual(record["exit_code"], 0)
+
+            log_path.write_text("no summary\n")
+            record = finalize_result(result_path, log_path, 0)
+            self.assertNotEqual(record["exit_code"], 0)
+
+    def test_aggregate_accepts_complete_partition(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            self._write_suite(results_dir, "python", 1, ["//python:test"])
+            self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
+            self._write_suite(
+                results_dir,
+                "slang",
+                2,
+                [f"//rtl:slang_{index}" for index in range(20)],
+            )
+            self._write_suite(
+                results_dir,
+                "verilator",
+                3,
+                [f"//sim:verilator_{index}" for index in range(30)],
+            )
+
+            outputs, errors, _ = aggregate_results(
+                results_dir,
+                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 3},
+            )
+
+            self.assertEqual(errors, [])
+            self.assertEqual(outputs["slang"]["total_tests"], 20)
+            self.assertEqual(outputs["verilator"]["passing_tests"], 30)
+
+    def test_aggregate_rejects_missing_duplicate_and_inconsistent_shards(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            paths = self._write_suite(
+                results_dir,
+                "slang",
+                2,
+                [f"//rtl:test_{index}" for index in range(20)],
+            )
+            paths[1].unlink()
+            self._write_suite(results_dir, "python", 1, ["//python:test"])
+            self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
+            self._write_suite(results_dir, "verilator", 1, ["//sim:test"])
+
+            _, errors, _ = aggregate_results(
+                results_dir,
+                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 1},
+            )
+            self.assertTrue(any("missing shard indexes" in error for error in errors))
+
+            duplicate = results_dir / "duplicate"
+            duplicate.mkdir()
+            duplicate_result = duplicate / paths[0].name
+            duplicate_result.write_text(paths[0].read_text(encoding="utf-8"))
+            target_name = json.loads(paths[0].read_text())["target_file"]
+            (duplicate / target_name).write_text(
+                (results_dir / target_name).read_text(encoding="utf-8")
+            )
+            _, errors, _ = aggregate_results(
+                results_dir,
+                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 1},
+            )
+            self.assertTrue(any("duplicate shard index" in error for error in errors))
+
+    def test_aggregate_rejects_manifest_tampering(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            self._write_suite(results_dir, "python", 1, ["//python:test"])
+            self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
+            paths = self._write_suite(results_dir, "slang", 1, ["//rtl:a", "//rtl:b"])
+            self._write_suite(results_dir, "verilator", 1, ["//sim:test"])
+            record = json.loads(paths[0].read_text(encoding="utf-8"))
+            (results_dir / record["target_file"]).write_text("//rtl:a\n")
+
+            _, errors, _ = aggregate_results(
+                results_dir,
+                {"python": 1, "stardoc": 1, "slang": 1, "verilator": 1},
+            )
+            self.assertTrue(any("does not match manifest" in error for error in errors))
+            self.assertTrue(any("union digest" in error for error in errors))
+
+    def test_aggregate_rejects_inconsistent_discovery(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            self._write_suite(results_dir, "python", 1, ["//python:test"])
+            self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
+            paths = self._write_suite(
+                results_dir,
+                "slang",
+                2,
+                [f"//rtl:test_{index}" for index in range(20)],
+            )
+            self._write_suite(results_dir, "verilator", 1, ["//sim:test"])
+            record = json.loads(paths[1].read_text(encoding="utf-8"))
+            record["discovered_sha256"] = "0" * 64
+            paths[1].write_text(json.dumps(record), encoding="utf-8")
+
+            _, errors, _ = aggregate_results(
+                results_dir,
+                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 1},
+            )
+            self.assertTrue(
+                any("discovered target digest" in error for error in errors)
+            )
+
+    def test_check_requires_successful_expected_suites(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            paths = self._write_suite(results_dir, "python", 1, ["//python:test"])
+            args = argparse.Namespace(
+                results_dir=results_dir, expected_suite=["python", "stardoc"]
+            )
+            with redirect_stderr(io.StringIO()):
+                self.assertEqual(command_check(args), 1)
+
+            record = json.loads(paths[0].read_text(encoding="utf-8"))
+            record["exit_code"] = 7
+            paths[0].write_text(json.dumps(record), encoding="utf-8")
+            args.expected_suite = ["python"]
+            with redirect_stderr(io.StringIO()):
+                self.assertEqual(command_check(args), 1)
+
+    @staticmethod
+    def _write_suite(
+        output_dir: Path, suite: str, shard_count: int, labels: list[str]
+    ) -> list[Path]:
+        result_paths = []
+        for shard_index in range(shard_count):
+            record, result_path, _ = prepare_partition(
+                suite, shard_index, shard_count, labels, output_dir
+            )
+            if record["errors"]:
+                raise AssertionError(record["errors"])
+            record["passing_tests"] = record["selected_count"]
+            record["exit_code"] = 0
+            result_path.write_text(
+                json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            result_paths.append(result_path)
+        return result_paths
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Problem

Main CI currently runs public and proprietary Bazel suites together on a self-hosted runner. This keeps open-source test logs private and makes the public Docker image untested by a GitHub-hosted runner. A single four-core hosted runner also cannot provide useful throughput for the thousands of generated Slang and Verilator tests.

# Solution

- Add a GitHub-hosted public matrix that builds the checked-out public Dockerfile and runs only explicit public-tool targets: one Python/Stardoc runner, four deterministic Slang shards, and eight deterministic Verilator shards.
- Partition labels with stable SHA-256 hashing, invoke Bazel once per shard through `--target_pattern_file`, and validate complete, non-overlapping coverage in the stable `bazel-oss-tool-test` aggregate check.
- Restore trusted Docker and Bazel caches in every shard, use stable per-shard Bazel disk-cache namespaces, disable PR cache saves, and allow only one trusted shard to export the shared Docker cache.
- Add `bazel-build-and-proprietary-tool-test` on the self-hosted runner. It runs `bazel build //...` plus Verific, AscentLint, and VCS with summary-only test output.
- Retarget suite badges to their owning aggregate/private jobs, gate public Docker image publication on the OSS aggregate succeeding, and update README CI documentation.

# Validation

- `python3.12 -m unittest python.ci.bazel_oss_sharding_test -v`
- `actionlint .github/workflows/ci.yml`
- Targeted pre-commit hooks for YAML, Black, Buildifier, Gitleaks, and repository policy checks
- Extracted container-shell `bash -n` validation and `git diff --check`

Repository-wide `pre-commit run --all-files` passes every hook except `end-of-file-fixer`, which cannot write the checkout's read-only bundled `.codex/skills` files.
