### PR TITLE
[FPV] Port initial formal suites to SBY

### DIFF
--- a/arb/fpv/BUILD.bazel
+++ b/arb/fpv/BUILD.bazel
@@ -86,6 +86,19 @@ verilog_elab_test(
     deps = [":br_arb_rr_fpv_monitor"],
 )
 
+verilog_library(
+    name = "br_arb_rr_sby_harness",
+    srcs = ["br_arb_rr_sby_harness.sv"],
+    deps = ["//arb/rtl:br_arb_rr"],
+)
+
+verilog_elab_test(
+    name = "br_arb_rr_sby_harness_elab_test",
+    tool = "slang",
+    top = "br_arb_rr_sby_harness",
+    deps = [":br_arb_rr_sby_harness"],
+)
+
 br_verilog_fpv_test_tools_suite(
     name = "br_arb_rr_test_suite",
     params = {
@@ -97,6 +110,10 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_arb_rr_fpv.jg.tcl",
+        "sby": {
+            "deps": [":br_arb_rr_sby_harness"],
+            "top": "br_arb_rr_sby_harness",
+        },
         "vcf": "br_arb_rr_fpv.vcf.tcl",
     },
     top = "br_arb_rr",

--- a/arb/fpv/br_arb_rr_sby_harness.sv
+++ b/arb/fpv/br_arb_rr_sby_harness.sv
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// SymbiYosys harness for the Bedrock-RTL round-robin arbiter.
+
+module br_arb_rr_sby_harness #(
+    parameter int NumRequesters = 2,
+    localparam int WaitWidth = $clog2(NumRequesters + 1)
+) (
+    input logic clk,
+    input logic rst,
+    input logic enable_priority_update,
+    input logic [NumRequesters-1:0] request
+);
+
+  logic [NumRequesters-1:0] grant;
+
+  br_arb_rr #(
+      .NumRequesters(NumRequesters)
+  ) dut (
+      .clk,
+      .rst,
+      .enable_priority_update,
+      .request,
+      .grant
+  );
+
+  logic [NumRequesters-1:0] priority_mask;
+  logic [NumRequesters-1:0] last_grant;
+  logic [NumRequesters-1:0] request_high;
+  logic [NumRequesters-1:0] expected_grant;
+
+  always_comb begin : calc_expected_grant
+    logic found;
+    priority_mask = dut.br_arb_rr_internal.gen_n_req.priority_mask;
+    last_grant = dut.br_arb_rr_internal.gen_n_req.rr_state_internal.last_grant;
+    request_high = request & ~priority_mask;
+    expected_grant = '0;
+    found = 1'b0;
+    for (int i = 0; i < NumRequesters; i++) begin
+      if (!found && request_high[i]) begin
+        expected_grant[i] = 1'b1;
+        found = 1'b1;
+      end
+    end
+    for (int i = 0; i < NumRequesters; i++) begin
+      if (!found && request[i]) begin
+        expected_grant[i] = 1'b1;
+        found = 1'b1;
+      end
+    end
+  end
+
+  logic fv_past_valid = 1'b0;
+  logic fv_prev_rst;
+  logic [NumRequesters-1:0] fv_prev_request;
+  logic [NumRequesters-1:0] fv_prev_grant;
+  logic [WaitWidth-1:0] fv_wait_count[NumRequesters];
+
+  always @(posedge clk) begin
+    fv_past_valid <= 1'b1;
+    assume (rst == !fv_past_valid);
+
+    if (fv_past_valid && !rst && !fv_prev_rst) begin
+      for (int i = 0; i < NumRequesters; i++) begin
+        if (fv_prev_request[i] && !fv_prev_grant[i]) begin
+          assume (request[i]);
+        end
+      end
+    end
+
+    if (rst) begin
+      for (int i = 0; i < NumRequesters; i++) begin
+        fv_wait_count[i] <= '0;
+      end
+    end else begin
+      assert ((grant & (grant - 1'b1)) == '0);
+      assert (last_grant != '0 && ((last_grant & (last_grant - 1'b1)) == '0));
+      assert ((grant & request) == grant);
+      assert ((|request) == (|grant));
+      assert (grant == expected_grant);
+
+      for (int i = 0; i < NumRequesters; i++) begin
+        if (!request[i] || grant[i] || !enable_priority_update) begin
+          fv_wait_count[i] <= '0;
+        end else begin
+          assert (fv_wait_count[i] < NumRequesters);
+          fv_wait_count[i] <= fv_wait_count[i] + 1'b1;
+        end
+
+        cover (last_grant[i]);
+        cover (request[i] && priority_mask[i] && grant[i]);
+      end
+
+      cover (&request);
+      cover (!enable_priority_update && |grant);
+    end
+
+    fv_prev_rst <= rst;
+    fv_prev_request <= request;
+    fv_prev_grant <= grant;
+  end
+
+endmodule : br_arb_rr_sby_harness

--- a/counter/fpv/BUILD.bazel
+++ b/counter/fpv/BUILD.bazel
@@ -200,6 +200,19 @@ verilog_elab_test(
     deps = [":br_counter_incr_fpv_monitor"],
 )
 
+verilog_library(
+    name = "br_counter_incr_sby_harness",
+    srcs = ["br_counter_incr_sby_harness.sv"],
+    deps = ["//counter/rtl:br_counter_incr"],
+)
+
+verilog_elab_test(
+    name = "br_counter_incr_sby_harness_elab_test",
+    tool = "slang",
+    top = "br_counter_incr_sby_harness",
+    deps = [":br_counter_incr_sby_harness"],
+)
+
 br_verilog_fpv_test_tools_suite(
     name = "br_counter_incr_test_suite",
     illegal_param_combinations = {
@@ -233,6 +246,10 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "br_counter_fpv.jg.tcl",
+        "sby": {
+            "deps": [":br_counter_incr_sby_harness"],
+            "top": "br_counter_incr_sby_harness",
+        },
     },
     top = "br_counter_incr",
     deps = [":br_counter_incr_fpv_monitor"],

--- a/counter/fpv/br_counter_incr_sby_harness.sv
+++ b/counter/fpv/br_counter_incr_sby_harness.sv
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// SymbiYosys harness for the Bedrock-RTL incrementing counter.
+
+module br_counter_incr_sby_harness #(
+    parameter int MaxValueWidth = 32,
+    parameter int MaxIncrementWidth = 32,
+    parameter logic [MaxValueWidth-1:0] MaxValue = 1,
+    parameter logic [MaxIncrementWidth-1:0] MaxIncrement = 1,
+    parameter bit EnableReinitAndIncr = 1,
+    parameter bit EnableSaturate = 0,
+    localparam int MaxValueP1Width = MaxValueWidth + 1,
+    localparam int MaxIncrementP1Width = MaxIncrementWidth + 1,
+    localparam int ValueWidth = $clog2(MaxValueP1Width'(MaxValue) + 1),
+    localparam int IncrementWidth = $clog2(MaxIncrementP1Width'(MaxIncrement) + 1)
+) (
+    input logic clk,
+    input logic rst,
+    input logic reinit,
+    input logic [ValueWidth-1:0] initial_value,
+    input logic incr_valid,
+    input logic [IncrementWidth-1:0] incr
+);
+
+  logic [ValueWidth-1:0] value;
+  logic [ValueWidth-1:0] value_next;
+
+  br_counter_incr #(
+      .MaxValueWidth(MaxValueWidth),
+      .MaxIncrementWidth(MaxIncrementWidth),
+      .MaxValue(MaxValue),
+      .MaxIncrement(MaxIncrement),
+      .EnableReinitAndIncr(EnableReinitAndIncr),
+      .EnableSaturate(EnableSaturate),
+      .EnableAssertFinalNotValid(0)
+  ) dut (
+      .clk,
+      .rst,
+      .reinit,
+      .initial_value,
+      .incr_valid,
+      .incr,
+      .value,
+      .value_next
+  );
+
+  function automatic logic [ValueWidth-1:0] adjust(input logic [ValueWidth-1:0] base,
+                                                   input logic [IncrementWidth-1:0] increment);
+    logic [ValueWidth:0] sum;
+
+    sum = {1'b0, base} + increment;
+    if (sum > MaxValue) begin
+      adjust = EnableSaturate ? ValueWidth'(MaxValue) : sum - MaxValue - 1'b1;
+    end else begin
+      adjust = sum[ValueWidth-1:0];
+    end
+  endfunction
+
+  logic [ValueWidth-1:0] fv_counter;
+  logic [ValueWidth-1:0] fv_expected_next;
+  logic [IncrementWidth-1:0] fv_increment;
+
+  always_comb begin
+    fv_increment = incr_valid ? incr : '0;
+    if (reinit) begin
+      fv_expected_next = EnableReinitAndIncr ? adjust(initial_value, fv_increment) : initial_value;
+    end else begin
+      fv_expected_next = adjust(value, fv_increment);
+    end
+  end
+
+  logic fv_past_valid = 1'b0;
+
+  always @(posedge clk) begin
+    fv_past_valid <= 1'b1;
+    assume (rst == !fv_past_valid);
+    assume (initial_value <= MaxValue);
+    assume (incr <= MaxIncrement);
+
+    if (rst) begin
+      fv_counter <= initial_value;
+    end else begin
+      assert (value == fv_counter);
+      assert (value <= MaxValue);
+      assert (value_next <= MaxValue);
+      assert (value_next == fv_expected_next);
+
+      fv_counter <= fv_expected_next;
+
+      cover (reinit && incr_valid && incr > 0);
+      cover ({1'b0, fv_counter} + fv_increment > MaxValue);
+    end
+  end
+
+endmodule : br_counter_incr_sby_harness

--- a/flow/fpv/fork/BUILD.bazel
+++ b/flow/fpv/fork/BUILD.bazel
@@ -22,6 +22,19 @@ verilog_elab_test(
     deps = [":br_flow_fork_fpv_monitor"],
 )
 
+verilog_library(
+    name = "br_flow_fork_sby_harness",
+    srcs = ["br_flow_fork_sby_harness.sv"],
+    deps = ["//flow/rtl:br_flow_fork"],
+)
+
+verilog_elab_test(
+    name = "br_flow_fork_sby_harness_elab_test",
+    tool = "slang",
+    top = "br_flow_fork_sby_harness",
+    deps = [":br_flow_fork_sby_harness"],
+)
+
 br_verilog_fpv_test_tools_suite(
     name = "br_flow_fork_test_suite",
     params = {
@@ -38,6 +51,10 @@ br_verilog_fpv_test_tools_suite(
     },
     tools = {
         "jg": "",
+        "sby": {
+            "deps": [":br_flow_fork_sby_harness"],
+            "top": "br_flow_fork_sby_harness",
+        },
     },
     top = "br_flow_fork",
     deps = [":br_flow_fork_fpv_monitor"],

--- a/flow/fpv/fork/br_flow_fork_sby_harness.sv
+++ b/flow/fpv/fork/br_flow_fork_sby_harness.sv
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// SymbiYosys harness for the Bedrock-RTL flow fork.
+
+module br_flow_fork_sby_harness #(
+    parameter int NumFlows = 1,
+    parameter bit EnableCoverPushBackpressure = 1
+) (
+    input logic clk,
+    input logic rst,
+    input logic push_valid,
+    input logic [NumFlows-1:0] pop_ready
+);
+
+  logic push_ready;
+  logic [NumFlows-1:0] pop_valid_unstable;
+
+  br_flow_fork #(
+      .NumFlows(NumFlows),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertFinalNotValid(0)
+  ) dut (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid,
+      .pop_ready,
+      .pop_valid_unstable
+  );
+
+  logic fv_past_valid = 1'b0;
+  logic fv_prev_rst;
+  logic fv_prev_push_ready;
+  logic fv_prev_push_valid;
+
+  always @(posedge clk) begin
+    fv_past_valid <= 1'b1;
+    assume (rst == !fv_past_valid);
+
+    if (fv_past_valid && !rst && !fv_prev_rst) begin
+      if (EnableCoverPushBackpressure && fv_prev_push_valid && !fv_prev_push_ready) begin
+        assume (push_valid);
+      end
+    end
+
+    if (!rst) begin
+      if (!EnableCoverPushBackpressure && !push_ready) begin
+        assume (!push_valid);
+      end
+
+      assert (push_ready == &pop_ready);
+      for (int i = 0; i < NumFlows; i++) begin
+        assert (pop_valid_unstable[i] == (push_valid && &(pop_ready | (NumFlows'(1) << i))));
+      end
+      if (push_valid && push_ready) begin
+        assert (&pop_valid_unstable);
+      end
+
+      cover (push_valid && push_ready);
+      if (EnableCoverPushBackpressure) begin
+        cover (push_valid && !push_ready);
+      end
+    end
+
+    fv_prev_rst <= rst;
+    fv_prev_push_ready <= push_ready;
+    fv_prev_push_valid <= push_valid;
+  end
+
+endmodule : br_flow_fork_sby_harness


### PR DESCRIPTION
# Problem

The existing round-robin arbiter, flow fork, and incrementing counter formal suites only run with proprietary tools, so the new SBY infrastructure has no representative open-source proofs.

# Solution

Add OSS-compatible immediate-assertion harnesses for all three modules and register SBY-specific tops and dependencies in their existing parameterized FPV suites. The generated matrix runs unbounded safety proofs and bounded cover tasks without changing the JasperGold or VCF monitors.