### PR TITLE
Add br_amba_axil2apb test

### DIFF
--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -4,6 +4,69 @@ load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test")
 
+BR_AMBA_SIM_MAX_CHECK_WIDTH_64 = "BR_AMBA_SIM_MAX_CHECK_WIDTH=64"
+
+BR_AMBA_SIM_DEFINES_64 = [
+    "BR_ASSERT_ON",
+    "BR_ENABLE_IMPL_CHECKS",
+    "SIMULATION",
+    BR_AMBA_SIM_MAX_CHECK_WIDTH_64,
+]
+
+verilog_library(
+    name = "br_amba_axil2apb_sim_pkg",
+    srcs = ["br_amba_axil2apb_sim_pkg.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//amba/rtl:br_amba_pkg",
+        "//amba/sim/drivers:br_amba_apb_sim_pkg",
+    ],
+)
+
+verilog_library(
+    name = "br_amba_axil2apb_tb",
+    srcs = ["br_amba_axil2apb_tb.sv"],
+    deps = [
+        ":br_amba_axil2apb_sim_pkg",
+        "//amba/rtl:br_amba_axil2apb",
+        "//amba/sim/drivers:br_amba_apb_sim_helpers",
+        "//amba/sim/drivers:br_amba_axil_requester_driver",
+        "//amba/sim/drivers:br_amba_sim_pkg",
+        "//amba/sim/monitors:br_amba_apb_monitor",
+        "//amba/sim/monitors:br_amba_axil2apb_scoreboard",
+        "//amba/sim/monitors:br_amba_axil_monitor",
+        "//amba/sim/monitors:br_amba_axil_monitor_sim_pkg",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_amba_axil2apb_tb_elab_test",
+    defines = [BR_AMBA_SIM_MAX_CHECK_WIDTH_64],
+    tool = "slang",
+    deps = [":br_amba_axil2apb_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_amba_axil2apb_sim_test_tools_suite",
+    defines = BR_AMBA_SIM_DEFINES_64,
+    params = {
+        "AddrWidth": [
+            "12",
+            "32",
+        ],
+        "DataWidth": [
+            "32",
+            "64",
+        ],
+    },
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_amba_axil2apb_tb"],
+)
+
 verilog_library(
     name = "br_amba_apb_timing_slice_tb",
     srcs = ["br_amba_apb_timing_slice_tb.sv"],

--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -392,3 +392,46 @@ br_verilog_sim_test_tools_suite(
     ],
     deps = [":br_amba_axil_default_target_tb"],
 )
+
+verilog_library(
+    name = "br_amba_atb_funnel_tb",
+    srcs = ["br_amba_atb_funnel_tb.sv"],
+    deps = [
+        "//amba/rtl:br_amba_atb_funnel",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_amba_atb_funnel_tb_elab_test",
+    tool = "slang",
+    deps = [":br_amba_atb_funnel_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_amba_atb_funnel_sim_test_tools_suite",
+    params = {
+        "DataWidth": [
+            "32",
+            "64",
+        ],
+        "NumSources": [
+            "2",
+            "4",
+            "17",
+        ],
+        "RegisterAtReady": [
+            "0",
+            "1",
+        ],
+        "UserWidth": [
+            "1",
+            "3",
+        ],
+    },
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_amba_atb_funnel_tb"],
+)

--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -13,6 +13,11 @@ BR_AMBA_SIM_DEFINES_64 = [
     BR_AMBA_SIM_MAX_CHECK_WIDTH_64,
 ]
 
+BR_AMBA_APB_TIMING_SLICE_DEFINES = [
+    "BR_AMBA_APB_SIM_ADDR_WIDTH=32",
+    "BR_AMBA_APB_SIM_DATA_WIDTH=32",
+]
+
 verilog_library(
     name = "br_amba_axil2apb_sim_pkg",
     srcs = ["br_amba_axil2apb_sim_pkg.sv"],
@@ -36,36 +41,50 @@ verilog_library(
         "//amba/sim/monitors:br_amba_axil2apb_scoreboard",
         "//amba/sim/monitors:br_amba_axil_monitor",
         "//amba/sim/monitors:br_amba_axil_monitor_sim_pkg",
+        "//macros:br_asserts",
         "//misc/sim:br_test_driver",
     ],
 )
 
 verilog_elab_test(
     name = "br_amba_axil2apb_tb_elab_test",
-    defines = [BR_AMBA_SIM_MAX_CHECK_WIDTH_64],
+    defines = [
+        "BR_AMBA_SIM_MAX_CHECK_WIDTH=32",
+        "BR_AMBA_AXIL_SIM_ADDR_WIDTH=12",
+        "BR_AMBA_AXIL_SIM_DATA_WIDTH=32",
+        "BR_AMBA_AXIL_SIM_USER_WIDTH=1",
+        "BR_AMBA_APB_SIM_ADDR_WIDTH=12",
+        "BR_AMBA_APB_SIM_DATA_WIDTH=32",
+    ],
     tool = "slang",
     deps = [":br_amba_axil2apb_tb"],
 )
 
-br_verilog_sim_test_tools_suite(
-    name = "br_amba_axil2apb_sim_test_tools_suite",
-    defines = BR_AMBA_SIM_DEFINES_64,
-    params = {
-        "AddrWidth": [
-            "12",
-            "32",
+[
+    br_verilog_sim_test_tools_suite(
+        name = "br_amba_axil2apb_sim_test_tools_suite_dw%s" % data_width,
+        defines = [
+            "BR_ASSERT_ON",
+            "BR_ENABLE_IMPL_CHECKS",
+            "SIMULATION",
+            "BR_AMBA_SIM_MAX_CHECK_WIDTH=%s" % data_width,
+            "BR_AMBA_AXIL_SIM_ADDR_WIDTH=12",
+            "BR_AMBA_AXIL_SIM_DATA_WIDTH=%s" % data_width,
+            "BR_AMBA_AXIL_SIM_USER_WIDTH=1",
+            "BR_AMBA_APB_SIM_ADDR_WIDTH=12",
+            "BR_AMBA_APB_SIM_DATA_WIDTH=%s" % data_width,
         ],
-        "DataWidth": [
-            "32",
-            "64",
+        tools = [
+            "vcs",
+            "verilator",
         ],
-    },
-    tools = [
-        "vcs",
-        "verilator",
-    ],
-    deps = [":br_amba_axil2apb_tb"],
-)
+        deps = [":br_amba_axil2apb_tb"],
+    )
+    for data_width in [
+        "32",
+        "64",
+    ]
+]
 
 verilog_library(
     name = "br_amba_apb_timing_slice_tb",
@@ -80,12 +99,14 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_amba_apb_timing_slice_tb_elab_test",
+    defines = BR_AMBA_APB_TIMING_SLICE_DEFINES,
     tool = "slang",
     deps = [":br_amba_apb_timing_slice_tb"],
 )
 
 br_verilog_sim_test_tools_suite(
     name = "br_amba_apb_timing_slice_sim_test_tools_suite",
+    defines = BR_AMBA_APB_TIMING_SLICE_DEFINES,
     params = {
         "AddrWidth": [
             "12",
@@ -239,6 +260,9 @@ verilog_elab_test(
         "BR_AMBA_AXI_SIM_DATA_WIDTH=32",
         "BR_AMBA_AXI_SIM_ID_WIDTH=3",
         "BR_AMBA_AXI_SIM_USER_WIDTH=2",
+        "BR_AMBA_AXIL_SIM_ADDR_WIDTH=12",
+        "BR_AMBA_AXIL_SIM_DATA_WIDTH=32",
+        "BR_AMBA_AXIL_SIM_USER_WIDTH=2",
     ],
     tool = "slang",
     deps = [":br_amba_axi2axil_tb"],
@@ -255,6 +279,9 @@ verilog_elab_test(
             "BR_AMBA_AXI_SIM_DATA_WIDTH=%s" % data_width,
             "BR_AMBA_AXI_SIM_ID_WIDTH=3",
             "BR_AMBA_AXI_SIM_USER_WIDTH=2",
+            "BR_AMBA_AXIL_SIM_ADDR_WIDTH=12",
+            "BR_AMBA_AXIL_SIM_DATA_WIDTH=%s" % data_width,
+            "BR_AMBA_AXIL_SIM_USER_WIDTH=2",
         ],
         params = {
             "MaxOutstandingReqs": [

--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -356,7 +356,8 @@ verilog_library(
     srcs = ["br_amba_axil_default_target_tb.sv"],
     deps = [
         "//amba/rtl:br_amba_axil_default_target",
-        "//amba/sim/drivers:br_amba_axil_driver",
+        "//amba/sim/drivers:br_amba_axil_completer_driver",
+        "//amba/sim/drivers:br_amba_sim_pkg",
         "//amba/sim/monitors:br_amba_axil_monitor",
         "//misc/sim:br_test_driver",
     ],

--- a/amba/sim/br_amba_apb_timing_slice_tb.sv
+++ b/amba/sim/br_amba_apb_timing_slice_tb.sv
@@ -89,6 +89,7 @@ module br_amba_apb_timing_slice_tb;
 
   logic monitor_enable;
   logic monitor_done;
+  logic completer_failed;
 
   br_amba_apb_timing_slice #(
       .AddrWidth(AddrWidth)
@@ -147,7 +148,8 @@ module br_amba_apb_timing_slice_tb;
       .target_penable(penable_out),
       .pready(pready_in),
       .prdata(prdata_in),
-      .pslverr(pslverr_in)
+      .pslverr(pslverr_in),
+      .failed(completer_failed)
   );
 
   br_amba_apb_timing_slice_monitor #(
@@ -183,7 +185,7 @@ module br_amba_apb_timing_slice_tb;
       input apb_request_t request, input apb_request_controls_t request_controls,
       input apb_response_t response, input apb_response_controls_t response_controls);
     for (int transaction = 0; transaction < response_controls.num_transactions; transaction++) begin
-      monitor.expect_response(response.rdata + 32'(transaction), response.slverr);
+      monitor.expect_response(32'(response.rdata) + 32'(transaction), response.slverr);
     end
     fork
       requester.run(request, request_controls);
@@ -281,6 +283,7 @@ module br_amba_apb_timing_slice_tb;
 
     td.check(monitor.pending_count() == 0, "monitor response queue not empty");
     td.check(monitor.get_error_count() == 0, "APB monitor reported errors");
+    td.check(!completer_failed, "APB completer reported failures");
     monitor_enable = 1'b0;
     monitor_done   = 1'b1;
     td.finish();

--- a/amba/sim/br_amba_apb_timing_slice_tb.sv
+++ b/amba/sim/br_amba_apb_timing_slice_tb.sv
@@ -61,11 +61,11 @@ module br_amba_apb_timing_slice_tb;
   function automatic apb_request_t get_request(
       input logic [AddrWidth-1:0] addr, input logic [ApbProtWidth-1:0] prot, input logic [3:0] strb,
       input logic write, input logic [31:0] wdata);
-    get_request.addr  = addr;
+    get_request.addr  = ApbAddrWidth'(addr);
     get_request.prot  = prot;
-    get_request.strb  = strb;
+    get_request.strb  = ApbStrbWidth'(strb);
     get_request.write = write;
-    get_request.wdata = wdata;
+    get_request.wdata = ApbDataWidth'(wdata);
   endfunction
 
   function automatic apb_request_controls_t get_request_controls(
@@ -77,7 +77,7 @@ module br_amba_apb_timing_slice_tb;
 
   function automatic apb_response_t get_response(input logic [31:0] rdata, input logic slverr);
     get_response.ready  = 1'b1;
-    get_response.rdata  = rdata;
+    get_response.rdata  = ApbDataWidth'(rdata);
     get_response.slverr = slverr;
   endfunction
 

--- a/amba/sim/br_amba_atb_funnel_tb.sv
+++ b/amba/sim/br_amba_atb_funnel_tb.sv
@@ -1,0 +1,659 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Directed simulation testbench for br_amba_atb_funnel.
+//
+// Scope:
+// - Idle after reset with no source traffic.
+// - Single-source and multi-source packet preservation.
+// - Destination backpressure and source payload stability while stalled.
+// - Continuous stress traffic with all sources enabled.
+// - Reset asserted during active traffic.
+// - Bazel-swept source count, data width, user width, and ready registration.
+
+module br_amba_atb_funnel_tb;
+  parameter int NumSources = 3;
+  parameter int DataWidth = 32;
+  parameter int UserWidth = 2;
+  parameter bit RegisterAtReady = 0;
+
+  localparam int ByteCountWidth = $clog2(DataWidth / 8);
+  localparam int ResetCycles = 5;
+  localparam int TimeoutCycles = 3000;
+  localparam int StressBeatsPerSource = 64;
+
+  // Destination ready patterns used to create no-stall and stalled sink behavior.
+  typedef enum int {
+    ReadyAlways,
+    ReadyAlternating,
+    ReadyPeriodicStall
+  } ready_pattern_t;
+
+  // One ATB beat as sampled by the source and destination monitors.
+  typedef struct packed {
+    logic [br_amba::AtbIdWidth-1:0] atid;
+    logic [DataWidth-1:0] atdata;
+    logic [ByteCountWidth-1:0] atbytes;
+    logic [UserWidth-1:0] atuser;
+  } atb_packet_t;
+
+  // Per-test scenario controls shared by the source driver and sink readiness logic.
+  typedef struct packed {
+    logic [NumSources-1:0] source_mask;
+    int unsigned beats_per_source;
+    int unsigned valid_gap_cycles;
+    int unsigned min_runtime_cycles;
+    ready_pattern_t ready_pattern;
+    bit alternate_sources;
+    bit check_full_rate;
+  } scenario_config_t;
+
+  // Clock and reset driven by br_test_driver.
+  logic clk;
+  logic rst;
+  logic td_rst;
+  logic pulse_rst;
+
+  // Source ATB interfaces driven by the testbench into the DUT.
+  logic [NumSources-1:0] src_atvalid;
+  logic [NumSources-1:0] src_atready;
+  logic [NumSources-1:0][br_amba::AtbIdWidth-1:0] src_atid;
+  logic [NumSources-1:0][DataWidth-1:0] src_atdata;
+  logic [NumSources-1:0][ByteCountWidth-1:0] src_atbytes;
+  logic [NumSources-1:0][UserWidth-1:0] src_atuser;
+
+  // Destination ATB interface observed and backpressured by the testbench.
+  logic dst_atvalid;
+  logic dst_atready;
+  logic [br_amba::AtbIdWidth-1:0] dst_atid;
+  logic [DataWidth-1:0] dst_atdata;
+  logic [ByteCountWidth-1:0] dst_atbytes;
+  logic [UserWidth-1:0] dst_atuser;
+
+  // Scenario-level timer and transfer counters.
+  logic scenario_timeout_seen;
+  int unsigned scenario_timer;
+  int unsigned accepted_count;
+  int unsigned observed_count;
+  logic destination_transfer_seen;
+
+  // Per-source stimulus state for issued beats, gaps, and accepted-beat retirement.
+  int unsigned source_sent_count[NumSources];
+  int unsigned source_gap_count[NumSources];
+  logic [NumSources-1:0] source_accepted_last_cycle;
+
+  // Previous-cycle source state used by background valid/payload stability monitors.
+  logic [NumSources-1:0] prev_src_atvalid;
+  logic [NumSources-1:0] prev_src_atready;
+  logic [NumSources-1:0][br_amba::AtbIdWidth-1:0] prev_src_atid;
+  logic [NumSources-1:0][DataWidth-1:0] prev_src_atdata;
+  logic [NumSources-1:0][ByteCountWidth-1:0] prev_src_atbytes;
+  logic [NumSources-1:0][UserWidth-1:0] prev_src_atuser;
+
+  // Previous-cycle destination state used by background valid/payload stability monitors.
+  logic prev_dst_atvalid;
+  logic prev_dst_atready;
+  logic [br_amba::AtbIdWidth-1:0] prev_dst_atid;
+  logic [DataWidth-1:0] prev_dst_atdata;
+  logic [ByteCountWidth-1:0] prev_dst_atbytes;
+  logic [UserWidth-1:0] prev_dst_atuser;
+
+  // Expected packet order collected from accepted source transfers.
+  atb_packet_t expected_packets[$];
+
+  // Received packet order collected from destination transfers.
+  atb_packet_t received_packets[$];
+
+  br_amba_atb_funnel #(
+      .NumSources(NumSources),
+      .DataWidth(DataWidth),
+      .UserWidth(UserWidth),
+      .RegisterAtReady(RegisterAtReady)
+  ) dut (
+      .clk(clk),
+      .rst(rst),
+      .src_atvalid(src_atvalid),
+      .src_atready(src_atready),
+      .src_atid(src_atid),
+      .src_atdata(src_atdata),
+      .src_atbytes(src_atbytes),
+      .src_atuser(src_atuser),
+      .dst_atvalid(dst_atvalid),
+      .dst_atready(dst_atready),
+      .dst_atid(dst_atid),
+      .dst_atdata(dst_atdata),
+      .dst_atbytes(dst_atbytes),
+      .dst_atuser(dst_atuser)
+  );
+
+  br_test_driver #(
+      .ResetCycles(ResetCycles)
+  ) td (
+      .clk(clk),
+      .rst(td_rst)
+  );
+
+  assign rst = td_rst || pulse_rst;
+
+  function automatic logic [NumSources-1:0] random_source_mask(input int unsigned enabled_sources);
+    logic [NumSources-1:0] mask = '0;
+    int unsigned target_sources = enabled_sources > NumSources ? NumSources : enabled_sources;
+    int unsigned available_sources[$];
+
+    for (int source = 0; source < NumSources; source++) begin
+      available_sources.push_back(source);
+    end
+
+    for (int count = 0; count < target_sources; count++) begin
+      int unsigned selected_position = $urandom_range(available_sources.size() - 1, 0);
+
+      mask[available_sources[selected_position]] = 1'b1;
+      available_sources.delete(selected_position);
+    end
+    return mask;
+  endfunction
+
+  function automatic int selected_alternating_source(input logic [NumSources-1:0] source_mask,
+                                                     input int unsigned beats_per_source);
+    for (int offset = 0; offset < NumSources; offset++) begin
+      int source = (scenario_timer + offset) % NumSources;
+
+      if (source_mask[source] && source_sent_count[source] < beats_per_source) begin
+        return source;
+      end
+    end
+
+    return NumSources;
+  endfunction
+
+  function automatic bit ready_for_timer(input ready_pattern_t pattern);
+    case (pattern)
+      ReadyAlways: return 1'b1;
+      ReadyAlternating: return scenario_timer[0];
+      ReadyPeriodicStall: return (scenario_timer % 7) >= 3;
+      default: return 1'b0;
+    endcase
+  endfunction
+
+  function automatic atb_packet_t make_packet();
+    atb_packet_t packet;
+
+    packet.atid = br_amba::AtbIdWidth'($urandom);
+    packet.atdata = DataWidth'({$urandom, $urandom});
+    packet.atbytes = ByteCountWidth'($urandom);
+    packet.atuser = UserWidth'($urandom);
+    return packet;
+  endfunction
+
+  // Clears one source interface after reset, completion, or an accepted transfer.
+  task automatic clear_source(input int source);
+    src_atvalid[source] = 1'b0;
+    src_atid[source] = '0;
+    src_atdata[source] = '0;
+    src_atbytes[source] = '0;
+    src_atuser[source] = '0;
+  endtask
+
+  // Generates and drives a new randomized packet for one source.
+  task automatic drive_source_packet(input int source);
+    atb_packet_t packet = make_packet();
+
+    src_atvalid[source] = 1'b1;
+    src_atid[source] = packet.atid;
+    src_atdata[source] = packet.atdata;
+    src_atbytes[source] = packet.atbytes;
+    src_atuser[source] = packet.atuser;
+  endtask
+
+  // Returns the bench-controlled interfaces, counters, and history state to idle.
+  task automatic init_signals();
+    src_atvalid = '0;
+    src_atid = '0;
+    src_atdata = '0;
+    src_atbytes = '0;
+    src_atuser = '0;
+    pulse_rst = 1'b0;
+    dst_atready = 1'b1;
+    scenario_timer = 0;
+    destination_transfer_seen = 1'b0;
+    source_accepted_last_cycle = '0;
+    prev_src_atvalid = '0;
+    prev_src_atready = '0;
+    prev_src_atid = '0;
+    prev_src_atdata = '0;
+    prev_src_atbytes = '0;
+    prev_src_atuser = '0;
+    prev_dst_atvalid = 1'b0;
+    prev_dst_atready = 1'b0;
+    prev_dst_atid = '0;
+    prev_dst_atdata = '0;
+    prev_dst_atbytes = '0;
+    prev_dst_atuser = '0;
+    expected_packets.delete();
+    received_packets.delete();
+  endtask
+
+  // Initializes per-source counters and clears any pending source gaps.
+  task automatic init_source_state(input logic [NumSources-1:0] source_mask);
+    for (int source = 0; source < NumSources; source++) begin
+      source_sent_count[source] = 0;
+      source_gap_count[source]  = 0;
+      clear_source(source);
+    end
+
+    source_accepted_last_cycle = '0;
+  endtask
+
+  // Checks source and destination stability, then samples state for the next cycle.
+  task automatic monitor_stability();
+    forever begin
+      @(posedge clk);
+
+      for (int source = 0; source < NumSources; source++) begin
+        if (!rst && prev_src_atvalid[source] && !prev_src_atready[source]) begin
+          td.check(src_atvalid[source], $sformatf(
+                   "source %0d dropped valid while backpressured", source));
+          td.check(
+              src_atid[source] === prev_src_atid[source] &&
+                   src_atdata[source] === prev_src_atdata[source] &&
+                   src_atbytes[source] === prev_src_atbytes[source] &&
+                   src_atuser[source] === prev_src_atuser[source],
+              $sformatf("source %0d changed payload while backpressured", source));
+        end
+      end
+
+      if (!rst && prev_dst_atvalid && !prev_dst_atready) begin
+        td.check(dst_atvalid, "destination dropped valid while backpressured");
+        td.check(
+            dst_atid === prev_dst_atid && dst_atdata === prev_dst_atdata &&
+                 dst_atbytes === prev_dst_atbytes && dst_atuser === prev_dst_atuser,
+            "destination changed payload while backpressured");
+      end
+
+      prev_src_atvalid = src_atvalid;
+      prev_src_atready = src_atready;
+      prev_src_atid = src_atid;
+      prev_src_atdata = src_atdata;
+      prev_src_atbytes = src_atbytes;
+      prev_src_atuser = src_atuser;
+      prev_dst_atvalid = dst_atvalid;
+      prev_dst_atready = dst_atready;
+      prev_dst_atid = dst_atid;
+      prev_dst_atdata = dst_atdata;
+      prev_dst_atbytes = dst_atbytes;
+      prev_dst_atuser = dst_atuser;
+    end
+  endtask
+
+  // Monitors that the destination is idle once no source is valid and all queued beats drained.
+  task automatic monitor_idle_source_to_destination(input string scenario_name);
+    forever begin
+      @(posedge clk);
+
+      if (!(|src_atvalid) && !(dst_atvalid && dst_atready) &&
+          expected_packets.size() == received_packets.size()) begin
+        td.check(!dst_atvalid, $sformatf(
+                 "%s destination valid while sources are idle", scenario_name));
+      end
+    end
+  endtask
+
+  // Records accepted source packets into the expected queue in the background.
+  task automatic monitor_source_transfers(input int unsigned expected_transfers,
+                                          input string scenario_name);
+    forever begin
+      @(posedge clk);
+      begin
+        int unsigned accepts_this_cycle = 0;
+
+        for (int source = 0; source < NumSources; source++) begin
+          if (!rst && src_atvalid[source] && src_atready[source]) begin
+            atb_packet_t packet;
+
+            packet.atid = src_atid[source];
+            packet.atdata = src_atdata[source];
+            packet.atbytes = src_atbytes[source];
+            packet.atuser = src_atuser[source];
+            expected_packets.push_back(packet);
+            source_sent_count[source]++;
+            source_accepted_last_cycle[source] = 1'b1;
+            accepted_count++;
+            accepts_this_cycle++;
+          end else begin
+            source_accepted_last_cycle[source] = 1'b0;
+          end
+        end
+
+        td.check(accepts_this_cycle <= 1, "more than one source transfer accepted in a cycle");
+        td.check(accepted_count <= expected_transfers, $sformatf(
+                 "%s accepted more source transfers than expected", scenario_name));
+      end
+    end
+  endtask
+
+  // Records destination transfers into the received queue in the background.
+  task automatic monitor_destination_transfers(input int unsigned expected_transfers,
+                                               input string scenario_name);
+    forever begin
+      @(posedge clk);
+      begin
+        bit transfer_seen = !rst && dst_atvalid && dst_atready;
+
+        destination_transfer_seen = transfer_seen;
+
+        if (transfer_seen) begin
+          atb_packet_t packet;
+
+          packet.atid = dst_atid;
+          packet.atdata = dst_atdata;
+          packet.atbytes = dst_atbytes;
+          packet.atuser = dst_atuser;
+          received_packets.push_back(packet);
+          observed_count++;
+        end
+
+        td.check(observed_count <= expected_transfers, $sformatf(
+                 "%s observed more destination transfers than expected", scenario_name));
+      end
+    end
+  endtask
+
+  // Checks source and destination transfer counts, then compares packet payloads.
+  task automatic check_recorded_packets(input string scenario_name,
+                                        input int unsigned expected_transfers);
+    td.check_integer(accepted_count, expected_transfers, $sformatf(
+                     "%s source transfer count mismatch", scenario_name));
+    td.check_integer(observed_count, expected_transfers, $sformatf(
+                     "%s destination transfer count mismatch", scenario_name));
+    td.check_integer(expected_packets.size(), expected_transfers, $sformatf(
+                     "%s expected packet count mismatch", scenario_name));
+    td.check_integer(received_packets.size(), expected_transfers, $sformatf(
+                     "%s received packet count mismatch", scenario_name));
+
+    for (int packet = 0; packet < expected_transfers; packet++) begin
+      if (packet < expected_packets.size() && packet < received_packets.size()) begin
+        td.check(received_packets[packet].atid === expected_packets[packet].atid, $sformatf(
+                 "%s packet %0d ATID mismatch", scenario_name, packet));
+        td.check(received_packets[packet].atdata === expected_packets[packet].atdata, $sformatf(
+                 "%s packet %0d ATDATA mismatch", scenario_name, packet));
+        td.check(received_packets[packet].atbytes === expected_packets[packet].atbytes, $sformatf(
+                 "%s packet %0d ATBYTES mismatch", scenario_name, packet));
+        td.check(received_packets[packet].atuser === expected_packets[packet].atuser, $sformatf(
+                 "%s packet %0d ATUSER mismatch", scenario_name, packet));
+      end
+    end
+  endtask
+
+  // Drives enabled sources, optionally rotating which source may launch next.
+  task automatic drive_sources(input logic [NumSources-1:0] source_mask,
+                               input int unsigned beats_per_source,
+                               input int unsigned valid_gap_cycles, input bit alternate_sources);
+    int selected_source = alternate_sources ? selected_alternating_source(
+        source_mask, beats_per_source
+    ) : NumSources;
+    bit pending_alternating_valid = 1'b0;
+
+    for (int source = 0; source < NumSources; source++) begin
+      pending_alternating_valid |= src_atvalid[source] && !source_accepted_last_cycle[source];
+    end
+
+    for (int source = 0; source < NumSources; source++) begin
+      if (source_accepted_last_cycle[source]) begin
+        // Retire the accepted beat; if no gap is selected, immediately offer the next packet.
+        if (source_mask[source] && source_sent_count[source] < beats_per_source) begin
+          int unsigned gap_cycles = $urandom_range(valid_gap_cycles, 0);
+
+          if (!alternate_sources && gap_cycles == 0) begin
+            drive_source_packet(source);
+          end else begin
+            clear_source(source);
+            source_gap_count[source] = gap_cycles == 0 ? 0 : gap_cycles - 1;
+          end
+        end else begin
+          clear_source(source);
+        end
+      end else if (!source_mask[source] || source_sent_count[source] >= beats_per_source) begin
+        // Keep inactive and completed sources idle.
+        clear_source(source);
+      end else if (src_atvalid[source]) begin
+        // Hold valid and payload stable until the DUT accepts the transfer.
+        src_atvalid[source] = 1'b1;
+      end else if (alternate_sources &&
+                   (pending_alternating_valid || source != selected_source)) begin
+        // In alternating mode, allow only the selected source to issue a new transfer.
+        clear_source(source);
+      end else if (source_gap_count[source] != 0) begin
+        // Wait out the randomized inter-transfer gap before issuing the next packet.
+        source_gap_count[source]--;
+        clear_source(source);
+      end else begin
+        // Source is enabled, not stalled by a gap, and ready to offer a new packet.
+        drive_source_packet(source);
+      end
+    end
+  endtask
+
+  // Deasserts all source valids and clears per-source accept bookkeeping.
+  task automatic clear_all_sources();
+    for (int source = 0; source < NumSources; source++) begin
+      clear_source(source);
+    end
+
+    source_accepted_last_cycle = '0;
+  endtask
+
+  // Tracks scenario runtime independently from the source stimulus driver.
+  task automatic timeout(input string scenario_name);
+    while (scenario_timer < TimeoutCycles) begin
+      @(posedge clk);
+      scenario_timer++;
+    end
+
+    scenario_timeout_seen = 1'b1;
+    td.check(1'b0, $sformatf("%s timed out", scenario_name));
+
+    forever begin
+      @(posedge clk);
+    end
+  endtask
+
+  // Runs one reset-aware scenario and checks ordering, counts, stability, and timeout.
+  task automatic run_scenario(input string scenario_name, input scenario_config_t scenario);
+    int unsigned expected_transfers = $countones(scenario.source_mask) * scenario.beats_per_source;
+    bit done = 1'b0;
+
+    scenario_timeout_seen = 1'b0;
+    scenario_timer = 0;
+    accepted_count = 0;
+    observed_count = 0;
+    destination_transfer_seen = 1'b0;
+    expected_packets.delete();
+    received_packets.delete();
+    init_source_state(scenario.source_mask);
+
+    $display("Running %s: mask=0x%0h beats=%0d gap_bound=%0d min_cycles=%0d", scenario_name,
+             scenario.source_mask, scenario.beats_per_source, scenario.valid_gap_cycles,
+             scenario.min_runtime_cycles);
+    $display("  ready=%0d alt=%0b full_rate=%0b", scenario.ready_pattern,
+             scenario.alternate_sources, scenario.check_full_rate);
+
+    fork
+      monitor_stability();
+      monitor_idle_source_to_destination(scenario_name);
+      monitor_source_transfers(expected_transfers, scenario_name);
+      monitor_destination_transfers(expected_transfers, scenario_name);
+      timeout(scenario_name);
+    join_none
+
+    while (!done && !scenario_timeout_seen) begin
+      @(negedge clk);
+
+      done = accepted_count == expected_transfers &&
+             observed_count == expected_transfers &&
+             expected_packets.size() == expected_transfers &&
+             received_packets.size() == expected_transfers &&
+             scenario_timer >= scenario.min_runtime_cycles;
+
+      if (scenario.check_full_rate && !rst && observed_count != 0 &&
+          observed_count < expected_transfers) begin
+        td.check(destination_transfer_seen, $sformatf(
+                 "%s inserted a destination transfer bubble", scenario_name));
+      end
+
+      if (!done && !scenario_timeout_seen) begin
+        dst_atready = ready_for_timer(scenario.ready_pattern);
+        if (rst) begin
+          clear_all_sources();
+        end else begin
+          drive_sources(scenario.source_mask, scenario.beats_per_source, scenario.valid_gap_cycles,
+                        scenario.alternate_sources);
+        end
+      end
+    end
+
+    disable fork;
+
+    check_recorded_packets(scenario_name, expected_transfers);
+
+    @(negedge clk);
+    clear_all_sources();
+    dst_atready = 1'b1;
+  endtask
+
+  // Intent: verify the DUT stays idle after reset with no source traffic.
+  task automatic test_smoke();
+    td.reset_dut();
+    init_signals();
+    run_scenario("smoke",
+                 '{
+                     source_mask: '0,
+                     beats_per_source: 0,
+                     valid_gap_cycles: 0,
+                     min_runtime_cycles: $urandom_range(20, 10),
+                     ready_pattern: ReadyAlways,
+                     alternate_sources: 1'b0,
+                     check_full_rate: 1'b0
+                 });
+  endtask
+
+  // Intent: verify one active source can stream at full rate without output bubbles.
+  task automatic test_single_source_full_rate();
+    td.reset_dut();
+    init_signals();
+    run_scenario("single_source_full_rate",
+                 '{
+                     source_mask: random_source_mask(1),
+                     beats_per_source: $urandom_range(24, 16),
+                     valid_gap_cycles: 0,
+                     min_runtime_cycles: 0,
+                     ready_pattern: ReadyAlways,
+                     alternate_sources: 1'b0,
+                     check_full_rate: 1'b1
+                 });
+  endtask
+
+  // Intent: verify randomized multi-source traffic while rotating active sources.
+  task automatic test_multi_source_basic();
+    int unsigned multi_source_count = $urandom_range(NumSources, 2);
+
+    td.reset_dut();
+    init_signals();
+    run_scenario("multi_source_basic",
+                 '{
+                     source_mask: random_source_mask(multi_source_count),
+                     beats_per_source: $urandom_range(10, 4),
+                     valid_gap_cycles: 0,
+                     min_runtime_cycles: 0,
+                     ready_pattern: ReadyAlways,
+                     alternate_sources: 1'b1,
+                     check_full_rate: 1'b0
+                 });
+  endtask
+
+  // Intent: verify payload stability and ordering under destination stalls.
+  task automatic test_destination_backpressure();
+    td.reset_dut();
+    init_signals();
+    run_scenario("destination_backpressure",
+                 '{
+                     source_mask: random_source_mask(NumSources),
+                     beats_per_source: $urandom_range(12, 5),
+                     valid_gap_cycles: $urandom_range(6, 2),
+                     min_runtime_cycles: 0,
+                     ready_pattern: ReadyPeriodicStall,
+                     alternate_sources: 1'b0,
+                     check_full_rate: 1'b0
+                 });
+  endtask
+
+  // Intent: verify continuous all-source traffic with no source gaps or backpressure.
+  task automatic test_stress();
+    td.reset_dut();
+    init_signals();
+    run_scenario("stress",
+                 '{
+                     source_mask: random_source_mask(NumSources),
+                     beats_per_source: StressBeatsPerSource,
+                     valid_gap_cycles: 0,
+                     min_runtime_cycles: 0,
+                     ready_pattern: ReadyAlways,
+                     alternate_sources: 1'b0,
+                     check_full_rate: 1'b1
+                 });
+  endtask
+
+  // Waits for active traffic, pulses reset, and restarts scenario accounting.
+  task automatic pulse_reset_after_transfers(input int unsigned reset_after_transfers,
+                                             input logic [NumSources-1:0] source_mask);
+    while ((observed_count < reset_after_transfers || !(|src_atvalid) && !dst_atvalid) &&
+           !scenario_timeout_seen) begin
+      @(posedge clk);
+    end
+
+    @(negedge clk);
+    pulse_rst = 1'b1;
+    clear_all_sources();
+    accepted_count = 0;
+    observed_count = 0;
+    expected_packets.delete();
+    received_packets.delete();
+    init_source_state(source_mask);
+    td.wait_cycles(ResetCycles);
+    td.check(!dst_atvalid, "destination valid during reset while active");
+    pulse_rst = 1'b0;
+  endtask
+
+  // Intent: verify reset can interrupt an active scenario without blocking post-reset completion.
+  task automatic test_reset_while_active();
+    logic [NumSources-1:0] source_mask = random_source_mask(2);
+    scenario_config_t scenario = '{
+        source_mask: source_mask,
+        beats_per_source: 8,
+        valid_gap_cycles: 0,
+        min_runtime_cycles: 0,
+        ready_pattern: ReadyAlways,
+        alternate_sources: 1'b0,
+        check_full_rate: 1'b0
+    };
+    int unsigned reset_after_transfers = ($countones(source_mask) * scenario.beats_per_source) / 2;
+
+    td.reset_dut();
+    init_signals();
+
+    fork
+      run_scenario("reset_while_active", scenario);
+      pulse_reset_after_transfers(reset_after_transfers, source_mask);
+    join
+  endtask
+
+  initial begin
+    test_smoke();
+    test_single_source_full_rate();
+    test_multi_source_basic();
+    test_destination_backpressure();
+    test_stress();
+    test_reset_while_active();
+
+    td.finish(10);
+  end
+
+endmodule : br_amba_atb_funnel_tb

--- a/amba/sim/br_amba_axil2apb_sim_pkg.sv
+++ b/amba/sim/br_amba_axil2apb_sim_pkg.sv
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+package br_amba_axil2apb_sim_pkg;
+  import br_amba::*;
+  import br_amba_apb_sim_pkg::*;
+
+  typedef enum int {
+    Axil2ApbTransactionWrite,
+    Axil2ApbTransactionRead
+  } axil2apb_transaction_kind_t;
+
+  typedef struct packed {
+    axil2apb_transaction_kind_t kind;
+    logic [ApbAddrWidth-1:0]    addr;
+    logic [AxiProtWidth-1:0]    prot;
+    logic [ApbStrbWidth-1:0]    strb;
+    logic [ApbDataWidth-1:0]    data;
+    logic                       slverr;
+  } axil2apb_transaction_t;
+
+  typedef struct {
+    int   num_writes;
+    int   num_reads;
+    int   min_aw_gap_cycles;
+    int   max_aw_gap_cycles;
+    int   min_w_gap_cycles;
+    int   max_w_gap_cycles;
+    int   min_ar_gap_cycles;
+    int   max_ar_gap_cycles;
+    int   min_b_stall_cycles;
+    int   max_b_stall_cycles;
+    int   min_r_stall_cycles;
+    int   max_r_stall_cycles;
+    int   apb_wait_cycles;
+    logic allow_slverr;
+    logic force_slverr;
+  } axil2apb_scenario_t;
+endpackage : br_amba_axil2apb_sim_pkg

--- a/amba/sim/br_amba_axil2apb_tb.sv
+++ b/amba/sim/br_amba_axil2apb_tb.sv
@@ -111,6 +111,7 @@ module br_amba_axil2apb_tb;
     default input #1step;
     input awvalid;
     input awready;
+    input wvalid;
     input psel;
     input penable;
     input bvalid;
@@ -728,12 +729,11 @@ module br_amba_axil2apb_tb;
       end
       begin
         @cb;
-        while (!(cb.awvalid && cb.awready)) @cb;
+        while (!(cb.awvalid && !cb.wvalid && !cb.awready)) @cb;
         td.reset_dut();
       end
       timeout(timeout_tick, MidResetTimeoutCycles,
-              "Timeout waiting for br_amba_axil2apb mid-transaction reset scenario",
-              timeout_failed);
+              "Timeout waiting to reset br_amba_axil2apb with only AW pending", timeout_failed);
     join_any
     disable fork;
 

--- a/amba/sim/br_amba_axil2apb_tb.sv
+++ b/amba/sim/br_amba_axil2apb_tb.sv
@@ -9,6 +9,8 @@ import br_amba_axil_sim_pkg::*;
 import br_amba_axil_monitor_sim_pkg::*;
 import br_amba_axil2apb_sim_pkg::*;
 
+`include "br_asserts.svh"
+
 // Directed simulation testbench for br_amba_axil2apb.
 //
 // Stimulus plan:
@@ -29,9 +31,8 @@ import br_amba_axil2apb_sim_pkg::*;
 // - mid-transaction reset: assert reset after a partial AXI write, during APB setup/access, and
 //   while AXI responses are pending; then reinitialize and run traffic.
 module br_amba_axil2apb_tb;
-  parameter int AddrWidth = 12;
-  parameter int DataWidth = 32;
-
+  localparam int AddrWidth = AxilAddrWidth;
+  localparam int DataWidth = AxilDataWidth;
   localparam int StrbWidth = DataWidth / 8;
   localparam int ResetCycles = 5;
   localparam int ClockPeriodNs = 10;
@@ -59,6 +60,11 @@ module br_amba_axil2apb_tb;
   localparam int MaxStressTransactions = 192;
   localparam logic [StrbWidth-1:0] ZeroStrobe = '0;
   localparam logic [StrbWidth-1:0] MidResetStrobe = '1;
+
+  `BR_ASSERT_STATIC(AxilApbAddrWidthMatch, AxilAddrWidth == ApbAddrWidth)
+  `BR_ASSERT_STATIC(AxilApbDataWidthMatch, AxilDataWidth == ApbDataWidth)
+  `BR_ASSERT_STATIC(AxilApbStrobeWidthMatch, AxilStrobeWidth == ApbStrbWidth)
+  `BR_ASSERT_STATIC(RandomDataWidthSupported, DataWidth <= BrAmbaSimMaxCheckWidth)
 
   logic clk;
   logic rst;
@@ -255,7 +261,6 @@ module br_amba_axil2apb_tb;
   );
 
   br_amba_axil2apb_scoreboard #(
-      .DataWidth(DataWidth),
       .ClockPeriodNs(ClockPeriodNs)
   ) scoreboard (
       .failed(scoreboard_failed)

--- a/amba/sim/br_amba_axil2apb_tb.sv
+++ b/amba/sim/br_amba_axil2apb_tb.sv
@@ -1,0 +1,874 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_sim_pkg::*;
+import br_amba_apb_sim_pkg::*;
+import br_amba_axil_sim_pkg::*;
+import br_amba_axil_monitor_sim_pkg::*;
+import br_amba_axil2apb_sim_pkg::*;
+
+// Directed simulation testbench for br_amba_axil2apb.
+//
+// Stimulus plan:
+// - reset/idle: reset the DUT and leave AXI-Lite/APB idle to check reset-visible outputs;
+// - write/read no-delay: issue one transaction with AXI ready and APB PREADY available immediately;
+// - zero-strobe write: issue a legal AXI-Lite write with WSTRB set to zero;
+// - APB write/read PREADY backpressure: hold PREADY low during APB accesses across random counts;
+// - write data skew: issue writes with AW before W;
+// - write address skew: issue writes with W before AW;
+// - read/write arbitration: present simultaneous read/write eligibility from reset and many
+//   reads/writes with randomized data, strobes, and no intentional source delay;
+// - AXI write response backpressure: delay BREADY across a random write transaction count;
+// - AXI read response backpressure: delay RREADY across a random read transaction count;
+// - error propagation: complete APB writes and reads with PSLVERR set across many transfers;
+// - mixed directed sequence: run reads and writes with representative gaps and wait states;
+// - stress: run sustained traffic with no intentional stalls on either side;
+// - mid-transaction reset: assert reset after a partial AXI write, during APB setup/access, and
+//   while AXI responses are pending; then reinitialize and run traffic.
+module br_amba_axil2apb_tb;
+  parameter int AddrWidth = 12;
+  parameter int DataWidth = 32;
+
+  localparam int StrbWidth = DataWidth / 8;
+  localparam int ResetCycles = 5;
+  localparam int ClockPeriodNs = 10;
+  localparam int TimeoutCycles = 5000;
+  localparam int MidResetTimeoutCycles = 64;
+  localparam int NoWrites = 0;
+  localparam int NoReads = 0;
+  localparam int SingleWrite = 1;
+  localparam int SingleRead = 1;
+  localparam int NoGapCycles = 0;
+  localparam int NoStallCycles = 0;
+  localparam int ChannelSkewCycles = 3;
+  localparam int ApbBackpressureWaitCycles = 3;
+  localparam int ResponseStallCycles = 3;
+  localparam int MixedAwGapCycles = 1;
+  localparam int MixedWGapCycles = 2;
+  localparam int MixedArGapCycles = 1;
+  localparam int MixedApbWaitCycles = 1;
+  localparam int MidResetWriteDataDelayCycles = 8;
+  localparam int MidResetResponseStallCycles = 16;
+  localparam int MidResetRecoveryWaitCycles = 5;
+  localparam int MinDirectedTransactions = 20;
+  localparam int MaxDirectedTransactions = 40;
+  localparam int MinStressTransactions = 128;
+  localparam int MaxStressTransactions = 192;
+  localparam logic [StrbWidth-1:0] ZeroStrobe = '0;
+  localparam logic [StrbWidth-1:0] MidResetStrobe = '1;
+
+  logic clk;
+  logic rst;
+  logic axil_driver_failed;
+  logic apb_completer_failed;
+  logic apb_monitor_failed;
+  logic axil_monitor_failed;
+  logic scoreboard_failed;
+  logic timeout_failed;
+  event timeout_tick;
+
+  // AXI4-Lite manager-side signals.
+  logic [AddrWidth-1:0] awaddr;
+  logic [AxiProtWidth-1:0] awprot;
+  logic awvalid;
+  logic awready;
+  logic [DataWidth-1:0] wdata;
+  logic [StrbWidth-1:0] wstrb;
+  logic wvalid;
+  logic wready;
+  logic [AxiRespWidth-1:0] bresp;
+  logic bvalid;
+  logic bready;
+  logic [AddrWidth-1:0] araddr;
+  logic [AxiProtWidth-1:0] arprot;
+  logic arvalid;
+  logic arready;
+  logic [DataWidth-1:0] rdata;
+  logic [AxiRespWidth-1:0] rresp;
+  logic rvalid;
+  logic rready;
+
+  // APB completer-side signals.
+  logic [AddrWidth-1:0] paddr;
+  logic psel;
+  logic penable;
+  logic [ApbProtWidth-1:0] pprot;
+  logic [StrbWidth-1:0] pstrb;
+  logic pwrite;
+  logic [DataWidth-1:0] pwdata;
+  logic [DataWidth-1:0] prdata;
+  logic pready;
+  logic pslverr;
+
+  always @(posedge clk) begin
+    ->timeout_tick;
+  end
+
+  clocking cb @(posedge clk);
+    default input #1step;
+    input awvalid;
+    input awready;
+    input psel;
+    input penable;
+    input bvalid;
+    input rvalid;
+  endclocking
+
+  br_test_driver #(
+      .ResetCycles  (ResetCycles),
+      .ClockPeriodNs(ClockPeriodNs)
+  ) td (
+      .clk(clk),
+      .rst(rst)
+  );
+
+  br_amba_axil2apb #(
+      .AddrWidth(AddrWidth),
+      .DataWidth(DataWidth)
+  ) dut (
+      .clk(clk),
+      .rst(rst),
+      .awaddr(awaddr),
+      .awprot(awprot),
+      .awvalid(awvalid),
+      .awready(awready),
+      .wdata(wdata),
+      .wstrb(wstrb),
+      .wvalid(wvalid),
+      .wready(wready),
+      .bresp(bresp),
+      .bvalid(bvalid),
+      .bready(bready),
+      .araddr(araddr),
+      .arprot(arprot),
+      .arvalid(arvalid),
+      .arready(arready),
+      .rdata(rdata),
+      .rresp(rresp),
+      .rvalid(rvalid),
+      .rready(rready),
+      .paddr(paddr),
+      .psel(psel),
+      .penable(penable),
+      .pprot(pprot),
+      .pstrb(pstrb),
+      .pwrite(pwrite),
+      .pwdata(pwdata),
+      .prdata(prdata),
+      .pready(pready),
+      .pslverr(pslverr)
+  );
+
+  br_amba_axil_requester_driver #(
+      .AddrWidth(AddrWidth),
+      .DataWidth(DataWidth)
+  ) axil_driver (
+      .clk(clk),
+      .rst(rst),
+      .axil_awaddr(awaddr),
+      .axil_awprot(awprot),
+      .axil_awvalid(awvalid),
+      .axil_awready(awready),
+      .axil_wdata(wdata),
+      .axil_wstrb(wstrb),
+      .axil_wvalid(wvalid),
+      .axil_wready(wready),
+      .axil_bvalid(bvalid),
+      .axil_bready(bready),
+      .axil_araddr(araddr),
+      .axil_arprot(arprot),
+      .axil_arvalid(arvalid),
+      .axil_arready(arready),
+      .axil_rvalid(rvalid),
+      .axil_rready(rready),
+      .failed(axil_driver_failed)
+  );
+
+  br_amba_apb_completer_driver #(
+      .DataWidth(DataWidth)
+  ) apb_completer (
+      .clk(clk),
+      .target_psel(psel),
+      .target_penable(penable),
+      .pready(pready),
+      .prdata(prdata),
+      .pslverr(pslverr),
+      .failed(apb_completer_failed)
+  );
+
+  br_amba_apb_monitor #(
+      .AddrWidth(AddrWidth),
+      .DataWidth(DataWidth)
+  ) apb_monitor (
+      .clk(clk),
+      .rst(rst),
+      .paddr(paddr),
+      .psel(psel),
+      .penable(penable),
+      .pprot(pprot),
+      .pstrb(pstrb),
+      .pwrite(pwrite),
+      .pwdata(pwdata),
+      .prdata(prdata),
+      .pready(pready),
+      .pslverr(pslverr),
+      .failed(apb_monitor_failed)
+  );
+
+  br_amba_axil_monitor #(
+      .AddrWidth(AddrWidth),
+      .DataWidth(DataWidth)
+  ) axil_monitor (
+      .clk(clk),
+      .rst(rst),
+      .axil_awaddr(awaddr),
+      .axil_awprot(awprot),
+      .axil_awuser('0),
+      .axil_awvalid(awvalid),
+      .axil_awready(awready),
+      .axil_wdata(wdata),
+      .axil_wstrb(wstrb),
+      .axil_wuser('0),
+      .axil_wvalid(wvalid),
+      .axil_wready(wready),
+      .axil_bresp(bresp),
+      .axil_buser('0),
+      .axil_bvalid(bvalid),
+      .axil_bready(bready),
+      .axil_araddr(araddr),
+      .axil_arprot(arprot),
+      .axil_aruser('0),
+      .axil_arvalid(arvalid),
+      .axil_arready(arready),
+      .axil_rdata(rdata),
+      .axil_rresp(rresp),
+      .axil_ruser('0),
+      .axil_rvalid(rvalid),
+      .axil_rready(rready),
+      .failed(axil_monitor_failed)
+  );
+
+  br_amba_axil2apb_scoreboard #(
+      .DataWidth(DataWidth),
+      .ClockPeriodNs(ClockPeriodNs)
+  ) scoreboard (
+      .failed(scoreboard_failed)
+  );
+
+  function automatic int directed_transaction_count();
+    directed_transaction_count = $urandom_range(MaxDirectedTransactions, MinDirectedTransactions);
+  endfunction
+
+  function automatic int stress_transaction_count();
+    stress_transaction_count = $urandom_range(MaxStressTransactions, MinStressTransactions);
+  endfunction
+
+  function automatic apb_response_t random_response(input logic allow_slverr,
+                                                    input logic force_slverr);
+    random_response.ready = Pready1;
+    random_response.rdata = ApbDataWidth'(DataWidth'(get_random_bits(DataWidth)));
+    random_response.slverr = force_slverr ?
+        Pslverr1 : (allow_slverr ? logic'($urandom_range(1, 0)) : Pslverr0);
+  endfunction
+
+  function automatic logic [StrbWidth-1:0] random_write_strobe();
+    random_write_strobe = StrbWidth'(get_random_bits(StrbWidth));
+  endfunction
+
+  task automatic init_scenario(output axil2apb_scenario_t scenario, input int num_writes,
+                               input int num_reads);
+    scenario.num_writes = num_writes;
+    scenario.num_reads = num_reads;
+    scenario.min_aw_gap_cycles = NoGapCycles;
+    scenario.max_aw_gap_cycles = NoGapCycles;
+    scenario.min_w_gap_cycles = NoGapCycles;
+    scenario.max_w_gap_cycles = NoGapCycles;
+    scenario.min_ar_gap_cycles = NoGapCycles;
+    scenario.max_ar_gap_cycles = NoGapCycles;
+    scenario.min_b_stall_cycles = NoStallCycles;
+    scenario.max_b_stall_cycles = NoStallCycles;
+    scenario.min_r_stall_cycles = NoStallCycles;
+    scenario.max_r_stall_cycles = NoStallCycles;
+    scenario.apb_wait_cycles = NoStallCycles;
+    scenario.allow_slverr = 1'b0;
+    scenario.force_slverr = 1'b0;
+  endtask
+
+  task automatic check_helpers(input string scenario_name);
+    string axil_driver_message = $sformatf(
+        "%s: AXI-Lite requester driver reported failures", scenario_name
+    );
+    string apb_completer_message = $sformatf(
+        "%s: APB completer driver reported failures", scenario_name
+    );
+    string apb_monitor_message = $sformatf("%s: APB monitor reported failures", scenario_name);
+    string axil_monitor_message = $sformatf(
+        "%s: AXI-Lite monitor reported failures", scenario_name
+    );
+    string scoreboard_message = $sformatf("%s: scoreboard reported failures", scenario_name);
+    string timeout_message = $sformatf("%s: timeout reported failures", scenario_name);
+
+    td.check(!axil_driver_failed, axil_driver_message);
+    td.check(!apb_completer_failed, apb_completer_message);
+    td.check(!apb_monitor_failed, apb_monitor_message);
+    td.check(!axil_monitor_failed, axil_monitor_message);
+    td.check(!scoreboard_failed, scoreboard_message);
+    td.check(!timeout_failed, timeout_message);
+  endtask
+
+  task automatic init_idle();
+    axil_driver.init_idle();
+    apb_completer.init_idle();
+    apb_monitor.init_idle();
+    axil_monitor.init_idle();
+    scoreboard.init_idle();
+    timeout_failed = 1'b0;
+  endtask
+
+  task automatic queue_random_write_with_strobe(input axil2apb_scenario_t scenario,
+                                                input logic [StrbWidth-1:0] strb,
+                                                output apb_response_t response);
+    logic [AddrWidth-1:0] addr = AddrWidth'($urandom());
+    logic [AxiProtWidth-1:0] prot = AxiProtWidth'($urandom());
+    logic [DataWidth-1:0] data = DataWidth'(get_random_bits(DataWidth));
+    int aw_gap_cycles = $urandom_range(scenario.max_aw_gap_cycles, scenario.min_aw_gap_cycles);
+    int w_gap_cycles = $urandom_range(scenario.max_w_gap_cycles, scenario.min_w_gap_cycles);
+    int b_stall_cycles = $urandom_range(scenario.max_b_stall_cycles, scenario.min_b_stall_cycles);
+
+    response = random_response(scenario.allow_slverr, scenario.force_slverr);
+    axil_driver.queue_write(addr, prot, data, strb, aw_gap_cycles, w_gap_cycles, b_stall_cycles);
+  endtask
+
+  task automatic queue_random_write(input axil2apb_scenario_t scenario,
+                                    output apb_response_t response);
+    queue_random_write_with_strobe(scenario, random_write_strobe(), response);
+  endtask
+
+  task automatic queue_random_read(input axil2apb_scenario_t scenario,
+                                   output apb_response_t response);
+    logic [AddrWidth-1:0] addr = AddrWidth'($urandom());
+    logic [AxiProtWidth-1:0] prot = AxiProtWidth'($urandom());
+    int ar_gap_cycles = $urandom_range(scenario.max_ar_gap_cycles, scenario.min_ar_gap_cycles);
+    int r_stall_cycles = $urandom_range(scenario.max_r_stall_cycles, scenario.min_r_stall_cycles);
+
+    response = random_response(scenario.allow_slverr, scenario.force_slverr);
+    axil_driver.queue_read(addr, prot, ar_gap_cycles, r_stall_cycles);
+  endtask
+
+  task automatic queue_writes(input axil2apb_scenario_t scenario,
+                              ref apb_response_t response_queue[$]);
+    check_scenario_cycle_ranges(scenario);
+    for (int i = 0; i < scenario.num_writes; i++) begin
+      apb_response_t response;
+
+      queue_random_write(scenario, response);
+      response_queue.push_back(response);
+    end
+  endtask
+
+  task automatic queue_reads(input axil2apb_scenario_t scenario,
+                             ref apb_response_t response_queue[$]);
+    check_scenario_cycle_ranges(scenario);
+    for (int i = 0; i < scenario.num_reads; i++) begin
+      apb_response_t response;
+
+      queue_random_read(scenario, response);
+      response_queue.push_back(response);
+    end
+  endtask
+
+  // Responses are queued in the same order as the stimulus is queued. The
+  // scoreboard predicts which accepted AXI-Lite request consumes each APB
+  // response from observed request timestamps.
+  task automatic queue_mixed_transactions(input axil2apb_scenario_t scenario,
+                                          ref apb_response_t response_queue[$]);
+    int max_transaction_count;
+
+    check_scenario_cycle_ranges(scenario);
+    max_transaction_count = scenario.num_writes > scenario.num_reads ? scenario.num_writes :
+                                                                                 scenario.num_reads;
+    for (int i = 0; i < max_transaction_count; i++) begin
+      apb_response_t response;
+
+      if (i < scenario.num_reads) begin
+        queue_random_read(scenario, response);
+        response_queue.push_back(response);
+      end
+      if (i < scenario.num_writes) begin
+        queue_random_write(scenario, response);
+        response_queue.push_back(response);
+      end
+    end
+  endtask
+
+  task automatic check_scenario_cycle_ranges(input axil2apb_scenario_t scenario);
+    td.check(scenario.max_aw_gap_cycles >= scenario.min_aw_gap_cycles,
+             "AXI-Lite AW gap max cycles is less than min cycles");
+    td.check(scenario.max_w_gap_cycles >= scenario.min_w_gap_cycles,
+             "AXI-Lite W gap max cycles is less than min cycles");
+    td.check(scenario.max_ar_gap_cycles >= scenario.min_ar_gap_cycles,
+             "AXI-Lite AR gap max cycles is less than min cycles");
+    td.check(scenario.max_b_stall_cycles >= scenario.min_b_stall_cycles,
+             "AXI-Lite B stall max cycles is less than min cycles");
+    td.check(scenario.max_r_stall_cycles >= scenario.min_r_stall_cycles,
+             "AXI-Lite R stall max cycles is less than min cycles");
+  endtask
+
+  task automatic check_observed_request_counts(input axil2apb_scenario_t scenario,
+                                               input axil_aw_observation_t observed_aw_queue[$],
+                                               input axil_w_observation_t observed_w_queue[$],
+                                               input axil_ar_observation_t observed_ar_queue[$]);
+    td.check(observed_aw_queue.size() == scenario.num_writes, $sformatf(
+             "Observed AW request count mismatch: expected %0d observed %0d",
+             scenario.num_writes,
+             observed_aw_queue.size()
+             ));
+    td.check(observed_w_queue.size() == scenario.num_writes, $sformatf(
+             "Observed W request count mismatch: expected %0d observed %0d",
+             scenario.num_writes,
+             observed_w_queue.size()
+             ));
+    td.check(observed_ar_queue.size() == scenario.num_reads, $sformatf(
+             "Observed AR request count mismatch: expected %0d observed %0d",
+             scenario.num_reads,
+             observed_ar_queue.size()
+             ));
+  endtask
+
+  // Runs queued AXI stimulus, APB response driving, protocol monitors, and the
+  // bridge scoreboard as one scenario-level unit.
+  task automatic run_queued_scenario(input string scenario_name, input axil2apb_scenario_t scenario,
+                                     input apb_response_t response_queue[$]);
+    apb_response_controls_t response_controls;
+    axil_request_state_observation_t observed_request_state_queue[$];
+    apb_transfer_observation_t observed_apb_queue[$];
+    axil_aw_observation_t observed_aw_queue[$];
+    axil_w_observation_t observed_w_queue[$];
+    axil_b_observation_t observed_b_queue[$];
+    axil_ar_observation_t observed_ar_queue[$];
+    axil_r_observation_t observed_r_queue[$];
+
+    response_controls.num_transactions = scenario.num_writes + scenario.num_reads;
+    response_controls.wait_cycles = scenario.apb_wait_cycles;
+    td.check(response_queue.size() == response_controls.num_transactions, $sformatf(
+             "Response queue size mismatch: expected %0d observed %0d",
+             response_controls.num_transactions,
+             response_queue.size()
+             ));
+
+    // Each scenario is self-contained. Resetting here keeps bridge arbitration
+    // state from leaking between directed tests and changing the expected
+    // read/write ordering.
+    td.reset_dut();
+
+    fork
+      begin
+        fork
+          axil_driver.run(scenario.num_writes, scenario.num_reads);
+          apb_completer.run_queue(response_queue, response_controls);
+        join
+      end
+      apb_monitor.run();
+      axil_monitor.run();
+      timeout(timeout_tick, TimeoutCycles, $sformatf(
+              "%s: timeout waiting for br_amba_axil2apb scenario completion", scenario_name),
+              timeout_failed);
+    join_any
+    disable fork;
+
+    apb_monitor.get_observed_transfers(observed_apb_queue);
+    axil_monitor.get_observed_request_state_observations(observed_request_state_queue);
+    axil_monitor.get_observed_request_observations(observed_aw_queue, observed_w_queue,
+                                                   observed_ar_queue);
+    axil_monitor.get_observed_response_observations(observed_b_queue, observed_r_queue);
+    check_observed_request_counts(scenario, observed_aw_queue, observed_w_queue, observed_ar_queue);
+    scoreboard.compare(observed_request_state_queue, observed_aw_queue, observed_w_queue,
+                       observed_ar_queue, response_queue, observed_apb_queue, observed_b_queue,
+                       observed_r_queue);
+    check_helpers(scenario_name);
+  endtask
+
+  task automatic test_reset_idle();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, NoWrites, NoReads);
+    init_idle();
+    run_queued_scenario("reset idle", scenario, response_queue);
+    td.check(!psel, "PSEL asserted while idle after reset");
+    td.check(!penable, "PENABLE asserted while idle after reset");
+    td.check(!bvalid, "BVALID asserted while idle after reset");
+    td.check(!rvalid, "RVALID asserted while idle after reset");
+  endtask
+
+  task automatic test_write_no_delay();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, SingleWrite, NoReads);
+    init_idle();
+    queue_writes(scenario, response_queue);
+    run_queued_scenario("write no delay", scenario, response_queue);
+  endtask
+
+  task automatic test_read_no_delay();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, NoWrites, SingleRead);
+    init_idle();
+    queue_reads(scenario, response_queue);
+    run_queued_scenario("read no delay", scenario, response_queue);
+  endtask
+
+  task automatic test_zero_strobe_write();
+    axil2apb_scenario_t scenario;
+    apb_response_t response;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, SingleWrite, NoReads);
+    init_idle();
+    queue_random_write_with_strobe(scenario, ZeroStrobe, response);
+    response_queue.push_back(response);
+    run_queued_scenario("zero strobe write", scenario, response_queue);
+  endtask
+
+  task automatic test_apb_pready_write_backpressure();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, directed_transaction_count(), NoReads);
+    scenario.apb_wait_cycles = ApbBackpressureWaitCycles;
+    init_idle();
+    queue_writes(scenario, response_queue);
+    run_queued_scenario("APB PREADY write backpressure", scenario, response_queue);
+  endtask
+
+  task automatic test_apb_pready_read_backpressure();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, NoWrites, directed_transaction_count());
+    scenario.apb_wait_cycles = ApbBackpressureWaitCycles;
+    init_idle();
+    queue_reads(scenario, response_queue);
+    run_queued_scenario("APB PREADY read backpressure", scenario, response_queue);
+  endtask
+
+  task automatic test_write_data_skew();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, directed_transaction_count(), NoReads);
+    scenario.min_w_gap_cycles = ChannelSkewCycles;
+    scenario.max_w_gap_cycles = ChannelSkewCycles;
+    init_idle();
+    queue_writes(scenario, response_queue);
+    run_queued_scenario("write data skew", scenario, response_queue);
+  endtask
+
+  task automatic test_write_address_skew();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, directed_transaction_count(), NoReads);
+    scenario.min_aw_gap_cycles = ChannelSkewCycles;
+    scenario.max_aw_gap_cycles = ChannelSkewCycles;
+    init_idle();
+    queue_writes(scenario, response_queue);
+    run_queued_scenario("write address skew", scenario, response_queue);
+  endtask
+
+  task automatic test_read_write_arbitration();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, directed_transaction_count(), directed_transaction_count());
+    init_idle();
+    queue_mixed_transactions(scenario, response_queue);
+    run_queued_scenario("read/write arbitration", scenario, response_queue);
+  endtask
+
+  task automatic test_axi_write_response_backpressure();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, directed_transaction_count(), NoReads);
+    scenario.max_b_stall_cycles = ResponseStallCycles;
+    init_idle();
+    queue_writes(scenario, response_queue);
+    run_queued_scenario("AXI write response backpressure", scenario, response_queue);
+  endtask
+
+  task automatic test_axi_read_response_backpressure();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, NoWrites, directed_transaction_count());
+    scenario.max_r_stall_cycles = ResponseStallCycles;
+    init_idle();
+    queue_reads(scenario, response_queue);
+    run_queued_scenario("AXI read response backpressure", scenario, response_queue);
+  endtask
+
+  task automatic test_error_response_propagation();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, directed_transaction_count(), directed_transaction_count());
+    scenario.force_slverr = 1'b1;
+
+    init_idle();
+    queue_mixed_transactions(scenario, response_queue);
+    run_queued_scenario("error response propagation", scenario, response_queue);
+  endtask
+
+  task automatic test_mixed_directed_sequence();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, directed_transaction_count(), directed_transaction_count());
+    scenario.max_aw_gap_cycles = MixedAwGapCycles;
+    scenario.max_w_gap_cycles  = MixedWGapCycles;
+    scenario.max_ar_gap_cycles = MixedArGapCycles;
+    scenario.apb_wait_cycles   = MixedApbWaitCycles;
+
+    init_idle();
+    queue_mixed_transactions(scenario, response_queue);
+    run_queued_scenario("mixed directed sequence", scenario, response_queue);
+  endtask
+
+  task automatic test_stress();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, stress_transaction_count(), stress_transaction_count());
+    scenario.allow_slverr = 1'b1;
+    init_idle();
+    queue_mixed_transactions(scenario, response_queue);
+    run_queued_scenario("stress", scenario, response_queue);
+  endtask
+
+  task automatic check_mid_reset_abort(input string scenario_name, input int expected_apb_transfers,
+                                       input logic expected_apb_request_seen);
+    apb_transfer_observation_t aborted_apb_queue[$];
+    logic aborted_apb_request_seen;
+    axil_b_observation_t aborted_b_queue[$];
+    axil_r_observation_t aborted_r_queue[$];
+
+    apb_monitor.get_observed_transfers(aborted_apb_queue);
+    aborted_apb_request_seen = apb_monitor.saw_request_phase();
+    axil_monitor.get_observed_response_observations(aborted_b_queue, aborted_r_queue);
+    td.check(aborted_apb_request_seen == expected_apb_request_seen, $sformatf(
+             "%s: APB request phase visibility mismatch", scenario_name));
+    td.check(aborted_apb_queue.size() == expected_apb_transfers, $sformatf(
+             "%s: APB transfer count mismatch before reset", scenario_name));
+    td.check(aborted_b_queue.size() == 0, $sformatf(
+             "%s: AXI-Lite B response observed across reset", scenario_name));
+    td.check(aborted_r_queue.size() == 0, $sformatf(
+             "%s: AXI-Lite R response observed across reset", scenario_name));
+    check_helpers(scenario_name);
+  endtask
+
+  task automatic check_mid_reset_recovery(input string scenario_name);
+    init_idle();
+    td.wait_cycles(MidResetRecoveryWaitCycles);
+    td.check(!psel, $sformatf(
+             "%s: PSEL asserted after mid-transaction reset recovery", scenario_name));
+    td.check(!penable, $sformatf(
+             "%s: PENABLE asserted after mid-transaction reset recovery", scenario_name));
+    td.check(!bvalid, $sformatf(
+             "%s: BVALID asserted after mid-transaction reset recovery", scenario_name));
+    td.check(!rvalid, $sformatf(
+             "%s: RVALID asserted after mid-transaction reset recovery", scenario_name));
+  endtask
+
+  task automatic reset_after_incomplete_write();
+    init_idle();
+    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()),
+                            DataWidth'(get_random_bits(DataWidth)), MidResetStrobe, NoGapCycles,
+                            MidResetWriteDataDelayCycles, NoStallCycles);
+    fork
+      begin
+        fork
+          axil_driver.run(SingleWrite, NoReads);
+          apb_monitor.run();
+          axil_monitor.run();
+        join
+      end
+      begin
+        @cb;
+        while (!(cb.awvalid && cb.awready)) @cb;
+        td.reset_dut();
+      end
+      timeout(timeout_tick, MidResetTimeoutCycles,
+              "Timeout waiting for br_amba_axil2apb mid-transaction reset scenario",
+              timeout_failed);
+    join_any
+    disable fork;
+
+    check_mid_reset_abort("reset after incomplete AXI-Lite write", 0, 1'b0);
+    check_mid_reset_recovery("reset after incomplete AXI-Lite write");
+  endtask
+
+  task automatic reset_during_apb_setup();
+    init_idle();
+    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()),
+                            DataWidth'(get_random_bits(DataWidth)), MidResetStrobe, NoGapCycles,
+                            NoGapCycles, NoStallCycles);
+    fork
+      begin
+        fork
+          axil_driver.run(SingleWrite, NoReads);
+          apb_monitor.run();
+          axil_monitor.run();
+        join
+      end
+      begin
+        @cb;
+        while (!(cb.psel && !cb.penable)) @cb;
+        td.reset_dut();
+      end
+      timeout(timeout_tick, MidResetTimeoutCycles,
+              "Timeout waiting to reset br_amba_axil2apb during APB setup", timeout_failed);
+    join_any
+    disable fork;
+
+    check_mid_reset_abort("reset during APB setup", 0, 1'b1);
+    check_mid_reset_recovery("reset during APB setup");
+  endtask
+
+  task automatic reset_during_apb_access();
+    init_idle();
+    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()),
+                            DataWidth'(get_random_bits(DataWidth)), MidResetStrobe, NoGapCycles,
+                            NoGapCycles, NoStallCycles);
+    fork
+      begin
+        fork
+          axil_driver.run(SingleWrite, NoReads);
+          apb_monitor.run();
+          axil_monitor.run();
+        join
+      end
+      begin
+        @cb;
+        while (!(cb.psel && cb.penable)) @cb;
+        td.reset_dut();
+      end
+      timeout(timeout_tick, MidResetTimeoutCycles,
+              "Timeout waiting to reset br_amba_axil2apb during APB access", timeout_failed);
+    join_any
+    disable fork;
+
+    check_mid_reset_abort("reset during APB access", 0, 1'b1);
+    check_mid_reset_recovery("reset during APB access");
+  endtask
+
+  task automatic reset_during_write_response();
+    apb_response_controls_t response_controls;
+    apb_response_t response_queue[$];
+
+    init_idle();
+    response_queue.push_back(random_response(1'b0, 1'b0));
+    response_controls.num_transactions = SingleWrite;
+    response_controls.wait_cycles = NoStallCycles;
+    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()),
+                            DataWidth'(get_random_bits(DataWidth)), MidResetStrobe, NoGapCycles,
+                            NoGapCycles, MidResetResponseStallCycles);
+    fork
+      begin
+        fork
+          axil_driver.run(SingleWrite, NoReads);
+          apb_completer.run_queue(response_queue, response_controls);
+          apb_monitor.run();
+          axil_monitor.run();
+        join
+      end
+      begin
+        @cb;
+        while (!cb.bvalid) @cb;
+        td.reset_dut();
+      end
+      timeout(timeout_tick, MidResetTimeoutCycles,
+              "Timeout waiting to reset br_amba_axil2apb during write response", timeout_failed);
+    join_any
+    disable fork;
+
+    check_mid_reset_abort("reset during AXI-Lite write response", 1, 1'b1);
+    check_mid_reset_recovery("reset during AXI-Lite write response");
+  endtask
+
+  task automatic reset_during_read_response();
+    apb_response_controls_t response_controls;
+    apb_response_t response_queue[$];
+
+    init_idle();
+    response_queue.push_back(random_response(1'b0, 1'b0));
+    response_controls.num_transactions = SingleRead;
+    response_controls.wait_cycles = NoStallCycles;
+    axil_driver.queue_read(AddrWidth'($urandom()), AxiProtWidth'($urandom()), NoGapCycles,
+                           MidResetResponseStallCycles);
+    fork
+      begin
+        fork
+          axil_driver.run(NoWrites, SingleRead);
+          apb_completer.run_queue(response_queue, response_controls);
+          apb_monitor.run();
+          axil_monitor.run();
+        join
+      end
+      begin
+        @cb;
+        while (!cb.rvalid) @cb;
+        td.reset_dut();
+      end
+      timeout(timeout_tick, MidResetTimeoutCycles,
+              "Timeout waiting to reset br_amba_axil2apb during read response", timeout_failed);
+    join_any
+    disable fork;
+
+    check_mid_reset_abort("reset during AXI-Lite read response", 1, 1'b1);
+    check_mid_reset_recovery("reset during AXI-Lite read response");
+  endtask
+
+  task automatic test_reset_mid_transaction();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    reset_after_incomplete_write();
+    reset_during_apb_setup();
+    reset_during_apb_access();
+    reset_during_write_response();
+    reset_during_read_response();
+
+    init_scenario(scenario, NoWrites, directed_transaction_count());
+    scenario.apb_wait_cycles = MidResetRecoveryWaitCycles;
+    init_idle();
+    queue_reads(scenario, response_queue);
+    run_queued_scenario("mid-transaction reset recovery traffic", scenario, response_queue);
+  endtask
+
+  initial begin
+    init_idle();
+    td.reset_dut();
+    test_reset_idle();
+    test_write_no_delay();
+    test_read_no_delay();
+    test_zero_strobe_write();
+    test_apb_pready_write_backpressure();
+    test_apb_pready_read_backpressure();
+    test_write_data_skew();
+    test_write_address_skew();
+    test_read_write_arbitration();
+    test_axi_write_response_backpressure();
+    test_axi_read_response_backpressure();
+    test_error_response_propagation();
+    test_mixed_directed_sequence();
+    test_stress();
+    test_reset_mid_transaction();
+    td.finish();
+  end
+endmodule : br_amba_axil2apb_tb

--- a/amba/sim/br_amba_axil2apb_tb.sv
+++ b/amba/sim/br_amba_axil2apb_tb.sv
@@ -22,6 +22,7 @@ import br_amba_axil2apb_sim_pkg::*;
 //   reads/writes with randomized data, strobes, and no intentional source delay;
 // - AXI write response backpressure: delay BREADY across a random write transaction count;
 // - AXI read response backpressure: delay RREADY across a random read transaction count;
+// - mixed AXI response backpressure: delay BREADY/RREADY with interleaved reads and writes;
 // - error propagation: complete APB writes and reads with PSLVERR set across many transfers;
 // - mixed directed sequence: run reads and writes with representative gaps and wait states;
 // - stress: run sustained traffic with no intentional stalls on either side;
@@ -404,16 +405,27 @@ module br_amba_axil2apb_tb;
   endtask
 
   task automatic check_scenario_cycle_ranges(input axil2apb_scenario_t scenario);
+    td.check(scenario.min_aw_gap_cycles >= 0, "AXI-Lite AW gap min cycles is negative");
+    td.check(scenario.max_aw_gap_cycles >= 0, "AXI-Lite AW gap max cycles is negative");
     td.check(scenario.max_aw_gap_cycles >= scenario.min_aw_gap_cycles,
              "AXI-Lite AW gap max cycles is less than min cycles");
+    td.check(scenario.min_w_gap_cycles >= 0, "AXI-Lite W gap min cycles is negative");
+    td.check(scenario.max_w_gap_cycles >= 0, "AXI-Lite W gap max cycles is negative");
     td.check(scenario.max_w_gap_cycles >= scenario.min_w_gap_cycles,
              "AXI-Lite W gap max cycles is less than min cycles");
+    td.check(scenario.min_ar_gap_cycles >= 0, "AXI-Lite AR gap min cycles is negative");
+    td.check(scenario.max_ar_gap_cycles >= 0, "AXI-Lite AR gap max cycles is negative");
     td.check(scenario.max_ar_gap_cycles >= scenario.min_ar_gap_cycles,
              "AXI-Lite AR gap max cycles is less than min cycles");
+    td.check(scenario.min_b_stall_cycles >= 0, "AXI-Lite B stall min cycles is negative");
+    td.check(scenario.max_b_stall_cycles >= 0, "AXI-Lite B stall max cycles is negative");
     td.check(scenario.max_b_stall_cycles >= scenario.min_b_stall_cycles,
              "AXI-Lite B stall max cycles is less than min cycles");
+    td.check(scenario.min_r_stall_cycles >= 0, "AXI-Lite R stall min cycles is negative");
+    td.check(scenario.max_r_stall_cycles >= 0, "AXI-Lite R stall max cycles is negative");
     td.check(scenario.max_r_stall_cycles >= scenario.min_r_stall_cycles,
              "AXI-Lite R stall max cycles is less than min cycles");
+    td.check(scenario.apb_wait_cycles >= 0, "APB wait cycles is negative");
   endtask
 
   task automatic check_observed_request_counts(input axil2apb_scenario_t scenario,
@@ -611,6 +623,20 @@ module br_amba_axil2apb_tb;
     init_idle();
     queue_reads(scenario, response_queue);
     run_queued_scenario("AXI read response backpressure", scenario, response_queue);
+  endtask
+
+  task automatic test_mixed_response_backpressure();
+    axil2apb_scenario_t scenario;
+    apb_response_t response_queue[$];
+
+    init_scenario(scenario, directed_transaction_count(), directed_transaction_count());
+    scenario.min_b_stall_cycles = ResponseStallCycles;
+    scenario.max_b_stall_cycles = ResponseStallCycles;
+    scenario.min_r_stall_cycles = ResponseStallCycles;
+    scenario.max_r_stall_cycles = ResponseStallCycles;
+    init_idle();
+    queue_mixed_transactions(scenario, response_queue);
+    run_queued_scenario("mixed AXI response backpressure", scenario, response_queue);
   endtask
 
   task automatic test_error_response_propagation();
@@ -865,6 +891,7 @@ module br_amba_axil2apb_tb;
     test_read_write_arbitration();
     test_axi_write_response_backpressure();
     test_axi_read_response_backpressure();
+    test_mixed_response_backpressure();
     test_error_response_propagation();
     test_mixed_directed_sequence();
     test_stress();

--- a/amba/sim/br_amba_axil2apb_tb.sv
+++ b/amba/sim/br_amba_axil2apb_tb.sv
@@ -164,7 +164,8 @@ module br_amba_axil2apb_tb;
 
   br_amba_axil_requester_driver #(
       .AddrWidth(AddrWidth),
-      .DataWidth(DataWidth)
+      .DataWidth(DataWidth),
+      .TimeoutCycles(TimeoutCycles)
   ) axil_driver (
       .clk(clk),
       .rst(rst),
@@ -188,7 +189,8 @@ module br_amba_axil2apb_tb;
   );
 
   br_amba_apb_completer_driver #(
-      .DataWidth(DataWidth)
+      .DataWidth(DataWidth),
+      .TimeoutCycles(TimeoutCycles)
   ) apb_completer (
       .clk(clk),
       .target_psel(psel),

--- a/amba/sim/br_amba_axil_default_target_tb.sv
+++ b/amba/sim/br_amba_axil_default_target_tb.sv
@@ -3,6 +3,7 @@
 `timescale 1ns / 1ps
 
 import br_amba::*;
+import br_amba_sim_pkg::*;
 
 typedef enum int {
   ResponseKindOkay   = 0,
@@ -56,6 +57,12 @@ module br_amba_axil_default_target_tb;
   logic target_rready;
   logic driver_failed;
   logic monitor_failed;
+  logic timeout_failed;
+  event timeout_tick;
+
+  always @(posedge clk) begin
+    ->timeout_tick;
+  end
 
   br_test_driver #(
       .ResetCycles(5)
@@ -87,7 +94,7 @@ module br_amba_axil_default_target_tb;
       .target_rready
   );
 
-  br_amba_axil_driver #(
+  br_amba_axil_completer_driver #(
       .TimeoutCycles(TimeoutCycles)
   ) axil_driver (
       .clk,
@@ -106,27 +113,135 @@ module br_amba_axil_default_target_tb;
   );
 
   br_amba_axil_monitor #(
-      .DataWidth(DataWidth),
-      .ExpectedResp(ExpectedResp),
-      .DefaultReadData(DefaultReadData)
+      .DataWidth(DataWidth)
   ) axil_monitor (
-      .clk,
-      .rst,
-      .target_awvalid,
-      .target_awready,
-      .target_wvalid,
-      .target_wready,
-      .target_bresp,
-      .target_bvalid,
-      .target_bready,
-      .target_arvalid,
-      .target_arready,
-      .target_rdata,
-      .target_rresp,
-      .target_rvalid,
-      .target_rready,
+      .clk(clk),
+      .rst(rst),
+      .axil_awaddr('0),
+      .axil_awprot('0),
+      .axil_awuser('0),
+      .axil_awvalid(target_awvalid),
+      .axil_awready(target_awready),
+      .axil_wdata('0),
+      .axil_wstrb('0),
+      .axil_wuser('0),
+      .axil_wvalid(target_wvalid),
+      .axil_wready(target_wready),
+      .axil_bresp(target_bresp),
+      .axil_buser('0),
+      .axil_bvalid(target_bvalid),
+      .axil_bready(target_bready),
+      .axil_araddr('0),
+      .axil_arprot('0),
+      .axil_aruser('0),
+      .axil_arvalid(target_arvalid),
+      .axil_arready(target_arready),
+      .axil_rdata(target_rdata),
+      .axil_rresp(target_rresp),
+      .axil_ruser('0),
+      .axil_rvalid(target_rvalid),
+      .axil_rready(target_rready),
       .failed(monitor_failed)
   );
+
+  task automatic wait_cycles(input int cycles = 1);
+    repeat (cycles) @(negedge clk);
+  endtask
+
+  // TODO: Move these DUT-specific checking tasks into a default-target scoreboard.
+  task automatic wait_for_aw_handshake();
+    logic observed = 1'b0;
+
+    fork
+      begin
+        wait (target_awvalid && target_awready);
+        observed = 1'b1;
+      end
+      timeout(timeout_tick, TimeoutCycles, "Timeout waiting for AXI-Lite AW handshake",
+              timeout_failed);
+    join_any
+    disable fork;
+    td.check(observed, "AXI-Lite AW handshake was not observed");
+  endtask
+
+  task automatic wait_for_w_handshake();
+    logic observed = 1'b0;
+
+    fork
+      begin
+        wait (target_wvalid && target_wready);
+        observed = 1'b1;
+      end
+      timeout(timeout_tick, TimeoutCycles, "Timeout waiting for AXI-Lite W handshake",
+              timeout_failed);
+    join_any
+    disable fork;
+    td.check(observed, "AXI-Lite W handshake was not observed");
+  endtask
+
+  task automatic wait_for_b_handshake();
+    logic observed = 1'b0;
+
+    fork
+      begin
+        @(posedge clk);
+        while (!(target_bvalid && target_bready)) @(posedge clk);
+        observed = 1'b1;
+      end
+      timeout(timeout_tick, TimeoutCycles, "Timeout waiting for AXI-Lite B handshake",
+              timeout_failed);
+    join_any
+    disable fork;
+    td.check(observed, "AXI-Lite B handshake was not observed");
+  endtask
+
+  task automatic wait_for_r_handshake();
+    logic observed = 1'b0;
+
+    fork
+      begin
+        @(posedge clk);
+        while (!(target_rvalid && target_rready)) @(posedge clk);
+        observed = 1'b1;
+      end
+      timeout(timeout_tick, TimeoutCycles, "Timeout waiting for AXI-Lite R handshake",
+              timeout_failed);
+    join_any
+    disable fork;
+    td.check(observed, "AXI-Lite R handshake was not observed");
+  endtask
+
+  task automatic check_no_bvalid_after_first_write_channel(input int awvalid_delay,
+                                                           input int wvalid_delay);
+    if (awvalid_delay < wvalid_delay) begin
+      wait_for_aw_handshake();
+      wait_cycles();
+      td.check(!target_bvalid, "B valid asserted before write data was accepted");
+    end else if (wvalid_delay < awvalid_delay) begin
+      wait_for_w_handshake();
+      wait_cycles();
+      td.check(!target_bvalid, "B valid asserted before write address was accepted");
+    end
+  endtask
+
+  task automatic check_b_responses(input int num_writes);
+    for (int i = 0; i < num_writes; i++) begin
+      wait_for_b_handshake();
+      td.check(target_bresp === ExpectedResp, "B response mismatch");
+    end
+    @(negedge clk);
+    td.check(!target_bvalid, "B valid remained asserted after final response handshake");
+  endtask
+
+  task automatic check_r_responses(input int num_reads);
+    for (int i = 0; i < num_reads; i++) begin
+      wait_for_r_handshake();
+      td.check(target_rdata === DefaultReadData, "R data mismatch");
+      td.check(target_rresp === ExpectedResp, "R response mismatch");
+    end
+    @(negedge clk);
+    td.check(!target_rvalid, "R valid remained asserted after final response handshake");
+  endtask
 
   task automatic test_write_address_before_data();
     axil_delays_t delays;
@@ -134,11 +249,19 @@ module br_amba_axil_default_target_tb;
     delays = '{default: 0};
     delays.wvalid = ChannelSkewCycles;
     fork
-      axil_driver.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
-                      .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid));
-      axil_monitor.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
-                       .wvalid_delay(delays.wvalid));
-    join
+      begin
+        fork
+          axil_driver.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
+                          .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid));
+          begin
+            check_no_bvalid_after_first_write_channel(delays.awvalid, delays.wvalid);
+            check_b_responses(NumTransactions);
+          end
+        join
+      end
+      axil_monitor.run();
+    join_any
+    disable fork;
   endtask
 
   task automatic test_write_data_before_address();
@@ -147,11 +270,19 @@ module br_amba_axil_default_target_tb;
     delays = '{default: 0};
     delays.awvalid = ChannelSkewCycles;
     fork
-      axil_driver.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
-                      .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid));
-      axil_monitor.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
-                       .wvalid_delay(delays.wvalid));
-    join
+      begin
+        fork
+          axil_driver.run(.num_writes(NumTransactions), .awvalid_delay(delays.awvalid),
+                          .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid));
+          begin
+            check_no_bvalid_after_first_write_channel(delays.awvalid, delays.wvalid);
+            check_b_responses(NumTransactions);
+          end
+        join
+      end
+      axil_monitor.run();
+    join_any
+    disable fork;
   endtask
 
   task automatic test_read_backpressure();
@@ -159,14 +290,20 @@ module br_amba_axil_default_target_tb;
 
     delays = '{default: 0};
     fork
-      axil_driver.run(.num_reads(NumTransactions), .awvalid_delay(delays.awvalid),
-                      .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid));
-      axil_monitor.run(.num_reads(NumTransactions), .awvalid_delay(delays.awvalid),
-                       .wvalid_delay(delays.wvalid));
-    join
+      begin
+        fork
+          axil_driver.run(.num_reads(NumTransactions), .awvalid_delay(delays.awvalid),
+                          .wvalid_delay(delays.wvalid), .arvalid_delay(delays.arvalid));
+          check_r_responses(NumTransactions);
+        join
+      end
+      axil_monitor.run();
+    join_any
+    disable fork;
   endtask
 
   initial begin
+    timeout_failed = 1'b0;
     axil_driver.init_idle();
     axil_monitor.init_idle();
     td.reset_dut();
@@ -181,6 +318,7 @@ module br_amba_axil_default_target_tb;
 
     td.check(!driver_failed, "AXI-Lite driver reported one or more failures");
     td.check(!monitor_failed, "AXI-Lite monitor reported one or more failures");
+    td.check(!timeout_failed, "Timeout reported failures");
     td.finish();
   end
 

--- a/amba/sim/br_amba_axil_default_target_tb.sv
+++ b/amba/sim/br_amba_axil_default_target_tb.sv
@@ -154,7 +154,8 @@ module br_amba_axil_default_target_tb;
 
     fork
       begin
-        wait (target_awvalid && target_awready);
+        @(posedge clk);
+        while (!(target_awvalid && target_awready)) @(posedge clk);
         observed = 1'b1;
       end
       timeout(timeout_tick, TimeoutCycles, "Timeout waiting for AXI-Lite AW handshake",
@@ -169,7 +170,8 @@ module br_amba_axil_default_target_tb;
 
     fork
       begin
-        wait (target_wvalid && target_wready);
+        @(posedge clk);
+        while (!(target_wvalid && target_wready)) @(posedge clk);
         observed = 1'b1;
       end
       timeout(timeout_tick, TimeoutCycles, "Timeout waiting for AXI-Lite W handshake",

--- a/amba/sim/drivers/BUILD.bazel
+++ b/amba/sim/drivers/BUILD.bazel
@@ -50,8 +50,8 @@ verilog_library(
 )
 
 verilog_library(
-    name = "br_amba_axil_driver",
-    srcs = ["br_amba_axil_driver.sv"],
+    name = "br_amba_axil_completer_driver",
+    srcs = ["br_amba_axil_completer_driver.sv"],
     visibility = ["//visibility:public"],
 )
 

--- a/amba/sim/drivers/BUILD.bazel
+++ b/amba/sim/drivers/BUILD.bazel
@@ -9,6 +9,7 @@ verilog_library(
     deps = [
         ":br_amba_sim_pkg",
         "//amba/rtl:br_amba_pkg",
+        "//macros:br_asserts",
     ],
 )
 
@@ -27,6 +28,7 @@ verilog_library(
     visibility = ["//visibility:public"],
     deps = [
         "//amba/rtl:br_amba_pkg",
+        "//macros:br_asserts",
     ],
 )
 

--- a/amba/sim/drivers/BUILD.bazel
+++ b/amba/sim/drivers/BUILD.bazel
@@ -38,6 +38,17 @@ verilog_library(
 )
 
 verilog_library(
+    name = "br_amba_axil_requester_driver",
+    srcs = ["br_amba_axil_requester_driver.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":br_amba_axil_sim_pkg",
+        ":br_amba_sim_pkg",
+        "//amba/rtl:br_amba_pkg",
+    ],
+)
+
+verilog_library(
     name = "br_amba_apb_sim_helpers",
     srcs = [
         "br_amba_apb_completer_driver.sv",
@@ -46,6 +57,7 @@ verilog_library(
     visibility = ["//visibility:public"],
     deps = [
         ":br_amba_apb_sim_pkg",
+        ":br_amba_sim_pkg",
     ],
 )
 

--- a/amba/sim/drivers/br_amba_apb_completer_driver.sv
+++ b/amba/sim/drivers/br_amba_apb_completer_driver.sv
@@ -2,6 +2,7 @@
 
 `timescale 1ns / 1ps
 
+import br_amba_sim_pkg::*;
 import br_amba_apb_sim_pkg::*;
 
 // APB completer-side response driver.
@@ -9,6 +10,7 @@ import br_amba_apb_sim_pkg::*;
 // The driver owns only PREADY/PRDATA/PSLVERR and issues one directed response
 // sequence per run call.
 module br_amba_apb_completer_driver #(
+    parameter int DataWidth = 32,
     parameter int TimeoutCycles = 100
 ) (
     input logic clk,
@@ -16,37 +18,54 @@ module br_amba_apb_completer_driver #(
     input logic target_penable,
 
     output logic pready,
-    output logic [31:0] prdata,
-    output logic pslverr
+    output logic [DataWidth-1:0] prdata,
+    output logic pslverr,
+    output logic failed
 );
 
   localparam logic [31:0] StallRdataBase = 32'h5a5a_0000;
 
   apb_response_t resp;
+  event sample_tick;
 
   assign pready  = resp.ready;
-  assign prdata  = resp.rdata;
+  assign prdata  = DataWidth'(resp.rdata);
   assign pslverr = resp.slverr;
+
+  clocking cb @(posedge clk);
+    default input #1step;
+    input target_psel;
+    input target_penable;
+  endclocking
+
+  always begin
+    @cb;
+    ->sample_tick;
+  end
 
   function automatic logic [31:0] stall_rdata(input int cycle);
     stall_rdata = StallRdataBase | cycle;
   endfunction
 
   task automatic init_idle();
-    resp = '0;
+    resp   = '0;
+    failed = 1'b0;
   endtask
 
-  task automatic wait_for_access();
-    int timeout = 0;
+  task automatic wait_for_transfer_start();
+    fork
+      do @cb; while (!cb.target_psel);
+      timeout(sample_tick, TimeoutCycles, "Timeout waiting for downstream APB transfer", failed);
+    join_any
+    disable fork;
+  endtask
 
-    @(posedge clk);
-    while (!(target_psel && target_penable) && timeout < TimeoutCycles) begin
-      @(posedge clk);
-      timeout++;
-    end
-    if (!(target_psel && target_penable)) begin
-      $error("Timeout waiting for downstream APB access");
-    end
+  task automatic wait_for_completion();
+    fork
+      do @cb; while (!(cb.target_psel && cb.target_penable && resp.ready));
+      timeout(sample_tick, TimeoutCycles, "Timeout waiting for downstream APB completion", failed);
+    join_any
+    disable fork;
   endtask
 
   task automatic issue_response(input apb_response_t response);
@@ -55,23 +74,57 @@ module br_amba_apb_completer_driver #(
     @(negedge clk);
   endtask
 
-  task automatic run(input apb_response_t inputs, input apb_response_controls_t controls);
+  task automatic run_queue(input apb_response_t inputs[$], input apb_response_controls_t controls);
     apb_response_t response;
 
     for (int transaction = 0; transaction < controls.num_transactions; transaction++) begin
-      wait_for_access();
+      if (transaction >= inputs.size()) begin
+        failed = 1'b1;
+        $error("APB completer response queue is shorter than requested transaction count");
+        return;
+      end
+      response.ready = Pready1;
+      response.rdata = inputs[transaction].rdata;
+      response.slverr = inputs[transaction].slverr;
+      resp = response;
+
+      wait_for_transfer_start();
+      if (failed) begin
+        return;
+      end
       for (int cycle = 0; cycle < controls.wait_cycles; cycle++) begin
         response.ready  = Pready0;
-        response.rdata  = stall_rdata(cycle);
+        response.rdata  = ApbDataWidth'(stall_rdata(cycle));
         response.slverr = Pslverr0;
         issue_response(response);
       end
       response.ready  = Pready1;
-      response.rdata  = inputs.rdata + 32'(transaction);
-      response.slverr = inputs.slverr;
-      issue_response(response);
+      response.rdata  = inputs[transaction].rdata;
+      response.slverr = inputs[transaction].slverr;
+      if (controls.wait_cycles != 0) begin
+        @(negedge clk);
+        resp = response;
+      end
+      wait_for_completion();
+      if (failed) begin
+        return;
+      end
+      @(negedge clk);
       resp = '0;
     end
+  endtask
+
+  task automatic run(input apb_response_t inputs, input apb_response_controls_t controls);
+    apb_response_t response_queue[$];
+    apb_response_t response;
+
+    for (int transaction = 0; transaction < controls.num_transactions; transaction++) begin
+      response.ready  = Pready1;
+      response.rdata  = inputs.rdata + ApbDataWidth'(transaction);
+      response.slverr = inputs.slverr;
+      response_queue.push_back(response);
+    end
+    run_queue(response_queue, controls);
   endtask
 
 endmodule : br_amba_apb_completer_driver

--- a/amba/sim/drivers/br_amba_apb_requester_driver.sv
+++ b/amba/sim/drivers/br_amba_apb_requester_driver.sv
@@ -11,8 +11,10 @@ import br_amba_apb_sim_pkg::*;
 // transfer per run call. Tests combine it with a DUT-specific monitor to check
 // response behavior without open-coding APB phase sequencing in each bench.
 module br_amba_apb_requester_driver #(
-    parameter int AddrWidth = 12,
-    parameter int TimeoutCycles = 100
+    parameter  int AddrWidth     = ApbAddrWidth,
+    parameter  int DataWidth     = ApbDataWidth,
+    parameter  int TimeoutCycles = 100,
+    localparam int StrbWidth     = DataWidth / 8
 ) (
     input logic clk,
     input logic pready,
@@ -21,20 +23,20 @@ module br_amba_apb_requester_driver #(
     output logic psel,
     output logic penable,
     output logic [ApbProtWidth-1:0] pprot,
-    output logic [3:0] pstrb,
+    output logic [StrbWidth-1:0] pstrb,
     output logic pwrite,
-    output logic [31:0] pwdata
+    output logic [DataWidth-1:0] pwdata
 );
 
   apb_request_beat_t apb_beat;
 
-  assign paddr   = apb_beat.request.addr;
+  assign paddr   = AddrWidth'(apb_beat.request.addr);
   assign psel    = apb_beat.psel;
   assign penable = apb_beat.penable;
   assign pprot   = apb_beat.request.prot;
-  assign pstrb   = apb_beat.request.strb;
+  assign pstrb   = StrbWidth'(apb_beat.request.strb);
   assign pwrite  = apb_beat.request.write;
-  assign pwdata  = apb_beat.request.wdata;
+  assign pwdata  = DataWidth'(apb_beat.request.wdata);
 
   function automatic apb_request_beat_t request_beat(
       input apb_request_t request, input logic psel_value, input logic penable_value);
@@ -83,8 +85,8 @@ module br_amba_apb_requester_driver #(
   endtask
 
   task automatic drive_idle(input int idle_cycles);
+    wait_for_response();
     if (idle_cycles > 0) begin
-      wait_for_response();
       @(negedge clk);
       apb_beat.psel    = Psel0;
       apb_beat.penable = Penable0;
@@ -100,7 +102,7 @@ module br_amba_apb_requester_driver #(
       request.prot  = inputs.prot;
       request.strb  = inputs.strb;
       request.write = inputs.write;
-      request.wdata = inputs.wdata + 32'(transaction);
+      request.wdata = inputs.wdata + ApbDataWidth'(transaction);
       issue_setup_request(request, controls.setup_cycles);
       issue_access_request(request);
       drive_idle(controls.idle_cycles);

--- a/amba/sim/drivers/br_amba_apb_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_apb_sim_pkg.sv
@@ -5,6 +5,10 @@
 package br_amba_apb_sim_pkg;
   import br_amba::*;
 
+  localparam int ApbAddrWidth = 64;
+  localparam int ApbDataWidth = 1024;
+  localparam int ApbStrbWidth = ApbDataWidth / 8;
+
   localparam logic Psel0 = 1'b0;
   localparam logic Psel1 = 1'b1;
   localparam logic Penable0 = 1'b0;
@@ -12,6 +16,7 @@ package br_amba_apb_sim_pkg;
   localparam logic Pready0 = 1'b0;
   localparam logic Pready1 = 1'b1;
   localparam logic Pslverr0 = 1'b0;
+  localparam logic Pslverr1 = 1'b1;
 
   typedef struct packed {
     logic [31:0] addr;
@@ -35,9 +40,24 @@ package br_amba_apb_sim_pkg;
 
   typedef struct packed {
     logic ready;
-    logic [31:0] rdata;
+    logic [ApbDataWidth-1:0] rdata;
     logic slverr;
   } apb_response_t;
+
+  typedef struct packed {
+    logic [ApbAddrWidth-1:0] addr;
+    logic [ApbProtWidth-1:0] prot;
+    logic [ApbStrbWidth-1:0] strb;
+    logic write;
+    logic [ApbDataWidth-1:0] data;
+    logic slverr;
+  } apb_transfer_t;
+
+  typedef struct {
+    apb_transfer_t packet;
+    time           request_timestamp;
+    time           completion_timestamp;
+  } apb_transfer_observation_t;
 
   typedef struct {
     int num_transactions;

--- a/amba/sim/drivers/br_amba_apb_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_apb_sim_pkg.sv
@@ -2,12 +2,26 @@
 
 `timescale 1ns / 1ps
 
+`include "br_asserts.svh"
+
 package br_amba_apb_sim_pkg;
   import br_amba::*;
 
-  localparam int ApbAddrWidth = 64;
-  localparam int ApbDataWidth = 1024;
+`ifndef BR_AMBA_APB_SIM_ADDR_WIDTH
+  `define BR_AMBA_APB_SIM_ADDR_WIDTH 64
+`endif
+
+`ifndef BR_AMBA_APB_SIM_DATA_WIDTH
+  `define BR_AMBA_APB_SIM_DATA_WIDTH 1024
+`endif
+
+  parameter int ApbAddrWidth = `BR_AMBA_APB_SIM_ADDR_WIDTH;
+  parameter int ApbDataWidth = `BR_AMBA_APB_SIM_DATA_WIDTH;
   localparam int ApbStrbWidth = ApbDataWidth / 8;
+
+  `BR_ASSERT_STATIC_IN_PACKAGE(ApbAddrWidthPositive, ApbAddrWidth > 0)
+  `BR_ASSERT_STATIC_IN_PACKAGE(ApbDataWidthPositive, ApbDataWidth > 0)
+  `BR_ASSERT_STATIC_IN_PACKAGE(ApbDataWidthByteAligned, ApbDataWidth % 8 == 0)
 
   localparam logic Psel0 = 1'b0;
   localparam logic Psel1 = 1'b1;
@@ -19,11 +33,11 @@ package br_amba_apb_sim_pkg;
   localparam logic Pslverr1 = 1'b1;
 
   typedef struct packed {
-    logic [31:0] addr;
+    logic [ApbAddrWidth-1:0] addr;
     logic [ApbProtWidth-1:0] prot;
-    logic [3:0] strb;
+    logic [ApbStrbWidth-1:0] strb;
     logic write;
-    logic [31:0] wdata;
+    logic [ApbDataWidth-1:0] wdata;
   } apb_request_t;
 
   typedef struct packed {

--- a/amba/sim/drivers/br_amba_axi_target_driver.sv
+++ b/amba/sim/drivers/br_amba_axi_target_driver.sv
@@ -53,7 +53,9 @@ module br_amba_axi_target_driver #(
     WaitTargetW,
     WaitTargetAr,
     WaitTargetB,
-    WaitTargetR
+    WaitTargetR,
+    WaitTargetBValid,
+    WaitTargetRValid
   } wait_condition_e;
 
   axi_aw_source_t target_aw_drive;
@@ -125,27 +127,31 @@ module br_amba_axi_target_driver #(
 
   function automatic logic is_wait_condition_met(input wait_condition_e condition);
     case (condition)
-      WaitTargetAw: is_wait_condition_met = cb.target_awvalid && cb.target_awready;
-      WaitTargetW:  is_wait_condition_met = cb.target_wvalid && cb.target_wready;
-      WaitTargetAr: is_wait_condition_met = cb.target_arvalid && cb.target_arready;
-      WaitTargetB:  is_wait_condition_met = cb.target_bvalid && cb.target_bready;
-      WaitTargetR:  is_wait_condition_met = cb.target_rvalid && cb.target_rready;
-      default:      is_wait_condition_met = 1'b0;
+      WaitTargetAw:     is_wait_condition_met = cb.target_awvalid && cb.target_awready;
+      WaitTargetW:      is_wait_condition_met = cb.target_wvalid && cb.target_wready;
+      WaitTargetAr:     is_wait_condition_met = cb.target_arvalid && cb.target_arready;
+      WaitTargetB:      is_wait_condition_met = cb.target_bvalid && cb.target_bready;
+      WaitTargetR:      is_wait_condition_met = cb.target_rvalid && cb.target_rready;
+      WaitTargetBValid: is_wait_condition_met = cb.target_bvalid;
+      WaitTargetRValid: is_wait_condition_met = cb.target_rvalid;
+      default:          is_wait_condition_met = 1'b0;
     endcase
   endfunction
 
   function automatic string wait_condition_name(input wait_condition_e condition);
     case (condition)
-      WaitTargetAw: wait_condition_name = "target AW";
-      WaitTargetW:  wait_condition_name = "target W";
-      WaitTargetAr: wait_condition_name = "target AR";
-      WaitTargetB:  wait_condition_name = "target B";
-      WaitTargetR:  wait_condition_name = "target R";
-      default:      wait_condition_name = "unknown AXI";
+      WaitTargetAw:     wait_condition_name = "target AW";
+      WaitTargetW:      wait_condition_name = "target W";
+      WaitTargetAr:     wait_condition_name = "target AR";
+      WaitTargetB:      wait_condition_name = "target B";
+      WaitTargetR:      wait_condition_name = "target R";
+      WaitTargetBValid: wait_condition_name = "target B";
+      WaitTargetRValid: wait_condition_name = "target R";
+      default:          wait_condition_name = "unknown AXI";
     endcase
   endfunction
 
-  task automatic wait_for(input wait_condition_e condition);
+  task automatic wait_for(input wait_condition_e condition, input string wait_item = "handshake");
     int timeout;
 
     timeout = TimeoutCycles;
@@ -156,7 +162,20 @@ module br_amba_axi_target_driver #(
         condition
     ) && timeout >= 0);
     check(is_wait_condition_met(condition), {
-          "Timeout waiting for ", wait_condition_name(condition), " handshake"});
+          "Timeout waiting for ", wait_condition_name(condition), " ", wait_item});
+  endtask
+
+  task automatic wait_response_stall(input wait_condition_e valid_condition,
+                                     input int stall_cycles);
+    for (int stall_cycle = 0; stall_cycle < stall_cycles; stall_cycle++) begin
+      if (stall_cycle == 0) begin
+        wait_for(valid_condition, "valid");
+        if (failed) begin
+          return;
+        end
+      end
+      wait_cycles();
+    end
   endtask
 
   function automatic axi_aw_t get_aw_transaction(input axi_aw_t base, input int index,
@@ -305,7 +324,10 @@ module br_amba_axi_target_driver #(
   task automatic accept_target_b(input int stall_cycles);
     if (stall_cycles > 0) begin
       target_bready_drive = 1'b0;
-      wait_cycles(stall_cycles);
+      wait_response_stall(WaitTargetBValid, stall_cycles);
+      if (failed) begin
+        return;
+      end
     end
     target_bready_drive = 1'b1;
     wait_for(WaitTargetB);
@@ -314,7 +336,10 @@ module br_amba_axi_target_driver #(
   task automatic accept_target_r(input int stall_cycles);
     if (stall_cycles > 0) begin
       target_rready_drive = 1'b0;
-      wait_cycles(stall_cycles);
+      wait_response_stall(WaitTargetRValid, stall_cycles);
+      if (failed) begin
+        return;
+      end
     end
     target_rready_drive = 1'b1;
     wait_for(WaitTargetR);

--- a/amba/sim/drivers/br_amba_axil_completer_driver.sv
+++ b/amba/sim/drivers/br_amba_axil_completer_driver.sv
@@ -8,7 +8,7 @@
 // request streams with configurable channel skew. Tests can combine it with a
 // DUT-specific monitor to check response behavior without open-coding AXI-Lite
 // handshakes in each bench.
-module br_amba_axil_driver #(
+module br_amba_axil_completer_driver #(
     parameter int TimeoutCycles = 20
 ) (
     input logic clk,
@@ -230,4 +230,4 @@ module br_amba_axil_driver #(
     wait_cycles();
   endtask
 
-endmodule : br_amba_axil_driver
+endmodule : br_amba_axil_completer_driver

--- a/amba/sim/drivers/br_amba_axil_requester_driver.sv
+++ b/amba/sim/drivers/br_amba_axil_requester_driver.sv
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_sim_pkg::*;
+import br_amba_axil_sim_pkg::*;
+
+// AXI4-Lite requester-side driver.
+//
+// The driver owns only AXI4-Lite requester outputs: AW/W/AR payloads and valids,
+// plus BREADY/RREADY. Payload observation and checking belong in monitors and
+// scoreboards.
+module br_amba_axil_requester_driver #(
+    parameter int AddrWidth = 12,
+    parameter int DataWidth = 32,
+    parameter int TimeoutCycles = 100,
+    localparam int StrbWidth = DataWidth / 8
+) (
+    input logic clk,
+    input logic rst,
+
+    output logic [AddrWidth-1:0] axil_awaddr,
+    output logic [AxiProtWidth-1:0] axil_awprot,
+    output logic axil_awvalid,
+    input logic axil_awready,
+    output logic [DataWidth-1:0] axil_wdata,
+    output logic [StrbWidth-1:0] axil_wstrb,
+    output logic axil_wvalid,
+    input logic axil_wready,
+    input logic axil_bvalid,
+    output logic axil_bready,
+    output logic [AddrWidth-1:0] axil_araddr,
+    output logic [AxiProtWidth-1:0] axil_arprot,
+    output logic axil_arvalid,
+    input logic axil_arready,
+    input logic axil_rvalid,
+    output logic axil_rready,
+
+    output logic failed
+);
+
+  int bready_stall_queue[$];
+  int rready_stall_queue[$];
+  axil_aw_driver_item_t aw_queue[$];
+  axil_w_driver_item_t w_queue[$];
+  axil_ar_driver_item_t ar_queue[$];
+  event sample_tick;
+
+  clocking cb @(posedge clk);
+    default input #1step;
+    input rst;
+    input axil_awready;
+    input axil_wready;
+    input axil_bvalid;
+    input axil_arready;
+    input axil_rvalid;
+    input axil_awvalid;
+    input axil_wvalid;
+    input axil_bready;
+    input axil_arvalid;
+    input axil_rready;
+  endclocking
+
+  always begin
+    @cb;
+    ->sample_tick;
+  end
+
+  task automatic init_idle();
+    axil_awaddr  = '0;
+    axil_awprot  = '0;
+    axil_awvalid = 1'b0;
+    axil_wdata   = '0;
+    axil_wstrb   = '0;
+    axil_wvalid  = 1'b0;
+    axil_bready  = 1'b0;
+    axil_araddr  = '0;
+    axil_arprot  = '0;
+    axil_arvalid = 1'b0;
+    axil_rready  = 1'b0;
+    failed       = 1'b0;
+    bready_stall_queue.delete();
+    rready_stall_queue.delete();
+    aw_queue.delete();
+    w_queue.delete();
+    ar_queue.delete();
+  endtask
+
+  task automatic fail(input string message);
+    failed = 1'b1;
+    $error("%s", message);
+  endtask
+
+  task automatic queue_write(input logic [AddrWidth-1:0] addr, input logic [AxiProtWidth-1:0] prot,
+                             input logic [DataWidth-1:0] data, input logic [StrbWidth-1:0] strb,
+                             input int aw_gap_cycles, input int w_gap_cycles,
+                             input int b_stall_cycles);
+    aw_queue.push_back('{addr: AxilAddrWidth'(addr), prot: prot, gap_cycles: aw_gap_cycles});
+    w_queue.push_back('{data: AxilDataWidth'(data), strb: AxilStrobeWidth'(strb),
+                      gap_cycles: w_gap_cycles});
+    bready_stall_queue.push_back(b_stall_cycles);
+  endtask
+
+  task automatic queue_read(input logic [AddrWidth-1:0] addr, input logic [AxiProtWidth-1:0] prot,
+                            input int ar_gap_cycles, input int r_stall_cycles);
+    ar_queue.push_back('{addr: AxilAddrWidth'(addr), prot: prot, gap_cycles: ar_gap_cycles});
+    rready_stall_queue.push_back(r_stall_cycles);
+  endtask
+
+  function automatic logic is_handshake_seen(input axil_handshake_channel_t channel);
+    unique case (channel)
+      AxilHandshakeAw: is_handshake_seen = cb.axil_awvalid && cb.axil_awready;
+      AxilHandshakeW:  is_handshake_seen = cb.axil_wvalid && cb.axil_wready;
+      AxilHandshakeB:  is_handshake_seen = cb.axil_bvalid && cb.axil_bready;
+      AxilHandshakeAr: is_handshake_seen = cb.axil_arvalid && cb.axil_arready;
+      AxilHandshakeR:  is_handshake_seen = cb.axil_rvalid && cb.axil_rready;
+      default:         is_handshake_seen = 1'b0;
+    endcase
+  endfunction
+
+  task automatic wait_handshake(input axil_handshake_channel_t channel, input string channel_name);
+    fork
+      do @cb; while (!is_handshake_seen(channel));
+      timeout(sample_tick, TimeoutCycles, $sformatf(
+              "Timeout waiting for AXI-Lite %s handshake", channel_name), failed);
+    join_any
+    disable fork;
+  endtask
+
+  task automatic drive_aw_channel(input int num_writes);
+    axil_aw_driver_item_t item;
+
+    for (int i = 0; i < num_writes; i++) begin
+      if (aw_queue.size() == 0) begin
+        fail("AXI-Lite requester AW queue underflow");
+        return;
+      end
+      item = aw_queue.pop_front();
+      repeat (item.gap_cycles) @(negedge clk);
+      axil_awaddr  = AddrWidth'(item.addr);
+      axil_awprot  = item.prot;
+      axil_awvalid = 1'b1;
+      wait_handshake(AxilHandshakeAw, "AW");
+      if (failed) begin
+        axil_awvalid = 1'b0;
+        return;
+      end
+      @(negedge clk);
+      axil_awvalid = 1'b0;
+    end
+  endtask
+
+  task automatic drive_w_channel(input int num_writes);
+    axil_w_driver_item_t item;
+
+    for (int i = 0; i < num_writes; i++) begin
+      if (w_queue.size() == 0) begin
+        fail("AXI-Lite requester W queue underflow");
+        return;
+      end
+      item = w_queue.pop_front();
+      repeat (item.gap_cycles) @(negedge clk);
+      axil_wdata  = DataWidth'(item.data);
+      axil_wstrb  = StrbWidth'(item.strb);
+      axil_wvalid = 1'b1;
+      wait_handshake(AxilHandshakeW, "W");
+      if (failed) begin
+        axil_wvalid = 1'b0;
+        return;
+      end
+      @(negedge clk);
+      axil_wvalid = 1'b0;
+    end
+  endtask
+
+  task automatic drive_b_channel(input int num_writes);
+    int stall_cycles;
+
+    for (int i = 0; i < num_writes; i++) begin
+      if (bready_stall_queue.size() == 0) begin
+        fail("AXI-Lite requester B stall queue underflow");
+        return;
+      end
+      stall_cycles = bready_stall_queue.pop_front();
+      repeat (stall_cycles) @(negedge clk);
+      axil_bready = 1'b1;
+      wait_handshake(AxilHandshakeB, "B");
+      if (failed) begin
+        axil_bready = 1'b0;
+        return;
+      end
+      @(negedge clk);
+      axil_bready = 1'b0;
+    end
+  endtask
+
+  task automatic drive_ar_channel(input int num_reads);
+    axil_ar_driver_item_t item;
+
+    for (int i = 0; i < num_reads; i++) begin
+      if (ar_queue.size() == 0) begin
+        fail("AXI-Lite requester AR queue underflow");
+        return;
+      end
+      item = ar_queue.pop_front();
+      repeat (item.gap_cycles) @(negedge clk);
+      axil_araddr  = AddrWidth'(item.addr);
+      axil_arprot  = item.prot;
+      axil_arvalid = 1'b1;
+      wait_handshake(AxilHandshakeAr, "AR");
+      if (failed) begin
+        axil_arvalid = 1'b0;
+        return;
+      end
+      @(negedge clk);
+      axil_arvalid = 1'b0;
+    end
+  endtask
+
+  task automatic drive_r_channel(input int num_reads);
+    int stall_cycles;
+
+    for (int i = 0; i < num_reads; i++) begin
+      if (rready_stall_queue.size() == 0) begin
+        fail("AXI-Lite requester R stall queue underflow");
+        return;
+      end
+      stall_cycles = rready_stall_queue.pop_front();
+      repeat (stall_cycles) @(negedge clk);
+      axil_rready = 1'b1;
+      wait_handshake(AxilHandshakeR, "R");
+      if (failed) begin
+        axil_rready = 1'b0;
+        return;
+      end
+      @(negedge clk);
+      axil_rready = 1'b0;
+    end
+  endtask
+
+  task automatic issue_write_transactions(input int num_writes);
+    fork
+      drive_aw_channel(num_writes);
+      drive_w_channel(num_writes);
+      drive_b_channel(num_writes);
+    join
+  endtask
+
+  task automatic issue_read_transactions(input int num_reads);
+    fork
+      drive_ar_channel(num_reads);
+      drive_r_channel(num_reads);
+    join
+  endtask
+
+  task automatic run(input int num_writes, input int num_reads);
+    fork
+      issue_write_transactions(num_writes);
+      issue_read_transactions(num_reads);
+    join
+  endtask
+endmodule : br_amba_axil_requester_driver

