### PR TITLE
[CI] Rename the public Docker image to bedrock-rtl-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,19 +47,19 @@ jobs:
           platforms: linux/amd64
           push: false
           load: true
-          tags: bedrock-rtl-ci:${{ github.sha }}
+          tags: bedrock-rtl-dev:${{ github.sha }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha,scope=bedrock-rtl-docker
-          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max,scope=bedrock-rtl-docker' || '' }}
+          cache-from: type=gha,scope=bedrock-rtl-dev-docker
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max,scope=bedrock-rtl-dev-docker' || '' }}
       - name: Export public Docker image
-        run: docker save bedrock-rtl-ci:${{ github.sha }} --output /tmp/bedrock-rtl-ci.tar
+        run: docker save bedrock-rtl-dev:${{ github.sha }} --output /tmp/bedrock-rtl-dev.tar
       - name: Upload public Docker image
         # actions/upload-artifact v7.0.1
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: bedrock-rtl-ci-image-${{ github.sha }}
-          path: /tmp/bedrock-rtl-ci.tar
+          name: bedrock-rtl-dev-image-${{ github.sha }}
+          path: /tmp/bedrock-rtl-dev.tar
           compression-level: 0
           retention-days: 1
 
@@ -157,10 +157,10 @@ jobs:
         # actions/download-artifact v8.0.1
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: bedrock-rtl-ci-image-${{ github.sha }}
+          name: bedrock-rtl-dev-image-${{ github.sha }}
           path: /tmp
       - name: Load public Docker image
-        run: docker load --input /tmp/bedrock-rtl-ci.tar
+        run: docker load --input /tmp/bedrock-rtl-dev.tar
       # Do not use `bazel test //...` with a tag filter here. Bazel would still
       # analyze targets that need proprietary verilog_runner plugins.
       - name: Run public Bazel test shard
@@ -184,7 +184,7 @@ jobs:
             --volume "${HOME}/.cache/bazel-disk:${HOME}/.cache/bazel-disk" \
             --volume "${HOME}/.cache/bazel-repo:${HOME}/.cache/bazel-repo" \
             --volume "${RUNNER_TEMP}/bazel-output:${RUNNER_TEMP}/bazel-output" \
-            bedrock-rtl-ci:${{ github.sha }} \
+            bedrock-rtl-dev:${{ github.sha }} \
             bash -s <<'EOF'
           set +e
           BAZEL_FLAGS=(
@@ -415,16 +415,16 @@ jobs:
           push: true
           # Attach max-detail BuildKit provenance to the published image.
           provenance: mode=max
-          tags: ghcr.io/xlsynth/bedrock-rtl:${{ needs.bazel-oss-tool-test.outputs.image-tag }}
+          tags: ghcr.io/xlsynth/bedrock-rtl-dev:${{ needs.bazel-oss-tool-test.outputs.image-tag }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
           # Reuse the layers populated by bazel-oss-tool-test before publishing.
-          cache-from: type=gha,scope=bedrock-rtl-docker
+          cache-from: type=gha,scope=bedrock-rtl-dev-docker
       - name: Attest Docker image provenance
         # actions/attest v4.1.1
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763
         with:
-          subject-name: ghcr.io/xlsynth/bedrock-rtl
+          subject-name: ghcr.io/xlsynth/bedrock-rtl-dev
           subject-digest: ${{ steps.publish.outputs.digest }}
           push-to-registry: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,8 +185,8 @@ USER user
 
 WORKDIR /home/user
 LABEL description="Docker image for building and testing Bedrock-RTL using open source tools." \
-    org.opencontainers.image.title="Bedrock-RTL" \
-    org.opencontainers.image.description="Open source toolchain for building and testing Bedrock-RTL." \
+    org.opencontainers.image.title="bedrock-rtl-dev" \
+    org.opencontainers.image.description="Bedrock-RTL development image with an open source toolchain for building and testing." \
     org.opencontainers.image.source="https://github.com/xlsynth/bedrock-rtl" \
     org.opencontainers.image.licenses="Apache-2.0"
 CMD ["/bin/bash"]

--- a/README.adoc
+++ b/README.adoc
@@ -71,7 +71,7 @@ Refer to the `BUILD.bazel` files for specifics.
 === Using the Published Docker Image
 
 Prebuilt `linux/amd64` images are published to the
-https://github.com/orgs/xlsynth/packages/container/package/bedrock-rtl[Bedrock-RTL package on GitHub Container Registry^].
+https://github.com/orgs/xlsynth/packages/container/package/bedrock-rtl-dev[Bedrock-RTL development package on GitHub Container Registry^].
 Each image has an immutable tag of the form `YYYY-MM-DD-<full-git-sha>`, where the date is the commit date in UTC.
 We intentionally do not publish a moving `latest` tag.
 
@@ -79,8 +79,8 @@ To use the latest image, open the package page linked above, copy the tag from t
 
 [source,shell]
 ----
-docker pull ghcr.io/xlsynth/bedrock-rtl:<tag>
-docker run --rm -it -v "$(pwd)":/src -w /src ghcr.io/xlsynth/bedrock-rtl:<tag> /bin/bash
+docker pull ghcr.io/xlsynth/bedrock-rtl-dev:<tag>
+docker run --rm -it -v "$(pwd)":/src -w /src ghcr.io/xlsynth/bedrock-rtl-dev:<tag> /bin/bash
 ----
 
 The package is public, so pulling it does not require GitHub Container Registry authentication.
@@ -92,8 +92,8 @@ To build the image from the checked-out Dockerfile instead:
 
 [source,shell]
 ----
-docker build --platform=linux/amd64 --tag=bedrock-rtl:${USER} .
-docker run --rm -it -v "$(pwd)":/src -w /src bedrock-rtl:${USER} /bin/bash
+docker build --platform=linux/amd64 --tag=bedrock-rtl-dev:${USER} .
+docker run --rm -it -v "$(pwd)":/src -w /src bedrock-rtl-dev:${USER} /bin/bash
 ----
 
 Then once inside the container, try `bazel build //... && bazel test //fifo/sim/... --test_tag_filters=verilator`.
@@ -103,7 +103,7 @@ Then once inside the container, try `bazel build //... && bazel test //fifo/sim/
 The public CI shard jobs in `.github/workflows/ci.yml` build the image for every pull request, push to `main`, and manual CI run, then use that exact image for the public-tool test suites.
 Python/ecc-codegen and Stardoc share one runner, while stable SHA-256 label partitioning distributes Slang across four runners and Verilator across eight runners.
 The `bazel-oss-tool-test` job validates and aggregates every shard into the stable check and badge interface.
-After those tests succeed, the `docker-image-publish` job deploys the image to `ghcr.io/xlsynth/bedrock-rtl` for pushes to `main` and manually dispatched CI runs.
+After those tests succeed, the `docker-image-publish` job deploys the development image to `ghcr.io/xlsynth/bedrock-rtl-dev` for pushes to `main` and manually dispatched CI runs.
 Pull requests build the image but do not publish it.
 
 All public shards restore the shared Docker layer cache, but only one shard updates it on trusted `main` or manually dispatched runs.


### PR DESCRIPTION
Rename the Docker image to `bedrock-rtl-dev` to indicate it's an image to use for development with open source tooling.