### PR TITLE
Set Dependabot updates to quarterly with 30-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,36 +8,36 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     cooldown:
       default-days: 30
   - package-ecosystem: "bazel"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     cooldown:
       default-days: 30
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     cooldown:
       default-days: 30
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     cooldown:
       default-days: 30
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     cooldown:
       default-days: 30
   - package-ecosystem: "cargo"
     directory: "/stitch"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     cooldown:
       default-days: 30


### PR DESCRIPTION
- Change all Dependabot update schedules from monthly to quarterly.
- Keep a 30-day cooldown for every configured package ecosystem.