--- a/amba/sim/drivers/br_amba_axil_requester_driver.sv
+++ b/amba/sim/drivers/br_amba_axil_requester_driver.sv
@@ -119,6 +119,17 @@ module br_amba_axil_requester_driver #(
     endcase
   endfunction
 
+  function automatic logic is_valid_seen(input axil_handshake_channel_t channel);
+    unique case (channel)
+      AxilHandshakeAw: is_valid_seen = cb.axil_awvalid;
+      AxilHandshakeW:  is_valid_seen = cb.axil_wvalid;
+      AxilHandshakeB:  is_valid_seen = cb.axil_bvalid;
+      AxilHandshakeAr: is_valid_seen = cb.axil_arvalid;
+      AxilHandshakeR:  is_valid_seen = cb.axil_rvalid;
+      default:         is_valid_seen = 1'b0;
+    endcase
+  endfunction
+
   task automatic wait_handshake(input axil_handshake_channel_t channel, input string channel_name);
     fork
       do @cb; while (!is_handshake_seen(channel));
@@ -126,6 +137,28 @@ module br_amba_axil_requester_driver #(
               "Timeout waiting for AXI-Lite %s handshake", channel_name), failed);
     join_any
     disable fork;
+  endtask
+
+  task automatic wait_valid(input axil_handshake_channel_t channel, input string channel_name);
+    fork
+      do @cb; while (!is_valid_seen(channel));
+      timeout(sample_tick, TimeoutCycles, $sformatf(
+              "Timeout waiting for AXI-Lite %s valid", channel_name), failed);
+    join_any
+    disable fork;
+  endtask
+
+  task automatic wait_response_stall(input axil_handshake_channel_t channel,
+                                     input string channel_name, input int stall_cycles);
+    for (int stall_cycle = 0; stall_cycle < stall_cycles; stall_cycle++) begin
+      if (stall_cycle == 0) begin
+        wait_valid(channel, channel_name);
+        if (failed) begin
+          return;
+        end
+      end
+      @(negedge clk);
+    end
   endtask
 
   task automatic drive_aw_channel(input int num_writes);
