### PR TITLE
Add generated AXI-Lite split simulation testbench

### DIFF
--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -4,15 +4,6 @@ load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
 load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
-BR_AMBA_SIM_MAX_CHECK_WIDTH_64 = "BR_AMBA_SIM_MAX_CHECK_WIDTH=64"
-
-BR_AMBA_SIM_DEFINES_64 = [
-    "BR_ASSERT_ON",
-    "BR_ENABLE_IMPL_CHECKS",
-    "SIMULATION",
-    BR_AMBA_SIM_MAX_CHECK_WIDTH_64,
-]
-
 BR_AMBA_APB_TIMING_SLICE_DEFINES = [
     "BR_AMBA_APB_SIM_ADDR_WIDTH=32",
     "BR_AMBA_APB_SIM_DATA_WIDTH=32",
@@ -27,6 +18,127 @@ verilog_library(
         "//amba/sim/drivers:br_amba_apb_sim_pkg",
     ],
 )
+
+verilog_library(
+    name = "br_amba_axil_split_sim_pkg",
+    srcs = ["br_amba_axil_split_sim_pkg.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//amba/rtl:br_amba_pkg",
+        "//amba/sim/drivers:br_amba_axil_sim_pkg",
+    ],
+)
+
+verilog_library(
+    name = "br_amba_axil_split_tb",
+    srcs = ["br_amba_axil_split_tb.sv"],
+    deps = [
+        ":br_amba_axil_split_sim_pkg",
+        "//amba/rtl:br_amba_axil_split",
+        "//amba/sim/drivers:br_amba_axil_requester_driver",
+        "//amba/sim/drivers:br_amba_axil_target_driver",
+        "//amba/sim/drivers:br_amba_sim_pkg",
+        "//amba/sim/monitors:br_amba_axil_monitor",
+        "//amba/sim/monitors:br_amba_axil_monitor_sim_pkg",
+        "//amba/sim/monitors:br_amba_axil_split_scoreboard",
+        "//macros:br_asserts",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_amba_axil_split_tb_elab_test",
+    defines = [
+        "BR_AMBA_AXIL_SIM_ADDR_WIDTH=12",
+        "BR_AMBA_AXIL_SIM_DATA_WIDTH=32",
+        "BR_AMBA_AXIL_SIM_USER_WIDTH=1",
+    ],
+    tool = "slang",
+    deps = [":br_amba_axil_split_tb"],
+)
+
+BR_AMBA_AXIL_SPLIT_TEST_CONFIGS = [
+    {
+        "addr_width": "12",
+        "data_width": "32",
+        "max_outstanding_reads": "1",
+        "max_outstanding_writes": "1",
+        "max_random_delay_cycles": "1",
+        "min_random_delay_cycles": "0",
+        "normalize_branch_address": "0",
+        "num_branch_addr_ranges": "1",
+        "user_width": "1",
+    },
+    {
+        "addr_width": "13",
+        "data_width": "32",
+        "max_outstanding_reads": "1",
+        "max_outstanding_writes": "2",
+        "max_random_delay_cycles": "3",
+        "min_random_delay_cycles": "0",
+        "normalize_branch_address": "1",
+        "num_branch_addr_ranges": "2",
+        "user_width": "3",
+    },
+    {
+        "addr_width": "17",
+        "data_width": "48",
+        "max_outstanding_reads": "5",
+        "max_outstanding_writes": "3",
+        "max_random_delay_cycles": "5",
+        "min_random_delay_cycles": "1",
+        "normalize_branch_address": "0",
+        "num_branch_addr_ranges": "5",
+        "user_width": "2",
+    },
+    {
+        "addr_width": "40",
+        "data_width": "64",
+        "max_outstanding_reads": "3",
+        "max_outstanding_writes": "3",
+        "max_random_delay_cycles": "7",
+        "min_random_delay_cycles": "2",
+        "normalize_branch_address": "1",
+        "num_branch_addr_ranges": "2",
+        "user_width": "3",
+    },
+]
+
+[
+    br_verilog_sim_test_tools_suite(
+        name = "br_amba_axil_split_sim_test_tools_suite_aw%s_dw%s_mor%s_mow%s_nbar%s_nba%s" % (
+            config["addr_width"],
+            config["data_width"],
+            config["max_outstanding_reads"],
+            config["max_outstanding_writes"],
+            config["num_branch_addr_ranges"],
+            config["normalize_branch_address"],
+        ),
+        timeout = "long",
+        defines = [
+            "BR_ASSERT_ON",
+            "BR_ENABLE_IMPL_CHECKS",
+            "SIMULATION",
+            "BR_AMBA_AXIL_SIM_ADDR_WIDTH=%s" % config["addr_width"],
+            "BR_AMBA_AXIL_SIM_DATA_WIDTH=%s" % config["data_width"],
+            "BR_AMBA_AXIL_SIM_USER_WIDTH=%s" % config["user_width"],
+        ],
+        params = {
+            "MaxOutstandingReads": [config["max_outstanding_reads"]],
+            "MaxOutstandingWrites": [config["max_outstanding_writes"]],
+            "MaxRandomDelayCycles": [config["max_random_delay_cycles"]],
+            "MinRandomDelayCycles": [config["min_random_delay_cycles"]],
+            "NormalizeBranchAddress": [config["normalize_branch_address"]],
+            "NumBranchAddrRanges": [config["num_branch_addr_ranges"]],
+        },
+        tools = [
+            "vcs",
+            "verilator",
+        ],
+        deps = [":br_amba_axil_split_tb"],
+    )
+    for config in BR_AMBA_AXIL_SPLIT_TEST_CONFIGS
+]
 
 verilog_library(
     name = "br_amba_axil2apb_tb",
@@ -49,7 +161,6 @@ verilog_library(
 verilog_elab_test(
     name = "br_amba_axil2apb_tb_elab_test",
     defines = [
-        "BR_AMBA_SIM_MAX_CHECK_WIDTH=32",
         "BR_AMBA_AXIL_SIM_ADDR_WIDTH=12",
         "BR_AMBA_AXIL_SIM_DATA_WIDTH=32",
         "BR_AMBA_AXIL_SIM_USER_WIDTH=1",
@@ -67,7 +178,6 @@ verilog_elab_test(
             "BR_ASSERT_ON",
             "BR_ENABLE_IMPL_CHECKS",
             "SIMULATION",
-            "BR_AMBA_SIM_MAX_CHECK_WIDTH=%s" % data_width,
             "BR_AMBA_AXIL_SIM_ADDR_WIDTH=12",
             "BR_AMBA_AXIL_SIM_DATA_WIDTH=%s" % data_width,
             "BR_AMBA_AXIL_SIM_USER_WIDTH=1",

--- a/amba/sim/br_amba_axil2apb_tb.sv
+++ b/amba/sim/br_amba_axil2apb_tb.sv
@@ -64,7 +64,6 @@ module br_amba_axil2apb_tb;
   `BR_ASSERT_STATIC(AxilApbAddrWidthMatch, AxilAddrWidth == ApbAddrWidth)
   `BR_ASSERT_STATIC(AxilApbDataWidthMatch, AxilDataWidth == ApbDataWidth)
   `BR_ASSERT_STATIC(AxilApbStrobeWidthMatch, AxilStrobeWidth == ApbStrbWidth)
-  `BR_ASSERT_STATIC(RandomDataWidthSupported, DataWidth <= BrAmbaSimMaxCheckWidth)
 
   logic clk;
   logic rst;
@@ -79,10 +78,12 @@ module br_amba_axil2apb_tb;
   // AXI4-Lite manager-side signals.
   logic [AddrWidth-1:0] awaddr;
   logic [AxiProtWidth-1:0] awprot;
+  logic [AxilUserWidth-1:0] axil_awuser_unused;
   logic awvalid;
   logic awready;
   logic [DataWidth-1:0] wdata;
   logic [StrbWidth-1:0] wstrb;
+  logic [AxilUserWidth-1:0] axil_wuser_unused;
   logic wvalid;
   logic wready;
   logic [AxiRespWidth-1:0] bresp;
@@ -90,6 +91,7 @@ module br_amba_axil2apb_tb;
   logic bready;
   logic [AddrWidth-1:0] araddr;
   logic [AxiProtWidth-1:0] arprot;
+  logic [AxilUserWidth-1:0] axil_aruser_unused;
   logic arvalid;
   logic arready;
   logic [DataWidth-1:0] rdata;
@@ -178,16 +180,19 @@ module br_amba_axil2apb_tb;
       .rst(rst),
       .axil_awaddr(awaddr),
       .axil_awprot(awprot),
+      .axil_awuser(axil_awuser_unused),
       .axil_awvalid(awvalid),
       .axil_awready(awready),
       .axil_wdata(wdata),
       .axil_wstrb(wstrb),
+      .axil_wuser(axil_wuser_unused),
       .axil_wvalid(wvalid),
       .axil_wready(wready),
       .axil_bvalid(bvalid),
       .axil_bready(bready),
       .axil_araddr(araddr),
       .axil_arprot(arprot),
+      .axil_aruser(axil_aruser_unused),
       .axil_arvalid(arvalid),
       .axil_arready(arready),
       .axil_rvalid(rvalid),
@@ -276,14 +281,26 @@ module br_amba_axil2apb_tb;
 
   function automatic apb_response_t random_response(input logic allow_slverr,
                                                     input logic force_slverr);
+    logic [DataWidth-1:0] rdata;
+
+    if (!std::randomize(rdata)) begin
+      $fatal(1, "Failed to randomize APB read response data");
+    end
+
     random_response.ready = Pready1;
-    random_response.rdata = ApbDataWidth'(DataWidth'(get_random_bits(DataWidth)));
+    random_response.rdata = ApbDataWidth'(rdata);
     random_response.slverr = force_slverr ?
         Pslverr1 : (allow_slverr ? logic'($urandom_range(1, 0)) : Pslverr0);
   endfunction
 
   function automatic logic [StrbWidth-1:0] random_write_strobe();
-    random_write_strobe = StrbWidth'(get_random_bits(StrbWidth));
+    logic [StrbWidth-1:0] strb;
+
+    if (!std::randomize(strb)) begin
+      $fatal(1, "Failed to randomize AXI-Lite write strobe");
+    end
+
+    random_write_strobe = strb;
   endfunction
 
   task automatic init_scenario(output axil2apb_scenario_t scenario, input int num_writes,
@@ -341,10 +358,14 @@ module br_amba_axil2apb_tb;
                                                 output apb_response_t response);
     logic [AddrWidth-1:0] addr = AddrWidth'($urandom());
     logic [AxiProtWidth-1:0] prot = AxiProtWidth'($urandom());
-    logic [DataWidth-1:0] data = DataWidth'(get_random_bits(DataWidth));
+    logic [DataWidth-1:0] data;
     int aw_gap_cycles = $urandom_range(scenario.max_aw_gap_cycles, scenario.min_aw_gap_cycles);
     int w_gap_cycles = $urandom_range(scenario.max_w_gap_cycles, scenario.min_w_gap_cycles);
     int b_stall_cycles = $urandom_range(scenario.max_b_stall_cycles, scenario.min_b_stall_cycles);
+
+    if (!std::randomize(data)) begin
+      td.check(1'b0, "Failed to randomize AXI-Lite write data");
+    end
 
     response = random_response(scenario.allow_slverr, scenario.force_slverr);
     axil_driver.queue_write(addr, prot, data, strb, aw_gap_cycles, w_gap_cycles, b_stall_cycles);
@@ -720,10 +741,15 @@ module br_amba_axil2apb_tb;
   endtask
 
   task automatic reset_after_incomplete_write();
+    logic [DataWidth-1:0] data;
+
     init_idle();
-    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()),
-                            DataWidth'(get_random_bits(DataWidth)), MidResetStrobe, NoGapCycles,
-                            MidResetWriteDataDelayCycles, NoStallCycles);
+    if (!std::randomize(data)) begin
+      td.check(1'b0, "Failed to randomize incomplete-write reset data");
+    end
+
+    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()), data, MidResetStrobe,
+                            NoGapCycles, MidResetWriteDataDelayCycles, NoStallCycles);
     fork
       begin
         fork
@@ -747,10 +773,15 @@ module br_amba_axil2apb_tb;
   endtask
 
   task automatic reset_during_apb_setup();
+    logic [DataWidth-1:0] data;
+
     init_idle();
-    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()),
-                            DataWidth'(get_random_bits(DataWidth)), MidResetStrobe, NoGapCycles,
-                            NoGapCycles, NoStallCycles);
+    if (!std::randomize(data)) begin
+      td.check(1'b0, "Failed to randomize APB setup reset data");
+    end
+
+    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()), data, MidResetStrobe,
+                            NoGapCycles, NoGapCycles, NoStallCycles);
     fork
       begin
         fork
@@ -774,10 +805,15 @@ module br_amba_axil2apb_tb;
   endtask
 
   task automatic reset_during_apb_access();
+    logic [DataWidth-1:0] data;
+
     init_idle();
-    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()),
-                            DataWidth'(get_random_bits(DataWidth)), MidResetStrobe, NoGapCycles,
-                            NoGapCycles, NoStallCycles);
+    if (!std::randomize(data)) begin
+      td.check(1'b0, "Failed to randomize APB access reset data");
+    end
+
+    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()), data, MidResetStrobe,
+                            NoGapCycles, NoGapCycles, NoStallCycles);
     fork
       begin
         fork
@@ -803,14 +839,18 @@ module br_amba_axil2apb_tb;
   task automatic reset_during_write_response();
     apb_response_controls_t response_controls;
     apb_response_t response_queue[$];
+    logic [DataWidth-1:0] data;
 
     init_idle();
+    if (!std::randomize(data)) begin
+      td.check(1'b0, "Failed to randomize write-response reset data");
+    end
+
     response_queue.push_back(random_response(1'b0, 1'b0));
     response_controls.num_transactions = SingleWrite;
     response_controls.wait_cycles = NoStallCycles;
-    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()),
-                            DataWidth'(get_random_bits(DataWidth)), MidResetStrobe, NoGapCycles,
-                            NoGapCycles, MidResetResponseStallCycles);
+    axil_driver.queue_write(AddrWidth'($urandom()), AxiProtWidth'($urandom()), data, MidResetStrobe,
+                            NoGapCycles, NoGapCycles, MidResetResponseStallCycles);
     fork
       begin
         fork

