### PR TITLE
Introduce testplanner as a way of deploying report

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -418,3 +418,7 @@ See link:MACROS.adoc[SystemVerilog Macros] for the list of available macros and 
 == RTL Libraries
 
 See link:LIBRARIES.adoc[RTL Libraries] for the list of available public RTL modules, packages, and formal libraries.
+
+== Report generation scripts
+
+See link:SCRIPTS.adoc[Scripts] for description of avaiable scripts.

--- a/SCRIPTS.adoc
+++ b/SCRIPTS.adoc
@@ -1,0 +1,36 @@
+== Report generation scripts
+
+In `+scripts/+` there are 3 scripts used to generate a static web page with test results.
+
+=== generate_testplan.py
+
+Python script that takes in a file containing a list of passed/failed tests printed by Bazel in the following format:
+
+.bazel logs
+[%collapsible]
+====
+[source]
+----
+//amba/sim:br_amba_axi_demux_tb_sim_test_tools_suite_verilator_sim_test PASSED in 16.5s
+//<test_path>:<test_name> <result> in <time>
+----
+====
+
+For each test path, it generates `+.hjson+` files in `+testplans/+` which are later used by
+link:https://github.com/antmicro/testplanner[testplanner] to generate a web page.
+
+=== generate_testreport.py
+
+Python script that takes as in a file containing a list of passed/failed tests printed by Bazel in the same format as
+`+generate_testplan.py+`, as well as a path to file containing the timestamp when Bazel started running the tests.
+For each test path, it generates `+hjson+` files in `+testreports/+` which are later used by
+link:https://github.com/antmicro/testplanner[testplanner] to generate a web page.
+
+=== generate_test_summary.sh
+
+Bash script that executes the report generation scripts described above to generate every file needed
+by `+testplanner+` to generate report web page. A few environment variables have to be set for it to work properly:
+
+* BAZEL_TEST_LOGS_PATH - path to file contatining output from a `+bazel test+` run, used to generate a list of failing/passing tests.
+* BAZEL_TEST_TIMESTAMP_PATH - path to file contatining the timestamp of when Bazel tests were ran.
+* BEDROCK_RTL_SOURCE_URL_PREFIX - URL base of the `+bedrock-rtl+` repository.