@@ -183,7 +216,10 @@ module br_amba_axil_requester_driver #(
         return;
       end
       stall_cycles = bready_stall_queue.pop_front();
-      repeat (stall_cycles) @(negedge clk);
+      wait_response_stall(AxilHandshakeB, "B", stall_cycles);
+      if (failed) begin
+        return;
+      end
       axil_bready = 1'b1;
       wait_handshake(AxilHandshakeB, "B");
       if (failed) begin
@@ -227,7 +263,10 @@ module br_amba_axil_requester_driver #(
         return;
       end
       stall_cycles = rready_stall_queue.pop_front();
-      repeat (stall_cycles) @(negedge clk);
+      wait_response_stall(AxilHandshakeR, "R", stall_cycles);
+      if (failed) begin
+        return;
+      end
       axil_rready = 1'b1;
       wait_handshake(AxilHandshakeR, "R");
       if (failed) begin

--- a/amba/sim/drivers/br_amba_axil_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_axil_sim_pkg.sv
@@ -2,13 +2,32 @@
 
 `timescale 1ns / 1ps
 
+`include "br_asserts.svh"
+
 package br_amba_axil_sim_pkg;
   import br_amba::*;
 
-  localparam int AxilAddrWidth = 64;
-  localparam int AxilDataWidth = 1024;
-  localparam int AxilUserWidth = 64;
+`ifndef BR_AMBA_AXIL_SIM_ADDR_WIDTH
+  `define BR_AMBA_AXIL_SIM_ADDR_WIDTH 64
+`endif
+
+`ifndef BR_AMBA_AXIL_SIM_DATA_WIDTH
+  `define BR_AMBA_AXIL_SIM_DATA_WIDTH 1024
+`endif
+
+`ifndef BR_AMBA_AXIL_SIM_USER_WIDTH
+  `define BR_AMBA_AXIL_SIM_USER_WIDTH 64
+`endif
+
+  parameter int AxilAddrWidth = `BR_AMBA_AXIL_SIM_ADDR_WIDTH;
+  parameter int AxilDataWidth = `BR_AMBA_AXIL_SIM_DATA_WIDTH;
+  parameter int AxilUserWidth = `BR_AMBA_AXIL_SIM_USER_WIDTH;
   localparam int AxilStrobeWidth = AxilDataWidth / 8;
