### PR TITLE
add BR_ENABLE_FPV to BR_ASSERT_STATIC_IN_PACKAGE

### DIFF
--- a/macros/br_asserts.svh
+++ b/macros/br_asserts.svh
@@ -62,11 +62,15 @@ __BR_ASSERT_STATIC_FAILED__``__name__ __BR_ASSERT_STATIC_FAILED__``__name__ (); 
 end
 `endif
 
+`ifdef BR_ENABLE_FPV
+`define BR_ASSERT_STATIC_IN_PACKAGE(__name__, __expr__) `BR_NOOP
+`else  // BR_ENABLE_FPV
 `define BR_ASSERT_STATIC_IN_PACKAGE(__name__, __expr__) \
 typedef enum logic [1:0] { \
     __BR_ASSERT_STATIC_IN_PACKAGE_OK__``__name__ = ((__expr__) ? 1 : 0), \
     __BR_ASSERT_STATIC_IN_PACKAGE_FAILED__``__name__ = 0 \
 } __br_static_assert_enum__``__name__;
+`endif  // BR_ENABLE_FPV
 
 ////////////////////////////////////////////////////////////////////////////////
 // Assertion error printing macros

--- a/macros/br_asserts_in_pkg_test.sv
+++ b/macros/br_asserts_in_pkg_test.sv
@@ -12,6 +12,8 @@ package br_asserts_test_pkg;
   localparam int Width = 4;
   `BR_ASSERT_STATIC_IN_PACKAGE(width_check_a, Width == 4)
 `ifdef BR_ENABLE_FPV
+  // This intentionally false assertion must elaborate under FPV, verifying that
+  // BR_ASSERT_STATIC_IN_PACKAGE expands to a no-op when BR_ENABLE_FPV is set.
   `BR_ASSERT_STATIC_IN_PACKAGE(fp_static_asserts_disabled_a, 0)
 `endif
 endpackage : br_asserts_test_pkg

--- a/macros/br_asserts_in_pkg_test.sv
+++ b/macros/br_asserts_in_pkg_test.sv
@@ -11,6 +11,9 @@
 package br_asserts_test_pkg;
   localparam int Width = 4;
   `BR_ASSERT_STATIC_IN_PACKAGE(width_check_a, Width == 4)
+`ifdef BR_ENABLE_FPV
+  `BR_ASSERT_STATIC_IN_PACKAGE(fp_static_asserts_disabled_a, 0)
+`endif
 endpackage : br_asserts_test_pkg
 
 module br_asserts_in_pkg_test;


### PR DESCRIPTION
BR_ASSERT_STATIC_IN_PACKAGE usually checks parameter correctness.
For example: 
- BR_ASSERT_STATIC_IN_PACKAGE(bank_correct_a, NumBank >= 16)

FV often overrides RTL parameters to reduce design complexity, which can intentionally violate the RTL's legal parameter assertions. That's usually fine because the FV engineer ensures the reduced configuration still covers all architectural behaviors—we're reducing the parameter space, not the architectural state space.