--- a/scripts/generate_test_summary.sh
+++ b/scripts/generate_test_summary.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cat ${BAZEL_TEST_LOGS_PATH} | grep ' in ' > ./.bazel-test-outputs.results
+
+python3 ./generate_testplan.py ./.bazel-test-outputs.results
+
+if [ $? -ne 0 ]; then
+  echo "generate_testplan.py failed"
+  exit -1
+fi
+
+python3 ./generate_testreport.py ./.bazel-test-outputs.results ${BAZEL_TEST_TIMESTAMP_PATH}
+
+if [ $? -ne 0 ]; then
+  echo "generate_testreport.py failed"
+  exit -1
+fi
+
+testplanner ./testplans/*.hjson -s ./testreports/*.hjson -ot ../out/generated/testplan.md \
+        -os ../out/sim-res --output-summary-title "Bedrock-RTL tests" --output-summary ../out/sim-res/index.html \
+        --project-root ../ --source-url-prefix ${BEDROCK_RTL_SOURCE_URL_PREFIX}

--- a/scripts/generate_testplan.py
+++ b/scripts/generate_testplan.py
@@ -1,0 +1,93 @@
+#!/bin/python
+
+from dataclasses import dataclass
+
+import re
+import os
+import json
+import sys
+
+
+@dataclass
+class TestResult:
+    category: str
+    name: str
+    result: str
+    time: str
+
+
+def get_tests_from_testpoint(tp, test_results):
+    tests = list()
+
+    for result in test_results:
+        if result.category == tp:
+            tests.append(result.name)
+
+    return tests
+
+
+def create_testpoints(test_results, tp, hjson_out):
+    tp_append = {
+        "name": tp,
+        "desc": tp + " tests",
+        "stage": "N.A.",
+        "tests": get_tests_from_testpoint(tp, test_results),
+        "tags": [""],
+    }
+    hjson_out["testpoints"].append(tp_append)
+
+
+def get_testpoints(test_results):
+    tp = set()
+
+    for result in test_results:
+        tp.add(result.category)
+
+    return tp
+
+
+def generate_testplan(input_file):
+    if not os.path.exists("./testplans"):
+        os.makedirs("./testplans")
+
+    pattern = re.compile(
+        r"""\s*//(?P<category>.*?)(?:/[a-zA-Z_]*)?:(?P<name>.*?)
+                             \s+(?P<result>.*?)\s+in\s+(?P<time>.*?)s""",
+        re.VERBOSE,
+    )
+    test_results = list()
+
+    with open(input_file) as f:
+        for line in f:
+            match = pattern.match(line)
+            if match == None:
+                print(f"Regex couldn't match the expression on line: {line.rstrip()}")
+                sys.exit(-1)
+
+            result = TestResult(
+                category=match.group("category"),
+                name=match.group("name"),
+                result=match.group("result"),
+                time=match.group("time"),
+            )
+            test_results.append(result)
+
+    tps = get_testpoints(test_results)
+
+    for tp in tps:
+        output_file = open(f"testplans/testplan_{tp}.hjson", "w")
+        hjson_out = {"name": tp, "testpoints": []}
+
+        create_testpoints(test_results, tp, hjson_out)
+        json.dump(hjson_out, output_file, indent=4)
+        output_file.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage {sys.argv[0]} <bazel_test_results>")
+        sys.exit(-1)
+
+    input_file = sys.argv[1]
+
+    generate_testplan(input_file)

--- a/scripts/generate_testreport.py
+++ b/scripts/generate_testreport.py
@@ -1,0 +1,123 @@
+#!/bin/python
+
+from dataclasses import dataclass
+
+import re
+import os
+import json
+import sys
+
+
+@dataclass
+class TestResult:
+    category: str
+    postfix: str
+    name: str
+    result: str
+    time: str
+
+
+def read_timestamp(timestamp_file):
+    return open(timestamp_file, "r").read().rstrip()
+
+
+def get_testplans(test_results):
+    tp = set()
+
+    for result in test_results:
+        tp.add(result.category)
+
+    return tp
+
+
+def create_testresult_path(test_result):
+    path = "testlogs/" + test_result.category + "/"
+
+    if test_result.postfix:
+        path += test_result.postfix + "/"
+
+    path += test_result.name + "/"
+    path += "test.log"
+
+    return path
+
+
+def get_simulated_time(test_result):
+    testlog = f"../{create_testresult_path(test_result)}"
+
+    pattern = re.compile(
+        r""".*?\$finish\s+at\s+(?P<sim_time>[\d.]+[a-zuns]+)\s*;""",
+        re.VERBOSE | re.IGNORECASE,
+    )
+
+    with open(testlog) as f:
+        for line in f:
+            match = pattern.match(line)
+            if match:
+                return match.group("sim_time")
+
+    return "N.A."
+
+
+def create_test_entry(test_result):
+    passed = 1 if test_result.result == "PASSED" else 0
+    simulated_time = get_simulated_time(test_result)
+    return {
+        "name": test_result.name,
+        "passing": passed,
+        "total": 1,
+        "job_runtime": float(test_result.time),
+        "simulated_time": simulated_time,
+    }
+
+
+def generate_testreport(input_file, timestamp):
+    if not os.path.exists("./testreports"):
+        os.makedirs("./testreports")
+
+    pattern = re.compile(
+        r"""\s*//(?P<category>[^/]+?)(?:/(?P<postfix>[^:]+?))?:(?P<name>.*?)
+                             \s+(?P<result>.*?)\s+in\s+(?P<time>.*?)s""",
+        re.VERBOSE,
+    )
+    test_results = list()
+
+    with open(input_file) as f:
+        for line in f:
+            match = pattern.match(line)
+            if match == None:
+                print("Regex couldn't match the expression on line: " + line, end="")
+                sys.exit(-1)
+
+            result = TestResult(
+                category=match.group("category"),
+                postfix=match.group("postfix"),
+                name=match.group("name"),
+                result=match.group("result"),
+                time=match.group("time"),
+            )
+            test_results.append(result)
+
+    tps = get_testplans(test_results)
+
+    for tp in tps:
+        hjson_out = {"timestamp": timestamp, "test_results": []}
+        output_file = open(f"./testreports/testreport_{tp}.hjson", "w")
+
+        for result in test_results:
+            if tp == result.category:
+                hjson_out["test_results"].append(create_test_entry(result))
+
+        json.dump(hjson_out, output_file, indent=4)
+        output_file.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage " + sys.argv[0] + " <bazel_test_results> <tests_timestamp>")
+        sys.exit(-1)
+
+    input_file = sys.argv[1]
+    timestamp = read_timestamp(sys.argv[2])
+
+    generate_testreport(input_file, timestamp)


### PR DESCRIPTION
Add testsuite report generation scripts. They generate .html site, using tesplanner, on which the test results are represented.