+
+  `BR_ASSERT_STATIC_IN_PACKAGE(AxilAddrWidthPositive, AxilAddrWidth > 0)
+  `BR_ASSERT_STATIC_IN_PACKAGE(AxilDataWidthPositive, AxilDataWidth > 0)
+  `BR_ASSERT_STATIC_IN_PACKAGE(AxilDataWidthByteAligned, AxilDataWidth % 8 == 0)
+  `BR_ASSERT_STATIC_IN_PACKAGE(AxilUserWidthPositive, AxilUserWidth > 0)
 
   typedef struct packed {
     logic [AxilAddrWidth-1:0] addr;

--- a/amba/sim/drivers/br_amba_axil_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_axil_sim_pkg.sv
@@ -45,4 +45,27 @@ package br_amba_axil_sim_pkg;
     AxilRequestAr
   } axil_request_channel_t;
 
+  typedef enum int {
+    AxilTransactionWrite,
+    AxilTransactionRead
+  } axil_transaction_kind_t;
+
+  typedef struct {
+    logic [AxilAddrWidth-1:0] addr;
+    logic [AxiProtWidth-1:0]  prot;
+    int                       gap_cycles;
+  } axil_aw_driver_item_t;
+
+  typedef struct {
+    logic [AxilDataWidth-1:0]   data;
+    logic [AxilStrobeWidth-1:0] strb;
+    int                         gap_cycles;
+  } axil_w_driver_item_t;
+
+  typedef struct {
+    logic [AxilAddrWidth-1:0] addr;
+    logic [AxiProtWidth-1:0]  prot;
+    int                       gap_cycles;
+  } axil_ar_driver_item_t;
+
 endpackage : br_amba_axil_sim_pkg

