### PR TITLE
Remove unnecessary reset x toggles 

### DIFF
--- a/arb/sim/br_arb_fixed_tb.sv
+++ b/arb/sim/br_arb_fixed_tb.sv
@@ -87,8 +87,6 @@ module br_arb_fixed_tb;
     cb_clk.request <= 'h0;
 
     // Wiggling the reset signal.
-    rst = 1'bx;
-    #RESET_DURATION;
     rst = 1'b1;
     #RESET_DURATION;
     rst = 1'b0;

--- a/arb/sim/br_arb_grant_hold_tb.sv
+++ b/arb/sim/br_arb_grant_hold_tb.sv
@@ -82,8 +82,6 @@ module br_arb_grant_hold_tb;
     enable_grant_hold_update = 1'b0;  // Reset value for enable_grant_hold_update
 
     // Wiggling the reset signal.
-    rst = 1'bx;  // Setting to undefined before asserting
-    #RESET_DURATION;
     rst = 1'b1;  // Assuming active high reset
     #RESET_DURATION;
     rst = 1'b0;  // Inactive value for reset

--- a/arb/sim/br_arb_lru_tb.sv
+++ b/arb/sim/br_arb_lru_tb.sv
@@ -93,8 +93,6 @@ module br_arb_lru_tb;
     cb_clk.request <= 'h0;
 
     // Wiggling the reset signal.
-    rst = 1'bx;
-    #RESET_DURATION;
     rst = 1'b1;
     #RESET_DURATION;
     rst = 1'b0;

--- a/arb/sim/br_arb_rr_tb.sv
+++ b/arb/sim/br_arb_rr_tb.sv
@@ -92,8 +92,6 @@ module br_arb_rr_tb;
     cb_clk.request <= 'h0;
 
     // Wiggling the reset signal.
-    rst = 1'bx;
-    #RESET_DURATION;
     rst = 1'b1;
     #RESET_DURATION;
     rst = 1'b0;

--- a/enc/sim/br_enc_onehot2bin_tb.sv
+++ b/enc/sim/br_enc_onehot2bin_tb.sv
@@ -92,8 +92,6 @@ module br_enc_onehot2bin_tb;
     cb_clk.in <= 'h0;
 
     // Wiggling the reset signal.
-    rst = 1'bx;
-    #RESET_DURATION;
     rst = 1'b1;
     #RESET_DURATION;
     rst = 1'b0;

--- a/ram/sim/br_ram_initializer_tb.sv
+++ b/ram/sim/br_ram_initializer_tb.sv
@@ -105,8 +105,6 @@ module br_ram_initializer_tb;
     cb_clk.start <= 'h0;
 
     // Wiggling the reset signal.
-    rst = 1'bx;
-    #RESET_DURATION;
     rst = 1'b1;
     #RESET_DURATION;
     rst = 1'b0;


### PR DESCRIPTION
A few tests were running the reset sequence starting with 'x' state. As per discussion with @mgottscho, it's not really needed anymore.