--- a/amba/sim/br_amba_axil_split_sim_pkg.sv
+++ b/amba/sim/br_amba_axil_split_sim_pkg.sv
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+package br_amba_axil_split_sim_pkg;
+  import br_amba::*;
+  import br_amba_axil_sim_pkg::*;
+
+  typedef enum bit {
+    AxilSplitRouteTrunk,
+    AxilSplitRouteBranch
+  } axil_split_route_t;
+
+  typedef enum int {
+    AxilSplitTransactionWrite,
+    AxilSplitTransactionRead
+  } axil_split_transaction_kind_t;
+
+  typedef enum int {
+    AxilResetTriggerAwBeforeW,
+    AxilResetTriggerWBeforeAw,
+    AxilResetTriggerBPending,
+    AxilResetTriggerRPending
+  } axil_reset_trigger_t;
+
+  typedef struct packed {
+    axil_split_transaction_kind_t kind;
+    axil_split_route_t            route;
+    logic [AxilAddrWidth-1:0]     root_addr;
+    logic [AxilAddrWidth-1:0]     routed_addr;
+    logic [AxiProtWidth-1:0]      prot;
+    logic [AxilUserWidth-1:0]     addr_user;
+    logic [AxilDataWidth-1:0]     data;
+    logic [AxilStrobeWidth-1:0]   strb;
+    logic [AxilUserWidth-1:0]     data_user;
+    logic [AxiRespWidth-1:0]      resp;
+    logic [AxilUserWidth-1:0]     response_user;
+    time                          request_ts;
+    time                          response_ts;
+  } axil_split_transaction_t;
+
+  typedef struct {
+    int   num_writes;
+    int   num_reads;
+    int   min_aw_gap_cycles;
+    int   max_aw_gap_cycles;
+    int   min_w_gap_cycles;
+    int   max_w_gap_cycles;
+    int   min_ar_gap_cycles;
+    int   max_ar_gap_cycles;
+    int   min_b_stall_cycles;
+    int   max_b_stall_cycles;
+    int   min_r_stall_cycles;
+    int   max_r_stall_cycles;
+    int   max_trunk_ready_stall_cycles;
+    int   max_branch_ready_stall_cycles;
+    logic allow_error_responses;
+    logic force_trunk_route;
+    logic force_branch_route;
+    logic check_max_outstanding_reads;
+    logic check_max_outstanding_writes;
+  } axil_split_scenario_t;
+
+  typedef struct {
+    int root_aw;
+    int root_w;
+    int root_ar;
+    int root_b;
+    int root_r;
+    int trunk_aw;
+    int trunk_w;
+    int trunk_ar;
+    int trunk_b;
+    int trunk_r;
+    int branch_aw;
+    int branch_w;
+    int branch_ar;
+    int branch_b;
+    int branch_r;
+  } axil_reset_counts_t;
+endpackage : br_amba_axil_split_sim_pkg