--- a/amba/sim/drivers/br_amba_axil_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_axil_sim_pkg.sv
@@ -50,6 +50,14 @@ package br_amba_axil_sim_pkg;
     AxilTransactionRead
   } axil_transaction_kind_t;
 
+  typedef enum int {
+    AxilHandshakeAw,
+    AxilHandshakeW,
+    AxilHandshakeB,
+    AxilHandshakeAr,
+    AxilHandshakeR
+  } axil_handshake_channel_t;
+
   typedef struct {
     logic [AxilAddrWidth-1:0] addr;
     logic [AxiProtWidth-1:0]  prot;

--- a/amba/sim/drivers/br_amba_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_sim_pkg.sv
@@ -3,9 +3,24 @@
 `timescale 1ns / 1ps
 
 package br_amba_sim_pkg;
+`ifdef BR_AMBA_SIM_MAX_CHECK_WIDTH
+  parameter int BrAmbaSimMaxCheckWidth = `BR_AMBA_SIM_MAX_CHECK_WIDTH;
+`else
+  parameter int BrAmbaSimMaxCheckWidth = 1024;
+`endif
+
   task automatic report_error(input string message, ref logic failed);
     failed = 1'b1;
     $error("%s", message);
+  endtask
+
+  task automatic check_eq(input logic [BrAmbaSimMaxCheckWidth-1:0] actual,
+                          input logic [BrAmbaSimMaxCheckWidth-1:0] expected, input string message,
+                          ref logic failed);
+    if (actual !== expected) begin
+      failed = 1'b1;
+      $error("%s: expected 0x%0h got 0x%0h", message, expected, actual);
+    end
   endtask
 
   task automatic timeout(input event tick, input int cycles, input string message,
@@ -19,6 +34,23 @@ package br_amba_sim_pkg;
       return 0;
     end
     return int'($urandom_range(max_stall_cycles, 0));
+  endfunction
+
+  function automatic logic [BrAmbaSimMaxCheckWidth-1:0] get_random_bits(input int width);
+    get_random_bits = '0;
+
+    if (width > BrAmbaSimMaxCheckWidth) begin
+      $fatal(1, "Requested %0d random bits exceeds common sim helper width %0d", width,
+             BrAmbaSimMaxCheckWidth);
+    end
+
+    for (int offset = 0; offset < width; offset += 32) begin
+      logic [31:0] word = $urandom();
+
+      for (int bit_idx = 0; bit_idx < 32 && offset + bit_idx < width; bit_idx++) begin
+        get_random_bits[offset+bit_idx] = word[bit_idx];
+      end
+    end
   endfunction
 
 endpackage : br_amba_sim_pkg

--- a/amba/sim/drivers/br_amba_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_sim_pkg.sv
@@ -14,15 +14,6 @@ package br_amba_sim_pkg;
     $error("%s", message);
   endtask
 
-  task automatic check_eq(input logic [BrAmbaSimMaxCheckWidth-1:0] actual,
-                          input logic [BrAmbaSimMaxCheckWidth-1:0] expected, input string message,
-                          ref logic failed);
-    if (actual !== expected) begin
-      failed = 1'b1;
-      $error("%s: expected 0x%0h got 0x%0h", message, expected, actual);
-    end
-  endtask
-
   task automatic timeout(input event tick, input int cycles, input string message,
                          ref logic failed);
     repeat (cycles) @tick;

--- a/amba/sim/monitors/BUILD.bazel
+++ b/amba/sim/monitors/BUILD.bazel
@@ -26,9 +26,9 @@ verilog_library(
     srcs = ["br_amba_axil_monitor.sv"],
     visibility = ["//visibility:public"],
     deps = [
+        ":br_amba_axil_monitor_sim_pkg",
         "//amba/rtl:br_amba_pkg",
         "//amba/sim/drivers:br_amba_axil_sim_pkg",
-        ":br_amba_axil_monitor_sim_pkg",
     ],
 )
 
@@ -47,10 +47,10 @@ verilog_library(
     srcs = ["br_amba_axil2apb_scoreboard.sv"],
     visibility = ["//visibility:public"],
     deps = [
+        ":br_amba_axil_monitor_sim_pkg",
         "//amba/sim:br_amba_axil2apb_sim_pkg",
         "//amba/sim/drivers:br_amba_apb_sim_pkg",
         "//amba/sim/drivers:br_amba_axil_sim_pkg",
-        ":br_amba_axil_monitor_sim_pkg",
     ],
 )
 

--- a/amba/sim/monitors/BUILD.bazel
+++ b/amba/sim/monitors/BUILD.bazel
@@ -18,6 +18,7 @@ verilog_library(
     visibility = ["//visibility:public"],
     deps = [
         "//amba/rtl:br_amba_pkg",
+        "//amba/sim/drivers:br_amba_axil_sim_pkg",
     ],
 )
 

--- a/amba/sim/monitors/BUILD.bazel
+++ b/amba/sim/monitors/BUILD.bazel
@@ -13,12 +13,44 @@ verilog_library(
 )
 
 verilog_library(
+    name = "br_amba_axil_monitor_sim_pkg",
+    srcs = ["br_amba_axil_monitor_sim_pkg.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//amba/sim/drivers:br_amba_axil_sim_pkg",
+    ],
+)
+
+verilog_library(
     name = "br_amba_axil_monitor",
     srcs = ["br_amba_axil_monitor.sv"],
     visibility = ["//visibility:public"],
     deps = [
         "//amba/rtl:br_amba_pkg",
         "//amba/sim/drivers:br_amba_axil_sim_pkg",
+        ":br_amba_axil_monitor_sim_pkg",
+    ],
+)
+
+verilog_library(
+    name = "br_amba_apb_monitor",
+    srcs = ["br_amba_apb_monitor.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//amba/rtl:br_amba_pkg",
+        "//amba/sim/drivers:br_amba_apb_sim_pkg",
+    ],
+)
+
+verilog_library(
+    name = "br_amba_axil2apb_scoreboard",
+    srcs = ["br_amba_axil2apb_scoreboard.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//amba/sim:br_amba_axil2apb_sim_pkg",
+        "//amba/sim/drivers:br_amba_apb_sim_pkg",
+        "//amba/sim/drivers:br_amba_axil_sim_pkg",
+        ":br_amba_axil_monitor_sim_pkg",
     ],
 )
 

--- a/amba/sim/monitors/BUILD.bazel
+++ b/amba/sim/monitors/BUILD.bazel
@@ -51,6 +51,7 @@ verilog_library(
         "//amba/sim:br_amba_axil2apb_sim_pkg",
         "//amba/sim/drivers:br_amba_apb_sim_pkg",
         "//amba/sim/drivers:br_amba_axil_sim_pkg",
+        "//amba/sim/drivers:br_amba_sim_pkg",
     ],
 )
 

--- a/amba/sim/monitors/br_amba_apb_monitor.sv
+++ b/amba/sim/monitors/br_amba_apb_monitor.sv
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_apb_sim_pkg::*;
+
+// APB protocol monitor.
+//
+// This monitor samples APB transfers according to PSEL/PENABLE/PREADY and checks
+// protocol-level APB sequencing rules.
+module br_amba_apb_monitor #(
+    parameter  int AddrWidth = 12,
+    parameter  int DataWidth = 32,
+    localparam int StrbWidth = DataWidth / 8
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [AddrWidth-1:0] paddr,
+    input logic psel,
+    input logic penable,
+    input logic [ApbProtWidth-1:0] pprot,
+    input logic [StrbWidth-1:0] pstrb,
+    input logic pwrite,
+    input logic [DataWidth-1:0] pwdata,
+    input logic [DataWidth-1:0] prdata,
+    input logic pready,
+    input logic pslverr,
+
+    output logic failed
+);
+
+  apb_transfer_observation_t transfer_queue[$];
+  logic request_phase_seen;
+
+  clocking cb @(posedge clk);
+    default input #1step;
+    input rst;
+    input paddr;
+    input psel;
+    input penable;
+    input pprot;
+    input pstrb;
+    input pwrite;
+    input pwdata;
+    input prdata;
+    input pready;
+    input pslverr;
+  endclocking
+
+  task automatic init_idle();
+    failed = 1'b0;
+    request_phase_seen = 1'b0;
+    transfer_queue.delete();
+  endtask
+
+  task automatic monitor_transfers();
+    apb_transfer_observation_t transfer;
+    logic transfer_active = 1'b0;
+
+    forever begin
+      @cb;
+      if (cb.rst) begin
+        transfer_active = 1'b0;
+      end else if (cb.psel && !transfer_active) begin
+        transfer.request_timestamp = $time;
+        transfer_active = 1'b1;
+      end
+
+      if (!cb.rst && cb.psel) begin
+        request_phase_seen = 1'b1;
+      end
+      if (!cb.rst && cb.psel && cb.penable && cb.pready) begin
+        transfer.packet.addr = ApbAddrWidth'(cb.paddr);
+        transfer.packet.prot = cb.pprot;
+        transfer.packet.strb = ApbStrbWidth'(cb.pstrb);
+        transfer.packet.write = cb.pwrite;
+        transfer.packet.data = cb.pwrite ? ApbDataWidth'(cb.pwdata) : ApbDataWidth'(cb.prdata);
+        transfer.packet.slverr = cb.pslverr;
+        transfer.completion_timestamp = $time;
+        transfer_queue.push_back(transfer);
+        transfer_active = 1'b0;
+      end
+    end
+  endtask
+
+  task automatic monitor_protocol();
+    logic [AddrWidth-1:0] prev_paddr = '0;
+    logic [ApbProtWidth-1:0] prev_pprot = '0;
+    logic [StrbWidth-1:0] prev_pstrb = '0;
+    logic prev_pwrite = 1'b0;
+    logic [DataWidth-1:0] prev_pwdata = '0;
+    logic [AddrWidth-1:0] setup_paddr = '0;
+    logic [ApbProtWidth-1:0] setup_pprot = '0;
+    logic [StrbWidth-1:0] setup_pstrb = '0;
+    logic setup_pwrite = 1'b0;
+    logic [DataWidth-1:0] setup_pwdata = '0;
+    logic setup_seen = 1'b0;
+    logic setup_payload_changed;
+    logic prev_psel = 1'b0;
+    logic prev_penable = 1'b0;
+    logic access_wait = 1'b0;
+
+    forever begin
+      @cb;
+      if (cb.rst) begin
+        prev_psel = 1'b0;
+        prev_penable = 1'b0;
+        access_wait = 1'b0;
+        setup_seen = 1'b0;
+      end else begin
+        if (cb.penable && !cb.psel) begin
+          failed = 1'b1;
+          $error("APB PENABLE asserted without PSEL");
+        end
+
+        if (cb.psel && !cb.penable && prev_psel && !prev_penable) begin
+          failed = 1'b1;
+          $error("APB setup phase lasted more than one cycle");
+        end
+
+        if (cb.psel && cb.penable && !(access_wait || (prev_psel && !prev_penable))) begin
+          failed = 1'b1;
+          $error("APB access phase observed without a preceding setup phase");
+        end
+
+        if (cb.psel && cb.penable && setup_seen) begin
+          setup_payload_changed = cb.paddr !== setup_paddr;
+          setup_payload_changed |= cb.pprot !== setup_pprot;
+          setup_payload_changed |= cb.pwrite !== setup_pwrite;
+          setup_payload_changed |= setup_pwrite && cb.pstrb !== setup_pstrb;
+          setup_payload_changed |= setup_pwrite && cb.pwdata !== setup_pwdata;
+
+          if (setup_payload_changed) begin
+            failed = 1'b1;
+            $error("APB request signals changed between setup and access phase");
+          end
+        end
+
+        // During APB wait states, request/control payload must remain stable
+        // until the transfer completes with PREADY. Write data and strobes are
+        // significant only for write transfers.
+        if (access_wait && !(cb.psel && cb.penable)) begin
+          failed = 1'b1;
+          $error("APB access phase ended before PREADY");
+        end else if (access_wait) begin
+          if (cb.paddr !== prev_paddr || cb.pprot !== prev_pprot || cb.pwrite !== prev_pwrite ||
+              (prev_pwrite && (cb.pstrb !== prev_pstrb || cb.pwdata !== prev_pwdata))) begin
+            failed = 1'b1;
+            $error("APB request signals changed while PREADY was low");
+          end
+        end
+
+        access_wait = cb.psel && cb.penable && !cb.pready;
+        if (access_wait) begin
+          prev_paddr  = cb.paddr;
+          prev_pprot  = cb.pprot;
+          prev_pstrb  = cb.pstrb;
+          prev_pwrite = cb.pwrite;
+          prev_pwdata = cb.pwdata;
+        end
+        if (cb.psel && !cb.penable) begin
+          setup_paddr  = cb.paddr;
+          setup_pprot  = cb.pprot;
+          setup_pstrb  = cb.pstrb;
+          setup_pwrite = cb.pwrite;
+          setup_pwdata = cb.pwdata;
+          setup_seen   = 1'b1;
+        end else if (cb.psel && cb.penable) begin
+          setup_seen = 1'b0;
+        end else begin
+          setup_seen = 1'b0;
+        end
+        prev_psel = cb.psel;
+        prev_penable = cb.penable;
+      end
+    end
+  endtask
+
+  task automatic get_observed_transfers(
+      output apb_transfer_observation_t observed_transfer_queue[$]);
+    observed_transfer_queue = transfer_queue;
+  endtask
+
+  function automatic logic saw_request_phase();
+    return request_phase_seen;
+  endfunction
+
+  task automatic run();
+    fork
+      monitor_transfers();
+      monitor_protocol();
+    join
+  endtask
+endmodule : br_amba_apb_monitor

--- a/amba/sim/monitors/br_amba_apb_timing_slice_monitor.sv
+++ b/amba/sim/monitors/br_amba_apb_timing_slice_monitor.sv
@@ -55,7 +55,7 @@ module br_amba_apb_timing_slice_monitor #(
       input logic [31:0] wdata);
     get_req.psel          = psel;
     get_req.penable       = penable;
-    get_req.request.addr  = 32'(addr);
+    get_req.request.addr  = ApbAddrWidth'(addr);
     get_req.request.prot  = prot;
     get_req.request.strb  = strb;
     get_req.request.write = write;
@@ -65,7 +65,7 @@ module br_amba_apb_timing_slice_monitor #(
   function automatic apb_response_t get_rsp(input logic ready, input logic [31:0] rdata,
                                             input logic slverr);
     get_rsp.ready  = ready;
-    get_rsp.rdata  = rdata;
+    get_rsp.rdata  = ApbDataWidth'(rdata);
     get_rsp.slverr = slverr;
   endfunction
 

--- a/amba/sim/monitors/br_amba_axil2apb_scoreboard.sv
+++ b/amba/sim/monitors/br_amba_axil2apb_scoreboard.sv
@@ -19,7 +19,6 @@ import br_amba_sim_pkg::*;
 // sides: accepted AXI-Lite request channels, completed APB transfers, and
 // returned AXI-Lite responses.
 module br_amba_axil2apb_scoreboard #(
-    parameter int DataWidth = 32,
     parameter int ClockPeriodNs = 10
 ) (
     output logic failed
@@ -46,7 +45,7 @@ module br_amba_axil2apb_scoreboard #(
 
   function automatic axil_r_t expected_r_response(input axil2apb_transaction_t transaction);
     expected_r_response = '0;
-    expected_r_response.data = AxilDataWidth'(DataWidth'(transaction.data));
+    expected_r_response.data = AxilDataWidth'(transaction.data);
     expected_r_response.resp = transaction.slverr ? AxiRespSlverr : AxiRespOkay;
   endfunction
 
@@ -66,7 +65,7 @@ module br_amba_axil2apb_scoreboard #(
     predict_read_transaction.addr   = ApbAddrWidth'(ar.addr);
     predict_read_transaction.prot   = ar.prot;
     predict_read_transaction.strb   = '0;
-    predict_read_transaction.data   = ApbDataWidth'(DataWidth'(response.rdata));
+    predict_read_transaction.data   = ApbDataWidth'(response.rdata);
     predict_read_transaction.slverr = response.slverr;
   endfunction
 

--- a/amba/sim/monitors/br_amba_axil2apb_scoreboard.sv
+++ b/amba/sim/monitors/br_amba_axil2apb_scoreboard.sv
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_apb_sim_pkg::*;
+import br_amba_axil_sim_pkg::*;
+import br_amba_axil_monitor_sim_pkg::*;
+import br_amba_axil2apb_sim_pkg::*;
+
+// br_amba_axil2apb scoreboard.
+//
+// The scoreboard predicts a protocol-agnostic expected transaction stream from
+// accepted AXI-Lite requests and the APB response policy driven by the testbench.
+// It then checks that each expected transaction is visible on both protocol
+// sides: accepted AXI-Lite request channels, completed APB transfers, and
+// returned AXI-Lite responses.
+module br_amba_axil2apb_scoreboard #(
+    parameter int DataWidth = 32,
+    parameter int ClockPeriodNs = 10
+) (
+    output logic failed
+);
+
+  task automatic init_idle();
+    failed = 1'b0;
+  endtask
+
+  function automatic apb_transfer_t expected_apb_transfer(input axil2apb_transaction_t transaction);
+    expected_apb_transfer = '0;
+    expected_apb_transfer.addr = transaction.addr;
+    expected_apb_transfer.prot = transaction.prot;
+    expected_apb_transfer.strb = transaction.strb;
+    expected_apb_transfer.write = transaction.kind == Axil2ApbTransactionWrite;
+    expected_apb_transfer.data = transaction.data;
+    expected_apb_transfer.slverr = transaction.slverr;
+  endfunction
+
+  function automatic axil_b_t expected_b_response(input axil2apb_transaction_t transaction);
+    expected_b_response = '0;
+    expected_b_response.resp = transaction.slverr ? AxiRespSlverr : AxiRespOkay;
+  endfunction
+
+  function automatic axil_r_t expected_r_response(input axil2apb_transaction_t transaction);
+    expected_r_response = '0;
+    expected_r_response.data = AxilDataWidth'(DataWidth'(transaction.data));
+    expected_r_response.resp = transaction.slverr ? AxiRespSlverr : AxiRespOkay;
+  endfunction
+
+  function automatic axil2apb_transaction_t predict_write_transaction(
+      input axil_aw_t aw, input axil_w_t w, input apb_response_t response);
+    predict_write_transaction.kind   = Axil2ApbTransactionWrite;
+    predict_write_transaction.addr   = ApbAddrWidth'(aw.addr);
+    predict_write_transaction.prot   = aw.prot;
+    predict_write_transaction.strb   = ApbStrbWidth'(w.strb);
+    predict_write_transaction.data   = ApbDataWidth'(w.data);
+    predict_write_transaction.slverr = response.slverr;
+  endfunction
+
+  function automatic axil2apb_transaction_t predict_read_transaction(input axil_ar_t ar,
+                                                                     input apb_response_t response);
+    predict_read_transaction.kind   = Axil2ApbTransactionRead;
+    predict_read_transaction.addr   = ApbAddrWidth'(ar.addr);
+    predict_read_transaction.prot   = ar.prot;
+    predict_read_transaction.strb   = '0;
+    predict_read_transaction.data   = ApbDataWidth'(DataWidth'(response.rdata));
+    predict_read_transaction.slverr = response.slverr;
+  endfunction
+
+  task automatic check_queue_sizes(input int expected_size, input int observed_size,
+                                   input string channel_name, inout logic sizes_match);
+    if (expected_size != observed_size) begin
+      failed = 1'b1;
+      sizes_match = 1'b0;
+      $error("%s queue size mismatch: expected %0d observed %0d", channel_name, expected_size,
+             observed_size);
+    end
+  endtask
+
+  task automatic predict_transactions(
+      input axil_aw_observation_t observed_aw_queue[$],
+      input axil_w_observation_t observed_w_queue[$],
+      input axil_ar_observation_t observed_ar_queue[$], input apb_response_t response_queue[$],
+      output axil2apb_transaction_t expected_transaction_queue[$], output logic prediction_valid);
+    int   write_index = 0;
+    int   read_index = 0;
+    int   response_index = 0;
+    logic last_read_grant = 1'b0;
+
+    expected_transaction_queue.delete();
+    prediction_valid = 1'b1;
+
+    while ((write_index < observed_aw_queue.size() && write_index < observed_w_queue.size()) ||
+           read_index < observed_ar_queue.size()) begin
+      logic has_write = write_index < observed_aw_queue.size() &&
+                        write_index < observed_w_queue.size();
+      logic has_read = read_index < observed_ar_queue.size();
+      time write_timestamp;
+      time read_timestamp;
+      logic choose_read;
+
+      if (response_index >= response_queue.size()) begin
+        failed = 1'b1;
+        prediction_valid = 1'b0;
+        $error("The test did not provide enough APB responses for the observed AXI-Lite traffic");
+        return;
+      end
+
+      write_timestamp = has_write ? (observed_aw_queue[write_index].timestamp >
+              observed_w_queue[write_index].timestamp ? observed_aw_queue[write_index].timestamp :
+              observed_w_queue[write_index].timestamp) : 0;
+      read_timestamp = has_read ? observed_ar_queue[read_index].timestamp : 0;
+
+      // Writes become eligible only after both AW and W handshakes. If read and
+      // write requests become eligible in the same sampled cycle, match the
+      // bridge's round-robin state: read has reset priority, then the previous
+      // grant becomes lowest priority.
+      if (has_read && has_write && read_timestamp == write_timestamp) begin
+        choose_read = !last_read_grant;
+      end else begin
+        choose_read = has_read && (!has_write || read_timestamp < write_timestamp);
+      end
+
+      if (choose_read) begin
+        expected_transaction_queue.push_back(
+            predict_read_transaction(
+            observed_ar_queue[read_index].packet, response_queue[response_index]));
+        read_index++;
+        last_read_grant = 1'b1;
+      end else begin
+        expected_transaction_queue.push_back(predict_write_transaction(
+                                             observed_aw_queue[write_index].packet,
+                                             observed_w_queue[write_index].packet,
+                                             response_queue[response_index]
+                                             ));
+        write_index++;
+        last_read_grant = 1'b0;
+      end
+      response_index++;
+    end
+
+    if (response_index != response_queue.size()) begin
+      failed = 1'b1;
+      prediction_valid = 1'b0;
+      $error(
+          "The test provided %0d APB responses, but only %0d AXI-Lite transactions were observed",
+          response_queue.size(), response_index);
+    end
+  endtask
+
+  task automatic check_apb_transfer(input axil2apb_transaction_t expected_transaction,
+                                    input apb_transfer_observation_t observed_transfer,
+                                    input int transaction_index, inout int mismatch_count);
+    apb_transfer_t expected_transfer = expected_apb_transfer(expected_transaction);
+
+    if (expected_transfer.addr !== observed_transfer.packet.addr ||
+        expected_transfer.prot !== observed_transfer.packet.prot ||
+        expected_transfer.strb !== observed_transfer.packet.strb ||
+        expected_transfer.write !== observed_transfer.packet.write ||
+        expected_transfer.data !== observed_transfer.packet.data ||
+        expected_transfer.slverr !== observed_transfer.packet.slverr) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error("APB transfer mismatch at transaction %0d", transaction_index);
+      $error("Expected APB: addr=0x%0h prot=0x%0h strb=0x%0h write=%0b data=0x%0h slverr=%0b",
+             expected_transfer.addr, expected_transfer.prot, expected_transfer.strb,
+             expected_transfer.write, expected_transfer.data, expected_transfer.slverr);
+      $error("Observed APB: addr=0x%0h prot=0x%0h strb=0x%0h write=%0b data=0x%0h slverr=%0b",
+             observed_transfer.packet.addr, observed_transfer.packet.prot,
+             observed_transfer.packet.strb, observed_transfer.packet.write,
+             observed_transfer.packet.data, observed_transfer.packet.slverr);
+    end
+  endtask
+
+  task automatic check_write_apb_timing(
+      input apb_transfer_observation_t observed_apb, input axil_aw_observation_t observed_aw,
+      input axil_w_observation_t observed_w, input int write_index, inout int mismatch_count);
+    time request_timestamp;
+    time expected_apb_timestamp;
+
+    request_timestamp = observed_aw.timestamp > observed_w.timestamp ? observed_aw.timestamp :
+                                                                     observed_w.timestamp;
+    expected_apb_timestamp = request_timestamp + ClockPeriodNs;
+    if (observed_apb.request_timestamp != expected_apb_timestamp) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error({"APB write request %0d was not observed one clock after AXI-Lite AW/W completed: ",
+              "apb=%0t expected=%0t aw=%0t w=%0t"}, write_index, observed_apb.request_timestamp,
+               expected_apb_timestamp, observed_aw.timestamp, observed_w.timestamp);
+    end
+  endtask
+
+  task automatic check_read_apb_timing(input apb_transfer_observation_t observed_apb,
+                                       input axil_ar_observation_t observed_ar,
+                                       input int read_index, inout int mismatch_count);
+    time expected_apb_timestamp = observed_ar.timestamp + ClockPeriodNs;
+
+    if (observed_apb.request_timestamp != expected_apb_timestamp) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error({"APB read request %0d was not observed one clock after AXI-Lite AR completed: ",
+              "apb=%0t expected=%0t ar=%0t"}, read_index, observed_apb.request_timestamp,
+               expected_apb_timestamp, observed_ar.timestamp);
+    end
+  endtask
+
+  task automatic check_write_request(
+      input axil2apb_transaction_t expected_transaction, input axil_aw_observation_t observed_aw,
+      input axil_w_observation_t observed_w, input int write_index, inout int mismatch_count);
+    if (observed_aw.packet.addr !== AxilAddrWidth'(expected_transaction.addr) ||
+        observed_aw.packet.prot !== expected_transaction.prot) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error("AXI-Lite AW request mismatch at write %0d", write_index);
+    end
+
+    if (observed_w.packet.data !== AxilDataWidth'(expected_transaction.data) ||
+        observed_w.packet.strb !== AxilStrobeWidth'(expected_transaction.strb)) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error("AXI-Lite W request mismatch at write %0d", write_index);
+    end
+  endtask
+
+  task automatic check_read_request(input axil2apb_transaction_t expected_transaction,
+                                    input axil_ar_observation_t observed_ar, input int read_index,
+                                    inout int mismatch_count);
+    if (observed_ar.packet.addr !== AxilAddrWidth'(expected_transaction.addr) ||
+        observed_ar.packet.prot !== expected_transaction.prot) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error("AXI-Lite AR request mismatch at read %0d", read_index);
+    end
+  endtask
+
+  task automatic check_write_response(input axil2apb_transaction_t expected_transaction,
+                                      input apb_transfer_observation_t observed_apb,
+                                      input axil_b_observation_t observed_b, input int write_index,
+                                      inout int mismatch_count);
+    axil_b_t expected_b = expected_b_response(expected_transaction);
+
+    if (expected_b !== observed_b.packet) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error("AXI-Lite B response mismatch at write %0d: expected 0x%0h observed 0x%0h",
+             write_index, expected_b, observed_b.packet);
+    end
+
+    if (observed_b.timestamp <= observed_apb.completion_timestamp) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error(
+          "AXI-Lite B response at write %0d was not observed after APB completion: b=%0t apb=%0t",
+          write_index, observed_b.timestamp, observed_apb.completion_timestamp);
+    end
+  endtask
+
+  task automatic check_read_response(input axil2apb_transaction_t expected_transaction,
+                                     input apb_transfer_observation_t observed_apb,
+                                     input axil_r_observation_t observed_r, input int read_index,
+                                     inout int mismatch_count);
+    axil_r_t expected_r = expected_r_response(expected_transaction);
+
+    if (expected_r !== observed_r.packet) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error("AXI-Lite R response mismatch at read %0d: expected 0x%0h observed 0x%0h", read_index,
+             expected_r, observed_r.packet);
+    end
+
+    if (observed_r.timestamp <= observed_apb.completion_timestamp) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error("AXI-Lite R response at read %0d was not observed after APB completion: r=%0t apb=%0t",
+             read_index, observed_r.timestamp, observed_apb.completion_timestamp);
+    end
+  endtask
+
+  task automatic check_read_write_priority(
+      input axil_request_state_observation_t observed_request_state_queue[$],
+      input axil2apb_transaction_t expected_transaction_queue[$],
+      input axil_b_observation_t observed_b_queue[$],
+      input axil_r_observation_t observed_r_queue[$], inout int mismatch_count);
+    logic last_read_grant = 1'b0;
+    time  bridge_available_timestamp = 0;
+    int   transaction_index = 0;
+    int   write_response_index = 0;
+    int   read_response_index = 0;
+
+    foreach (observed_request_state_queue[i]) begin
+      axil_request_state_observation_t request_state = observed_request_state_queue[i];
+      logic write_eligible = request_state.awvalid && request_state.wvalid;
+      logic read_eligible = request_state.arvalid;
+      logic write_grant = request_state.awready && request_state.wready;
+      logic read_grant = request_state.arready;
+
+      if (request_state.timestamp >= bridge_available_timestamp && (write_eligible ||
+                                                                    read_eligible)) begin
+        logic expect_read_grant = read_eligible && (!write_eligible || !last_read_grant);
+        logic expect_write_grant = write_eligible && (!read_eligible || last_read_grant);
+
+        if (expect_read_grant && (!read_grant || write_grant)) begin
+          failed = 1'b1;
+          mismatch_count++;
+          $error("AXI-Lite arbitration mismatch at %0t: expected read grant",
+                 request_state.timestamp);
+        end else if (expect_write_grant && (!write_grant || read_grant)) begin
+          failed = 1'b1;
+          mismatch_count++;
+          $error("AXI-Lite arbitration mismatch at %0t: expected write grant",
+                 request_state.timestamp);
+        end
+      end
+
+      if (!read_grant && !write_grant) begin
+        continue;
+      end
+
+      if (read_grant && write_grant) begin
+        failed = 1'b1;
+        mismatch_count++;
+        $error("AXI-Lite read and write grants were observed in the same cycle");
+        continue;
+      end else if (transaction_index >= expected_transaction_queue.size()) begin
+        failed = 1'b1;
+        mismatch_count++;
+        $error("AXI-Lite grant observed after all expected bridge transactions were complete");
+        continue;
+      end else if (write_grant &&
+                   expected_transaction_queue[transaction_index].kind !=
+                       Axil2ApbTransactionWrite) begin
+        failed = 1'b1;
+        mismatch_count++;
+        $error("AXI-Lite write grant observed when the scoreboard expected a read grant");
+        continue;
+      end else if (read_grant &&
+                   expected_transaction_queue[transaction_index].kind !=
+                       Axil2ApbTransactionRead) begin
+        failed = 1'b1;
+        mismatch_count++;
+        $error("AXI-Lite read grant observed when the scoreboard expected a write grant");
+        continue;
+      end
+
+      if (write_grant) begin
+        if (write_response_index >= observed_b_queue.size()) begin
+          failed = 1'b1;
+          mismatch_count++;
+          $error("AXI-Lite write grant at %0t did not produce a matching B response",
+                 request_state.timestamp);
+          continue;
+        end
+        bridge_available_timestamp = observed_b_queue[write_response_index].timestamp +
+                                     ClockPeriodNs;
+        write_response_index++;
+        last_read_grant = 1'b0;
+      end else begin
+        if (read_response_index >= observed_r_queue.size()) begin
+          failed = 1'b1;
+          mismatch_count++;
+          $error("AXI-Lite read grant at %0t did not produce a matching R response",
+                 request_state.timestamp);
+          continue;
+        end
+        bridge_available_timestamp = observed_r_queue[read_response_index].timestamp +
+                                     ClockPeriodNs;
+        read_response_index++;
+        last_read_grant = 1'b1;
+      end
+      transaction_index++;
+    end
+  endtask
+
+  task automatic compare(input axil_request_state_observation_t observed_request_state_queue[$],
+                         input axil_aw_observation_t observed_aw_queue[$],
+                         input axil_w_observation_t observed_w_queue[$],
+                         input axil_ar_observation_t observed_ar_queue[$],
+                         input apb_response_t response_queue[$],
+                         input apb_transfer_observation_t observed_apb_queue[$],
+                         input axil_b_observation_t observed_b_queue[$],
+                         input axil_r_observation_t observed_r_queue[$]);
+    axil2apb_transaction_t expected_transaction_queue[$];
+    int expected_write_count = 0;
+    int expected_read_count = 0;
+    int write_index = 0;
+    int read_index = 0;
+    int mismatch_count = 0;
+    logic sizes_match = 1'b1;
+    logic prediction_valid;
+
+    check_queue_sizes(observed_aw_queue.size(), observed_w_queue.size(),
+                      "AXI-Lite AW/W write request", sizes_match);
+    if (!sizes_match) begin
+      return;
+    end
+
+    predict_transactions(observed_aw_queue, observed_w_queue, observed_ar_queue, response_queue,
+                         expected_transaction_queue, prediction_valid);
+    if (!prediction_valid) begin
+      return;
+    end
+
+    foreach (expected_transaction_queue[i]) begin
+      if (expected_transaction_queue[i].kind == Axil2ApbTransactionWrite) begin
+        expected_write_count++;
+      end else begin
+        expected_read_count++;
+      end
+    end
+
+    check_queue_sizes(expected_transaction_queue.size(), observed_apb_queue.size(), "APB transfer",
+                      sizes_match);
+    check_queue_sizes(expected_write_count, observed_aw_queue.size(), "AXI-Lite AW request",
+                      sizes_match);
+    check_queue_sizes(expected_write_count, observed_w_queue.size(), "AXI-Lite W request",
+                      sizes_match);
+    check_queue_sizes(expected_write_count, observed_b_queue.size(), "AXI-Lite B response",
+                      sizes_match);
+    check_queue_sizes(expected_read_count, observed_ar_queue.size(), "AXI-Lite AR request",
+                      sizes_match);
+    check_queue_sizes(expected_read_count, observed_r_queue.size(), "AXI-Lite R response",
+                      sizes_match);
+    if (!sizes_match) begin
+      return;
+    end
+
+    check_read_write_priority(observed_request_state_queue, expected_transaction_queue,
+                              observed_b_queue, observed_r_queue, mismatch_count);
+
+    foreach (expected_transaction_queue[transaction_index]) begin
+      axil2apb_transaction_t expected_transaction;
+
+      expected_transaction = expected_transaction_queue[transaction_index];
+      check_apb_transfer(expected_transaction, observed_apb_queue[transaction_index],
+                         transaction_index, mismatch_count);
+
+      if (expected_transaction.kind == Axil2ApbTransactionWrite) begin
+        check_write_request(expected_transaction, observed_aw_queue[write_index],
+                            observed_w_queue[write_index], write_index, mismatch_count);
+        check_write_apb_timing(observed_apb_queue[transaction_index],
+                               observed_aw_queue[write_index], observed_w_queue[write_index],
+                               write_index, mismatch_count);
+        check_write_response(expected_transaction, observed_apb_queue[transaction_index],
+                             observed_b_queue[write_index], write_index, mismatch_count);
+        write_index++;
+      end else begin
+        check_read_request(expected_transaction, observed_ar_queue[read_index], read_index,
+                           mismatch_count);
+        check_read_apb_timing(observed_apb_queue[transaction_index], observed_ar_queue[read_index],
+                              read_index, mismatch_count);
+        check_read_response(expected_transaction, observed_apb_queue[transaction_index],
+                            observed_r_queue[read_index], read_index, mismatch_count);
+        read_index++;
+      end
+    end
+
+    if (mismatch_count != 0) begin
+      $error("br_amba_axil2apb scoreboard found %0d item mismatches", mismatch_count);
+    end
+  endtask
+endmodule : br_amba_axil2apb_scoreboard

--- a/amba/sim/monitors/br_amba_axil2apb_scoreboard.sv
+++ b/amba/sim/monitors/br_amba_axil2apb_scoreboard.sv
@@ -7,6 +7,9 @@ import br_amba_apb_sim_pkg::*;
 import br_amba_axil_sim_pkg::*;
 import br_amba_axil_monitor_sim_pkg::*;
 import br_amba_axil2apb_sim_pkg::*;
+import br_amba_sim_pkg::*;
+
+`include "br_amba_sim_macros.svh"
 
 // br_amba_axil2apb scoreboard.
 //
@@ -153,23 +156,11 @@ module br_amba_axil2apb_scoreboard #(
                                     input int transaction_index, inout int mismatch_count);
     apb_transfer_t expected_transfer = expected_apb_transfer(expected_transaction);
 
