### PR TITLE
[codex] Build CI Docker image once before test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,44 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
 
+  bazel-oss-docker-image:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      # actions/checkout v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      # docker/setup-buildx-action v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df1
+      - name: Build and load public Docker image
+        # docker/build-push-action v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: bedrock-rtl-ci:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=bedrock-rtl-docker
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max,scope=bedrock-rtl-docker' || '' }}
+      - name: Export public Docker image
+        run: docker save bedrock-rtl-ci:${{ github.sha }} --output /tmp/bedrock-rtl-ci.tar
+      - name: Upload public Docker image
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: bedrock-rtl-ci-image-${{ github.sha }}
+          path: /tmp/bedrock-rtl-ci.tar
+          compression-level: 0
+          retention-days: 1
+
   bazel-oss-tool-test-shard:
     name: bazel-oss-tool-test-shard (${{ matrix.name }})
     runs-on: ubuntu-24.04
+    needs: bazel-oss-docker-image
     permissions:
       contents: read
     strategy:
@@ -42,67 +77,54 @@ jobs:
             suite: python-stardoc
             shard_index: 0
             shard_count: 1
-            docker_cache_writer: true
           - name: slang-1-of-4
             suite: slang
             shard_index: 0
             shard_count: 4
-            docker_cache_writer: false
           - name: slang-2-of-4
             suite: slang
             shard_index: 1
             shard_count: 4
-            docker_cache_writer: false
           - name: slang-3-of-4
             suite: slang
             shard_index: 2
             shard_count: 4
-            docker_cache_writer: false
           - name: slang-4-of-4
             suite: slang
             shard_index: 3
             shard_count: 4
-            docker_cache_writer: false
           - name: verilator-1-of-8
             suite: verilator
             shard_index: 0
             shard_count: 8
-            docker_cache_writer: false
           - name: verilator-2-of-8
             suite: verilator
             shard_index: 1
             shard_count: 8
-            docker_cache_writer: false
           - name: verilator-3-of-8
             suite: verilator
             shard_index: 2
             shard_count: 8
-            docker_cache_writer: false
           - name: verilator-4-of-8
             suite: verilator
             shard_index: 3
             shard_count: 8
-            docker_cache_writer: false
           - name: verilator-5-of-8
             suite: verilator
             shard_index: 4
             shard_count: 8
-            docker_cache_writer: false
           - name: verilator-6-of-8
             suite: verilator
             shard_index: 5
             shard_count: 8
-            docker_cache_writer: false
           - name: verilator-7-of-8
             suite: verilator
             shard_index: 6
             shard_count: 8
-            docker_cache_writer: false
           - name: verilator-8-of-8
             suite: verilator
             shard_index: 7
             shard_count: 8
-            docker_cache_writer: false
     steps:
       # actions/checkout v6
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -131,25 +153,14 @@ jobs:
           # The Slang plugin executes $SLANG_PATH directly rather than looking
           # up `slang` on PATH. The public Docker image installs it here.
           echo 'common --action_env=SLANG_PATH=/usr/local/bin/slang' > ci.bazelrc
-      # docker/setup-buildx-action v4.1.0
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
-      - name: Build and load public Docker image
-        # docker/build-push-action v7.2.0
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+      - name: Download public Docker image
+        # actions/download-artifact v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          push: false
-          # Every shard tests the exact image built from its checkout.
-          load: true
-          tags: bedrock-rtl-ci:${{ github.sha }}
-          labels: |
-            org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha,scope=bedrock-rtl-docker
-          # Only one trusted shard updates this shared cache. All other shards
-          # are read-only, avoiding concurrent exports and PR cache pollution.
-          cache-to: ${{ matrix.docker_cache_writer && github.event_name != 'pull_request' && 'type=gha,mode=max,scope=bedrock-rtl-docker' || '' }}
+          name: bedrock-rtl-ci-image-${{ github.sha }}
+          path: /tmp
+      - name: Load public Docker image
+        run: docker load --input /tmp/bedrock-rtl-ci.tar
       # Do not use `bazel test //...` with a tag filter here. Bazel would still
       # analyze targets that need proprietary verilog_runner plugins.
       - name: Run public Bazel test shard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       # actions/checkout v6
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       # docker/setup-buildx-action v4.1.0
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df1
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Build and load public Docker image
         # docker/build-push-action v7.2.0
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf


### PR DESCRIPTION
## Summary

- Build and load the public CI Docker image once in a prerequisite job.
- Export the image as a short-lived artifact for the sharded Bazel jobs.
- Have each shard download and load the exact SHA-tagged image instead of rebuilding it.

## Why

The previous matrix configuration rebuilt the same uncached image independently for every shard, wasting substantial CI compute.

## Validation

- YAML parsing passed.
- Targeted pre-commit checks passed.
- Commit-time pre-commit checks passed.