--- a/amba/sim/br_amba_axil_split_tb.sv
+++ b/amba/sim/br_amba_axil_split_tb.sv
@@ -1,0 +1,1478 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_axil_sim_pkg::*;
+import br_amba_axil_monitor_sim_pkg::*;
+import br_amba_axil_split_sim_pkg::*;
+import br_amba_sim_pkg::*;
+
+`include "br_asserts.svh"
+`include "br_amba_sim_macros.svh"
+
+// Directed simulation testbench for br_amba_axil_split. The scenarios cover route smoke tests,
+// range boundaries and overlaps, channel skew, backpressure, outstanding depth, randomized traffic,
+// and reset recovery. Split-specific prediction and data checks live in the scoreboard.
+module br_amba_axil_split_tb;
+  // Testbench clock/reset and global scenario timeout.
+  localparam int ResetCycles = 5;
+  localparam int ClockPeriodNs = 10;
+  localparam int TimeoutCycles = 100000;
+
+  // Common transaction-count aliases for directed scenarios.
+  localparam int NoWrites = 0;
+  localparam int NoReads = 0;
+  localparam int SingleWrite = 1;
+  localparam int SingleRead = 1;
+
+  // Default no-delay channel timing used by init_scenario.
+  localparam int NoGapCycles = 0;
+  localparam int NoStallCycles = 0;
+
+  // Directed timing knobs shared by write-skew, outstanding, and reset scenarios.
+  localparam int WriteSkewGapCycles = 4;
+  localparam int OutstandingResponseStallCycles = 8;
+  localparam int MidResetResponseStallCycles = 8;
+  localparam int MidResetTimeoutCycles = 64;
+
+  // Bounded random traffic size for directed backpressure and mixed-traffic scenarios.
+  localparam int MinDirectedTransactions = 20;
+  localparam int MaxDirectedTransactions = 40;
+
+  // Address-space endpoints used by branch range generation and boundary tests.
+  localparam logic [AxilAddrWidth-1:0] MinAxilAddr = '0;
+  localparam logic [AxilAddrWidth-1:0] MaxAxilAddr = '1;
+  localparam logic [AxilAddrWidth-1:0] MaxBranchRangeAddr = MaxAxilAddr - AxilAddrWidth'(1);
+
+  // DUT parameters swept by the Bazel simulation matrix.
+  parameter int MaxOutstandingReads = 1;
+  parameter int MaxOutstandingWrites = 1;
+  parameter int NumBranchAddrRanges = 1;
+  parameter int MinRandomDelayCycles = 0;
+  parameter int MaxRandomDelayCycles = 3;
+  parameter bit NormalizeBranchAddress = 0;
+
+  localparam int NumBranchRanges = NumBranchAddrRanges;
+
+  `BR_ASSERT_STATIC(NumBranchRangesPositive, NumBranchRanges > 0)
+  `BR_ASSERT_STATIC(MinRandomDelayCyclesNonnegative, MinRandomDelayCycles >= 0)
+  `BR_ASSERT_STATIC(RandomDelayRangeValid, MaxRandomDelayCycles >= MinRandomDelayCycles)
+
+  // Widened arithmetic type for address-range generation without wraparound.
+  localparam int AddrCalcWidth = AxilAddrWidth + $clog2(NumBranchRanges + 1) + 1;
+
+  logic clk;
+  logic rst;
+  logic root_driver_failed;
+  logic trunk_target_failed;
+  logic branch_target_failed;
+  logic root_monitor_failed;
+  logic trunk_monitor_failed;
+  logic branch_monitor_failed;
+  logic scoreboard_failed;
+  logic timeout_failed;
+  logic reset_monitor_enabled = 1'b0;
+  event timeout_tick;
+
+  logic [NumBranchRanges-1:0][AxilAddrWidth-1:0] branch_start_addr;
+  logic [NumBranchRanges-1:0][AxilAddrWidth-1:0] branch_end_addr;
+
+  // AXI4-Lite root target interface.
+  logic [AxilAddrWidth-1:0] root_awaddr;
+  logic [AxiProtWidth-1:0] root_awprot;
+  logic [AxilUserWidth-1:0] root_awuser;
+  logic root_awvalid;
+  logic root_awready;
+  logic [AxilDataWidth-1:0] root_wdata;
+  logic [AxilStrobeWidth-1:0] root_wstrb;
+  logic [AxilUserWidth-1:0] root_wuser;
+  logic root_wvalid;
+  logic root_wready;
+  logic [AxiRespWidth-1:0] root_bresp;
+  logic root_bvalid;
+  logic root_bready;
+  logic [AxilAddrWidth-1:0] root_araddr;
+  logic [AxiProtWidth-1:0] root_arprot;
+  logic [AxilUserWidth-1:0] root_aruser;
+  logic root_arvalid;
+  logic root_arready;
+  logic [AxilDataWidth-1:0] root_rdata;
+  logic [AxiRespWidth-1:0] root_rresp;
+  logic [AxilUserWidth-1:0] root_ruser;
+  logic root_rvalid;
+  logic root_rready;
+
+  // AXI4-Lite trunk initiator interface.
+  logic [AxilAddrWidth-1:0] trunk_awaddr;
+  logic [AxiProtWidth-1:0] trunk_awprot;
+  logic [AxilUserWidth-1:0] trunk_awuser;
+  logic trunk_awvalid;
+  logic trunk_awready;
+  logic [AxilDataWidth-1:0] trunk_wdata;
+  logic [AxilStrobeWidth-1:0] trunk_wstrb;
+  logic [AxilUserWidth-1:0] trunk_wuser;
+  logic trunk_wvalid;
+  logic trunk_wready;
+  logic [AxiRespWidth-1:0] trunk_bresp;
+  logic [AxilUserWidth-1:0] trunk_buser;
+  logic trunk_bvalid;
+  logic trunk_bready;
+  logic [AxilAddrWidth-1:0] trunk_araddr;
+  logic [AxiProtWidth-1:0] trunk_arprot;
+  logic [AxilUserWidth-1:0] trunk_aruser;
+  logic trunk_arvalid;
+  logic trunk_arready;
+  logic [AxilDataWidth-1:0] trunk_rdata;
+  logic [AxiRespWidth-1:0] trunk_rresp;
+  logic [AxilUserWidth-1:0] trunk_ruser;
+  logic trunk_rvalid;
+  logic trunk_rready;
+
+  // AXI4-Lite branch initiator interface.
+  logic [AxilAddrWidth-1:0] branch_awaddr;
+  logic [AxiProtWidth-1:0] branch_awprot;
+  logic [AxilUserWidth-1:0] branch_awuser;
+  logic branch_awvalid;
+  logic branch_awready;
+  logic [AxilDataWidth-1:0] branch_wdata;
+  logic [AxilStrobeWidth-1:0] branch_wstrb;
+  logic [AxilUserWidth-1:0] branch_wuser;
+  logic branch_wvalid;
+  logic branch_wready;
+  logic [AxiRespWidth-1:0] branch_bresp;
+  logic [AxilUserWidth-1:0] branch_buser;
+  logic branch_bvalid;
+  logic branch_bready;
+  logic [AxilAddrWidth-1:0] branch_araddr;
+  logic [AxiProtWidth-1:0] branch_arprot;
+  logic [AxilUserWidth-1:0] branch_aruser;
+  logic branch_arvalid;
+  logic branch_arready;
+  logic [AxilDataWidth-1:0] branch_rdata;
+  logic [AxiRespWidth-1:0] branch_rresp;
+  logic [AxilUserWidth-1:0] branch_ruser;
+  logic branch_rvalid;
+  logic branch_rready;
+
+  always @(posedge clk) begin
+    ->timeout_tick;
+  end
+
+  br_test_driver #(
+      .ResetCycles  (ResetCycles),
+      .ClockPeriodNs(ClockPeriodNs)
+  ) td (
+      .clk(clk),
+      .rst(rst)
+  );
+
+  br_amba_axil_split #(
+      .AddrWidth(AxilAddrWidth),
+      .DataWidth(AxilDataWidth),
+      .AWUserWidth(AxilUserWidth),
+      .WUserWidth(AxilUserWidth),
+      .ARUserWidth(AxilUserWidth),
+      .RUserWidth(AxilUserWidth),
+      .MaxOutstandingReads(MaxOutstandingReads),
+      .MaxOutstandingWrites(MaxOutstandingWrites),
+      .NumBranchAddrRanges(NumBranchRanges),
+      .NormalizeBranchAddress(NormalizeBranchAddress)
+  ) dut (
+      .clk(clk),
+      .rst(rst),
+      .branch_start_addr(branch_start_addr),
+      .branch_end_addr(branch_end_addr),
+      .root_awaddr(root_awaddr),
+      .root_awprot(root_awprot),
+      .root_awuser(root_awuser),
+      .root_awvalid(root_awvalid),
+      .root_awready(root_awready),
+      .root_wdata(root_wdata),
+      .root_wstrb(root_wstrb),
+      .root_wuser(root_wuser),
+      .root_wvalid(root_wvalid),
+      .root_wready(root_wready),
+      .root_bresp(root_bresp),
+      .root_bvalid(root_bvalid),
+      .root_bready(root_bready),
+      .root_araddr(root_araddr),
+      .root_arprot(root_arprot),
+      .root_aruser(root_aruser),
+      .root_arvalid(root_arvalid),
+      .root_arready(root_arready),
+      .root_rdata(root_rdata),
+      .root_rresp(root_rresp),
+      .root_ruser(root_ruser),
+      .root_rvalid(root_rvalid),
+      .root_rready(root_rready),
+      .trunk_awaddr(trunk_awaddr),
+      .trunk_awprot(trunk_awprot),
+      .trunk_awuser(trunk_awuser),
+      .trunk_awvalid(trunk_awvalid),
+      .trunk_awready(trunk_awready),
+      .trunk_wdata(trunk_wdata),
+      .trunk_wstrb(trunk_wstrb),
+      .trunk_wuser(trunk_wuser),
+      .trunk_wvalid(trunk_wvalid),
+      .trunk_wready(trunk_wready),
+      .trunk_bresp(trunk_bresp),
+      .trunk_bvalid(trunk_bvalid),
+      .trunk_bready(trunk_bready),
+      .trunk_araddr(trunk_araddr),
+      .trunk_arprot(trunk_arprot),
+      .trunk_aruser(trunk_aruser),
+      .trunk_arvalid(trunk_arvalid),
+      .trunk_arready(trunk_arready),
+      .trunk_rdata(trunk_rdata),
+      .trunk_rresp(trunk_rresp),
+      .trunk_ruser(trunk_ruser),
+      .trunk_rvalid(trunk_rvalid),
+      .trunk_rready(trunk_rready),
+      .branch_awaddr(branch_awaddr),
+      .branch_awprot(branch_awprot),
+      .branch_awuser(branch_awuser),
+      .branch_awvalid(branch_awvalid),
+      .branch_awready(branch_awready),
+      .branch_wdata(branch_wdata),
+      .branch_wstrb(branch_wstrb),
+      .branch_wuser(branch_wuser),
+      .branch_wvalid(branch_wvalid),
+      .branch_wready(branch_wready),
+      .branch_bresp(branch_bresp),
+      .branch_bvalid(branch_bvalid),
+      .branch_bready(branch_bready),
+      .branch_araddr(branch_araddr),
+      .branch_arprot(branch_arprot),
+      .branch_aruser(branch_aruser),
+      .branch_arvalid(branch_arvalid),
+      .branch_arready(branch_arready),
+      .branch_rdata(branch_rdata),
+      .branch_rresp(branch_rresp),
+      .branch_ruser(branch_ruser),
+      .branch_rvalid(branch_rvalid),
+      .branch_rready(branch_rready)
+  );
+
+  br_amba_axil_requester_driver #(
+      .AddrWidth(AxilAddrWidth),
+      .DataWidth(AxilDataWidth),
+      .AWUserWidth(AxilUserWidth),
+      .WUserWidth(AxilUserWidth),
+      .ARUserWidth(AxilUserWidth),
+      .TimeoutCycles(TimeoutCycles)
+  ) root_driver (
+      .clk(clk),
+      .rst(rst),
+      .axil_awaddr(root_awaddr),
+      .axil_awprot(root_awprot),
+      .axil_awuser(root_awuser),
+      .axil_awvalid(root_awvalid),
+      .axil_awready(root_awready),
+      .axil_wdata(root_wdata),
+      .axil_wstrb(root_wstrb),
+      .axil_wuser(root_wuser),
+      .axil_wvalid(root_wvalid),
+      .axil_wready(root_wready),
+      .axil_bvalid(root_bvalid),
+      .axil_bready(root_bready),
+      .axil_araddr(root_araddr),
+      .axil_arprot(root_arprot),
+      .axil_aruser(root_aruser),
+      .axil_arvalid(root_arvalid),
+      .axil_arready(root_arready),
+      .axil_rvalid(root_rvalid),
+      .axil_rready(root_rready),
+      .failed(root_driver_failed)
+  );
+
+  br_amba_axil_target_driver #(
+      .DataWidth(AxilDataWidth),
+      .BUserWidth(AxilUserWidth),
+      .RUserWidth(AxilUserWidth),
+      .TimeoutCycles(TimeoutCycles)
+  ) trunk_target (
+      .clk(clk),
+      .rst(rst),
+      .axil_awvalid(trunk_awvalid),
+      .axil_awready(trunk_awready),
+      .axil_wvalid(trunk_wvalid),
+      .axil_wready(trunk_wready),
+      .axil_bresp(trunk_bresp),
+      .axil_buser(trunk_buser),
+      .axil_bvalid(trunk_bvalid),
+      .axil_bready(trunk_bready),
+      .axil_arvalid(trunk_arvalid),
+      .axil_arready(trunk_arready),
+      .axil_rdata(trunk_rdata),
+      .axil_rresp(trunk_rresp),
+      .axil_ruser(trunk_ruser),
+      .axil_rvalid(trunk_rvalid),
+      .axil_rready(trunk_rready),
+      .failed(trunk_target_failed)
+  );
+
+  br_amba_axil_target_driver #(
+      .DataWidth(AxilDataWidth),
+      .BUserWidth(AxilUserWidth),
+      .RUserWidth(AxilUserWidth),
+      .TimeoutCycles(TimeoutCycles)
+  ) branch_target (
+      .clk(clk),
+      .rst(rst),
+      .axil_awvalid(branch_awvalid),
+      .axil_awready(branch_awready),
+      .axil_wvalid(branch_wvalid),
+      .axil_wready(branch_wready),
+      .axil_bresp(branch_bresp),
+      .axil_buser(branch_buser),
+      .axil_bvalid(branch_bvalid),
+      .axil_bready(branch_bready),
+      .axil_arvalid(branch_arvalid),
+      .axil_arready(branch_arready),
+      .axil_rdata(branch_rdata),
+      .axil_rresp(branch_rresp),
+      .axil_ruser(branch_ruser),
+      .axil_rvalid(branch_rvalid),
+      .axil_rready(branch_rready),
+      .failed(branch_target_failed)
+  );
+
+  br_amba_axil_monitor #(
+      .AddrWidth  (AxilAddrWidth),
+      .DataWidth  (AxilDataWidth),
+      .AWUserWidth(AxilUserWidth),
+      .WUserWidth (AxilUserWidth),
+      .BUserWidth (AxilUserWidth),
+      .ARUserWidth(AxilUserWidth),
+      .RUserWidth (AxilUserWidth)
+  ) root_monitor (
+      .clk(clk),
+      .rst(rst),
+      .axil_awaddr(root_awaddr),
+      .axil_awprot(root_awprot),
+      .axil_awuser(root_awuser),
+      .axil_awvalid(root_awvalid),
+      .axil_awready(root_awready),
+      .axil_wdata(root_wdata),
+      .axil_wstrb(root_wstrb),
+      .axil_wuser(root_wuser),
+      .axil_wvalid(root_wvalid),
+      .axil_wready(root_wready),
+      .axil_bresp(root_bresp),
+      .axil_buser('0),
+      .axil_bvalid(root_bvalid),
+      .axil_bready(root_bready),
+      .axil_araddr(root_araddr),
+      .axil_arprot(root_arprot),
+      .axil_aruser(root_aruser),
+      .axil_arvalid(root_arvalid),
+      .axil_arready(root_arready),
+      .axil_rdata(root_rdata),
+      .axil_rresp(root_rresp),
+      .axil_ruser(root_ruser),
+      .axil_rvalid(root_rvalid),
+      .axil_rready(root_rready),
+      .failed(root_monitor_failed)
+  );
+
+  br_amba_axil_monitor #(
+      .AddrWidth  (AxilAddrWidth),
+      .DataWidth  (AxilDataWidth),
+      .AWUserWidth(AxilUserWidth),
+      .WUserWidth (AxilUserWidth),
+      .BUserWidth (AxilUserWidth),
+      .ARUserWidth(AxilUserWidth),
+      .RUserWidth (AxilUserWidth)
+  ) trunk_monitor (
+      .clk(clk),
+      .rst(rst),
+      .axil_awaddr(trunk_awaddr),
+      .axil_awprot(trunk_awprot),
+      .axil_awuser(trunk_awuser),
+      .axil_awvalid(trunk_awvalid),
+      .axil_awready(trunk_awready),
+      .axil_wdata(trunk_wdata),
+      .axil_wstrb(trunk_wstrb),
+      .axil_wuser(trunk_wuser),
+      .axil_wvalid(trunk_wvalid),
+      .axil_wready(trunk_wready),
+      .axil_bresp(trunk_bresp),
+      .axil_buser(trunk_buser),
+      .axil_bvalid(trunk_bvalid),
+      .axil_bready(trunk_bready),
+      .axil_araddr(trunk_araddr),
+      .axil_arprot(trunk_arprot),
+      .axil_aruser(trunk_aruser),
+      .axil_arvalid(trunk_arvalid),
+      .axil_arready(trunk_arready),
+      .axil_rdata(trunk_rdata),
+      .axil_rresp(trunk_rresp),
+      .axil_ruser(trunk_ruser),
+      .axil_rvalid(trunk_rvalid),
+      .axil_rready(trunk_rready),
+      .failed(trunk_monitor_failed)
+  );
+
+  br_amba_axil_monitor #(
+      .AddrWidth  (AxilAddrWidth),
+      .DataWidth  (AxilDataWidth),
+      .AWUserWidth(AxilUserWidth),
+      .WUserWidth (AxilUserWidth),
+      .BUserWidth (AxilUserWidth),
+      .ARUserWidth(AxilUserWidth),
+      .RUserWidth (AxilUserWidth)
+  ) branch_monitor (
+      .clk(clk),
+      .rst(rst),
+      .axil_awaddr(branch_awaddr),
+      .axil_awprot(branch_awprot),
+      .axil_awuser(branch_awuser),
+      .axil_awvalid(branch_awvalid),
+      .axil_awready(branch_awready),
+      .axil_wdata(branch_wdata),
+      .axil_wstrb(branch_wstrb),
+      .axil_wuser(branch_wuser),
+      .axil_wvalid(branch_wvalid),
+      .axil_wready(branch_wready),
+      .axil_bresp(branch_bresp),
+      .axil_buser(branch_buser),
+      .axil_bvalid(branch_bvalid),
+      .axil_bready(branch_bready),
+      .axil_araddr(branch_araddr),
+      .axil_arprot(branch_arprot),
+      .axil_aruser(branch_aruser),
+      .axil_arvalid(branch_arvalid),
+      .axil_arready(branch_arready),
+      .axil_rdata(branch_rdata),
+      .axil_rresp(branch_rresp),
+      .axil_ruser(branch_ruser),
+      .axil_rvalid(branch_rvalid),
+      .axil_rready(branch_rready),
+      .failed(branch_monitor_failed)
+  );
+
+  br_amba_axil_split_scoreboard #(
+      .NumBranchAddrRanges(NumBranchRanges),
+      .NormalizeBranchAddress(NormalizeBranchAddress)
+  ) scoreboard (
+      .failed(scoreboard_failed)
+  );
+
+  int num_trunk_writes;
+  int num_trunk_reads;
+  int num_branch_writes;
+  int num_branch_reads;
+  logic [AxilAddrWidth-1:0] trunk_addr_q[$];
+  logic [AxilAddrWidth-1:0] branch_addr_q[$];
+
+  function automatic logic [AxilAddrWidth-1:0] random_addr(
+      input logic [AxilAddrWidth-1:0] min_value, input logic [AxilAddrWidth-1:0] max_value);
+    logic [  AxilAddrWidth:0] span = {1'b0, max_value} - {1'b0, min_value} + 1'b1;
+    logic [AxilAddrWidth-1:0] random_addr_bits;
+
+    `BR_SIM_RANDOMIZE((random_addr_bits), "AXI-Lite split address bits");
+    random_addr = min_value + AxilAddrWidth'({1'b0, random_addr_bits} % span);
+  endfunction
+
+  function automatic logic is_branch_addr(input logic [AxilAddrWidth-1:0] addr);
+    is_branch_addr = 1'b0;
+    for (int i = 0; i < NumBranchRanges; i++) begin
+      is_branch_addr |= addr >= branch_start_addr[i] && addr <= branch_end_addr[i];
+    end
+  endfunction
+
+  // Route-directed stimulus is derived from the same branch range state driven into the DUT.
+  task automatic populate_addr_queues();
+    logic [AxilAddrWidth-1:0] trunk_candidate;
+
+    trunk_addr_q.delete();
+    branch_addr_q.delete();
+    for (int i = 0; i < NumBranchRanges; i++) begin
+      branch_addr_q.push_back(branch_start_addr[i]);
+      branch_addr_q.push_back(branch_end_addr[i]);
+      if (branch_start_addr[i] != MinAxilAddr) begin
+        trunk_candidate = branch_start_addr[i] - AxilAddrWidth'(1);
+        if (!is_branch_addr(trunk_candidate)) trunk_addr_q.push_back(trunk_candidate);
+      end
+      if (branch_end_addr[i] != MaxAxilAddr) begin
+        trunk_candidate = branch_end_addr[i] + AxilAddrWidth'(1);
+        if (!is_branch_addr(trunk_candidate)) trunk_addr_q.push_back(trunk_candidate);
+      end
+    end
+    if (trunk_addr_q.size() == 0) trunk_addr_q.push_back(MaxAxilAddr);
+    td.check(trunk_addr_q.size() != 0, "No trunk address available outside branch ranges");
+  endtask
+
+  task automatic init_empty_ranges();
+    for (int i = 0; i < NumBranchRanges; i++) begin
+      branch_start_addr[i] = MinAxilAddr;
+      branch_end_addr[i]   = MinAxilAddr;
+    end
+  endtask
+
+  task automatic init_disjoint_ranges(input logic [AddrCalcWidth-1:0] addr_space_size);
+    logic [NumBranchRanges-1:0][AxilAddrWidth-1:0] range_start_addr;
+
+    if (addr_space_size < AddrCalcWidth'(NumBranchRanges)) begin
+      td.check(1'b0, "AXI-Lite address space cannot fit requested non-overlapping branch ranges");
+      init_empty_ranges();
+      return;
+    end
+
+    for (int i = 0; i < NumBranchRanges; i++) begin
+      logic [AddrCalcWidth-1:0] min_start_ext;
+      logic [AddrCalcWidth-1:0] max_start_ext;
+
+      // Choose monotonically increasing starts with enough remaining address points for later ranges.
+      min_start_ext = (i == 0) ? '0 : AddrCalcWidth'(range_start_addr[i-1]) + 1'b1;
+      max_start_ext = addr_space_size - AddrCalcWidth'(NumBranchRanges - i);
+      range_start_addr[i] =
+          random_addr(AxilAddrWidth'(min_start_ext), AxilAddrWidth'(max_start_ext));
+    end
+
+    for (int i = 0; i < NumBranchRanges; i++) begin
+      logic [AxilAddrWidth-1:0] max_end_addr;
+
+      branch_start_addr[i] = range_start_addr[i];
+      max_end_addr = (i == NumBranchRanges - 1) ? MaxBranchRangeAddr : range_start_addr[i+1] - 1'b1;
+      branch_end_addr[i] = random_addr(branch_start_addr[i], max_end_addr);
+    end
+  endtask
+
+  task automatic init_overlap_ranges(input logic [AddrCalcWidth-1:0] addr_space_size);
+    if (addr_space_size < AddrCalcWidth'(2)) begin
+      td.check(1'b0, "AXI-Lite address space cannot fit non-empty overlapping branch ranges");
+      init_empty_ranges();
+      return;
+    end
+
+    for (int i = 0; i < NumBranchRanges; i++) begin
+      logic [AxilAddrWidth-1:0] max_start_addr;
+
+      // Overlapping ranges can reuse address space, but each start must leave room for end > start.
+      max_start_addr = AxilAddrWidth'(addr_space_size - AddrCalcWidth'(2));
+      branch_start_addr[i] = random_addr(MinAxilAddr, max_start_addr);
+      branch_end_addr[i] = random_addr(branch_start_addr[i] + 1'b1, MaxBranchRangeAddr);
+    end
+
+    if (NumBranchRanges > 1) begin
+      int overlap_range_index = 1;
+
+      // Force at least one deterministic overlap after random range generation so the overlap
+      // scenario always exercises priority/normalization behavior.
+      branch_start_addr[overlap_range_index] =
+          random_addr(branch_start_addr[0] + 1'b1, branch_end_addr[0]);
+      branch_end_addr[overlap_range_index] =
+          random_addr(branch_start_addr[overlap_range_index], MaxBranchRangeAddr);
+    end
+  endtask
+
+  task automatic init_ranges(input logic allow_overlap);
+    logic [AddrCalcWidth-1:0] addr_space_size;
+
+    // Leave the all-ones address outside branch space so every generated setup has at least one
+    // guaranteed trunk address. Use widened math here to avoid wrapping when AxilAddrWidth is large.
+    addr_space_size = (AddrCalcWidth'(1) << AxilAddrWidth) - 1'b1;
+    if (allow_overlap) init_overlap_ranges(addr_space_size);
+    else init_disjoint_ranges(addr_space_size);
+    populate_addr_queues();
+  endtask
+
+  task automatic init_scenario(output axil_split_scenario_t scenario, input int num_writes,
+                               input int num_reads);
+    scenario.num_writes = num_writes;
+    scenario.num_reads = num_reads;
+    scenario.min_aw_gap_cycles = NoGapCycles;
+    scenario.max_aw_gap_cycles = NoGapCycles;
+    scenario.min_w_gap_cycles = NoGapCycles;
+    scenario.max_w_gap_cycles = NoGapCycles;
+    scenario.min_ar_gap_cycles = NoGapCycles;
+    scenario.max_ar_gap_cycles = NoGapCycles;
+    scenario.min_b_stall_cycles = NoStallCycles;
+    scenario.max_b_stall_cycles = NoStallCycles;
+    scenario.min_r_stall_cycles = NoStallCycles;
+    scenario.max_r_stall_cycles = NoStallCycles;
+    scenario.max_trunk_ready_stall_cycles = NoStallCycles;
+    scenario.max_branch_ready_stall_cycles = NoStallCycles;
+    scenario.allow_error_responses = 1'b0;
+    scenario.force_trunk_route = 1'b0;
+    scenario.force_branch_route = 1'b0;
+    scenario.check_max_outstanding_reads = 1'b0;
+    scenario.check_max_outstanding_writes = 1'b0;
+  endtask
+
+  task automatic init_idle();
+    root_driver.init_idle();
+    trunk_target.init_idle();
+    branch_target.init_idle();
+    root_monitor.init_idle();
+    trunk_monitor.init_idle();
+    branch_monitor.init_idle();
+    scoreboard.init_idle();
+    timeout_failed = 1'b0;
+    num_trunk_writes = 0;
+    num_trunk_reads = 0;
+    num_branch_writes = 0;
+    num_branch_reads = 0;
+    init_ranges(.allow_overlap(1'b0));
+  endtask
+
+  function automatic logic [AxilAddrWidth-1:0] addr_for_route(input axil_split_route_t route,
+                                                              input logic is_write);
+    int branch_queue_index = is_write ? num_branch_writes : num_branch_reads;
+    int trunk_queue_index = is_write ? num_trunk_writes : num_trunk_reads;
+
+    if (route == AxilSplitRouteBranch)
+      addr_for_route = branch_addr_q[branch_queue_index%branch_addr_q.size()];
+    else addr_for_route = trunk_addr_q[trunk_queue_index%trunk_addr_q.size()];
+  endfunction
+
+  function automatic logic [AxilAddrWidth-1:0] fallback_trunk_addr();
+    fallback_trunk_addr = addr_for_route(AxilSplitRouteTrunk, 1'b1);
+  endfunction
+
+  function automatic axil_b_t random_b_response(input logic allow_error);
+    axi_resp_t response_choice;
+
+    `BR_SIM_RANDOMIZE((response_choice), "AXI response choice");
+    random_b_response = '0;
+    random_b_response.resp = allow_error ? response_choice : AxiRespOkay;
+  endfunction
+
+  function automatic axil_b_t b_response(input logic [AxiRespWidth-1:0] resp);
+    b_response = '0;
+    b_response.resp = resp;
+  endfunction
+
+  function automatic axil_r_t random_r_response(input logic allow_error);
+    logic [AxilDataWidth-1:0] data;
+    logic [AxilUserWidth-1:0] user;
+    axi_resp_t response_choice;
+
+    `BR_SIM_RANDOMIZE((response_choice), "AXI response choice");
+    `BR_SIM_RANDOMIZE((data), "AXI-Lite R data");
+    `BR_SIM_RANDOMIZE((user), "AXI-Lite R user");
+    random_r_response = '0;
+    random_r_response.data = data;
+    random_r_response.resp = allow_error ? response_choice : AxiRespOkay;
+    random_r_response.user = user;
+  endfunction
+
+  function automatic axil_r_t r_response(input logic [AxiRespWidth-1:0] resp);
+    logic [AxilDataWidth-1:0] data;
+    logic [AxilUserWidth-1:0] user;
+
+    `BR_SIM_RANDOMIZE((data), "AXI-Lite R data");
+    `BR_SIM_RANDOMIZE((user), "AXI-Lite R user");
+    r_response = '0;
+    r_response.data = data;
+    r_response.resp = resp;
+    r_response.user = user;
+  endfunction
+
+  task automatic queue_write_addr_response(
+      input axil_split_scenario_t scenario, input axil_split_route_t route,
+      input logic [AxilAddrWidth-1:0] addr, input logic [AxilStrobeWidth-1:0] strb,
+      input axil_b_t response);
+    logic [AxiProtWidth-1:0] prot;
+    logic [AxilUserWidth-1:0] awuser;
+    logic [AxilDataWidth-1:0] data;
+    logic [AxilUserWidth-1:0] wuser;
+    int aw_gap_cycles = $urandom_range(scenario.max_aw_gap_cycles, scenario.min_aw_gap_cycles);
+    int w_gap_cycles = $urandom_range(scenario.max_w_gap_cycles, scenario.min_w_gap_cycles);
+    int b_stall_cycles = $urandom_range(scenario.max_b_stall_cycles, scenario.min_b_stall_cycles);
+
+    `BR_SIM_RANDOMIZE((prot, awuser, data, wuser), "AXI-Lite write payload");
+    root_driver.queue_write_user(addr, prot, awuser, data, strb, wuser, aw_gap_cycles, w_gap_cycles,
+                                 b_stall_cycles);
+    if (route == AxilSplitRouteBranch) begin
+      branch_target.queue_b_response(response);
+      num_branch_writes++;
+    end else begin
+      trunk_target.queue_b_response(response);
+      num_trunk_writes++;
+    end
+  endtask
+
+  task automatic queue_write_addr(input axil_split_scenario_t scenario,
+                                  input axil_split_route_t route,
+                                  input logic [AxilAddrWidth-1:0] addr);
+    axil_b_t response = random_b_response(scenario.allow_error_responses);
+    logic [AxilStrobeWidth-1:0] strb;
+
+    `BR_SIM_RANDOMIZE((strb), "AXI-Lite write strobe");
+    queue_write_addr_response(scenario, route, addr, strb, response);
+  endtask
+
+  task automatic queue_write(input axil_split_scenario_t scenario, input axil_split_route_t route);
+    logic [AxilAddrWidth-1:0] addr = addr_for_route(route, 1'b1);
+
+    queue_write_addr(scenario, route, addr);
+  endtask
+
+  task automatic queue_write_strobe(input axil_split_scenario_t scenario,
+                                    input axil_split_route_t route,
+                                    input logic [AxilStrobeWidth-1:0] strb);
+    logic [AxilAddrWidth-1:0] addr = addr_for_route(route, 1'b1);
+    axil_b_t response = random_b_response(scenario.allow_error_responses);
+
+    queue_write_addr_response(scenario, route, addr, strb, response);
+  endtask
+
+  task automatic queue_write_response(input axil_split_scenario_t scenario,
+                                      input axil_split_route_t route, input axil_b_t response);
+    logic [  AxilAddrWidth-1:0] addr = addr_for_route(route, 1'b1);
+    logic [AxilStrobeWidth-1:0] strb;
+
+    `BR_SIM_RANDOMIZE((strb), "AXI-Lite write strobe");
+    queue_write_addr_response(scenario, route, addr, strb, response);
+  endtask
+
+  task automatic queue_read_addr_response(
+      input axil_split_scenario_t scenario, input axil_split_route_t route,
+      input logic [AxilAddrWidth-1:0] addr, input axil_r_t response);
+    logic [AxiProtWidth-1:0] prot;
+    logic [AxilUserWidth-1:0] aruser;
+    int ar_gap_cycles = $urandom_range(scenario.max_ar_gap_cycles, scenario.min_ar_gap_cycles);
+    int r_stall_cycles = $urandom_range(scenario.max_r_stall_cycles, scenario.min_r_stall_cycles);
+
+    `BR_SIM_RANDOMIZE((prot, aruser), "AXI-Lite read request payload");
+    root_driver.queue_read_user(addr, prot, aruser, ar_gap_cycles, r_stall_cycles);
+    if (route == AxilSplitRouteBranch) begin
+      branch_target.queue_r_response(response);
+      num_branch_reads++;
+    end else begin
+      trunk_target.queue_r_response(response);
+      num_trunk_reads++;
+    end
+  endtask
+
+  task automatic queue_read_addr(input axil_split_scenario_t scenario,
+                                 input axil_split_route_t route,
+                                 input logic [AxilAddrWidth-1:0] addr);
+    queue_read_addr_response(scenario, route, addr, random_r_response(scenario.allow_error_responses
+                             ));
+  endtask
+
+  task automatic queue_read(input axil_split_scenario_t scenario, input axil_split_route_t route);
+    logic [AxilAddrWidth-1:0] addr = addr_for_route(route, 1'b0);
+
+    queue_read_addr(scenario, route, addr);
+  endtask
+
+  task automatic queue_read_response(input axil_split_scenario_t scenario,
+                                     input axil_split_route_t route, input axil_r_t response);
+    logic [AxilAddrWidth-1:0] addr = addr_for_route(route, 1'b0);
+
+    queue_read_addr_response(scenario, route, addr, response);
+  endtask
+
+  task automatic queue_mixed_transactions(input axil_split_scenario_t scenario);
+    int remaining_writes = scenario.num_writes;
+    int remaining_reads = scenario.num_reads;
+
+    while (remaining_writes != 0 || remaining_reads != 0) begin
+      axil_split_route_t route;
+      logic is_write;
+
+      if (scenario.force_branch_route) route = AxilSplitRouteBranch;
+      else if (scenario.force_trunk_route) route = AxilSplitRouteTrunk;
+      else `BR_SIM_RANDOMIZE((route), "AXI-Lite split route");
+
+      if (remaining_reads == 0) is_write = 1'b1;
+      else if (remaining_writes == 0) is_write = 1'b0;
+      else is_write = $urandom_range(1, 0);
+
+      if (is_write) begin
+        queue_write(scenario, route);
+        remaining_writes--;
+      end else begin
+        queue_read(scenario, route);
+        remaining_reads--;
+      end
+    end
+  endtask
+
+  task automatic collect_scoreboard_observations();
+    axil_aw_observation_t root_aw_q[$];
+    axil_w_observation_t root_w_q[$];
+    axil_ar_observation_t root_ar_q[$];
+    axil_b_observation_t root_b_q[$];
+    axil_r_observation_t root_r_q[$];
+    axil_aw_observation_t trunk_aw_q[$];
+    axil_w_observation_t trunk_w_q[$];
+    axil_ar_observation_t trunk_ar_q[$];
+    axil_b_observation_t trunk_b_q[$];
+    axil_r_observation_t trunk_r_q[$];
+    axil_aw_observation_t branch_aw_q[$];
+    axil_w_observation_t branch_w_q[$];
+    axil_ar_observation_t branch_ar_q[$];
+    axil_b_observation_t branch_b_q[$];
+    axil_r_observation_t branch_r_q[$];
+
+    root_monitor.get_observed_request_observations(root_aw_q, root_w_q, root_ar_q);
+    root_monitor.get_observed_response_observations(root_b_q, root_r_q);
+    trunk_monitor.get_observed_request_observations(trunk_aw_q, trunk_w_q, trunk_ar_q);
+    trunk_monitor.get_observed_response_observations(trunk_b_q, trunk_r_q);
+    branch_monitor.get_observed_request_observations(branch_aw_q, branch_w_q, branch_ar_q);
+    branch_monitor.get_observed_response_observations(branch_b_q, branch_r_q);
+    scoreboard.set_root_observations(root_aw_q, root_w_q, root_ar_q, root_b_q, root_r_q);
+    scoreboard.set_trunk_observations(trunk_aw_q, trunk_w_q, trunk_ar_q, trunk_b_q, trunk_r_q);
+    scoreboard.set_branch_observations(branch_aw_q, branch_w_q, branch_ar_q, branch_b_q,
+                                       branch_r_q);
+  endtask
+
+  task automatic run_queued_scenario(input string scenario_name,
+                                     input axil_split_scenario_t scenario);
+    int expected_max_reads = scenario.check_max_outstanding_reads ? MaxOutstandingReads : 0;
+    int expected_max_writes = scenario.check_max_outstanding_writes ? MaxOutstandingWrites : 0;
+
+    $display("Running br_amba_axil_split scenario: %s", scenario_name);
+    fork
+      begin
+        fork
+          root_driver.run(scenario.num_writes, scenario.num_reads);
+          trunk_target.run(num_trunk_writes, num_trunk_reads,
+                           scenario.max_trunk_ready_stall_cycles);
+          branch_target.run(num_branch_writes, num_branch_reads,
+                            scenario.max_branch_ready_stall_cycles);
+        join
+        td.wait_cycles(1);
+      end
+      root_monitor.run();
+      trunk_monitor.run();
+      branch_monitor.run();
+      timeout(timeout_tick, TimeoutCycles, $sformatf(
+              "Timeout waiting for br_amba_axil_split scenario %s", scenario_name), timeout_failed);
+    join_any
+    disable fork;
+
+    collect_scoreboard_observations();
+    scoreboard.compare(scenario.num_writes, scenario.num_reads, expected_max_reads,
+                       expected_max_writes, branch_start_addr, branch_end_addr);
+    td.check(!root_driver_failed, "AXI-Lite root requester driver reported failure");
+    td.check(!trunk_target_failed, "AXI-Lite trunk target driver reported failure");
+    td.check(!branch_target_failed, "AXI-Lite branch target driver reported failure");
+    td.check(!root_monitor_failed, "AXI-Lite root monitor reported failure");
+    td.check(!trunk_monitor_failed, "AXI-Lite trunk monitor reported failure");
+    td.check(!branch_monitor_failed, "AXI-Lite branch monitor reported failure");
+    td.check(!scoreboard_failed, "AXI-Lite split scoreboard reported failure");
+    td.check(!timeout_failed, "AXI-Lite split scenario timed out");
+  endtask
+
+  task automatic check_observed_count(input string scenario_name, input string channel_name,
+                                      input int actual, input int expected);
+    td.check_integer(actual, expected, $sformatf(
+                     "%s pre-reset %s count mismatch", scenario_name, channel_name));
+  endtask
+
+  task automatic check_observed_axi_counts(
+      input string scenario_name, input string interface_name, input int aw_actual,
+      input int w_actual, input int ar_actual, input int b_actual, input int r_actual,
+      input int aw_expected, input int w_expected, input int ar_expected, input int b_expected,
+      input int r_expected);
+    check_observed_count(scenario_name, {interface_name, " AW"}, aw_actual, aw_expected);
+    check_observed_count(scenario_name, {interface_name, " W"}, w_actual, w_expected);
+    check_observed_count(scenario_name, {interface_name, " AR"}, ar_actual, ar_expected);
+    check_observed_count(scenario_name, {interface_name, " B"}, b_actual, b_expected);
+    check_observed_count(scenario_name, {interface_name, " R"}, r_actual, r_expected);
+  endtask
+
+  task automatic check_reset_pre_reset_traffic(input string scenario_name,
+                                               input axil_reset_counts_t expected);
+    axil_aw_observation_t root_aw_q[$];
+    axil_w_observation_t root_w_q[$];
+    axil_ar_observation_t root_ar_q[$];
+    axil_b_observation_t root_b_q[$];
+    axil_r_observation_t root_r_q[$];
+    axil_aw_observation_t trunk_aw_q[$];
+    axil_w_observation_t trunk_w_q[$];
+    axil_ar_observation_t trunk_ar_q[$];
+    axil_b_observation_t trunk_b_q[$];
+    axil_r_observation_t trunk_r_q[$];
+    axil_aw_observation_t branch_aw_q[$];
+    axil_w_observation_t branch_w_q[$];
+    axil_ar_observation_t branch_ar_q[$];
+    axil_b_observation_t branch_b_q[$];
+    axil_r_observation_t branch_r_q[$];
+
+    root_monitor.get_observed_request_observations(root_aw_q, root_w_q, root_ar_q);
+    root_monitor.get_observed_response_observations(root_b_q, root_r_q);
+    trunk_monitor.get_observed_request_observations(trunk_aw_q, trunk_w_q, trunk_ar_q);
+    trunk_monitor.get_observed_response_observations(trunk_b_q, trunk_r_q);
+    branch_monitor.get_observed_request_observations(branch_aw_q, branch_w_q, branch_ar_q);
+    branch_monitor.get_observed_response_observations(branch_b_q, branch_r_q);
+
+    check_observed_axi_counts(scenario_name, "root", root_aw_q.size(), root_w_q.size(),
+                              root_ar_q.size(), root_b_q.size(), root_r_q.size(), expected.root_aw,
+                              expected.root_w, expected.root_ar, expected.root_b, expected.root_r);
+    check_observed_axi_counts(scenario_name, "trunk", trunk_aw_q.size(), trunk_w_q.size(),
+                              trunk_ar_q.size(), trunk_b_q.size(), trunk_r_q.size(),
+                              expected.trunk_aw, expected.trunk_w, expected.trunk_ar,
+                              expected.trunk_b, expected.trunk_r);
+    check_observed_axi_counts(scenario_name, "branch", branch_aw_q.size(), branch_w_q.size(),
+                              branch_ar_q.size(), branch_b_q.size(), branch_r_q.size(),
+                              expected.branch_aw, expected.branch_w, expected.branch_ar,
+                              expected.branch_b, expected.branch_r);
+    td.check(!root_monitor_failed, $sformatf(
+             "%s root monitor reported failure before reset", scenario_name));
+    td.check(!trunk_monitor_failed, $sformatf(
+             "%s trunk monitor reported failure before reset", scenario_name));
+    td.check(!branch_monitor_failed, $sformatf(
+             "%s branch monitor reported failure before reset", scenario_name));
+  endtask
+
+  task automatic check_idle(input string check_context, input logic only_during_reset = 1'b0,
+                            input logic check_root_responses = 1'b1);
+    forever begin
+      @(posedge clk);
+      if (!only_during_reset || rst) begin
+        td.check(!trunk_awvalid, $sformatf("%s: Trunk AWVALID asserted", check_context));
+        td.check(!trunk_wvalid, $sformatf("%s: Trunk WVALID asserted", check_context));
+        td.check(!trunk_arvalid, $sformatf("%s: Trunk ARVALID asserted", check_context));
+        td.check(!branch_awvalid, $sformatf("%s: Branch AWVALID asserted", check_context));
+        td.check(!branch_wvalid, $sformatf("%s: Branch WVALID asserted", check_context));
+        td.check(!branch_arvalid, $sformatf("%s: Branch ARVALID asserted", check_context));
+        if (check_root_responses) begin
+          td.check(!root_bvalid, $sformatf("%s: Root BVALID asserted", check_context));
+          td.check(!root_rvalid, $sformatf("%s: Root RVALID asserted", check_context));
+        end
+      end
+    end
+  endtask
+
+  // Sample each post-reset edge so a one-cycle invalid VALID pulse cannot slip through.
+  task automatic test_reset_idle();
+    init_idle();
+    td.reset_dut();
+    fork
+      td.wait_cycles(2);
+      check_idle("Reset idle post-reset");
+    join_any
+    disable fork;
+  endtask
+
+  task automatic test_single_transaction(input string scenario_name, input axil_split_route_t route,
+                                         input logic is_write);
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, is_write ? SingleWrite : NoWrites, is_write ? NoReads : SingleRead);
+    scenario.force_branch_route = route == AxilSplitRouteBranch;
+    scenario.force_trunk_route  = route == AxilSplitRouteTrunk;
+    init_idle();
+    if (is_write) queue_write(scenario, route);
+    else queue_read(scenario, route);
+    run_queued_scenario(scenario_name, scenario);
+  endtask
+
+  task automatic test_range_boundaries();
+    localparam int BoundaryTransactionsPerRange = 4;
+
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, NumBranchRanges * BoundaryTransactionsPerRange,
+                  NumBranchRanges * BoundaryTransactionsPerRange);
+    init_idle();
+    for (int i = 0; i < NumBranchRanges; i++) begin
+      logic [AxilAddrWidth-1:0] trunk_below_addr;
+      logic [AxilAddrWidth-1:0] trunk_above_addr;
+
+      queue_write_addr(scenario, AxilSplitRouteBranch, branch_start_addr[i]);
+      queue_read_addr(scenario, AxilSplitRouteBranch, branch_start_addr[i]);
+      queue_write_addr(scenario, AxilSplitRouteBranch, branch_end_addr[i]);
+      queue_read_addr(scenario, AxilSplitRouteBranch, branch_end_addr[i]);
+
+      trunk_below_addr = branch_start_addr[i] - AxilAddrWidth'(1);
+      if (branch_start_addr[i] == MinAxilAddr || is_branch_addr(trunk_below_addr))
+        trunk_below_addr = fallback_trunk_addr();
+      queue_write_addr(scenario, AxilSplitRouteTrunk, trunk_below_addr);
+      queue_read_addr(scenario, AxilSplitRouteTrunk, trunk_below_addr);
+
+      trunk_above_addr = branch_end_addr[i] + AxilAddrWidth'(1);
+      if (branch_end_addr[i] == MaxAxilAddr || is_branch_addr(trunk_above_addr))
+        trunk_above_addr = fallback_trunk_addr();
+      queue_write_addr(scenario, AxilSplitRouteTrunk, trunk_above_addr);
+      queue_read_addr(scenario, AxilSplitRouteTrunk, trunk_above_addr);
+    end
+    run_queued_scenario("range_boundaries", scenario);
+  endtask
+
+  // Force a controlled partial overlap while keeping start <= end.
+  task automatic test_overlapping_branch_ranges();
+    axil_split_scenario_t scenario;
+    int overlap_range_index = 1;
+    logic [AxilAddrWidth-1:0] overlap_addr;
+
+    if (NumBranchRanges < 2) return;
+
+    init_scenario(scenario, SingleWrite, SingleRead);
+    init_idle();
+    init_ranges(.allow_overlap(1'b1));
+    overlap_addr = branch_start_addr[overlap_range_index];
+    queue_write_addr(scenario, AxilSplitRouteBranch, overlap_addr);
+    queue_read_addr(scenario, AxilSplitRouteBranch, overlap_addr);
+    run_queued_scenario("overlapping_branch_ranges", scenario);
+  endtask
+
+  // The RTL does not enforce the static-range contract, so document current idle reconfiguration.
+  task automatic test_unsupported_idle_range_reconfigure();
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, SingleWrite, SingleRead);
+    scenario.force_branch_route = 1'b1;
+    init_idle();
+    td.reset_dut();
+    branch_start_addr[0] = MinAxilAddr;
+    branch_end_addr[0]   = MinAxilAddr + AxilAddrWidth'(1);
+    populate_addr_queues();
+    queue_write(scenario, AxilSplitRouteBranch);
+    queue_read(scenario, AxilSplitRouteBranch);
+    run_queued_scenario("unsupported_idle_range_reconfigure", scenario);
+  endtask
+
+  task automatic test_multi_range_routing();
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, NumBranchRanges * 2, NumBranchRanges * 2);
+    init_idle();
+    for (int i = 0; i < NumBranchRanges; i++) begin
+      queue_write(scenario, AxilSplitRouteBranch);
+      queue_write(scenario, AxilSplitRouteTrunk);
+      queue_read(scenario, AxilSplitRouteBranch);
+      queue_read(scenario, AxilSplitRouteTrunk);
+    end
+    run_queued_scenario("multi_range_routing", scenario);
+  endtask
+
+  task automatic test_write_channel_skew(input string scenario_name, input int aw_gap_cycles,
+                                         input int w_gap_cycles);
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, SingleWrite, NoReads);
+    scenario.min_aw_gap_cycles = aw_gap_cycles;
+    scenario.max_aw_gap_cycles = aw_gap_cycles;
+    scenario.min_w_gap_cycles  = w_gap_cycles;
+    scenario.max_w_gap_cycles  = w_gap_cycles;
+    init_idle();
+    queue_write(scenario, AxilSplitRouteBranch);
+    run_queued_scenario(scenario_name, scenario);
+  endtask
+
+  task automatic test_write_address_before_data();
+    test_write_channel_skew("write_address_before_data", NoGapCycles, WriteSkewGapCycles);
+  endtask
+
+  task automatic test_write_data_before_address();
+    test_write_channel_skew("write_data_before_address", WriteSkewGapCycles, NoGapCycles);
+  endtask
+
+  task automatic test_zero_strobe_write();
+    localparam logic [AxilStrobeWidth-1:0] ZeroStrobe = '0;
+
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, 2, NoReads);
+    init_idle();
+    queue_write_strobe(scenario, AxilSplitRouteTrunk, ZeroStrobe);
+    queue_write_strobe(scenario, AxilSplitRouteBranch, ZeroStrobe);
+    run_queued_scenario("zero_strobe_write", scenario);
+  endtask
+
+  task automatic test_request_sidebands_and_resp_types();
+    localparam int NumResponseTypes = 2 ** AxiRespWidth;
+
+    axi_resp_t responses[NumResponseTypes] = '{
+        AxiRespOkay,
+        AxiRespExOkay,
+        AxiRespSlverr,
+        AxiRespDecerr
+    };
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, NumResponseTypes * 2, NumResponseTypes * 2);
+    init_idle();
+    foreach (responses[i]) begin
+      queue_write_response(scenario, AxilSplitRouteTrunk, b_response(responses[i]));
+      queue_write_response(scenario, AxilSplitRouteBranch, b_response(responses[i]));
+      queue_read_response(scenario, AxilSplitRouteTrunk, r_response(responses[i]));
+      queue_read_response(scenario, AxilSplitRouteBranch, r_response(responses[i]));
+    end
+    run_queued_scenario("request_sidebands_and_resp_types", scenario);
+  endtask
+
+  task automatic test_route_switch_blocked_by_outstanding(input string scenario_name,
+                                                          input logic is_write);
+    localparam int RouteSwitchTransactions = 4;
+    localparam int RouteSwitchResponseStallCycles = 4;
+
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, is_write ? RouteSwitchTransactions : NoWrites,
+                  is_write ? NoReads : RouteSwitchTransactions);
+    if (is_write) begin
+      scenario.min_b_stall_cycles = RouteSwitchResponseStallCycles;
+      scenario.max_b_stall_cycles = RouteSwitchResponseStallCycles;
+    end else begin
+      scenario.min_r_stall_cycles = RouteSwitchResponseStallCycles;
+      scenario.max_r_stall_cycles = RouteSwitchResponseStallCycles;
+    end
+    init_idle();
+    for (int i = 0; i < RouteSwitchTransactions; i++) begin
+      axil_split_route_t route = (i % 2 == 0) ? AxilSplitRouteBranch : AxilSplitRouteTrunk;
+
+      if (is_write) queue_write(scenario, route);
+      else queue_read(scenario, route);
+    end
+    run_queued_scenario(scenario_name, scenario);
+  endtask
+
+  task automatic check_read_pending_write_route_independence(input string scenario_name);
+    axil_aw_observation_t trunk_aw_q[$];
+    axil_w_observation_t trunk_w_q[$];
+    axil_ar_observation_t trunk_ar_q[$];
+    axil_b_observation_t branch_b_q[$];
+    axil_r_observation_t branch_r_q[$];
+    logic observed_expected_events;
+    time trunk_write_request_ts;
+
+    trunk_monitor.get_observed_request_observations(trunk_aw_q, trunk_w_q, trunk_ar_q);
+    branch_monitor.get_observed_response_observations(branch_b_q, branch_r_q);
+    observed_expected_events = trunk_aw_q.size() != 0 && trunk_w_q.size() != 0 &&
+        branch_r_q.size() != 0;
+    td.check(observed_expected_events, $sformatf(
+             "%s did not observe expected trunk write and branch R", scenario_name));
+    if (observed_expected_events) begin
+      trunk_write_request_ts = `BR_SIM_MAX(trunk_aw_q[0].timestamp, trunk_w_q[0].timestamp);
+      td.check(trunk_write_request_ts < branch_r_q[0].timestamp, $sformatf(
+               "%s trunk write waited for branch read response", scenario_name));
+    end
+  endtask
+
+  task automatic check_write_pending_read_route_independence(input string scenario_name);
+    axil_aw_observation_t trunk_aw_q[$];
+    axil_w_observation_t trunk_w_q[$];
+    axil_ar_observation_t trunk_ar_q[$];
+    axil_b_observation_t branch_b_q[$];
+    axil_r_observation_t branch_r_q[$];
+    logic observed_expected_events;
+
+    trunk_monitor.get_observed_request_observations(trunk_aw_q, trunk_w_q, trunk_ar_q);
+    branch_monitor.get_observed_response_observations(branch_b_q, branch_r_q);
+    observed_expected_events = trunk_ar_q.size() != 0 && branch_b_q.size() != 0;
+    td.check(observed_expected_events, $sformatf(
+             "%s did not observe expected trunk read and branch B", scenario_name));
+    if (observed_expected_events) begin
+      td.check(trunk_ar_q[0].timestamp < branch_b_q[0].timestamp, $sformatf(
+               "%s trunk read waited for branch write response", scenario_name));
+    end
+  endtask
+
+  task automatic test_read_pending_write_other_route();
+    string scenario_name = "read_pending_write_other_route";
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, SingleWrite, SingleRead);
+    scenario.min_r_stall_cycles = OutstandingResponseStallCycles;
+    scenario.max_r_stall_cycles = OutstandingResponseStallCycles;
+    init_idle();
+    queue_read(scenario, AxilSplitRouteBranch);
+    queue_write(scenario, AxilSplitRouteTrunk);
+    run_queued_scenario(scenario_name, scenario);
+    check_read_pending_write_route_independence(scenario_name);
+  endtask
+
+  task automatic test_write_pending_read_other_route();
+    string scenario_name = "write_pending_read_other_route";
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, SingleWrite, SingleRead);
+    scenario.min_b_stall_cycles = OutstandingResponseStallCycles;
+    scenario.max_b_stall_cycles = OutstandingResponseStallCycles;
+    init_idle();
+    queue_write(scenario, AxilSplitRouteBranch);
+    queue_read(scenario, AxilSplitRouteTrunk);
+    run_queued_scenario(scenario_name, scenario);
+    check_write_pending_read_route_independence(scenario_name);
+  endtask
+
+  task automatic test_max_outstanding_reads(input string scenario_name,
+                                            input axil_split_route_t route);
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, NoWrites, MaxOutstandingReads + 2);
+    scenario.force_branch_route = route == AxilSplitRouteBranch;
+    scenario.force_trunk_route = route == AxilSplitRouteTrunk;
+    scenario.min_r_stall_cycles = OutstandingResponseStallCycles;
+    scenario.max_r_stall_cycles = OutstandingResponseStallCycles;
+    scenario.check_max_outstanding_reads = 1'b1;
+    init_idle();
+    queue_mixed_transactions(scenario);
+    run_queued_scenario(scenario_name, scenario);
+  endtask
+
+  task automatic test_max_outstanding_writes(input string scenario_name,
+                                             input axil_split_route_t route);
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, MaxOutstandingWrites + 2, NoReads);
+    scenario.force_branch_route = route == AxilSplitRouteBranch;
+    scenario.force_trunk_route = route == AxilSplitRouteTrunk;
+    scenario.min_b_stall_cycles = OutstandingResponseStallCycles;
+    scenario.max_b_stall_cycles = OutstandingResponseStallCycles;
+    scenario.check_max_outstanding_writes = 1'b1;
+    init_idle();
+    queue_mixed_transactions(scenario);
+    run_queued_scenario(scenario_name, scenario);
+  endtask
+
+  task automatic test_route_backpressure(input string scenario_name,
+                                         input axil_split_route_t route);
+    localparam int BackpressureReadyStallCycles = 3;
+
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, $urandom_range(MaxDirectedTransactions, MinDirectedTransactions),
+                  $urandom_range(MaxDirectedTransactions, MinDirectedTransactions));
+    scenario.force_branch_route = route == AxilSplitRouteBranch;
+    scenario.force_trunk_route  = route == AxilSplitRouteTrunk;
+    if (route == AxilSplitRouteBranch)
+      scenario.max_branch_ready_stall_cycles = BackpressureReadyStallCycles;
+    else scenario.max_trunk_ready_stall_cycles = BackpressureReadyStallCycles;
+    init_idle();
+    queue_mixed_transactions(scenario);
+    run_queued_scenario(scenario_name, scenario);
+  endtask
+
+  task automatic test_mixed_random_traffic();
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, $urandom_range(MaxDirectedTransactions, MinDirectedTransactions),
+                  $urandom_range(MaxDirectedTransactions, MinDirectedTransactions));
+    scenario.min_aw_gap_cycles = $urandom_range(MaxRandomDelayCycles, MinRandomDelayCycles);
+    scenario.max_aw_gap_cycles = $urandom_range(MaxRandomDelayCycles, scenario.min_aw_gap_cycles);
+    scenario.min_w_gap_cycles = $urandom_range(MaxRandomDelayCycles, MinRandomDelayCycles);
+    scenario.max_w_gap_cycles = $urandom_range(MaxRandomDelayCycles, scenario.min_w_gap_cycles);
+    scenario.min_ar_gap_cycles = $urandom_range(MaxRandomDelayCycles, MinRandomDelayCycles);
+    scenario.max_ar_gap_cycles = $urandom_range(MaxRandomDelayCycles, scenario.min_ar_gap_cycles);
+    scenario.min_b_stall_cycles = $urandom_range(MaxRandomDelayCycles, MinRandomDelayCycles);
+    scenario.max_b_stall_cycles = $urandom_range(MaxRandomDelayCycles, scenario.min_b_stall_cycles);
+    scenario.min_r_stall_cycles = $urandom_range(MaxRandomDelayCycles, MinRandomDelayCycles);
+    scenario.max_r_stall_cycles = $urandom_range(MaxRandomDelayCycles, scenario.min_r_stall_cycles);
+    scenario.allow_error_responses = 1'b1;
+    init_idle();
+    queue_mixed_transactions(scenario);
+    run_queued_scenario("mixed_random_traffic", scenario);
+  endtask
+
+  task automatic test_stress();
+    localparam int MinStressTransactions = 256;
+    localparam int MaxStressTransactions = 512;
+
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, $urandom_range(MaxStressTransactions, MinStressTransactions),
+                  $urandom_range(MaxStressTransactions, MinStressTransactions));
+    scenario.allow_error_responses = 1'b1;
+    init_idle();
+    queue_mixed_transactions(scenario);
+    run_queued_scenario("stress", scenario);
+  endtask
+
+  task automatic run_reset_recovery(input string scenario_name);
+    axil_split_scenario_t scenario;
+
+    init_idle();
+    init_scenario(scenario, SingleWrite, SingleRead);
+    queue_mixed_transactions(scenario);
+    run_queued_scenario(scenario_name, scenario);
+  endtask
+
+  function automatic string reset_trigger_name(input axil_reset_trigger_t trigger);
+    case (trigger)
+      AxilResetTriggerAwBeforeW: reset_trigger_name = "AW-before-W";
+      AxilResetTriggerWBeforeAw: reset_trigger_name = "W-before-AW";
+      AxilResetTriggerBPending:  reset_trigger_name = "pending B";
+      AxilResetTriggerRPending:  reset_trigger_name = "pending R";
+      default:                   reset_trigger_name = "unknown";
+    endcase
+  endfunction
+
+  function automatic string route_name(input axil_split_route_t route);
+    if (route == AxilSplitRouteBranch) route_name = "branch";
+    else route_name = "trunk";
+  endfunction
+
+  task automatic run_pre_reset_target(input axil_split_route_t route);
+    if (route == AxilSplitRouteBranch)
+      branch_target.run(num_branch_writes, num_branch_reads, NoStallCycles);
+    else trunk_target.run(num_trunk_writes, num_trunk_reads, NoStallCycles);
+  endtask
+
+  task automatic wait_for_reset_trigger(input axil_reset_trigger_t trigger);
+    @(posedge clk);
+    unique case (trigger)
+      AxilResetTriggerAwBeforeW: begin
+        while (!(root_awvalid && !root_wvalid)) @(posedge clk);
+        td.check(root_awvalid && !root_wvalid,
+                 "AW-before-W reset did not reach AWVALID-before-WVALID phase");
+      end
+      AxilResetTriggerWBeforeAw: begin
+        while (!(root_wvalid && !root_awvalid)) @(posedge clk);
+        td.check(root_wvalid && !root_awvalid,
+                 "W-before-AW reset did not reach WVALID-before-AWVALID phase");
+      end
+      AxilResetTriggerBPending: begin
+        while (!(root_bvalid && !root_bready)) @(posedge clk);
+      end
+      AxilResetTriggerRPending: begin
+        while (!(root_rvalid && !root_rready)) @(posedge clk);
+      end
+    endcase
+    td.reset_dut();
+  endtask
+
+  task automatic run_reset_scenario(
+      input string scenario_name, input string recovery_name, input axil_split_scenario_t scenario,
+      input axil_reset_trigger_t trigger, input logic check_pre_reset,
+      input axil_split_route_t route, input axil_reset_counts_t expected_counts);
+    if (check_pre_reset) begin
+      fork : pre_reset_observation_threads
+        run_pre_reset_target(route);
+        root_monitor.run();
+        trunk_monitor.run();
+        branch_monitor.run();
+      join_none
+    end
+    fork
+      root_driver.run(scenario.num_writes, scenario.num_reads);
+      wait_for_reset_trigger(trigger);
+      timeout(timeout_tick, MidResetTimeoutCycles, $sformatf(
+              "Timeout waiting for %s reset trigger", reset_trigger_name(trigger)), timeout_failed);
+    join_any
+    disable fork;
+    if (check_pre_reset) disable pre_reset_observation_threads;
+    td.check(!timeout_failed, $sformatf("%s reset trigger timed out", reset_trigger_name(trigger)));
+    if (check_pre_reset) check_reset_pre_reset_traffic(scenario_name, expected_counts);
+    run_reset_recovery(recovery_name);
+  endtask
+
+  task automatic test_reset_write_before_data();
+    localparam int MidResetWriteDataGapCycles = 8;
+
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, SingleWrite, NoReads);
+    scenario.force_branch_route = 1'b1;
+    scenario.min_w_gap_cycles   = MidResetWriteDataGapCycles;
+    scenario.max_w_gap_cycles   = MidResetWriteDataGapCycles;
+    init_idle();
+    queue_write(scenario, AxilSplitRouteBranch);
+    // This reset point intentionally occurs before an AW/W pair can handshake downstream.
+    run_reset_scenario("AW-before-W reset", "reset_write_before_data_recovery", scenario,
+                       AxilResetTriggerAwBeforeW, 1'b0, AxilSplitRouteBranch, '{default: 0});
+  endtask
+
+  task automatic test_reset_write_data_before_address();
+    localparam int MidResetWriteAddrGapCycles = 8;
+
+    axil_split_scenario_t scenario;
+
+    init_scenario(scenario, SingleWrite, NoReads);
+    scenario.force_branch_route = 1'b1;
+    scenario.min_aw_gap_cycles  = MidResetWriteAddrGapCycles;
+    scenario.max_aw_gap_cycles  = MidResetWriteAddrGapCycles;
+    init_idle();
+    queue_write(scenario, AxilSplitRouteBranch);
+    // This reset point intentionally occurs before an AW/W pair can handshake downstream.
+    run_reset_scenario("W-before-AW reset", "reset_write_data_before_address_recovery", scenario,
+                       AxilResetTriggerWBeforeAw, 1'b0, AxilSplitRouteBranch, '{default: 0});
+  endtask
+
+  task automatic test_reset_write_response_pending(input axil_split_route_t route);
+    axil_split_scenario_t scenario;
+    axil_reset_counts_t   expected_counts = '{default: 0, root_aw: 1, root_w: 1};
+
+    if (route == AxilSplitRouteBranch) begin
+      expected_counts.branch_aw = 1;
+      expected_counts.branch_w  = 1;
+    end else begin
+      expected_counts.trunk_aw = 1;
+      expected_counts.trunk_w  = 1;
+    end
+
+    init_scenario(scenario, SingleWrite, NoReads);
+    scenario.force_branch_route = route == AxilSplitRouteBranch;
+    scenario.force_trunk_route  = route == AxilSplitRouteTrunk;
+    scenario.min_b_stall_cycles = MidResetResponseStallCycles;
+    scenario.max_b_stall_cycles = MidResetResponseStallCycles;
+    init_idle();
+    queue_write(scenario, route);
+    run_reset_scenario($sformatf("%s pending B reset", route_name(route)), $sformatf(
+                       "reset_%s_write_response_pending_recovery", route_name(route)), scenario,
+                       AxilResetTriggerBPending, 1'b1, route, expected_counts);
+  endtask
+
+  task automatic test_reset_read_response_pending(input axil_split_route_t route);
+    axil_split_scenario_t scenario;
+    axil_reset_counts_t   expected_counts = '{default: 0, root_ar: 1};
+
+    if (route == AxilSplitRouteBranch) expected_counts.branch_ar = 1;
+    else expected_counts.trunk_ar = 1;
+
+    init_scenario(scenario, NoWrites, SingleRead);
+    scenario.force_branch_route = route == AxilSplitRouteBranch;
+    scenario.force_trunk_route  = route == AxilSplitRouteTrunk;
+    scenario.min_r_stall_cycles = MidResetResponseStallCycles;
+    scenario.max_r_stall_cycles = MidResetResponseStallCycles;
+    init_idle();
+    queue_read(scenario, route);
+    run_reset_scenario($sformatf("%s pending R reset", route_name(route)), $sformatf(
+                       "reset_%s_read_response_pending_recovery", route_name(route)), scenario,
+                       AxilResetTriggerRPending, 1'b1, route, expected_counts);
+  endtask
+
+  initial begin
+    wait (reset_monitor_enabled);
+    // The RTL reset contract only guarantees routed request outputs stay idle during reset.
+    check_idle("During reset", .only_during_reset(1'b1), .check_root_responses(1'b0));
+  end
+
+  initial begin
+    init_idle();
+    reset_monitor_enabled = 1'b1;
+    td.reset_dut();
+    test_reset_idle();
+    test_single_transaction("trunk_write_no_delay", AxilSplitRouteTrunk, 1'b1);
+    test_single_transaction("trunk_read_no_delay", AxilSplitRouteTrunk, 1'b0);
+    test_single_transaction("branch_write_no_delay", AxilSplitRouteBranch, 1'b1);
+    test_single_transaction("branch_read_no_delay", AxilSplitRouteBranch, 1'b0);
+    test_range_boundaries();
+    test_overlapping_branch_ranges();
+    test_unsupported_idle_range_reconfigure();
+    test_multi_range_routing();
+    test_write_address_before_data();
+    test_write_data_before_address();
+    test_zero_strobe_write();
+    test_request_sidebands_and_resp_types();
+    test_route_switch_blocked_by_outstanding("read_route_switch_blocked_by_outstanding", 1'b0);
+    test_route_switch_blocked_by_outstanding("write_route_switch_blocked_by_outstanding", 1'b1);
+    test_read_pending_write_other_route();
+    test_write_pending_read_other_route();
+    test_max_outstanding_reads("branch_max_outstanding_reads", AxilSplitRouteBranch);
+    test_max_outstanding_reads("trunk_max_outstanding_reads", AxilSplitRouteTrunk);
+    test_max_outstanding_writes("branch_max_outstanding_writes", AxilSplitRouteBranch);
+    test_max_outstanding_writes("trunk_max_outstanding_writes", AxilSplitRouteTrunk);
+    test_route_backpressure("trunk_backpressure", AxilSplitRouteTrunk);
+    test_route_backpressure("branch_backpressure", AxilSplitRouteBranch);
+    test_mixed_random_traffic();
+    test_stress();
+    test_reset_write_before_data();
+    test_reset_write_data_before_address();
+    test_reset_write_response_pending(AxilSplitRouteBranch);
+    test_reset_write_response_pending(AxilSplitRouteTrunk);
+    test_reset_read_response_pending(AxilSplitRouteBranch);
+    test_reset_read_response_pending(AxilSplitRouteTrunk);
+    td.finish();
+  end
+endmodule : br_amba_axil_split_tb

--- a/amba/sim/drivers/br_amba_axil_requester_driver.sv
+++ b/amba/sim/drivers/br_amba_axil_requester_driver.sv
@@ -12,26 +12,32 @@ import br_amba_axil_sim_pkg::*;
 // plus BREADY/RREADY. Payload observation and checking belong in monitors and
 // scoreboards.
 module br_amba_axil_requester_driver #(
-    parameter int AddrWidth = 12,
-    parameter int DataWidth = 32,
-    parameter int TimeoutCycles = 100,
-    localparam int StrbWidth = DataWidth / 8
+    parameter  int AddrWidth     = 12,
+    parameter  int DataWidth     = 32,
+    parameter  int AWUserWidth   = 1,
+    parameter  int WUserWidth    = 1,
+    parameter  int ARUserWidth   = 1,
+    parameter  int TimeoutCycles = 100,
+    localparam int StrbWidth     = DataWidth / 8
 ) (
     input logic clk,
     input logic rst,
 
     output logic [AddrWidth-1:0] axil_awaddr,
     output logic [AxiProtWidth-1:0] axil_awprot,
+    output logic [AWUserWidth-1:0] axil_awuser,
     output logic axil_awvalid,
     input logic axil_awready,
     output logic [DataWidth-1:0] axil_wdata,
     output logic [StrbWidth-1:0] axil_wstrb,
+    output logic [WUserWidth-1:0] axil_wuser,
     output logic axil_wvalid,
     input logic axil_wready,
     input logic axil_bvalid,
     output logic axil_bready,
     output logic [AddrWidth-1:0] axil_araddr,
     output logic [AxiProtWidth-1:0] axil_arprot,
+    output logic [ARUserWidth-1:0] axil_aruser,
     output logic axil_arvalid,
     input logic axil_arready,
     input logic axil_rvalid,
@@ -70,13 +76,16 @@ module br_amba_axil_requester_driver #(
   task automatic init_idle();
     axil_awaddr  = '0;
     axil_awprot  = '0;
+    axil_awuser  = '0;
     axil_awvalid = 1'b0;
     axil_wdata   = '0;
     axil_wstrb   = '0;
+    axil_wuser   = '0;
     axil_wvalid  = 1'b0;
     axil_bready  = 1'b0;
     axil_araddr  = '0;
     axil_arprot  = '0;
+    axil_aruser  = '0;
     axil_arvalid = 1'b0;
     axil_rready  = 1'b0;
     failed       = 1'b0;
@@ -96,15 +105,31 @@ module br_amba_axil_requester_driver #(
                              input logic [DataWidth-1:0] data, input logic [StrbWidth-1:0] strb,
                              input int aw_gap_cycles, input int w_gap_cycles,
                              input int b_stall_cycles);
-    aw_queue.push_back('{addr: AxilAddrWidth'(addr), prot: prot, gap_cycles: aw_gap_cycles});
+    queue_write_user(addr, prot, '0, data, strb, '0, aw_gap_cycles, w_gap_cycles, b_stall_cycles);
+  endtask
+
+  task automatic queue_write_user(
+      input logic [AddrWidth-1:0] addr, input logic [AxiProtWidth-1:0] prot,
+      input logic [AWUserWidth-1:0] awuser, input logic [DataWidth-1:0] data,
+      input logic [StrbWidth-1:0] strb, input logic [WUserWidth-1:0] wuser, input int aw_gap_cycles,
+      input int w_gap_cycles, input int b_stall_cycles);
+    aw_queue.push_back('{addr: AxilAddrWidth'(addr), prot: prot, user: AxilUserWidth'(awuser),
+                       gap_cycles: aw_gap_cycles});
     w_queue.push_back('{data: AxilDataWidth'(data), strb: AxilStrobeWidth'(strb),
-                      gap_cycles: w_gap_cycles});
+                      user: AxilUserWidth'(wuser), gap_cycles: w_gap_cycles});
     bready_stall_queue.push_back(b_stall_cycles);
   endtask
 
   task automatic queue_read(input logic [AddrWidth-1:0] addr, input logic [AxiProtWidth-1:0] prot,
                             input int ar_gap_cycles, input int r_stall_cycles);
-    ar_queue.push_back('{addr: AxilAddrWidth'(addr), prot: prot, gap_cycles: ar_gap_cycles});
+    queue_read_user(addr, prot, '0, ar_gap_cycles, r_stall_cycles);
+  endtask
+
+  task automatic queue_read_user(
+      input logic [AddrWidth-1:0] addr, input logic [AxiProtWidth-1:0] prot,
+      input logic [ARUserWidth-1:0] aruser, input int ar_gap_cycles, input int r_stall_cycles);
+    ar_queue.push_back('{addr: AxilAddrWidth'(addr), prot: prot, user: AxilUserWidth'(aruser),
+                       gap_cycles: ar_gap_cycles});
     rready_stall_queue.push_back(r_stall_cycles);
   endtask
 
@@ -173,6 +198,7 @@ module br_amba_axil_requester_driver #(
       repeat (item.gap_cycles) @(negedge clk);
       axil_awaddr  = AddrWidth'(item.addr);
       axil_awprot  = item.prot;
+      axil_awuser  = AWUserWidth'(item.user);
       axil_awvalid = 1'b1;
       wait_handshake(AxilHandshakeAw, "AW");
       if (failed) begin
@@ -196,6 +222,7 @@ module br_amba_axil_requester_driver #(
       repeat (item.gap_cycles) @(negedge clk);
       axil_wdata  = DataWidth'(item.data);
       axil_wstrb  = StrbWidth'(item.strb);
+      axil_wuser  = WUserWidth'(item.user);
       axil_wvalid = 1'b1;
       wait_handshake(AxilHandshakeW, "W");
       if (failed) begin
@@ -243,6 +270,7 @@ module br_amba_axil_requester_driver #(
       repeat (item.gap_cycles) @(negedge clk);
       axil_araddr  = AddrWidth'(item.addr);
       axil_arprot  = item.prot;
+      axil_aruser  = ARUserWidth'(item.user);
       axil_arvalid = 1'b1;
       wait_handshake(AxilHandshakeAr, "AR");
       if (failed) begin

--- a/amba/sim/drivers/br_amba_axil_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_axil_sim_pkg.sv
@@ -80,18 +80,21 @@ package br_amba_axil_sim_pkg;
   typedef struct {
     logic [AxilAddrWidth-1:0] addr;
     logic [AxiProtWidth-1:0]  prot;
+    logic [AxilUserWidth-1:0] user;
     int                       gap_cycles;
   } axil_aw_driver_item_t;
 
   typedef struct {
     logic [AxilDataWidth-1:0]   data;
     logic [AxilStrobeWidth-1:0] strb;
+    logic [AxilUserWidth-1:0]   user;
     int                         gap_cycles;
   } axil_w_driver_item_t;
 
   typedef struct {
     logic [AxilAddrWidth-1:0] addr;
     logic [AxiProtWidth-1:0]  prot;
+    logic [AxilUserWidth-1:0] user;
     int                       gap_cycles;
   } axil_ar_driver_item_t;
 

--- a/amba/sim/drivers/br_amba_sim_macros.svh
+++ b/amba/sim/drivers/br_amba_sim_macros.svh
@@ -3,6 +3,14 @@
 `ifndef BR_AMBA_SIM_MACROS_SVH
 `define BR_AMBA_SIM_MACROS_SVH
 
+`define BR_SIM_MIN(lhs, rhs) (((lhs) < (rhs)) ? (lhs) : (rhs))
+`define BR_SIM_MAX(lhs, rhs) (((lhs) > (rhs)) ? (lhs) : (rhs))
+
+`define BR_SIM_RANDOMIZE(randomize_vars, description) \
+  do begin \
+    if (!std::randomize randomize_vars) $fatal(1, "Failed to randomize %s", description); \
+  end while (0)
+
 `define BR_AMBA_SIM_CHECK_EQ(actual, expected, message, failed) \
   do begin \
     if ((actual) !== (expected)) begin \

--- a/amba/sim/drivers/br_amba_sim_pkg.sv
+++ b/amba/sim/drivers/br_amba_sim_pkg.sv
@@ -3,12 +3,6 @@
 `timescale 1ns / 1ps
 
 package br_amba_sim_pkg;
-`ifdef BR_AMBA_SIM_MAX_CHECK_WIDTH
-  parameter int BrAmbaSimMaxCheckWidth = `BR_AMBA_SIM_MAX_CHECK_WIDTH;
-`else
-  parameter int BrAmbaSimMaxCheckWidth = 1024;
-`endif
-
   task automatic report_error(input string message, ref logic failed);
     failed = 1'b1;
     $error("%s", message);
@@ -25,23 +19,6 @@ package br_amba_sim_pkg;
       return 0;
     end
     return int'($urandom_range(max_stall_cycles, 0));
-  endfunction
-
-  function automatic logic [BrAmbaSimMaxCheckWidth-1:0] get_random_bits(input int width);
-    get_random_bits = '0;
-
-    if (width > BrAmbaSimMaxCheckWidth) begin
-      $fatal(1, "Requested %0d random bits exceeds common sim helper width %0d", width,
-             BrAmbaSimMaxCheckWidth);
-    end
-
-    for (int offset = 0; offset < width; offset += 32) begin
-      logic [31:0] word = $urandom();
-
-      for (int bit_idx = 0; bit_idx < 32 && offset + bit_idx < width; bit_idx++) begin
-        get_random_bits[offset+bit_idx] = word[bit_idx];
-      end
-    end
   endfunction
 
 endpackage : br_amba_sim_pkg

--- a/amba/sim/monitors/BUILD.bazel
+++ b/amba/sim/monitors/BUILD.bazel
@@ -56,6 +56,18 @@ verilog_library(
 )
 
 verilog_library(
+    name = "br_amba_axil_split_scoreboard",
+    srcs = ["br_amba_axil_split_scoreboard.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":br_amba_axil_monitor_sim_pkg",
+        "//amba/sim:br_amba_axil_split_sim_pkg",
+        "//amba/sim/drivers:br_amba_axil_sim_pkg",
+        "//amba/sim/drivers:br_amba_sim_pkg",
+    ],
+)
+
+verilog_library(
     name = "br_amba_axi_default_target_monitor",
     srcs = ["br_amba_axi_default_target_monitor.sv"],
     visibility = ["//visibility:public"],

--- a/amba/sim/monitors/br_amba_axil_split_scoreboard.sv
+++ b/amba/sim/monitors/br_amba_axil_split_scoreboard.sv
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+import br_amba::*;
+import br_amba_axil_sim_pkg::*;
+import br_amba_axil_monitor_sim_pkg::*;
+import br_amba_axil_split_sim_pkg::*;
+import br_amba_sim_pkg::*;
+
+`include "br_amba_sim_macros.svh"
+
+// br_amba_axil_split scoreboard.
+//
+// The scoreboard owns split-specific prediction and checking. Generic AXI-Lite
+// monitors provide observed root/trunk/branch channel queues with timestamps.
+module br_amba_axil_split_scoreboard #(
+    parameter int NumBranchAddrRanges = 1,
+    parameter bit NormalizeBranchAddress = 0
+) (
+    output logic failed
+);
+
+  axil_aw_observation_t root_aw_q[$];
+  axil_w_observation_t root_w_q[$];
+  axil_ar_observation_t root_ar_q[$];
+  axil_b_observation_t root_b_q[$];
+  axil_r_observation_t root_r_q[$];
+  axil_aw_observation_t trunk_aw_q[$];
+  axil_w_observation_t trunk_w_q[$];
+  axil_ar_observation_t trunk_ar_q[$];
+  axil_b_observation_t trunk_b_q[$];
+  axil_r_observation_t trunk_r_q[$];
+  axil_aw_observation_t branch_aw_q[$];
+  axil_w_observation_t branch_w_q[$];
+  axil_ar_observation_t branch_ar_q[$];
+  axil_b_observation_t branch_b_q[$];
+  axil_r_observation_t branch_r_q[$];
+
+  initial begin
+    failed = 1'b0;
+  end
+
+  task automatic init_idle();
+    failed = 1'b0;
+    root_aw_q.delete();
+    root_w_q.delete();
+    root_ar_q.delete();
+    root_b_q.delete();
+    root_r_q.delete();
+    trunk_aw_q.delete();
+    trunk_w_q.delete();
+    trunk_ar_q.delete();
+    trunk_b_q.delete();
+    trunk_r_q.delete();
+    branch_aw_q.delete();
+    branch_w_q.delete();
+    branch_ar_q.delete();
+    branch_b_q.delete();
+    branch_r_q.delete();
+  endtask
+
+  task automatic set_root_observations(
+      input axil_aw_observation_t aw_q[$], input axil_w_observation_t w_q[$],
+      input axil_ar_observation_t ar_q[$], input axil_b_observation_t b_q[$],
+      input axil_r_observation_t r_q[$]);
+    root_aw_q = aw_q;
+    root_w_q  = w_q;
+    root_ar_q = ar_q;
+    root_b_q  = b_q;
+    root_r_q  = r_q;
+  endtask
+
+  task automatic set_trunk_observations(
+      input axil_aw_observation_t aw_q[$], input axil_w_observation_t w_q[$],
+      input axil_ar_observation_t ar_q[$], input axil_b_observation_t b_q[$],
+      input axil_r_observation_t r_q[$]);
+    trunk_aw_q = aw_q;
+    trunk_w_q  = w_q;
+    trunk_ar_q = ar_q;
+    trunk_b_q  = b_q;
+    trunk_r_q  = r_q;
+  endtask
+
+  task automatic set_branch_observations(
+      input axil_aw_observation_t aw_q[$], input axil_w_observation_t w_q[$],
+      input axil_ar_observation_t ar_q[$], input axil_b_observation_t b_q[$],
+      input axil_r_observation_t r_q[$]);
+    branch_aw_q = aw_q;
+    branch_w_q  = w_q;
+    branch_ar_q = ar_q;
+    branch_b_q  = b_q;
+    branch_r_q  = r_q;
+  endtask
+
+  task automatic report_failure(input string message);
+    failed = 1'b1;
+    $error("%s", message);
+  endtask
+
+  task automatic report_mismatch(input string message, inout int mismatch_count);
+    mismatch_count++;
+    report_failure(message);
+  endtask
+
+  task automatic check_count(input string stream_name, input int expected_count,
+                             input int observed_count, inout logic sizes_match);
+    if (observed_count != expected_count) begin
+      sizes_match = 1'b0;
+      report_failure($sformatf(
+                     "%s count mismatch: expected %0d observed %0d",
+                     stream_name,
+                     expected_count,
+                     observed_count
+                     ));
+    end
+  endtask
+
+  // For overlapping ranges, the first match is only used to classify the address as branch.
+  function automatic int branch_range_index(
+      input logic [AxilAddrWidth-1:0] addr,
+      input logic [NumBranchAddrRanges-1:0][AxilAddrWidth-1:0] branch_start_addr,
+      input logic [NumBranchAddrRanges-1:0][AxilAddrWidth-1:0] branch_end_addr);
+    branch_range_index = -1;
+    for (int i = 0; i < NumBranchAddrRanges; i++) begin
+      if (addr >= branch_start_addr[i] && addr <= branch_end_addr[i]) return i;
+    end
+  endfunction
+
+  function automatic logic aw_matches(input axil_aw_t packet,
+                                      input logic [AxilAddrWidth-1:0] expected_addr,
+                                      input axil_split_transaction_t expected);
+    aw_matches = packet.addr === expected_addr && packet.prot === expected.prot &&
+        packet.user === expected.addr_user;
+  endfunction
+
+  function automatic logic w_matches(input axil_w_t packet,
+                                     input axil_split_transaction_t expected);
+    w_matches = packet.data === expected.data && packet.strb === expected.strb &&
+        packet.user === expected.data_user;
+  endfunction
+
+  function automatic logic ar_matches(input axil_ar_t packet,
+                                      input logic [AxilAddrWidth-1:0] expected_addr,
+                                      input axil_split_transaction_t expected);
+    ar_matches = packet.addr === expected_addr && packet.prot === expected.prot &&
+        packet.user === expected.addr_user;
+  endfunction
+
+  function automatic logic b_matches(input axil_b_t packet,
+                                     input axil_split_transaction_t expected);
+    b_matches = packet.resp === expected.resp;
+  endfunction
+
+  function automatic logic r_matches(input axil_r_t packet,
+                                     input axil_split_transaction_t expected);
+    r_matches = packet.data === expected.data && packet.resp === expected.resp &&
+        packet.user === expected.response_user;
+  endfunction
+
+  function automatic logic [AxilAddrWidth-1:0] routed_branch_addr(
+      input logic [AxilAddrWidth-1:0] root_addr,
+      input logic [NumBranchAddrRanges-1:0][AxilAddrWidth-1:0] branch_start_addr);
+    routed_branch_addr = NormalizeBranchAddress ? root_addr - branch_start_addr[0] : root_addr;
+  endfunction
+
+  // Root AW/W and AR streams are independent, so prediction first builds write/read transactions
+  // separately and then merges them by accepted-request timestamp.
+  task automatic predict_transactions(
+      input logic [NumBranchAddrRanges-1:0][AxilAddrWidth-1:0] branch_start_addr,
+      input logic [NumBranchAddrRanges-1:0][AxilAddrWidth-1:0] branch_end_addr,
+      input axil_aw_observation_t root_aw_q[$], input axil_w_observation_t root_w_q[$],
+      input axil_ar_observation_t root_ar_q[$], input axil_b_observation_t root_b_q[$],
+      input axil_r_observation_t root_r_q[$], output axil_split_transaction_t exp_q[$],
+      output logic prediction_valid);
+    axil_split_transaction_t write_q[$];
+    axil_split_transaction_t read_q[$];
+    int write_index = 0;
+    int read_index = 0;
+
+    exp_q.delete();
+    prediction_valid = 1'b1;
+
+    if (root_aw_q.size() != root_w_q.size() ||
+        root_aw_q.size() != root_b_q.size() ||
+        root_ar_q.size() != root_r_q.size()) begin
+      prediction_valid = 1'b0;
+      return;
+    end
+
+    for (int i = 0; i < root_aw_q.size(); i++) begin
+      axil_split_transaction_t transaction;
+      logic [AxilAddrWidth-1:0] root_addr = AxilAddrWidth'(root_aw_q[i].packet.addr);
+      int range_index = branch_range_index(root_addr, branch_start_addr, branch_end_addr);
+
+      transaction = '0;
+      transaction.kind = AxilSplitTransactionWrite;
+      transaction.route = (range_index >= 0) ? AxilSplitRouteBranch : AxilSplitRouteTrunk;
+      transaction.root_addr = root_aw_q[i].packet.addr;
+      transaction.routed_addr = (transaction.route == AxilSplitRouteBranch) ?
+          AxilAddrWidth'(routed_branch_addr(root_addr, branch_start_addr)) :
+          root_aw_q[i].packet.addr;
+      transaction.prot = root_aw_q[i].packet.prot;
+      transaction.addr_user = root_aw_q[i].packet.user;
+      transaction.data = root_w_q[i].packet.data;
+      transaction.strb = root_w_q[i].packet.strb;
+      transaction.data_user = root_w_q[i].packet.user;
+      transaction.resp = root_b_q[i].packet.resp;
+      transaction.request_ts = `BR_SIM_MAX(root_aw_q[i].timestamp, root_w_q[i].timestamp);
+      transaction.response_ts = root_b_q[i].timestamp;
+      write_q.push_back(transaction);
+    end
+
+    for (int i = 0; i < root_ar_q.size(); i++) begin
+      axil_split_transaction_t transaction;
+      logic [AxilAddrWidth-1:0] root_addr = AxilAddrWidth'(root_ar_q[i].packet.addr);
+      int range_index = branch_range_index(root_addr, branch_start_addr, branch_end_addr);
+
+      transaction = '0;
+      transaction.kind = AxilSplitTransactionRead;
+      transaction.route = (range_index >= 0) ? AxilSplitRouteBranch : AxilSplitRouteTrunk;
+      transaction.root_addr = root_ar_q[i].packet.addr;
+      transaction.routed_addr = (transaction.route == AxilSplitRouteBranch) ?
+          AxilAddrWidth'(routed_branch_addr(root_addr, branch_start_addr)) :
+          root_ar_q[i].packet.addr;
+      transaction.prot = root_ar_q[i].packet.prot;
+      transaction.addr_user = root_ar_q[i].packet.user;
+      transaction.data = root_r_q[i].packet.data;
+      transaction.resp = root_r_q[i].packet.resp;
+      transaction.response_user = root_r_q[i].packet.user;
+      transaction.request_ts = root_ar_q[i].timestamp;
+      transaction.response_ts = root_r_q[i].timestamp;
+      read_q.push_back(transaction);
+    end
+
+    while (write_index < write_q.size() || read_index < read_q.size()) begin
+      logic is_write;
+
+      if (write_index >= write_q.size()) is_write = 1'b0;
+      else if (read_index >= read_q.size()) is_write = 1'b1;
+      else is_write = write_q[write_index].request_ts <= read_q[read_index].request_ts;
+
+      if (is_write) begin
+        exp_q.push_back(write_q[write_index]);
+        write_index++;
+      end else begin
+        exp_q.push_back(read_q[read_index]);
+        read_index++;
+      end
+    end
+  endtask
+
+  task automatic check_root_request_counts(
+      input int expected_writes, input int expected_reads, input axil_aw_observation_t root_aw_q[$],
+      input axil_w_observation_t root_w_q[$], input axil_ar_observation_t root_ar_q[$],
+      inout logic sizes_match);
+    check_count("Root AW request", expected_writes, root_aw_q.size(), sizes_match);
+    check_count("Root W request", expected_writes, root_w_q.size(), sizes_match);
+    check_count("Root AR request", expected_reads, root_ar_q.size(), sizes_match);
+  endtask
+
+  task automatic count_expected_transactions(input axil_split_transaction_t exp_q[$],
+                                             output int trunk_writes, output int trunk_reads,
+                                             output int branch_writes, output int branch_reads);
+    trunk_writes  = 0;
+    trunk_reads   = 0;
+    branch_writes = 0;
+    branch_reads  = 0;
+
+    for (int i = 0; i < exp_q.size(); i++) begin
+      logic is_write = exp_q[i].kind == AxilSplitTransactionWrite;
+      logic is_branch = exp_q[i].route == AxilSplitRouteBranch;
+
+      branch_writes += is_write && is_branch;
+      trunk_writes += is_write && !is_branch;
+      branch_reads += !is_write && is_branch;
+      trunk_reads += !is_write && !is_branch;
+    end
+  endtask
+
+  task automatic check_routed_request_counts(
+      input axil_split_transaction_t exp_q[$], input axil_aw_observation_t trunk_aw_q[$],
+      input axil_w_observation_t trunk_w_q[$], input axil_ar_observation_t trunk_ar_q[$],
+      input axil_aw_observation_t branch_aw_q[$], input axil_w_observation_t branch_w_q[$],
+      input axil_ar_observation_t branch_ar_q[$], inout logic sizes_match);
+    int trunk_writes = 0;
+    int trunk_reads = 0;
+    int branch_writes = 0;
+    int branch_reads = 0;
+
+    count_expected_transactions(exp_q, trunk_writes, trunk_reads, branch_writes, branch_reads);
+
+    check_count("Trunk AW request", trunk_writes, trunk_aw_q.size(), sizes_match);
+    check_count("Trunk W request", trunk_writes, trunk_w_q.size(), sizes_match);
+    check_count("Branch AW request", branch_writes, branch_aw_q.size(), sizes_match);
+    check_count("Branch W request", branch_writes, branch_w_q.size(), sizes_match);
+    check_count("Trunk read request", trunk_reads, trunk_ar_q.size(), sizes_match);
+    check_count("Branch read request", branch_reads, branch_ar_q.size(), sizes_match);
+  endtask
+
+  task automatic check_response_counts(
+      input axil_split_transaction_t exp_q[$], input axil_b_observation_t root_b_q[$],
+      input axil_r_observation_t root_r_q[$], input axil_b_observation_t trunk_b_q[$],
+      input axil_r_observation_t trunk_r_q[$], input axil_b_observation_t branch_b_q[$],
+      input axil_r_observation_t branch_r_q[$], inout logic sizes_match);
+    int writes;
+    int reads;
+    int trunk_writes = 0;
+    int trunk_reads = 0;
+    int branch_writes = 0;
+    int branch_reads = 0;
+
+    count_expected_transactions(exp_q, trunk_writes, trunk_reads, branch_writes, branch_reads);
+    writes = trunk_writes + branch_writes;
+    reads  = trunk_reads + branch_reads;
+
+    check_count("Root B response", writes, root_b_q.size(), sizes_match);
+    check_count("Root R response", reads, root_r_q.size(), sizes_match);
+    check_count("Trunk B response", trunk_writes, trunk_b_q.size(), sizes_match);
+    check_count("Branch B response", branch_writes, branch_b_q.size(), sizes_match);
+    check_count("Trunk R response", trunk_reads, trunk_r_q.size(), sizes_match);
+    check_count("Branch R response", branch_reads, branch_r_q.size(), sizes_match);
+  endtask
+
+  function automatic logic next_event_is_request(input time req_ts_q[$], input time resp_ts_q[$],
+                                                 input int req_i, input int resp_i);
+    if (resp_i >= resp_ts_q.size()) next_event_is_request = 1'b1;
+    else if (req_i >= req_ts_q.size()) next_event_is_request = 1'b0;
+    else next_event_is_request = req_ts_q[req_i] < resp_ts_q[resp_i];
+  endfunction
+
+  function automatic int max_outstanding(input time req_ts_q[$], input time resp_ts_q[$]);
+    int req_i = 0;
+    int resp_i = 0;
+    int pending = 0;
+
+    max_outstanding = 0;
+    while (req_i + resp_i < req_ts_q.size() + resp_ts_q.size()) begin
+      logic is_req = next_event_is_request(req_ts_q, resp_ts_q, req_i, resp_i);
+
+      if (is_req) begin
+        pending++;
+        req_i++;
+      end else begin
+        pending--;
+        resp_i++;
+      end
+      if (pending > max_outstanding) max_outstanding = pending;
+    end
+  endfunction
+
+  // Walk request and response timestamps in order to measure the real outstanding depth, proving
+  // the backpressure scenarios hit the configured limit instead of merely queueing traffic.
+  task automatic check_outstanding_depths(
+      input int exp_max_reads, input int exp_max_writes, input axil_ar_observation_t root_ar_q[$],
+      input axil_r_observation_t root_r_q[$], input axil_aw_observation_t root_aw_q[$],
+      input axil_b_observation_t root_b_q[$], inout int mismatch_count);
+    time read_req_ts_q[$];
+    time read_resp_ts_q[$];
+    time write_req_ts_q[$];
+    time write_resp_ts_q[$];
+    int max_pending_reads;
+    int max_pending_writes;
+
+    for (int i = 0; i < root_ar_q.size(); i++) read_req_ts_q.push_back(root_ar_q[i].timestamp);
+    for (int i = 0; i < root_r_q.size(); i++) read_resp_ts_q.push_back(root_r_q[i].timestamp);
+    for (int i = 0; i < root_aw_q.size(); i++) write_req_ts_q.push_back(root_aw_q[i].timestamp);
+    for (int i = 0; i < root_b_q.size(); i++) write_resp_ts_q.push_back(root_b_q[i].timestamp);
+    max_pending_reads  = max_outstanding(read_req_ts_q, read_resp_ts_q);
+    max_pending_writes = max_outstanding(write_req_ts_q, write_resp_ts_q);
+
+    if (exp_max_reads > 0 && max_pending_reads != exp_max_reads) begin
+      report_mismatch(
+          $sformatf(
+          "Read outstanding depth did not reach %0d; observed %0d", exp_max_reads, max_pending_reads
+          ), mismatch_count);
+    end
+    if (exp_max_writes > 0 && max_pending_writes != exp_max_writes) begin
+      report_mismatch($sformatf(
+                      "Write outstanding depth did not reach %0d; observed %0d",
+                      exp_max_writes,
+                      max_pending_writes
+                      ), mismatch_count);
+    end
+  endtask
+
+  task automatic check_write_transaction(
+      input axil_split_transaction_t expected_transaction, input axil_aw_observation_t root_aw,
+      input axil_w_observation_t root_w, input axil_aw_observation_t routed_aw,
+      input axil_w_observation_t routed_w, input axil_b_observation_t routed_b,
+      input axil_b_observation_t root_b, input int write_index, inout int mismatch_count);
+    if (!aw_matches(
+            root_aw.packet, expected_transaction.root_addr, expected_transaction
+        ) || !w_matches(
+            root_w.packet, expected_transaction
+        )) begin
+      report_mismatch($sformatf("Root write transaction %0d payload mismatch", write_index),
+                      mismatch_count);
+    end
+    if (!aw_matches(
+            routed_aw.packet, expected_transaction.routed_addr, expected_transaction
+        ) || !w_matches(
+            routed_w.packet, expected_transaction
+        )) begin
+      report_mismatch($sformatf("Routed write transaction %0d payload mismatch", write_index),
+                      mismatch_count);
+    end
+    if (!b_matches(
+            routed_b.packet, expected_transaction
+        ) || !b_matches(
+            root_b.packet, expected_transaction
+        )) begin
+      report_mismatch($sformatf("Write transaction %0d response mismatch", write_index),
+                      mismatch_count);
+    end
+  endtask
+
+  task automatic check_read_transaction(
+      input axil_split_transaction_t expected_transaction, input axil_ar_observation_t root_ar,
+      input axil_ar_observation_t routed_ar, input axil_r_observation_t routed_r,
+      input axil_r_observation_t root_r, input int read_index, inout int mismatch_count);
+    if (!ar_matches(root_ar.packet, expected_transaction.root_addr, expected_transaction)) begin
+      report_mismatch($sformatf("Root read transaction %0d payload mismatch", read_index),
+                      mismatch_count);
+    end
+    if (!ar_matches(routed_ar.packet, expected_transaction.routed_addr, expected_transaction)) begin
+      report_mismatch($sformatf("Routed read transaction %0d payload mismatch", read_index),
+                      mismatch_count);
+    end
+    if (!r_matches(
+            routed_r.packet, expected_transaction
+        ) || !r_matches(
+            root_r.packet, expected_transaction
+        )) begin
+      report_mismatch($sformatf("Read transaction %0d response mismatch", read_index),
+                      mismatch_count);
+    end
+  endtask
+
+  // Route switching is legal only after the previous route's outstanding responses have drained.
+  // Reads and writes are tracked independently because the DUT has separate outstanding limits.
+  task automatic check_route_switching_rules(input axil_split_transaction_t exp_q[$],
+                                             inout int mismatch_count);
+    axil_split_route_t active_read_route;
+    axil_split_route_t active_write_route;
+    logic              read_route_active = 1'b0;
+    logic              write_route_active = 1'b0;
+    time               read_route_drain_ts = 0;
+    time               write_route_drain_ts = 0;
+
+    for (int i = 0; i < exp_q.size(); i++) begin
+      axil_split_transaction_t transaction = exp_q[i];
+
+      if (transaction.kind == AxilSplitTransactionRead) begin
+        if (read_route_active && transaction.route != active_read_route &&
+            transaction.request_ts <= read_route_drain_ts) begin
+          report_mismatch(
+              $sformatf(
+              "Read route switched before outstanding responses drained at transaction %0d", i),
+              mismatch_count);
+        end
+        active_read_route = transaction.route;
+        read_route_active = 1'b1;
+        if (transaction.response_ts > read_route_drain_ts) begin
+          read_route_drain_ts = transaction.response_ts;
+        end
+      end else begin
+        if (write_route_active && transaction.route != active_write_route &&
+            transaction.request_ts <= write_route_drain_ts) begin
+          report_mismatch(
+              $sformatf(
+              "Write route switched before outstanding responses drained at transaction %0d", i),
+              mismatch_count);
+        end
+        active_write_route = transaction.route;
+        write_route_active = 1'b1;
+        if (transaction.response_ts > write_route_drain_ts) begin
+          write_route_drain_ts = transaction.response_ts;
+        end
+      end
+    end
+  endtask
+
+  task automatic compare(input int expected_writes, input int expected_reads,
+                         input int exp_max_reads, input int exp_max_writes,
+                         input logic [NumBranchAddrRanges-1:0][AxilAddrWidth-1:0] branch_start_addr,
+                         input logic [NumBranchAddrRanges-1:0][AxilAddrWidth-1:0] branch_end_addr);
+    axil_split_transaction_t exp_q[$];
+    logic sizes_match = 1'b1;
+    logic prediction_valid;
+    int mismatch_count = 0;
+    int write_index = 0;
+    int read_index = 0;
+    int trunk_write_index = 0;
+    int trunk_read_index = 0;
+    int branch_write_index = 0;
+    int branch_read_index = 0;
+
+    check_root_request_counts(expected_writes, expected_reads, root_aw_q, root_w_q, root_ar_q,
+                              sizes_match);
+    predict_transactions(branch_start_addr, branch_end_addr, root_aw_q, root_w_q, root_ar_q,
+                         root_b_q, root_r_q, exp_q, prediction_valid);
+    if (!prediction_valid) begin
+      report_failure("Root AXI-Lite observations cannot form complete split transactions");
+      return;
+    end
+
+    check_routed_request_counts(exp_q, trunk_aw_q, trunk_w_q, trunk_ar_q, branch_aw_q, branch_w_q,
+                                branch_ar_q, sizes_match);
+    check_response_counts(exp_q, root_b_q, root_r_q, trunk_b_q, trunk_r_q, branch_b_q, branch_r_q,
+                          sizes_match);
+    if (!sizes_match) begin
+      return;
+    end
+
+    for (int i = 0; i < exp_q.size(); i++) begin
+      if (exp_q[i].kind == AxilSplitTransactionWrite) begin
+        if (exp_q[i].route == AxilSplitRouteBranch) begin
+          check_write_transaction(exp_q[i], root_aw_q[write_index], root_w_q[write_index],
+                                  branch_aw_q[branch_write_index], branch_w_q[branch_write_index],
+                                  branch_b_q[branch_write_index], root_b_q[write_index],
+                                  write_index, mismatch_count);
+          branch_write_index++;
+        end else begin
+          check_write_transaction(exp_q[i], root_aw_q[write_index], root_w_q[write_index],
+                                  trunk_aw_q[trunk_write_index], trunk_w_q[trunk_write_index],
+                                  trunk_b_q[trunk_write_index], root_b_q[write_index], write_index,
+                                  mismatch_count);
+          trunk_write_index++;
+        end
+        write_index++;
+      end else begin
+        if (exp_q[i].route == AxilSplitRouteBranch) begin
+          check_read_transaction(exp_q[i], root_ar_q[read_index], branch_ar_q[branch_read_index],
+                                 branch_r_q[branch_read_index], root_r_q[read_index], read_index,
+                                 mismatch_count);
+          branch_read_index++;
+        end else begin
+          check_read_transaction(exp_q[i], root_ar_q[read_index], trunk_ar_q[trunk_read_index],
+                                 trunk_r_q[trunk_read_index], root_r_q[read_index], read_index,
+                                 mismatch_count);
+          trunk_read_index++;
+        end
+        read_index++;
+      end
+    end
+
+    check_route_switching_rules(exp_q, mismatch_count);
+    check_outstanding_depths(exp_max_reads, exp_max_writes, root_ar_q, root_r_q, root_aw_q,
+                             root_b_q, mismatch_count);
+    if (mismatch_count != 0) begin
+      $error("br_amba_axil_split scoreboard found %0d mismatches", mismatch_count);
+    end
+  endtask
+endmodule : br_amba_axil_split_scoreboard

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -1844,6 +1844,14 @@ def verilog_fpv_test_suite(
                     **kwargs
                 )
 
+_VERILOG_SIM_TEST_ONLY_KWARGS = [
+    "flaky",
+    "local",
+    "shard_count",
+    "size",
+    "timeout",
+]
+
 def verilog_sim_test_suite(
         name,
         defines = [],
@@ -1869,6 +1877,13 @@ def verilog_sim_test_suite(
     param_values_list = [params[key] for key in param_keys]
     param_combinations = _cartesian_product(param_values_list)
     tool = kwargs.get("tool", False)
+
+    # Coverage-data targets are not Bazel test rules, so strip test-only attributes.
+    coverage_kwargs = {
+        key: value
+        for key, value in kwargs.items()
+        if key not in _VERILOG_SIM_TEST_ONLY_KWARGS
+    }
     coverage_data = []
 
     if coverage and tool != "verilator":
@@ -1892,7 +1907,7 @@ def verilog_sim_test_suite(
                 name = coverage_data_name,
                 defines = defines,
                 params = params,
-                **kwargs
+                **coverage_kwargs
             )
             coverage_data.append(":" + coverage_data_name)
 


### PR DESCRIPTION
Adds a directed simulation testbench for `br_amba_axil_split`, including a split-specific scoreboard.