-    if (expected_transfer.addr !== observed_transfer.packet.addr ||
-        expected_transfer.prot !== observed_transfer.packet.prot ||
-        expected_transfer.strb !== observed_transfer.packet.strb ||
-        expected_transfer.write !== observed_transfer.packet.write ||
-        expected_transfer.data !== observed_transfer.packet.data ||
-        expected_transfer.slverr !== observed_transfer.packet.slverr) begin
-      failed = 1'b1;
+    if (observed_transfer.packet !== expected_transfer) begin
       mismatch_count++;
-      $error("APB transfer mismatch at transaction %0d", transaction_index);
-      $error("Expected APB: addr=0x%0h prot=0x%0h strb=0x%0h write=%0b data=0x%0h slverr=%0b",
-             expected_transfer.addr, expected_transfer.prot, expected_transfer.strb,
-             expected_transfer.write, expected_transfer.data, expected_transfer.slverr);
-      $error("Observed APB: addr=0x%0h prot=0x%0h strb=0x%0h write=%0b data=0x%0h slverr=%0b",
-             observed_transfer.packet.addr, observed_transfer.packet.prot,
-             observed_transfer.packet.strb, observed_transfer.packet.write,
-             observed_transfer.packet.data, observed_transfer.packet.slverr);
     end
+    `BR_AMBA_SIM_CHECK_EQ(observed_transfer.packet, expected_transfer, $sformatf(
+                          "APB transfer mismatch at transaction %0d", transaction_index), failed);
   endtask
 
   task automatic check_write_apb_timing(
@@ -182,12 +173,15 @@ module br_amba_axil2apb_scoreboard #(
                                                                      observed_w.timestamp;
     expected_apb_timestamp = request_timestamp + ClockPeriodNs;
     if (observed_apb.request_timestamp != expected_apb_timestamp) begin
-      failed = 1'b1;
       mismatch_count++;
-      $error({"APB write request %0d was not observed one clock after AXI-Lite AW/W completed: ",
-              "apb=%0t expected=%0t aw=%0t w=%0t"}, write_index, observed_apb.request_timestamp,
-               expected_apb_timestamp, observed_aw.timestamp, observed_w.timestamp);
     end
+    `BR_AMBA_SIM_CHECK_EQ(observed_apb.request_timestamp, expected_apb_timestamp, $sformatf(
+                          {
+                            "APB write request %0d was not observed one clock after ",
+                            "AXI-Lite AW/W completed"
+                          },
+                          write_index
+                          ), failed);
   endtask
 
   task automatic check_read_apb_timing(input apb_transfer_observation_t observed_apb,
@@ -196,41 +190,57 @@ module br_amba_axil2apb_scoreboard #(
     time expected_apb_timestamp = observed_ar.timestamp + ClockPeriodNs;
 
     if (observed_apb.request_timestamp != expected_apb_timestamp) begin
-      failed = 1'b1;
       mismatch_count++;
-      $error({"APB read request %0d was not observed one clock after AXI-Lite AR completed: ",
-              "apb=%0t expected=%0t ar=%0t"}, read_index, observed_apb.request_timestamp,
-               expected_apb_timestamp, observed_ar.timestamp);
     end
+    `BR_AMBA_SIM_CHECK_EQ(observed_apb.request_timestamp, expected_apb_timestamp, $sformatf(
+                          {
+                            "APB read request %0d was not observed one clock after ",
+                            "AXI-Lite AR completed"
+                          },
+                          read_index
+                          ), failed);
   endtask
 
   task automatic check_write_request(
       input axil2apb_transaction_t expected_transaction, input axil_aw_observation_t observed_aw,
       input axil_w_observation_t observed_w, input int write_index, inout int mismatch_count);
-    if (observed_aw.packet.addr !== AxilAddrWidth'(expected_transaction.addr) ||
-        observed_aw.packet.prot !== expected_transaction.prot) begin
-      failed = 1'b1;
-      mismatch_count++;
-      $error("AXI-Lite AW request mismatch at write %0d", write_index);
-    end
+    axil_aw_t expected_aw;
+    axil_w_t  expected_w;
 
-    if (observed_w.packet.data !== AxilDataWidth'(expected_transaction.data) ||
-        observed_w.packet.strb !== AxilStrobeWidth'(expected_transaction.strb)) begin
-      failed = 1'b1;
+    expected_aw = '0;
+    expected_aw.addr = AxilAddrWidth'(expected_transaction.addr);
+    expected_aw.prot = expected_transaction.prot;
+
+    expected_w = '0;
+    expected_w.data = AxilDataWidth'(expected_transaction.data);
+    expected_w.strb = AxilStrobeWidth'(expected_transaction.strb);
+
+    if (observed_aw.packet !== expected_aw) begin
       mismatch_count++;
-      $error("AXI-Lite W request mismatch at write %0d", write_index);
     end
+    `BR_AMBA_SIM_CHECK_EQ(observed_aw.packet, expected_aw, $sformatf(
+                          "AXI-Lite AW request mismatch at write %0d", write_index), failed);
+    if (observed_w.packet !== expected_w) begin
+      mismatch_count++;
+    end
+    `BR_AMBA_SIM_CHECK_EQ(observed_w.packet, expected_w, $sformatf(
+                          "AXI-Lite W request mismatch at write %0d", write_index), failed);
   endtask
 
   task automatic check_read_request(input axil2apb_transaction_t expected_transaction,
                                     input axil_ar_observation_t observed_ar, input int read_index,
                                     inout int mismatch_count);
-    if (observed_ar.packet.addr !== AxilAddrWidth'(expected_transaction.addr) ||
-        observed_ar.packet.prot !== expected_transaction.prot) begin
-      failed = 1'b1;
+    axil_ar_t expected_ar;
+
+    expected_ar = '0;
+    expected_ar.addr = AxilAddrWidth'(expected_transaction.addr);
+    expected_ar.prot = expected_transaction.prot;
+
+    if (observed_ar.packet !== expected_ar) begin
       mismatch_count++;
-      $error("AXI-Lite AR request mismatch at read %0d", read_index);
     end
+    `BR_AMBA_SIM_CHECK_EQ(observed_ar.packet, expected_ar, $sformatf(
+                          "AXI-Lite AR request mismatch at read %0d", read_index), failed);
   endtask
 
   task automatic check_write_response(input axil2apb_transaction_t expected_transaction,
@@ -241,19 +251,21 @@ module br_amba_axil2apb_scoreboard #(
     time expected_bvalid_timestamp = observed_apb.completion_timestamp + ClockPeriodNs;
 
     if (expected_b !== observed_b.packet) begin
-      failed = 1'b1;
       mismatch_count++;
-      $error("AXI-Lite B response mismatch at write %0d: expected 0x%0h observed 0x%0h",
-             write_index, expected_b, observed_b.packet);
     end
+    `BR_AMBA_SIM_CHECK_EQ(observed_b.packet, expected_b, $sformatf(
+                          "AXI-Lite B response mismatch at write %0d", write_index), failed);
 
     if (observed_b.valid_timestamp != expected_bvalid_timestamp) begin
-      failed = 1'b1;
       mismatch_count++;
-      $error({"AXI-Lite BVALID at write %0d was not observed one clock after APB completion: ",
-              "bvalid=%0t expected=%0t apb=%0t"}, write_index, observed_b.valid_timestamp,
-               expected_bvalid_timestamp, observed_apb.completion_timestamp);
     end
+    `BR_AMBA_SIM_CHECK_EQ(observed_b.valid_timestamp, expected_bvalid_timestamp, $sformatf(
+                          {
+                            "AXI-Lite BVALID at write %0d was not observed one clock ",
+                            "after APB completion"
+                          },
+                          write_index
+                          ), failed);
 
     if (observed_b.timestamp < observed_b.valid_timestamp) begin
       failed = 1'b1;
@@ -271,19 +283,21 @@ module br_amba_axil2apb_scoreboard #(
     time expected_rvalid_timestamp = observed_apb.completion_timestamp + ClockPeriodNs;
 
     if (expected_r !== observed_r.packet) begin
-      failed = 1'b1;
       mismatch_count++;
-      $error("AXI-Lite R response mismatch at read %0d: expected 0x%0h observed 0x%0h", read_index,
-             expected_r, observed_r.packet);
     end
+    `BR_AMBA_SIM_CHECK_EQ(observed_r.packet, expected_r, $sformatf(
+                          "AXI-Lite R response mismatch at read %0d", read_index), failed);
 
     if (observed_r.valid_timestamp != expected_rvalid_timestamp) begin
-      failed = 1'b1;
       mismatch_count++;
-      $error({"AXI-Lite RVALID at read %0d was not observed one clock after APB completion: ",
-              "rvalid=%0t expected=%0t apb=%0t"}, read_index, observed_r.valid_timestamp,
-               expected_rvalid_timestamp, observed_apb.completion_timestamp);
     end
+    `BR_AMBA_SIM_CHECK_EQ(observed_r.valid_timestamp, expected_rvalid_timestamp, $sformatf(
+                          {
+                            "AXI-Lite RVALID at read %0d was not observed one clock ",
+                            "after APB completion"
+                          },
+                          read_index
+                          ), failed);
 
     if (observed_r.timestamp < observed_r.valid_timestamp) begin
       failed = 1'b1;

--- a/amba/sim/monitors/br_amba_axil2apb_scoreboard.sv
+++ b/amba/sim/monitors/br_amba_axil2apb_scoreboard.sv
@@ -238,6 +238,7 @@ module br_amba_axil2apb_scoreboard #(
                                       input axil_b_observation_t observed_b, input int write_index,
                                       inout int mismatch_count);
     axil_b_t expected_b = expected_b_response(expected_transaction);
+    time expected_bvalid_timestamp = observed_apb.completion_timestamp + ClockPeriodNs;
 
     if (expected_b !== observed_b.packet) begin
       failed = 1'b1;
@@ -246,12 +247,19 @@ module br_amba_axil2apb_scoreboard #(
              write_index, expected_b, observed_b.packet);
     end
 
