### PR TITLE
Disable invalid autoupdate valid stability assertion

### DIFF
--- a/cdc/rtl/br_cdc_stable_data_autoupdate.sv
+++ b/cdc/rtl/br_cdc_stable_data_autoupdate.sv
@@ -47,7 +47,8 @@ module br_cdc_stable_data_autoupdate #(
       .Width(Width),
       .RegisterResetActive(RegisterResetActive),
       .NumSyncStages(NumSyncStages),
-      // Data can change if data changes while register is backpressured
+      // Both valid and data can change if src_data changes while the register is backpressured.
+      .EnableAssertPushValidStability(0),
       .EnableAssertPushDataStability(0)
   ) br_cdc_reg_inst (
       .push_clk  (src_clk),    // ri lint_check_waive SAME_CLOCK_NAME


### PR DESCRIPTION
## Summary

Disable the `br_cdc_reg` push-valid stability assertion inside `br_cdc_stable_data_autoupdate`.

## Root cause

`src_valid` is generated combinationally from `src_data != src_data_reg`. While the internal CDC register is backpressured, a changing input can return to `src_data_reg`, causing `src_valid` to deassert. This is valid behavior for the autoupdate wrapper, but it violates the generic ready/valid stability check and produces a false DV failure.

The wrapper already disables push-data stability because `src_data` may change during backpressure. This change also disables push-valid stability for the same reason.

## Impact

Rapidly changing autoupdate inputs no longer trigger a false internal assertion. Functional RTL behavior is unchanged.

## Validation

- All 32 VCS parameter combinations for `br_cdc_stable_data_autoupdate` passed.
- Slang elaboration passed with integration assertions, all assertions, and no assertions.
- All three focused lint configurations passed.
- Pre-commit checks passed.