-    if (observed_b.timestamp <= observed_apb.completion_timestamp) begin
+    if (observed_b.valid_timestamp != expected_bvalid_timestamp) begin
       failed = 1'b1;
       mismatch_count++;
-      $error(
-          "AXI-Lite B response at write %0d was not observed after APB completion: b=%0t apb=%0t",
-          write_index, observed_b.timestamp, observed_apb.completion_timestamp);
+      $error({"AXI-Lite BVALID at write %0d was not observed one clock after APB completion: ",
+              "bvalid=%0t expected=%0t apb=%0t"}, write_index, observed_b.valid_timestamp,
+               expected_bvalid_timestamp, observed_apb.completion_timestamp);
+    end
+
+    if (observed_b.timestamp < observed_b.valid_timestamp) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error("AXI-Lite B handshake at write %0d was observed before BVALID: b=%0t bvalid=%0t",
+             write_index, observed_b.timestamp, observed_b.valid_timestamp);
     end
   endtask
 
@@ -260,6 +268,7 @@ module br_amba_axil2apb_scoreboard #(
                                      input axil_r_observation_t observed_r, input int read_index,
                                      inout int mismatch_count);
     axil_r_t expected_r = expected_r_response(expected_transaction);
+    time expected_rvalid_timestamp = observed_apb.completion_timestamp + ClockPeriodNs;
 
     if (expected_r !== observed_r.packet) begin
       failed = 1'b1;
@@ -268,11 +277,19 @@ module br_amba_axil2apb_scoreboard #(
              expected_r, observed_r.packet);
     end
 
-    if (observed_r.timestamp <= observed_apb.completion_timestamp) begin
+    if (observed_r.valid_timestamp != expected_rvalid_timestamp) begin
       failed = 1'b1;
       mismatch_count++;
-      $error("AXI-Lite R response at read %0d was not observed after APB completion: r=%0t apb=%0t",
-             read_index, observed_r.timestamp, observed_apb.completion_timestamp);
+      $error({"AXI-Lite RVALID at read %0d was not observed one clock after APB completion: ",
+              "rvalid=%0t expected=%0t apb=%0t"}, read_index, observed_r.valid_timestamp,
+               expected_rvalid_timestamp, observed_apb.completion_timestamp);
+    end
+
+    if (observed_r.timestamp < observed_r.valid_timestamp) begin
+      failed = 1'b1;
+      mismatch_count++;
+      $error("AXI-Lite R handshake at read %0d was observed before RVALID: r=%0t rvalid=%0t",
+             read_index, observed_r.timestamp, observed_r.valid_timestamp);
     end
   endtask
 
@@ -316,7 +333,12 @@ module br_amba_axil2apb_scoreboard #(
         continue;
       end
 
-      if (read_grant && write_grant) begin
+      if (request_state.timestamp < bridge_available_timestamp) begin
+        failed = 1'b1;
+        mismatch_count++;
+        $error("AXI-Lite grant observed before the bridge completed the previous transaction");
+        continue;
+      end else if (read_grant && write_grant) begin
         failed = 1'b1;
         mismatch_count++;
         $error("AXI-Lite read and write grants were observed in the same cycle");

--- a/amba/sim/monitors/br_amba_axil_monitor.sv
+++ b/amba/sim/monitors/br_amba_axil_monitor.sv
@@ -3,117 +3,226 @@
 `timescale 1ns / 1ps
 
 import br_amba::*;
+import br_amba_axil_sim_pkg::*;
 
-// AXI-Lite default-target response monitor.
+// AXI4-Lite protocol monitor skeleton.
 //
-// This is not a generic AXI-Lite bus monitor. It checks the specific
-// br_amba_axil_default_target contract: writes respond only after both write channels
-// are accepted, reads return the configured default data, and all responses use the
-// expected response code.
+// This monitor samples all AXI4-Lite channels according to ready/valid and records
+// packaged observations. It does not compare expected behavior.
 module br_amba_axil_monitor #(
-    parameter int DataWidth = 32,
-    parameter logic [AxiRespWidth-1:0] ExpectedResp = AxiRespDecerr,
-    parameter logic [DataWidth-1:0] DefaultReadData = '0
+    parameter  int AddrWidth   = 12,
+    parameter  int DataWidth   = 32,
+    parameter  int AWUserWidth = 1,
+    parameter  int WUserWidth  = 1,
+    parameter  int BUserWidth  = 1,
+    parameter  int ARUserWidth = 1,
+    parameter  int RUserWidth  = 1,
+    localparam int StrbWidth   = DataWidth / 8
 ) (
     input logic clk,
     input logic rst,
 
-    input logic target_awvalid,
-    input logic target_awready,
-    input logic target_wvalid,
-    input logic target_wready,
-    input logic [AxiRespWidth-1:0] target_bresp,
-    input logic target_bvalid,
-    input logic target_bready,
-    input logic target_arvalid,
-    input logic target_arready,
-    input logic [DataWidth-1:0] target_rdata,
-    input logic [AxiRespWidth-1:0] target_rresp,
-    input logic target_rvalid,
-    input logic target_rready,
+    input logic [AddrWidth-1:0] axil_awaddr,
+    input logic [AxiProtWidth-1:0] axil_awprot,
+    input logic [AWUserWidth-1:0] axil_awuser,
+    input logic axil_awvalid,
+    input logic axil_awready,
+    input logic [DataWidth-1:0] axil_wdata,
+    input logic [StrbWidth-1:0] axil_wstrb,
+    input logic [WUserWidth-1:0] axil_wuser,
+    input logic axil_wvalid,
+    input logic axil_wready,
+    input logic [AxiRespWidth-1:0] axil_bresp,
+    input logic [BUserWidth-1:0] axil_buser,
+    input logic axil_bvalid,
+    input logic axil_bready,
+    input logic [AddrWidth-1:0] axil_araddr,
+    input logic [AxiProtWidth-1:0] axil_arprot,
+    input logic [ARUserWidth-1:0] axil_aruser,
+    input logic axil_arvalid,
+    input logic axil_arready,
+    input logic [DataWidth-1:0] axil_rdata,
+    input logic [AxiRespWidth-1:0] axil_rresp,
+    input logic [RUserWidth-1:0] axil_ruser,
+    input logic axil_rvalid,
+    input logic axil_rready,
 
     output logic failed
 );
 
-  task automatic check(input logic condition, input string message = "Check failed");
-    if (!condition) begin
-      failed = 1'b1;
-      $error("%s", message);
-    end
-  endtask
+  axil_aw_t aw_queue[$];
+  axil_w_t w_queue[$];
+  axil_b_t b_queue[$];
+  axil_ar_t ar_queue[$];
+  axil_r_t r_queue[$];
+  axil_transaction_kind_t transaction_order_queue[$];
+  event posedge_clk;
+
+  clocking cb @(posedge clk);
+    default input #1step;
+    input axil_awaddr;
+    input axil_awprot;
+    input axil_awuser;
+    input axil_awvalid;
+    input axil_awready;
+    input axil_wdata;
+    input axil_wstrb;
+    input axil_wuser;
+    input axil_wvalid;
+    input axil_wready;
+    input axil_bresp;
+    input axil_buser;
+    input axil_bvalid;
+    input axil_bready;
+    input axil_araddr;
+    input axil_arprot;
+    input axil_aruser;
+    input axil_arvalid;
+    input axil_arready;
+    input axil_rdata;
+    input axil_rresp;
+    input axil_ruser;
+    input axil_rvalid;
+    input axil_rready;
+  endclocking
+
+  always @(posedge clk) begin
+    ->posedge_clk;
+  end
 
   task automatic init_idle();
     failed = 1'b0;
+    aw_queue.delete();
+    w_queue.delete();
+    b_queue.delete();
+    ar_queue.delete();
+    r_queue.delete();
+    transaction_order_queue.delete();
   endtask
 
-  task automatic wait_cycles(input int cycles = 1);
-    repeat (cycles) @(negedge clk);
-  endtask
+  task automatic monitor_aw_channel();
+    axil_aw_t aw;
 
-  task automatic check_no_bvalid_after_first_write_channel(input int awvalid_delay,
-                                                           input int wvalid_delay);
-    if (awvalid_delay < wvalid_delay) begin
-      wait (target_awvalid && target_awready);
-      wait_cycles();
-      check(!target_bvalid, "B valid asserted before write data was accepted");
-    end else if (wvalid_delay < awvalid_delay) begin
-      wait (target_wvalid && target_wready);
-      wait_cycles();
-      check(!target_bvalid, "B valid asserted before write address was accepted");
+    forever begin
+      @cb;
+      if (cb.axil_awvalid && cb.axil_awready) begin
+        aw.addr = AxilAddrWidth'(cb.axil_awaddr);
+        aw.prot = cb.axil_awprot;
+        aw.user = AxilUserWidth'(cb.axil_awuser);
+        aw_queue.push_back(aw);
+      end
     end
   endtask
 
-  task automatic monitor_b_response(input bit is_final);
-    // Wait for a completed B-channel transfer before checking the sampled response.
-    @(posedge clk);
-    while (!(target_bvalid && target_bready)) begin
-      @(posedge clk);
-    end
+  task automatic monitor_w_channel();
+    axil_w_t w;
 
-    check(target_bresp === ExpectedResp, $sformatf(
-          "%s: expected 0x%0h got 0x%0h", "B response mismatch", ExpectedResp, target_bresp));
-    if (is_final) begin
-      @(negedge clk);
-      check(!target_bvalid, "B valid remained asserted after final response handshake");
-    end
-  endtask
-
-  task automatic monitor_r_response(input bit is_final);
-    // Wait for a completed R-channel transfer before checking response and read data.
-    @(posedge clk);
-    while (!(target_rvalid && target_rready)) begin
-      @(posedge clk);
-    end
-
-    check(target_rresp === ExpectedResp, $sformatf(
-          "%s: expected 0x%0h got 0x%0h", "R response mismatch", ExpectedResp, target_rresp));
-    check(target_rdata === DefaultReadData, $sformatf(
-          "%s: expected 0x%0h got 0x%0h", "R data mismatch", DefaultReadData, target_rdata));
-    if (is_final) begin
-      @(negedge clk);
-      check(!target_rvalid, "R valid remained asserted after final response handshake");
+    forever begin
+      @cb;
+      if (cb.axil_wvalid && cb.axil_wready) begin
+        w.data = AxilDataWidth'(cb.axil_wdata);
+        w.strb = AxilStrobeWidth'(cb.axil_wstrb);
+        w.user = AxilUserWidth'(cb.axil_wuser);
+        w_queue.push_back(w);
+      end
     end
   endtask
 
-  task automatic run(input int num_writes = 0, input int num_reads = 0, input int awvalid_delay = 0,
-                     input int wvalid_delay = 0);
+  task automatic monitor_b_channel();
+    axil_b_t b;
+
+    forever begin
+      @cb;
+      if (cb.axil_bvalid && cb.axil_bready) begin
+        b.resp = cb.axil_bresp;
+        b.user = AxilUserWidth'(cb.axil_buser);
+        b_queue.push_back(b);
+      end
+    end
+  endtask
+
+  task automatic monitor_ar_channel();
+    axil_ar_t ar;
+
+    forever begin
+      @cb;
+      if (cb.axil_arvalid && cb.axil_arready) begin
+        ar.addr = AxilAddrWidth'(cb.axil_araddr);
+        ar.prot = cb.axil_arprot;
+        ar.user = AxilUserWidth'(cb.axil_aruser);
+        ar_queue.push_back(ar);
+      end
+    end
+  endtask
+
+  task automatic monitor_r_channel();
+    axil_r_t r;
+
+    forever begin
+      @cb;
+      if (cb.axil_rvalid && cb.axil_rready) begin
+        r.data = AxilDataWidth'(cb.axil_rdata);
+        r.resp = cb.axil_rresp;
+        r.user = AxilUserWidth'(cb.axil_ruser);
+        r_queue.push_back(r);
+      end
+    end
+  endtask
+
+  // Record the order of complete AXI-Lite transactions. A write is complete once
+  // both AW and W have handshaken; a read is complete on AR handshake.
+  task automatic monitor_transaction_order();
+    int pending_aw = 0;
+    int pending_w = 0;
+
+    forever begin
+      @cb;
+      if (cb.axil_awvalid && cb.axil_awready) begin
+        if (pending_w != 0) begin
+          pending_w--;
+          transaction_order_queue.push_back(AxilTransactionWrite);
+        end else begin
+          pending_aw++;
+        end
+      end
+      if (cb.axil_wvalid && cb.axil_wready) begin
+        if (pending_aw != 0) begin
+          pending_aw--;
+          transaction_order_queue.push_back(AxilTransactionWrite);
+        end else begin
+          pending_w++;
+        end
+      end
+      if (cb.axil_arvalid && cb.axil_arready) begin
+        transaction_order_queue.push_back(AxilTransactionRead);
+      end
+    end
+  endtask
+
+  task automatic get_observed_channels(
+      output axil_aw_t observed_aw_queue[$], output axil_w_t observed_w_queue[$],
+      output axil_b_t observed_b_queue[$], output axil_ar_t observed_ar_queue[$],
+      output axil_r_t observed_r_queue[$]);
+    observed_aw_queue = aw_queue;
+    observed_w_queue  = w_queue;
+    observed_b_queue  = b_queue;
+    observed_ar_queue = ar_queue;
+    observed_r_queue  = r_queue;
+  endtask
+
+  task automatic get_observed_transaction_order(
+      output axil_transaction_kind_t observed_transaction_order_queue[$]);
+    observed_transaction_order_queue = transaction_order_queue;
+  endtask
+
+  task automatic run();
     fork
-      begin
-        if (num_writes > 0) begin
-          check_no_bvalid_after_first_write_channel(awvalid_delay, wvalid_delay);
-          for (int i = 0; i < num_writes; i++) begin
-            monitor_b_response(i == num_writes - 1);
-          end
-        end
-      end
-      begin
-        if (num_reads > 0) begin
-          for (int i = 0; i < num_reads; i++) begin
-            monitor_r_response(i == num_reads - 1);
-          end
-        end
-      end
+      monitor_aw_channel();
+      monitor_w_channel();
+      monitor_b_channel();
+      monitor_ar_channel();
+      monitor_r_channel();
+      monitor_transaction_order();
     join
   endtask
-
 endmodule : br_amba_axil_monitor

--- a/amba/sim/monitors/br_amba_axil_monitor.sv
+++ b/amba/sim/monitors/br_amba_axil_monitor.sv
@@ -4,11 +4,13 @@
 
 import br_amba::*;
 import br_amba_axil_sim_pkg::*;
+import br_amba_axil_monitor_sim_pkg::*;
 
-// AXI4-Lite protocol monitor skeleton.
+// AXI4-Lite protocol monitor.
 //
-// This monitor samples all AXI4-Lite channels according to ready/valid and records
-// packaged observations. It does not compare expected behavior.
+// This monitor samples all AXI4-Lite channels according to ready/valid,
+// records packaged observations, and checks protocol-local rules. DUT-specific
+// expected behavior belongs in scoreboards.
 module br_amba_axil_monitor #(
     parameter  int AddrWidth   = 12,
     parameter  int DataWidth   = 32,
@@ -50,16 +52,21 @@ module br_amba_axil_monitor #(
     output logic failed
 );
 
-  axil_aw_t aw_queue[$];
-  axil_w_t w_queue[$];
-  axil_b_t b_queue[$];
-  axil_ar_t ar_queue[$];
-  axil_r_t r_queue[$];
-  axil_transaction_kind_t transaction_order_queue[$];
-  event posedge_clk;
+  axil_aw_observation_t aw_queue[$];
+  axil_w_observation_t w_queue[$];
+  axil_b_observation_t b_queue[$];
+  axil_ar_observation_t ar_queue[$];
+  axil_r_observation_t r_queue[$];
+  axil_request_state_observation_t request_state_queue[$];
+  logic aw_handshake;
+  logic w_handshake;
+  logic b_handshake;
+  logic ar_handshake;
+  logic r_handshake;
 
   clocking cb @(posedge clk);
     default input #1step;
+    input rst;
     input axil_awaddr;
     input axil_awprot;
     input axil_awuser;
@@ -86,8 +93,12 @@ module br_amba_axil_monitor #(
     input axil_rready;
   endclocking
 
-  always @(posedge clk) begin
-    ->posedge_clk;
+  always_comb begin
+    aw_handshake = cb.axil_awvalid && cb.axil_awready;
+    w_handshake  = cb.axil_wvalid && cb.axil_wready;
+    b_handshake  = cb.axil_bvalid && cb.axil_bready;
+    ar_handshake = cb.axil_arvalid && cb.axil_arready;
+    r_handshake  = cb.axil_rvalid && cb.axil_rready;
   end
 
   task automatic init_idle();
@@ -97,132 +108,348 @@ module br_amba_axil_monitor #(
     b_queue.delete();
     ar_queue.delete();
     r_queue.delete();
-    transaction_order_queue.delete();
+    request_state_queue.delete();
   endtask
 
-  task automatic monitor_aw_channel();
-    axil_aw_t aw;
+  task automatic monitor_request_state();
+    axil_request_state_observation_t request_state;
 
     forever begin
       @cb;
-      if (cb.axil_awvalid && cb.axil_awready) begin
-        aw.addr = AxilAddrWidth'(cb.axil_awaddr);
-        aw.prot = cb.axil_awprot;
-        aw.user = AxilUserWidth'(cb.axil_awuser);
+      if (!cb.rst && (cb.axil_awvalid || cb.axil_awready || cb.axil_wvalid ||
+                      cb.axil_wready || cb.axil_arvalid || cb.axil_arready)) begin
+        request_state.awvalid   = cb.axil_awvalid;
+        request_state.awready   = cb.axil_awready;
+        request_state.wvalid    = cb.axil_wvalid;
+        request_state.wready    = cb.axil_wready;
+        request_state.arvalid   = cb.axil_arvalid;
+        request_state.arready   = cb.axil_arready;
+        request_state.timestamp = $time;
+        request_state_queue.push_back(request_state);
+      end
+    end
+  endtask
+
+  task automatic monitor_aw_channel();
+    axil_aw_observation_t aw;
+
+    forever begin
+      @cb;
+      if (!cb.rst && aw_handshake) begin
+        aw.packet.addr = AxilAddrWidth'(cb.axil_awaddr);
+        aw.packet.prot = cb.axil_awprot;
+        aw.packet.user = AxilUserWidth'(cb.axil_awuser);
+        aw.timestamp   = $time;
         aw_queue.push_back(aw);
       end
     end
   endtask
 
   task automatic monitor_w_channel();
-    axil_w_t w;
+    axil_w_observation_t w;
 
     forever begin
       @cb;
-      if (cb.axil_wvalid && cb.axil_wready) begin
-        w.data = AxilDataWidth'(cb.axil_wdata);
-        w.strb = AxilStrobeWidth'(cb.axil_wstrb);
-        w.user = AxilUserWidth'(cb.axil_wuser);
+      if (!cb.rst && w_handshake) begin
+        w.packet.data = AxilDataWidth'(cb.axil_wdata);
+        w.packet.strb = AxilStrobeWidth'(cb.axil_wstrb);
+        w.packet.user = AxilUserWidth'(cb.axil_wuser);
+        w.timestamp   = $time;
         w_queue.push_back(w);
       end
     end
   endtask
 
   task automatic monitor_b_channel();
-    axil_b_t b;
+    axil_b_observation_t b;
 
     forever begin
       @cb;
-      if (cb.axil_bvalid && cb.axil_bready) begin
-        b.resp = cb.axil_bresp;
-        b.user = AxilUserWidth'(cb.axil_buser);
+      if (!cb.rst && b_handshake) begin
+        b.packet.resp = cb.axil_bresp;
+        b.packet.user = AxilUserWidth'(cb.axil_buser);
+        b.timestamp   = $time;
         b_queue.push_back(b);
       end
     end
   endtask
 
   task automatic monitor_ar_channel();
-    axil_ar_t ar;
+    axil_ar_observation_t ar;
 
     forever begin
       @cb;
-      if (cb.axil_arvalid && cb.axil_arready) begin
-        ar.addr = AxilAddrWidth'(cb.axil_araddr);
-        ar.prot = cb.axil_arprot;
-        ar.user = AxilUserWidth'(cb.axil_aruser);
+      if (!cb.rst && ar_handshake) begin
+        ar.packet.addr = AxilAddrWidth'(cb.axil_araddr);
+        ar.packet.prot = cb.axil_arprot;
+        ar.packet.user = AxilUserWidth'(cb.axil_aruser);
+        ar.timestamp   = $time;
         ar_queue.push_back(ar);
       end
     end
   endtask
 
   task automatic monitor_r_channel();
-    axil_r_t r;
+    axil_r_observation_t r;
 
     forever begin
       @cb;
-      if (cb.axil_rvalid && cb.axil_rready) begin
-        r.data = AxilDataWidth'(cb.axil_rdata);
-        r.resp = cb.axil_rresp;
-        r.user = AxilUserWidth'(cb.axil_ruser);
+      if (!cb.rst && r_handshake) begin
+        r.packet.data = AxilDataWidth'(cb.axil_rdata);
+        r.packet.resp = cb.axil_rresp;
+        r.packet.user = AxilUserWidth'(cb.axil_ruser);
+        r.timestamp   = $time;
         r_queue.push_back(r);
       end
     end
   endtask
 
-  // Record the order of complete AXI-Lite transactions. A write is complete once
-  // both AW and W have handshaken; a read is complete on AR handshake.
-  task automatic monitor_transaction_order();
-    int pending_aw = 0;
-    int pending_w = 0;
-
-    forever begin
-      @cb;
-      if (cb.axil_awvalid && cb.axil_awready) begin
-        if (pending_w != 0) begin
-          pending_w--;
-          transaction_order_queue.push_back(AxilTransactionWrite);
-        end else begin
-          pending_aw++;
-        end
-      end
-      if (cb.axil_wvalid && cb.axil_wready) begin
-        if (pending_aw != 0) begin
-          pending_aw--;
-          transaction_order_queue.push_back(AxilTransactionWrite);
-        end else begin
-          pending_w++;
-        end
-      end
-      if (cb.axil_arvalid && cb.axil_arready) begin
-        transaction_order_queue.push_back(AxilTransactionRead);
+  task automatic check_aw_wait(input logic aw_wait, input axil_aw_t held_aw);
+    if (aw_wait) begin
+      if (!cb.axil_awvalid) begin
+        failed = 1'b1;
+        $error("AXI-Lite AWVALID deasserted before AWREADY");
+      end else if (held_aw.addr !== AxilAddrWidth'(cb.axil_awaddr) ||
+                   held_aw.prot !== cb.axil_awprot ||
+                   held_aw.user !== AxilUserWidth'(cb.axil_awuser)) begin
+        failed = 1'b1;
+        $error("AXI-Lite AW payload changed while AWVALID was waiting for AWREADY");
       end
     end
   endtask
 
-  task automatic get_observed_channels(
-      output axil_aw_t observed_aw_queue[$], output axil_w_t observed_w_queue[$],
-      output axil_b_t observed_b_queue[$], output axil_ar_t observed_ar_queue[$],
-      output axil_r_t observed_r_queue[$]);
-    observed_aw_queue = aw_queue;
-    observed_w_queue  = w_queue;
-    observed_b_queue  = b_queue;
-    observed_ar_queue = ar_queue;
-    observed_r_queue  = r_queue;
+  task automatic check_w_wait(input logic w_wait, input axil_w_t held_w);
+    if (w_wait) begin
+      if (!cb.axil_wvalid) begin
+        failed = 1'b1;
+        $error("AXI-Lite WVALID deasserted before WREADY");
+      end else if (held_w.data !== AxilDataWidth'(cb.axil_wdata) ||
+                   held_w.strb !== AxilStrobeWidth'(cb.axil_wstrb) ||
+                   held_w.user !== AxilUserWidth'(cb.axil_wuser)) begin
+        failed = 1'b1;
+        $error("AXI-Lite W payload changed while WVALID was waiting for WREADY");
+      end
+    end
   endtask
 
-  task automatic get_observed_transaction_order(
-      output axil_transaction_kind_t observed_transaction_order_queue[$]);
-    observed_transaction_order_queue = transaction_order_queue;
+  task automatic check_b_wait(input logic b_wait, input axil_b_t held_b);
+    if (b_wait) begin
+      if (!cb.axil_bvalid) begin
+        failed = 1'b1;
+        $error("AXI-Lite BVALID deasserted before BREADY");
+      end else if (held_b.resp !== cb.axil_bresp ||
+                   held_b.user !== AxilUserWidth'(cb.axil_buser)) begin
+        failed = 1'b1;
+        $error("AXI-Lite B payload changed while BVALID was waiting for BREADY");
+      end
+    end
+  endtask
+
+  task automatic check_ar_wait(input logic ar_wait, input axil_ar_t held_ar);
+    if (ar_wait) begin
+      if (!cb.axil_arvalid) begin
+        failed = 1'b1;
+        $error("AXI-Lite ARVALID deasserted before ARREADY");
+      end else if (held_ar.addr !== AxilAddrWidth'(cb.axil_araddr) ||
+                   held_ar.prot !== cb.axil_arprot ||
+                   held_ar.user !== AxilUserWidth'(cb.axil_aruser)) begin
+        failed = 1'b1;
+        $error("AXI-Lite AR payload changed while ARVALID was waiting for ARREADY");
+      end
+    end
+  endtask
+
+  task automatic check_r_wait(input logic r_wait, input axil_r_t held_r);
+    if (r_wait) begin
+      if (!cb.axil_rvalid) begin
+        failed = 1'b1;
+        $error("AXI-Lite RVALID deasserted before RREADY");
+      end else if (held_r.data !== AxilDataWidth'(cb.axil_rdata) ||
+                   held_r.resp !== cb.axil_rresp ||
+                   held_r.user !== AxilUserWidth'(cb.axil_ruser)) begin
+        failed = 1'b1;
+        $error("AXI-Lite R payload changed while RVALID was waiting for RREADY");
+      end
+    end
+  endtask
+
+  task automatic check_waiting_payloads(
+      input logic aw_wait, input logic w_wait, input logic b_wait, input logic ar_wait,
+      input logic r_wait, input axil_aw_t held_aw, input axil_w_t held_w, input axil_b_t held_b,
+      input axil_ar_t held_ar, input axil_r_t held_r);
+    check_aw_wait(aw_wait, held_aw);
+    check_w_wait(w_wait, held_w);
+    check_b_wait(b_wait, held_b);
+    check_ar_wait(ar_wait, held_ar);
+    check_r_wait(r_wait, held_r);
+  endtask
+
+  task automatic update_pending_counts(ref int unmatched_aw, ref int unmatched_w,
+                                       ref int awaiting_b, ref int awaiting_r);
+    if (aw_handshake) begin
+      if (unmatched_w != 0) begin
+        unmatched_w--;
+        awaiting_b++;
+      end else begin
+        unmatched_aw++;
+      end
+    end
+    if (w_handshake) begin
+      if (unmatched_aw != 0) begin
+        unmatched_aw--;
+        awaiting_b++;
+      end else begin
+        unmatched_w++;
+      end
+    end
+    if (ar_handshake) begin
+      awaiting_r++;
+    end
+
+    // Apply current-cycle request handshakes before response checks so a
+    // zero-latency completer can return B/R valid in the same sampled cycle
+    // as the matching request acceptance.
+    if (cb.axil_bvalid && awaiting_b == 0) begin
+      failed = 1'b1;
+      $error("AXI-Lite BVALID asserted before an AW/W write request completed");
+    end
+    if (cb.axil_rvalid && awaiting_r == 0) begin
+      failed = 1'b1;
+      $error("AXI-Lite RVALID asserted before an AR read request completed");
+    end
+
+    if (b_handshake && awaiting_b != 0) begin
+      awaiting_b--;
+    end
+    if (r_handshake && awaiting_r != 0) begin
+      awaiting_r--;
+    end
+  endtask
+
+  task automatic update_wait_tracking(ref logic aw_wait, ref logic w_wait, ref logic b_wait,
+                                      ref logic ar_wait, ref logic r_wait, ref axil_aw_t held_aw,
+                                      ref axil_w_t held_w, ref axil_b_t held_b,
+                                      ref axil_ar_t held_ar, ref axil_r_t held_r);
+    if (aw_handshake || !cb.axil_awvalid) begin
+      aw_wait = 1'b0;
+    end else if (!aw_wait && cb.axil_awvalid && !cb.axil_awready) begin
+      aw_wait = 1'b1;
+      held_aw.addr = AxilAddrWidth'(cb.axil_awaddr);
+      held_aw.prot = cb.axil_awprot;
+      held_aw.user = AxilUserWidth'(cb.axil_awuser);
+    end
+    if (w_handshake || !cb.axil_wvalid) begin
+      w_wait = 1'b0;
+    end else if (!w_wait && cb.axil_wvalid && !cb.axil_wready) begin
+      w_wait = 1'b1;
+      held_w.data = AxilDataWidth'(cb.axil_wdata);
+      held_w.strb = AxilStrobeWidth'(cb.axil_wstrb);
+      held_w.user = AxilUserWidth'(cb.axil_wuser);
+    end
+    if (b_handshake || !cb.axil_bvalid) begin
+      b_wait = 1'b0;
+    end else if (!b_wait && cb.axil_bvalid && !cb.axil_bready) begin
+      b_wait = 1'b1;
+      held_b.resp = cb.axil_bresp;
+      held_b.user = AxilUserWidth'(cb.axil_buser);
+    end
+    if (ar_handshake || !cb.axil_arvalid) begin
+      ar_wait = 1'b0;
+    end else if (!ar_wait && cb.axil_arvalid && !cb.axil_arready) begin
+      ar_wait = 1'b1;
+      held_ar.addr = AxilAddrWidth'(cb.axil_araddr);
+      held_ar.prot = cb.axil_arprot;
+      held_ar.user = AxilUserWidth'(cb.axil_aruser);
+    end
+    if (r_handshake || !cb.axil_rvalid) begin
+      r_wait = 1'b0;
+    end else if (!r_wait && cb.axil_rvalid && !cb.axil_rready) begin
+      r_wait = 1'b1;
+      held_r.data = AxilDataWidth'(cb.axil_rdata);
+      held_r.resp = cb.axil_rresp;
+      held_r.user = AxilUserWidth'(cb.axil_ruser);
+    end
+  endtask
+
+  task automatic reset_protocol_state(ref int unmatched_aw, ref int unmatched_w, ref int awaiting_b,
+                                      ref int awaiting_r, ref logic aw_wait, ref logic w_wait,
+                                      ref logic b_wait, ref logic ar_wait, ref logic r_wait);
+    unmatched_aw = 0;
+    unmatched_w = 0;
+    awaiting_b = 0;
+    awaiting_r = 0;
+    aw_wait = 1'b0;
+    w_wait = 1'b0;
+    b_wait = 1'b0;
+    ar_wait = 1'b0;
+    r_wait = 1'b0;
+  endtask
+
+  // Checks protocol-local AXI-Lite rules from one sampled clock view:
+  // - VALID and payload remain stable while waiting for READY;
+  // - BVALID is not asserted before matching AW and W handshakes;
+  // - RVALID is not asserted before a matching AR handshake.
+  task automatic monitor_protocol();
+    int unmatched_aw = 0;
+    int unmatched_w = 0;
+    int awaiting_b = 0;
+    int awaiting_r = 0;
+    logic aw_wait = 1'b0;
+    logic w_wait = 1'b0;
+    logic b_wait = 1'b0;
+    logic ar_wait = 1'b0;
+    logic r_wait = 1'b0;
+    axil_aw_t held_aw;
+    axil_w_t held_w;
+    axil_b_t held_b;
+    axil_ar_t held_ar;
+    axil_r_t held_r;
+
+    forever begin
+      @cb;
+      if (cb.rst) begin
+        reset_protocol_state(unmatched_aw, unmatched_w, awaiting_b, awaiting_r, aw_wait, w_wait,
+                             b_wait, ar_wait, r_wait);
+      end else begin
+        check_waiting_payloads(aw_wait, w_wait, b_wait, ar_wait, r_wait, held_aw, held_w, held_b,
+                               held_ar, held_r);
+        update_pending_counts(unmatched_aw, unmatched_w, awaiting_b, awaiting_r);
+        update_wait_tracking(aw_wait, w_wait, b_wait, ar_wait, r_wait, held_aw, held_w, held_b,
+                             held_ar, held_r);
+      end
+    end
+  endtask
+
+  task automatic get_observed_request_observations(
+      output axil_aw_observation_t observed_aw_queue[$],
+      output axil_w_observation_t observed_w_queue[$],
+      output axil_ar_observation_t observed_ar_queue[$]);
+    observed_aw_queue = aw_queue;
+    observed_w_queue  = w_queue;
+    observed_ar_queue = ar_queue;
+  endtask
+
+  task automatic get_observed_response_observations(
+      output axil_b_observation_t observed_b_queue[$],
+      output axil_r_observation_t observed_r_queue[$]);
+    observed_b_queue = b_queue;
+    observed_r_queue = r_queue;
+  endtask
+
+  task automatic get_observed_request_state_observations(
+      output axil_request_state_observation_t observed_request_state_queue[$]);
+    observed_request_state_queue = request_state_queue;
   endtask
 
   task automatic run();
     fork
+      monitor_request_state();
       monitor_aw_channel();
       monitor_w_channel();
       monitor_b_channel();
       monitor_ar_channel();
       monitor_r_channel();
-      monitor_transaction_order();
+      monitor_protocol();
     join
   endtask
 endmodule : br_amba_axil_monitor

--- a/amba/sim/monitors/br_amba_axil_monitor.sv
+++ b/amba/sim/monitors/br_amba_axil_monitor.sv
@@ -162,14 +162,25 @@ module br_amba_axil_monitor #(
 
   task automatic monitor_b_channel();
     axil_b_observation_t b;
+    logic bvalid_seen = 1'b0;
+    time bvalid_timestamp;
 
     forever begin
       @cb;
+      if (cb.rst || !cb.axil_bvalid) begin
+        bvalid_seen = 1'b0;
+      end else if (!bvalid_seen) begin
+        bvalid_seen = 1'b1;
+        bvalid_timestamp = $time;
+      end
+
       if (!cb.rst && b_handshake) begin
         b.packet.resp = cb.axil_bresp;
         b.packet.user = AxilUserWidth'(cb.axil_buser);
-        b.timestamp   = $time;
+        b.timestamp = $time;
+        b.valid_timestamp = bvalid_timestamp;
         b_queue.push_back(b);
+        bvalid_seen = 1'b0;
       end
     end
   endtask
@@ -191,15 +202,26 @@ module br_amba_axil_monitor #(
 
   task automatic monitor_r_channel();
     axil_r_observation_t r;
+    logic rvalid_seen = 1'b0;
+    time rvalid_timestamp;
 
     forever begin
       @cb;
+      if (cb.rst || !cb.axil_rvalid) begin
+        rvalid_seen = 1'b0;
+      end else if (!rvalid_seen) begin
+        rvalid_seen = 1'b1;
+        rvalid_timestamp = $time;
+      end
+
       if (!cb.rst && r_handshake) begin
         r.packet.data = AxilDataWidth'(cb.axil_rdata);
         r.packet.resp = cb.axil_rresp;
         r.packet.user = AxilUserWidth'(cb.axil_ruser);
-        r.timestamp   = $time;
+        r.timestamp = $time;
+        r.valid_timestamp = rvalid_timestamp;
         r_queue.push_back(r);
+        rvalid_seen = 1'b0;
       end
     end
   endtask

--- a/amba/sim/monitors/br_amba_axil_monitor_sim_pkg.sv
+++ b/amba/sim/monitors/br_amba_axil_monitor_sim_pkg.sv
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+package br_amba_axil_monitor_sim_pkg;
+  import br_amba_axil_sim_pkg::*;
+
+  typedef struct {
+    axil_aw_t packet;
+    time      timestamp;
+  } axil_aw_observation_t;
+
+  typedef struct {
+    axil_w_t packet;
+    time     timestamp;
+  } axil_w_observation_t;
+
+  typedef struct {
+    axil_ar_t packet;
+    time      timestamp;
+  } axil_ar_observation_t;
+
+  typedef struct {
+    axil_b_t packet;
+    time     timestamp;
+  } axil_b_observation_t;
+
+  typedef struct {
+    axil_r_t packet;
+    time     timestamp;
+  } axil_r_observation_t;
+
+  typedef struct {
+    logic awvalid;
+    logic awready;
+    logic wvalid;
+    logic wready;
+    logic arvalid;
+    logic arready;
+    time  timestamp;
+  } axil_request_state_observation_t;
+endpackage : br_amba_axil_monitor_sim_pkg

--- a/amba/sim/monitors/br_amba_axil_monitor_sim_pkg.sv
+++ b/amba/sim/monitors/br_amba_axil_monitor_sim_pkg.sv
@@ -23,11 +23,13 @@ package br_amba_axil_monitor_sim_pkg;
   typedef struct {
     axil_b_t packet;
     time     timestamp;
+    time     valid_timestamp;
   } axil_b_observation_t;
 
   typedef struct {
     axil_r_t packet;
     time     timestamp;
+    time     valid_timestamp;
   } axil_r_observation_t;
 
   typedef struct {


### PR DESCRIPTION
Add simulation coverage for `br_amba_axil2apb` and refactor shared AMBA simulation helpers so AXI-Lite/APB drivers and monitors can be reused across benches.
- Add `br_amba_axil2apb_tb` with directed and randomized scenarios for:
  - reset/idle behavior
  - no-delay reads and writes
  - zero-strobe writes
  - APB `PREADY` backpressure on reads and writes
  - independent AW/W channel skew
  - read/write arbitration
  - AXI B/R response backpressure
  - APB `PSLVERR` propagation
  - mixed directed traffic
  - sustained stress traffic
  - mid-transaction reset recovery

- Add `br_amba_axil2apb_scoreboard` to predict protocol-agnostic transactions from AXI-Lite observations and verify:
  - AXI-Lite request payloads
  - APB transfer payloads and timing
  - AXI-Lite response payloads and timing
  - read/write arbitration priority

- Add/refactor reusable simulation components:
  - generic AXI-Lite requester driver
  - generic AXI-Lite monitor with channel observations and protocol checks
  - generic APB monitor with request/completion timestamps
  - APB completer response queue support
  - shared AMBA sim helpers and protocol transaction types

- Rename the existing AXI-Lite driver to `br_amba_axil_completer_driver` to clarify side ownership.
- Update AXI-Lite default target tests to use the common helper structure.

Depends on: https://github.com/xlsynth/bedrock-rtl/pull/1183 and https://github.com/xlsynth/bedrock-rtl/pull/1197.