### PR TITLE
br_apb_demux Implementation

### DIFF
--- a/amba/rtl/BUILD.bazel
+++ b/amba/rtl/BUILD.bazel
@@ -119,6 +119,30 @@ verilog_library(
     ],
 )
 
+verilog_library(
+    name = "br_apb_demux_select_onehot",
+    srcs = ["br_apb_demux_select_onehot.sv"],
+    deps = [
+        ":br_amba_apb_timing_slice",
+        ":br_amba_pkg",
+        "//macros:br_asserts_internal",
+        "//macros:br_unused",
+        "//mux/rtl:br_mux_onehot",
+    ],
+)
+
+verilog_library(
+    name = "br_apb_demux",
+    srcs = ["br_apb_demux.sv"],
+    deps = [
+        ":br_amba_pkg",
+        ":br_apb_demux_select_onehot",
+        "//demux/rtl:br_demux_addr_decode",
+        "//macros:br_asserts_internal",
+        "//macros:br_unused",
+    ],
+)
+
 br_verilog_elab_and_lint_test_suite(
     name = "br_amba_axil2apb_test_suite",
     params = {
@@ -339,6 +363,113 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_amba_apb_timing_slice"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_apb_demux_select_onehot_test_suite",
+    params = {
+        "AddrWidth": [
+            "12",
+            "32",
+        ],
+        "EnableDecodeError": [
+            "0",
+            "1",
+        ],
+        "NumDownstreams": [
+            "2",
+            "3",
+        ],
+    },
+    deps = [":br_apb_demux_select_onehot"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_apb_demux_select_onehot_test_suite_single_downstream",
+    params = {
+        "AddrWidth": [
+            "12",
+            "32",
+        ],
+        "EnableDecodeError": [
+            "0",
+            "1",
+        ],
+        "NumDownstreams": ["1"],
+    },
+    deps = [":br_apb_demux_select_onehot"],
+)
+
+br_verilog_synth_suite(
+    name = "br_apb_demux_select_onehot_baseline_ppa",
+    params = {
+        "AddrWidth": ["16"],
+        "EnableDecodeError": ["1"],
+        "NumDownstreams": ["4"],
+    },
+    deps = [":br_apb_demux_select_onehot"],
+)
+
+br_verilog_synth_suite(
+    name = "br_apb_demux_select_onehot_scaled_ppa",
+    params = {
+        "AddrWidth": ["32"],
+        "EnableDecodeError": ["0"],
+        "NumDownstreams": ["16"],
+    },
+    deps = [":br_apb_demux_select_onehot"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_apb_demux_test_suite",
+    params = {
+        "AddrWidth": [
+            "12",
+            "32",
+        ],
+        "HasDefaultDownstream": [
+            "0",
+            "1",
+        ],
+        "NumDownstreams": [
+            "2",
+            "3",
+        ],
+    },
+    deps = [":br_apb_demux"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_apb_demux_test_suite_single_downstream",
+    params = {
+        "AddrWidth": [
+            "12",
+            "32",
+        ],
+        "HasDefaultDownstream": ["0"],
+        "NumDownstreams": ["1"],
+    },
+    deps = [":br_apb_demux"],
+)
+
+br_verilog_synth_suite(
+    name = "br_apb_demux_baseline_ppa",
+    params = {
+        "AddrWidth": ["16"],
+        "HasDefaultDownstream": ["0"],
+        "NumDownstreams": ["4"],
+    },
+    deps = [":br_apb_demux"],
+)
+
+br_verilog_synth_suite(
+    name = "br_apb_demux_scaled_ppa",
+    params = {
+        "AddrWidth": ["32"],
+        "HasDefaultDownstream": ["1"],
+        "NumDownstreams": ["16"],
+    },
+    deps = [":br_apb_demux"],
 )
 
 verilog_library(

--- a/amba/rtl/br_apb_demux.sv
+++ b/amba/rtl/br_apb_demux.sv
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bedrock-RTL Address-Decoding APB Demux
+//
+// Routes APB transfers to the correct downstream interface based on PADDR.
+// Address ranges, optional masking, normalization, and default routing use the
+// protocol-neutral br_demux_addr_decode helper. APB fanout, timing, and
+// response handling use br_apb_demux_select_onehot.
+
+`include "br_asserts_internal.svh"
+`include "br_unused.svh"
+
+module br_apb_demux #(
+    parameter int AddrWidth = 12,  // Must be at least 12
+    parameter int NumDownstreams = 1,  // Must be at least 1
+    // ri lint_check_waive ARRAY_LENGTH_ONE
+    parameter int NumRetimeStages[NumDownstreams] = '{default: 0},
+    // When set, the final downstream receives every address that misses the
+    // explicit ranges. Otherwise, misses complete with PSLVERR.
+    parameter bit HasDefaultDownstream = 0,
+    localparam int NumAddressRanges = HasDefaultDownstream ? NumDownstreams - 1 : NumDownstreams,
+    // Require enabled ranges to be power-of-two sized and naturally aligned.
+    // ri lint_check_waive ARRAY_LENGTH_ONE
+    parameter bit RequirePowerOfTwoAlignedRanges[NumAddressRanges] = '{default: 1},
+    // Rebase each explicit downstream address before applying its output mask.
+    // ri lint_check_waive ARRAY_LENGTH_ONE
+    parameter bit NormalizeDownstreamAddress[NumAddressRanges] = '{default: 0},
+    // Mask used only for address decode; forwarded addresses remain unmasked.
+    parameter logic [AddrWidth-1:0] UpstreamAddrMask = '1,
+    // Mask applied to each forwarded address after optional normalization.
+    parameter logic [NumDownstreams-1:0][AddrWidth-1:0] DownstreamAddrMask = '1
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [AddrWidth-1:0] upstream_paddr,
+    input logic upstream_psel,
+    input logic upstream_penable,
+    input logic [br_amba::ApbProtWidth-1:0] upstream_pprot,
+    input logic [3:0] upstream_pstrb,
+    input logic upstream_pwrite,
+    // TODO(twabbott): Parameterize APB data/strobe widths once br_amba_apb_timing_slice supports it.
+    input logic [31:0] upstream_pwdata,
+    output logic [31:0] upstream_prdata,
+    output logic upstream_pready,
+    output logic upstream_pslverr,
+
+    // Configurable ranges must remain stable while an APB transfer is pending.
+    input logic [NumAddressRanges-1:0][AddrWidth-1:0] downstream_addr_base,
+    input logic [NumAddressRanges-1:0][AddrWidth-1:0] downstream_addr_size,
+
+    output logic [NumDownstreams-1:0][AddrWidth-1:0] downstream_paddr,
+    output logic [NumDownstreams-1:0] downstream_psel,
+    output logic [NumDownstreams-1:0] downstream_penable,
+    output logic [NumDownstreams-1:0][br_amba::ApbProtWidth-1:0] downstream_pprot,
+    output logic [NumDownstreams-1:0][3:0] downstream_pstrb,
+    output logic [NumDownstreams-1:0] downstream_pwrite,
+    output logic [NumDownstreams-1:0][31:0] downstream_pwdata,
+    input logic [NumDownstreams-1:0][31:0] downstream_prdata,
+    input logic [NumDownstreams-1:0] downstream_pready,
+    input logic [NumDownstreams-1:0] downstream_pslverr
+);
+  // Integration Checks
+
+  logic upstream_request_pending;
+
+  assign upstream_request_pending = upstream_psel && (!upstream_penable || !upstream_pready);
+
+  `BR_ASSERT_STATIC(legal_num_downstreams_a, NumDownstreams >= 1 + HasDefaultDownstream)
+  `BR_ASSERT_STATIC(legal_addr_width_a, AddrWidth >= 12)
+  `BR_ASSERT_INTG(addr_map_stable_while_pending_a, upstream_request_pending |=> $stable
+                                                   ({downstream_addr_base, downstream_addr_size}))
+  `BR_UNUSED(upstream_request_pending)
+
+  // Implementation
+
+  logic [NumDownstreams-1:0] select_onehot;
+  logic [NumDownstreams-1:0][AddrWidth-1:0] downstream_paddr_unmasked;
+
+  br_demux_addr_decode #(
+      .AddrWidth(AddrWidth),
+      .NumDownstreams(NumDownstreams),
+      .HasDefaultDownstream(HasDefaultDownstream),
+      .RequirePowerOfTwoAlignedRanges(RequirePowerOfTwoAlignedRanges),
+      .NormalizeDownstreamAddress(NormalizeDownstreamAddress),
+      .UpstreamAddrMask(UpstreamAddrMask),
+      .DownstreamAddrMask(DownstreamAddrMask)
+  ) br_demux_addr_decode (
+      .clk,
+      .rst,
+      .addr_valid(upstream_psel),
+      .upstream_addr(upstream_paddr),
+      .downstream_addr_base,
+      .downstream_addr_size,
+      .downstream_addr_in(downstream_paddr_unmasked),
+      .select_onehot,
+      .downstream_addr_out(downstream_paddr)
+  );
+
+  br_apb_demux_select_onehot #(
+      .AddrWidth(AddrWidth),
+      .NumDownstreams(NumDownstreams),
+      .EnableDecodeError(!HasDefaultDownstream),
+      .NumRetimeStages(NumRetimeStages)
+  ) br_apb_demux_select_onehot (
+      .clk,
+      .rst,
+      .select_onehot,
+      .upstream_paddr,
+      .upstream_psel,
+      .upstream_penable,
+      .upstream_pprot,
+      .upstream_pstrb,
+      .upstream_pwrite,
+      .upstream_pwdata,
+      .upstream_prdata,
+      .upstream_pready,
+      .upstream_pslverr,
+      .downstream_paddr(downstream_paddr_unmasked),
+      .downstream_psel,
+      .downstream_penable,
+      .downstream_pprot,
+      .downstream_pstrb,
+      .downstream_pwrite,
+      .downstream_pwdata,
+      .downstream_prdata,
+      .downstream_pready,
+      .downstream_pslverr
+  );
+
+endmodule : br_apb_demux

--- a/amba/rtl/br_apb_demux_select_onehot.sv
+++ b/amba/rtl/br_apb_demux_select_onehot.sv
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bedrock-RTL APB Demux with Onehot Select
+//
+// Routes an APB transfer according to a onehot selection input. Responses from
+// downstream interfaces are muxed together and passed upstream. Each downstream
+// interface can independently insert APB timing slices.
+//
+// When enabled, a selected transfer with no matching downstream completes with
+// PSLVERR.
+
+`include "br_asserts_internal.svh"
+`include "br_unused.svh"
+
+module br_apb_demux_select_onehot #(
+    parameter int AddrWidth = 12,  // Must be at least 12
+    parameter int NumDownstreams = 1,  // Must be at least 1
+    parameter bit EnableDecodeError = 1,
+    // ri lint_check_waive ARRAY_LENGTH_ONE
+    parameter int NumRetimeStages[NumDownstreams] = '{default: 0}
+) (
+    input logic clk,
+    input logic rst,
+
+    // For an active transfer, select one downstream or leave all zero.
+    input logic [NumDownstreams-1:0] select_onehot,
+
+    input logic [AddrWidth-1:0] upstream_paddr,
+    input logic upstream_psel,
+    input logic upstream_penable,
+    input logic [br_amba::ApbProtWidth-1:0] upstream_pprot,
+    input logic [3:0] upstream_pstrb,
+    input logic upstream_pwrite,
+    input logic [31:0] upstream_pwdata,
+    output logic [31:0] upstream_prdata,
+    output logic upstream_pready,
+    output logic upstream_pslverr,
+
+    output logic [NumDownstreams-1:0][AddrWidth-1:0] downstream_paddr,
+    output logic [NumDownstreams-1:0] downstream_psel,
+    output logic [NumDownstreams-1:0] downstream_penable,
+    output logic [NumDownstreams-1:0][br_amba::ApbProtWidth-1:0] downstream_pprot,
+    output logic [NumDownstreams-1:0][3:0] downstream_pstrb,
+    output logic [NumDownstreams-1:0] downstream_pwrite,
+    output logic [NumDownstreams-1:0][31:0] downstream_pwdata,
+    input logic [NumDownstreams-1:0][31:0] downstream_prdata,
+    input logic [NumDownstreams-1:0] downstream_pready,
+    input logic [NumDownstreams-1:0] downstream_pslverr
+);
+  // Integration Checks
+
+  logic upstream_access_waiting;
+  logic upstream_request_pending;
+
+  assign upstream_access_waiting  = upstream_psel && upstream_penable && !upstream_pready;
+  assign upstream_request_pending = upstream_psel && (!upstream_penable || !upstream_pready);
+
+  `BR_ASSERT_STATIC(legal_num_downstreams_a, NumDownstreams >= 1)
+  `BR_ASSERT_STATIC(legal_addr_width_a, AddrWidth >= 12)
+  `BR_ASSERT_INTG(enable_requires_select_a, upstream_penable |-> upstream_psel)
+  `BR_ASSERT_INTG(access_stable_while_waiting_a,
+                  upstream_access_waiting |=> upstream_psel && upstream_penable)
+  `BR_ASSERT_INTG(
+      request_stable_while_pending_a,
+      upstream_request_pending |=> upstream_psel && $stable(select_onehot) && $stable
+      ({upstream_paddr, upstream_pprot, upstream_pstrb, upstream_pwrite, upstream_pwdata}))
+  `BR_UNUSED(upstream_access_waiting)
+  `BR_UNUSED(upstream_request_pending)
+
+  // Implementation
+
+  typedef struct packed {
+    logic [31:0] rdata;
+    logic ready;
+    logic slverr;
+  } resp_t;
+
+  logic [NumDownstreams-1:0] downstream_req_valid_int;
+  logic [NumDownstreams-1:0][31:0] downstream_prdata_int;
+  logic [NumDownstreams-1:0] downstream_pready_int;
+  logic [NumDownstreams-1:0] downstream_pslverr_int;
+  resp_t [NumDownstreams-1:0] downstream_resp;
+  resp_t upstream_resp;
+
+  assign downstream_req_valid_int = select_onehot & {NumDownstreams{upstream_psel}};
+
+  for (genvar i = 0; i < NumDownstreams; i++) begin : gen_downstream
+    `BR_ASSERT_STATIC(legal_num_retime_stages_a, NumRetimeStages[i] >= 0)
+
+    if (NumRetimeStages[i] == 0) begin : gen_no_retime
+      `BR_UNUSED(clk)
+      `BR_UNUSED(rst)
+
+      assign downstream_paddr[i] = upstream_paddr;
+      assign downstream_psel[i] = downstream_req_valid_int[i];
+      assign downstream_penable[i] = downstream_req_valid_int[i] && upstream_penable;
+      assign downstream_pprot[i] = upstream_pprot;
+      assign downstream_pstrb[i] = upstream_pstrb;
+      assign downstream_pwrite[i] = upstream_pwrite;
+      assign downstream_pwdata[i] = upstream_pwdata;
+      assign downstream_prdata_int[i] = downstream_prdata[i];
+      assign downstream_pready_int[i] = downstream_pready[i];
+      assign downstream_pslverr_int[i] = downstream_pslverr[i];
+    end else begin : gen_retime
+      logic [NumRetimeStages[i]:0][AddrWidth-1:0] paddr;
+      logic [NumRetimeStages[i]:0] psel;
+      logic [NumRetimeStages[i]:0] penable;
+      logic [NumRetimeStages[i]:0][br_amba::ApbProtWidth-1:0] pprot;
+      logic [NumRetimeStages[i]:0][3:0] pstrb;
+      logic [NumRetimeStages[i]:0] pwrite;
+      logic [NumRetimeStages[i]:0][31:0] pwdata;
+      logic [NumRetimeStages[i]:0][31:0] prdata;
+      logic [NumRetimeStages[i]:0] pready;
+      logic [NumRetimeStages[i]:0] pslverr;
+
+      assign paddr[0] = upstream_paddr;
+      assign psel[0] = downstream_req_valid_int[i];
+      assign penable[0] = downstream_req_valid_int[i] && upstream_penable;
+      assign pprot[0] = upstream_pprot;
+      assign pstrb[0] = upstream_pstrb;
+      assign pwrite[0] = upstream_pwrite;
+      assign pwdata[0] = upstream_pwdata;
+      assign prdata[NumRetimeStages[i]] = downstream_prdata[i];
+      assign pready[NumRetimeStages[i]] = downstream_pready[i];
+      assign pslverr[NumRetimeStages[i]] = downstream_pslverr[i];
+
+      for (genvar j = 0; j < NumRetimeStages[i]; j++) begin : gen_retime_stage
+        br_amba_apb_timing_slice #(
+            .AddrWidth(AddrWidth)
+        ) br_amba_apb_timing_slice (
+            .clk,
+            .rst,
+            .paddr_in(paddr[j]),
+            .psel_in(psel[j]),
+            .penable_in(penable[j]),
+            .pprot_in(pprot[j]),
+            .pstrb_in(pstrb[j]),
+            .pwrite_in(pwrite[j]),
+            .pwdata_in(pwdata[j]),
+            .prdata_out(prdata[j]),
+            .pready_out(pready[j]),
+            .pslverr_out(pslverr[j]),
+            .paddr_out(paddr[j+1]),
+            .psel_out(psel[j+1]),
+            .penable_out(penable[j+1]),
+            .pprot_out(pprot[j+1]),
+            .pstrb_out(pstrb[j+1]),
+            .pwrite_out(pwrite[j+1]),
+            .pwdata_out(pwdata[j+1]),
+            .prdata_in(prdata[j+1]),
+            .pready_in(pready[j+1]),
+            .pslverr_in(pslverr[j+1])
+        );
+      end
+
+      assign downstream_paddr[i] = paddr[NumRetimeStages[i]];
+      assign downstream_psel[i] = psel[NumRetimeStages[i]];
+      assign downstream_penable[i] = penable[NumRetimeStages[i]];
+      assign downstream_pprot[i] = pprot[NumRetimeStages[i]];
+      assign downstream_pstrb[i] = pstrb[NumRetimeStages[i]];
+      assign downstream_pwrite[i] = pwrite[NumRetimeStages[i]];
+      assign downstream_pwdata[i] = pwdata[NumRetimeStages[i]];
+      assign downstream_prdata_int[i] = prdata[0];
+      assign downstream_pready_int[i] = pready[0];
+      assign downstream_pslverr_int[i] = pslverr[0];
+    end
+
+    assign downstream_resp[i] = '{
+            rdata: downstream_prdata_int[i],
+            ready: downstream_pready_int[i],
+            slverr: downstream_pslverr_int[i]
+        };
+  end
+
+  if (EnableDecodeError) begin : gen_decode_error
+    resp_t decode_error_resp;
+    logic  decode_miss;
+
+    assign decode_miss = upstream_psel && !(|select_onehot);
+    assign decode_error_resp = '{rdata: '0, ready: 1'b1, slverr: 1'b1};
+
+    br_mux_onehot #(
+        .NumSymbolsIn(NumDownstreams + 1),
+        .SymbolWidth ($bits(resp_t))
+    ) br_mux_onehot_resp (
+        .select({decode_miss, downstream_req_valid_int}),
+        .in({decode_error_resp, downstream_resp}),
+        .out(upstream_resp)
+    );
+  end else begin : gen_no_decode_error
+    br_mux_onehot #(
+        .NumSymbolsIn(NumDownstreams),
+        .SymbolWidth ($bits(resp_t))
+    ) br_mux_onehot_resp (
+        .select(downstream_req_valid_int),
+        .in(downstream_resp),
+        .out(upstream_resp)
+    );
+  end
+
+  assign upstream_prdata  = upstream_resp.rdata;
+  assign upstream_pready  = upstream_psel && upstream_penable && upstream_resp.ready;
+  assign upstream_pslverr = upstream_psel && upstream_penable && upstream_resp.slverr;
+
+endmodule : br_apb_demux_select_onehot

--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -121,6 +121,50 @@ br_verilog_sim_test_tools_suite(
 )
 
 verilog_library(
+    name = "br_apb_demux_tb",
+    srcs = ["br_apb_demux_tb.sv"],
+    deps = [
+        "//amba/rtl:br_amba_pkg",
+        "//amba/rtl:br_apb_demux",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_apb_demux_tb_elab_test",
+    tool = "slang",
+    deps = [":br_apb_demux_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_apb_demux_sim_test_tools_suite",
+    params = {
+        "AddrWidth": [
+            "12",
+            "16",
+        ],
+        "HasDefaultDownstream": [
+            "0",
+            "1",
+        ],
+        "NumDownstreams": [
+            "2",
+            "4",
+        ],
+        "NumRetimeStagesPerDownstream": [
+            "0",
+            "1",
+            "2",
+        ],
+    },
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_apb_demux_tb"],
+)
+
+verilog_library(
     name = "br_amba_axi_timing_slice_tb",
     srcs = ["br_amba_axi_timing_slice_tb.sv"],
     deps = [

--- a/amba/sim/br_apb_demux_tb.sv
+++ b/amba/sim/br_apb_demux_tb.sv
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+module br_apb_demux_tb;
+  parameter int AddrWidth = 12;
+  parameter int NumDownstreams = 2;
+  parameter int NumRetimeStagesPerDownstream = 0;
+  parameter bit HasDefaultDownstream = 0;
+
+  localparam int NumAddressRanges = HasDefaultDownstream ? NumDownstreams - 1 : NumDownstreams;
+  localparam int NumRetimeStages[NumDownstreams] = '{0: 0, default: NumRetimeStagesPerDownstream};
+  localparam bit NormalizeDownstreamAddress[NumAddressRanges] = '{default: 1};
+  localparam logic [AddrWidth-1:0] AddrMask = {1'b0, {(AddrWidth - 1) {1'b1}}};
+  localparam logic [NumDownstreams-1:0][AddrWidth-1:0] DownstreamAddrMask =
+      {NumDownstreams{AddrMask}};
+  localparam int RangeSize = 256;
+  localparam int TimeoutCycles = 40;
+  localparam logic [31:0] NoiseRdata = 32'hbad0_bad0;
+
+  logic clk;
+  logic rst;
+
+  logic [AddrWidth-1:0] upstream_paddr;
+  logic upstream_psel;
+  logic upstream_penable;
+  logic [br_amba::ApbProtWidth-1:0] upstream_pprot;
+  logic [3:0] upstream_pstrb;
+  logic upstream_pwrite;
+  logic [31:0] upstream_pwdata;
+  logic [31:0] upstream_prdata;
+  logic upstream_pready;
+  logic upstream_pslverr;
+
+  logic [NumAddressRanges-1:0][AddrWidth-1:0] downstream_addr_base;
+  logic [NumAddressRanges-1:0][AddrWidth-1:0] downstream_addr_size;
+
+  logic [NumDownstreams-1:0][AddrWidth-1:0] downstream_paddr;
+  logic [NumDownstreams-1:0] downstream_psel;
+  logic [NumDownstreams-1:0] downstream_penable;
+  logic [NumDownstreams-1:0][br_amba::ApbProtWidth-1:0] downstream_pprot;
+  logic [NumDownstreams-1:0][3:0] downstream_pstrb;
+  logic [NumDownstreams-1:0] downstream_pwrite;
+  logic [NumDownstreams-1:0][31:0] downstream_pwdata;
+  logic [NumDownstreams-1:0][31:0] downstream_prdata;
+  logic [NumDownstreams-1:0] downstream_pready;
+  logic [NumDownstreams-1:0] downstream_pslverr;
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  br_apb_demux #(
+      .AddrWidth(AddrWidth),
+      .NumDownstreams(NumDownstreams),
+      .NumRetimeStages(NumRetimeStages),
+      .HasDefaultDownstream(HasDefaultDownstream),
+      .NormalizeDownstreamAddress(NormalizeDownstreamAddress),
+      .UpstreamAddrMask(AddrMask),
+      .DownstreamAddrMask(DownstreamAddrMask)
+  ) dut (
+      .clk,
+      .rst,
+      .upstream_paddr,
+      .upstream_psel,
+      .upstream_penable,
+      .upstream_pprot,
+      .upstream_pstrb,
+      .upstream_pwrite,
+      .upstream_pwdata,
+      .upstream_prdata,
+      .upstream_pready,
+      .upstream_pslverr,
+      .downstream_addr_base,
+      .downstream_addr_size,
+      .downstream_paddr,
+      .downstream_psel,
+      .downstream_penable,
+      .downstream_pprot,
+      .downstream_pstrb,
+      .downstream_pwrite,
+      .downstream_pwdata,
+      .downstream_prdata,
+      .downstream_pready,
+      .downstream_pslverr
+  );
+
+  task automatic check_downstream_request(
+      input int expected_dest, input logic [AddrWidth-1:0] expected_addr,
+      input logic [br_amba::ApbProtWidth-1:0] expected_prot, input logic [3:0] expected_strb,
+      input logic expected_write, input logic [31:0] expected_wdata);
+    td.check_integer(32'(downstream_psel), 1 << expected_dest, "downstream PSEL mismatch");
+    td.check_integer(32'(downstream_paddr[expected_dest]), 32'(expected_addr),
+                     "downstream PADDR mismatch");
+    td.check_integer(32'(downstream_pprot[expected_dest]), 32'(expected_prot),
+                     "downstream PPROT mismatch");
+    td.check_integer(32'(downstream_pstrb[expected_dest]), 32'(expected_strb),
+                     "downstream PSTRB mismatch");
+    td.check_integer(32'(downstream_pwrite[expected_dest]), 32'(expected_write),
+                     "downstream PWRITE mismatch");
+    td.check_integer(downstream_pwdata[expected_dest], expected_wdata,
+                     "downstream PWDATA mismatch");
+  endtask
+
+  task automatic drive_upstream(input logic [AddrWidth-1:0] addr,
+                                input logic [br_amba::ApbProtWidth-1:0] prot,
+                                input logic [3:0] strb, input logic write, input logic [31:0] wdata,
+                                input logic [31:0] expected_rdata, input logic expected_slverr);
+    bit completed;
+
+    @(negedge clk);
+    upstream_paddr = addr;
+    upstream_psel = 1'b1;
+    upstream_penable = 1'b0;
+    upstream_pprot = prot;
+    upstream_pstrb = strb;
+    upstream_pwrite = write;
+    upstream_pwdata = wdata;
+
+    @(posedge clk);
+    td.check(!upstream_pready, "PREADY asserted during APB setup");
+    td.check(!upstream_pslverr, "PSLVERR asserted during APB setup");
+
+    @(negedge clk);
+    upstream_penable = 1'b1;
+    completed = 1'b0;
+    for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
+      @(posedge clk);
+      if (upstream_pready) begin
+        td.check_integer(upstream_prdata, expected_rdata, "upstream PRDATA mismatch");
+        td.check(upstream_pslverr == expected_slverr, "upstream PSLVERR mismatch");
+        completed = 1'b1;
+        break;
+      end
+    end
+    td.check(completed, "timeout waiting for upstream APB completion");
+
+    @(negedge clk);
+    upstream_psel = 1'b0;
+    upstream_penable = 1'b0;
+  endtask
+
+  task automatic drive_downstream(
+      input int expected_dest, input logic [AddrWidth-1:0] expected_addr,
+      input logic [br_amba::ApbProtWidth-1:0] expected_prot, input logic [3:0] expected_strb,
+      input logic expected_write, input logic [31:0] expected_wdata, input int wait_cycles,
+      input logic [31:0] rdata, input logic slverr);
+    bit saw_setup;
+    bit saw_access;
+
+    downstream_prdata  = {NumDownstreams{NoiseRdata}};
+    downstream_pready  = '1;
+    downstream_pslverr = '1;
+    if (expected_dest < 0) begin
+      for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
+        @(posedge clk);
+        if (upstream_psel) begin
+          td.check(downstream_psel == '0, "decode miss asserted downstream PSEL");
+          td.check(downstream_penable == '0, "decode miss asserted downstream PENABLE");
+        end
+        if (upstream_pready) begin
+          break;
+        end
+      end
+      return;
+    end
+
+    downstream_prdata[expected_dest] = '0;
+    downstream_pready[expected_dest] = 1'b0;
+    downstream_pslverr[expected_dest] = 1'b0;
+
+    saw_setup = 1'b0;
+    for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
+      @(posedge clk);
+      if (downstream_psel[expected_dest]) begin
+        td.check(!downstream_penable[expected_dest], "downstream APB setup was not observed");
+        check_downstream_request(expected_dest, expected_addr, expected_prot, expected_strb,
+                                 expected_write, expected_wdata);
+        saw_setup = 1'b1;
+        break;
+      end
+    end
+    td.check(saw_setup, "timeout waiting for downstream APB setup");
+
+    saw_access = 1'b0;
+    for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
+      @(posedge clk);
+      if (downstream_penable[expected_dest]) begin
+        check_downstream_request(expected_dest, expected_addr, expected_prot, expected_strb,
+                                 expected_write, expected_wdata);
+        saw_access = 1'b1;
+        break;
+      end
+    end
+    td.check(saw_access, "timeout waiting for downstream APB access");
+
+    repeat (wait_cycles) begin
+      @(posedge clk);
+      td.check(downstream_psel[expected_dest] && downstream_penable[expected_dest],
+               "downstream APB access dropped while waiting");
+      check_downstream_request(expected_dest, expected_addr, expected_prot, expected_strb,
+                               expected_write, expected_wdata);
+    end
+
+    @(negedge clk);
+    downstream_prdata[expected_dest]  = rdata;
+    downstream_pready[expected_dest]  = 1'b1;
+    downstream_pslverr[expected_dest] = slverr;
+    @(posedge clk);
+    td.check(downstream_psel[expected_dest] && downstream_penable[expected_dest],
+             "downstream APB access dropped before completion");
+  endtask
+
+  task automatic send_and_check(input logic [AddrWidth-1:0] addr, input int expected_dest,
+                                input logic write, input int wait_cycles,
+                                input logic expected_slverr);
+    logic [AddrWidth-1:0] expected_addr;
+    logic [br_amba::ApbProtWidth-1:0] prot;
+    logic [3:0] strb;
+    logic [31:0] wdata;
+    logic [31:0] rdata;
+
+    prot = write ? 3'b011 : 3'b101;
+    strb = write ? 4'b1011 : 4'b0000;
+    wdata = 32'hd000_0000 | 32'(addr);
+    rdata = 32'hc000_0000 | 32'(addr);
+    expected_addr = addr & AddrMask;
+    if (expected_dest >= 0 && expected_dest < NumAddressRanges) begin
+      expected_addr = (addr - downstream_addr_base[expected_dest]) & AddrMask;
+    end
+    if (expected_dest < 0) begin
+      rdata = '0;
+    end
+
+    fork
+      drive_upstream(addr, prot, strb, write, wdata, rdata, expected_slverr);
+      drive_downstream(expected_dest, expected_addr, prot, strb, write, wdata, wait_cycles, rdata,
+                       expected_slverr);
+    join
+    @(negedge clk);
+    downstream_prdata  = '0;
+    downstream_pready  = '0;
+    downstream_pslverr = '0;
+  endtask
+
+  initial begin
+    logic [AddrWidth-1:0] addr;
+    int miss_dest;
+
+    upstream_paddr = '0;
+    upstream_psel = 1'b0;
+    upstream_penable = 1'b0;
+    upstream_pprot = '0;
+    upstream_pstrb = '0;
+    upstream_pwrite = 1'b0;
+    upstream_pwdata = '0;
+    downstream_prdata = '0;
+    downstream_pready = '0;
+    downstream_pslverr = '0;
+
+    for (int i = 0; i < NumAddressRanges; i++) begin
+      downstream_addr_base[i] = AddrWidth'((i + 1) * RangeSize);
+      downstream_addr_size[i] = AddrWidth'(RangeSize);
+    end
+
+    td.reset_dut();
+    td.wait_cycles(2);
+    td.check(downstream_psel == '0, "downstream PSEL asserted during reset/idle");
+    td.check(downstream_penable == '0, "downstream PENABLE asserted during reset/idle");
+    td.check(!upstream_pready, "upstream PREADY asserted during reset/idle");
+    td.check(!upstream_pslverr, "upstream PSLVERR asserted during reset/idle");
+
+    for (int i = 0; i < NumAddressRanges; i++) begin
+      send_and_check(downstream_addr_base[i], i, 1'b1, 0, 1'b0);
+      send_and_check(downstream_addr_base[i] + AddrWidth'(RangeSize - 1), i, 1'b0, 2, 1'b1);
+    end
+
+    addr = downstream_addr_base[0] + AddrWidth'(32);
+    addr[AddrWidth-1] = 1'b1;
+    send_and_check(addr, 0, 1'b0, 1, 1'b0);
+
+    miss_dest = HasDefaultDownstream ? NumDownstreams - 1 : -1;
+    addr = AddrWidth'((NumAddressRanges + 2) * RangeSize);
+    send_and_check(addr, miss_dest, 1'b1, 0, !HasDefaultDownstream);
+
+    downstream_addr_size[0] = '0;
+    send_and_check(downstream_addr_base[0], miss_dest, 1'b0, 1, !HasDefaultDownstream);
+
+    td.finish();
+  end
+endmodule : br_apb_demux_tb

--- a/csr/rtl/BUILD.bazel
+++ b/csr/rtl/BUILD.bazel
@@ -136,6 +136,7 @@ verilog_library(
     srcs = ["br_csr_demux.sv"],
     deps = [
         ":br_csr_demux_select_onehot",
+        "//demux/rtl:br_demux_addr_decode",
         "//macros:br_asserts_internal",
     ],
 )

--- a/csr/rtl/br_csr_demux.sv
+++ b/csr/rtl/br_csr_demux.sv
@@ -87,80 +87,30 @@ module br_csr_demux #(
   `BR_ASSERT_STATIC(legal_addr_width_a, AddrWidth >= 1)
   `BR_ASSERT_STATIC(legal_data_width_a, DataWidth == 32 || DataWidth == 64)
 
-  // Derive inclusive route bounds and check the enabled routes on each request.
-  logic [NumAddressRanges-1:0][AddrWidth-1:0] downstream_addr_limit;
-  logic [NumAddressRanges-1:0] downstream_addr_range_disabled;
-
-  for (genvar i = 0; i < NumAddressRanges; i++) begin : gen_range_check
-    assign downstream_addr_limit[i] = downstream_addr_base[i] + downstream_addr_size[i] - 1'b1;
-    assign downstream_addr_range_disabled[i] = downstream_addr_size[i] == '0;
-
-    // One-bit addresses permit only disabled or single-entry ranges, making these checks vacuous.
-    if (AddrWidth > 1) begin : gen_multi_bit_addr_range_check
-      `BR_ASSERT_INTG(downstream_addr_range_no_overflow_a,
-                      upstream_req_valid |-> downstream_addr_range_disabled[i] ||
-                          downstream_addr_limit[i] >= downstream_addr_base[i])
-
-      if (RequirePowerOfTwoAlignedRanges[i]) begin : gen_power_of_two_aligned_range_check
-        // Require a power-of-two range size, or zero for a disabled range.
-        `BR_ASSERT_INTG(downstream_addr_size_power_of_two_a,
-                        upstream_req_valid |-> $onehot0(downstream_addr_size[i]))
-        // Require the range base to start at its natural power-of-two boundary.
-        `BR_ASSERT_INTG(downstream_addr_base_aligned_a,
-                        upstream_req_valid |-> downstream_addr_range_disabled[i] ||
-                (downstream_addr_base[i] & (downstream_addr_size[i] - 1'b1)) == '0)
-        if (DownstreamAddrMask[i] != '1) begin : gen_downstream_addr_mask_check
-          // Preserve every in-range offset bit to prevent forwarded address aliasing.
-          `BR_ASSERT_INTG(downstream_addr_mask_preserves_offsets_a,
-                          upstream_req_valid |-> downstream_addr_range_disabled[i] ||
-                  ((downstream_addr_size[i] - 1'b1) & ~DownstreamAddrMask[i]) == '0)
-        end
-      end
-    end
-  end
-
-  for (genvar i = 0; i < NumAddressRanges - 1; i++) begin : gen_range_overlap_check_i
-    for (genvar j = i + 1; j < NumAddressRanges; j++) begin : gen_range_overlap_check_j
-      `BR_ASSERT_INTG(downstream_addr_range_overlap_a,
-                      upstream_req_valid |-> downstream_addr_range_disabled[i] ||
-                          downstream_addr_range_disabled[j] ||
-                          downstream_addr_limit[i] < downstream_addr_base[j] ||
-                          downstream_addr_base[i] > downstream_addr_limit[j])
-    end
-  end
-
   // Implementation
 
-  logic [AddrWidth-1:0] upstream_req_addr_masked;
   logic [NumDownstreams-1:0] select_onehot;
   logic [NumDownstreams-1:0][AddrWidth-1:0] downstream_req_addr_unmasked;
 
-  assign upstream_req_addr_masked = upstream_req_addr & UpstreamAddrMask;
-
-  // Decode and forward the request address for each explicit downstream range.
-  // ri lint_check_off PARAM_BIT_SEL
-  for (genvar i = 0; i < NumAddressRanges; i++) begin : gen_downstream_addr_translate
-    // Decode enabled ranges only.
-    assign select_onehot[i] =
-        !downstream_addr_range_disabled[i] &&
-        (upstream_req_addr_masked >= downstream_addr_base[i]) &&
-        (upstream_req_addr_masked <= downstream_addr_limit[i]);
-
-    if (NormalizeDownstreamAddress[i]) begin : gen_normalize_downstream_address
-      assign downstream_req_addr[i] =
-          (downstream_req_addr_unmasked[i] - downstream_addr_base[i]) & DownstreamAddrMask[i];
-    end else begin : gen_passthrough_downstream_address
-      assign downstream_req_addr[i] = downstream_req_addr_unmasked[i] & DownstreamAddrMask[i];
-    end
-  end
-  if (HasDefaultDownstream) begin : gen_default_downstream_addr_translate
-    // A default downstream has no explicit address decoding or normalization and
-    // handles any request whose address misses the explicit ranges.
-    assign select_onehot[NumDownstreams-1] = !(|select_onehot[NumAddressRanges-1:0]);
-    assign downstream_req_addr[NumDownstreams-1] =
-        downstream_req_addr_unmasked[NumDownstreams-1] & DownstreamAddrMask[NumDownstreams-1];
-  end
-  // ri lint_check_on PARAM_BIT_SEL
+  br_demux_addr_decode #(
+      .AddrWidth(AddrWidth),
+      .NumDownstreams(NumDownstreams),
+      .HasDefaultDownstream(HasDefaultDownstream),
+      .RequirePowerOfTwoAlignedRanges(RequirePowerOfTwoAlignedRanges),
+      .NormalizeDownstreamAddress(NormalizeDownstreamAddress),
+      .UpstreamAddrMask(UpstreamAddrMask),
+      .DownstreamAddrMask(DownstreamAddrMask)
+  ) br_demux_addr_decode (
+      .clk,
+      .rst,
+      .addr_valid(upstream_req_valid),
+      .upstream_addr(upstream_req_addr),
+      .downstream_addr_base,
+      .downstream_addr_size,
+      .downstream_addr_in(downstream_req_addr_unmasked),
+      .select_onehot,
+      .downstream_addr_out(downstream_req_addr)
+  );
 
   br_csr_demux_select_onehot #(
       .AddrWidth(AddrWidth),

--- a/demux/rtl/BUILD.bazel
+++ b/demux/rtl/BUILD.bazel
@@ -22,6 +22,14 @@ verilog_library(
     ],
 )
 
+verilog_library(
+    name = "br_demux_addr_decode",
+    srcs = ["br_demux_addr_decode.sv"],
+    deps = [
+        "//macros:br_asserts_internal",
+    ],
+)
+
 br_verilog_synth_suite(
     name = "br_demux_bin_ppa",
     params = {
@@ -88,4 +96,36 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_demux_onehot"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_demux_addr_decode_test_suite",
+    params = {
+        "AddrWidth": [
+            "1",
+            "4",
+        ],
+        "HasDefaultDownstream": [
+            "0",
+            "1",
+        ],
+        "NumDownstreams": [
+            "2",
+            "3",
+        ],
+    },
+    deps = [":br_demux_addr_decode"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_demux_addr_decode_test_suite_single_downstream",
+    params = {
+        "AddrWidth": [
+            "1",
+            "4",
+        ],
+        "HasDefaultDownstream": ["0"],
+        "NumDownstreams": ["1"],
+    },
+    deps = [":br_demux_addr_decode"],
 )

--- a/demux/rtl/br_demux_addr_decode.sv
+++ b/demux/rtl/br_demux_addr_decode.sv
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bedrock-RTL Address Decoder for Protocol Demultiplexers
+//
+// Decodes an upstream address into a one-hot downstream selection and applies
+// optional address normalization and masking to forwarded downstream
+// addresses. Address ranges are configurable inputs and are checked whenever
+// addr_valid is asserted.
+
+`include "br_asserts_internal.svh"
+
+module br_demux_addr_decode #(
+    parameter int AddrWidth = 1,  // Must be at least 1
+    parameter int NumDownstreams = 1,  // Must be at least 1
+    parameter bit HasDefaultDownstream = 0,
+    localparam int NumAddressRanges = HasDefaultDownstream ? NumDownstreams - 1 : NumDownstreams,
+    // ri lint_check_waive ARRAY_LENGTH_ONE
+    parameter bit RequirePowerOfTwoAlignedRanges[NumAddressRanges] = '{default: 1},
+    // ri lint_check_waive ARRAY_LENGTH_ONE
+    parameter bit NormalizeDownstreamAddress[NumAddressRanges] = '{default: 0},
+    parameter logic [AddrWidth-1:0] UpstreamAddrMask = '1,
+    parameter logic [NumDownstreams-1:0][AddrWidth-1:0] DownstreamAddrMask = '1
+) (
+    // Used only by integration assertions.
+    // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic clk,
+    // Used only by integration assertions.
+    // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic rst,
+
+    // Used only by integration assertions.
+    // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
+    input logic addr_valid,
+    input logic [AddrWidth-1:0] upstream_addr,
+
+    input logic [NumAddressRanges-1:0][AddrWidth-1:0] downstream_addr_base,
+    input logic [NumAddressRanges-1:0][AddrWidth-1:0] downstream_addr_size,
+
+    input logic [NumDownstreams-1:0][AddrWidth-1:0] downstream_addr_in,
+    output logic [NumDownstreams-1:0] select_onehot,
+    output logic [NumDownstreams-1:0][AddrWidth-1:0] downstream_addr_out
+);
+  // Integration Checks
+
+  `BR_ASSERT_STATIC(legal_num_downstreams_a, NumDownstreams >= 1 + HasDefaultDownstream)
+  `BR_ASSERT_STATIC(legal_addr_width_a, AddrWidth >= 1)
+
+  logic [NumAddressRanges-1:0][AddrWidth-1:0] downstream_addr_limit;
+  logic [NumAddressRanges-1:0] downstream_addr_range_disabled;
+
+  for (genvar i = 0; i < NumAddressRanges; i++) begin : gen_range_check
+    assign downstream_addr_limit[i] = downstream_addr_base[i] + downstream_addr_size[i] - 1'b1;
+    assign downstream_addr_range_disabled[i] = downstream_addr_size[i] == '0;
+
+    if (AddrWidth > 1) begin : gen_multi_bit_addr_range_check
+      `BR_ASSERT_INTG(downstream_addr_range_no_overflow_a,
+                      addr_valid |-> downstream_addr_range_disabled[i] ||
+                          downstream_addr_limit[i] >= downstream_addr_base[i])
+
+      if (RequirePowerOfTwoAlignedRanges[i]) begin : gen_power_of_two_aligned_range_check
+        `BR_ASSERT_INTG(downstream_addr_size_power_of_two_a,
+                        addr_valid |-> $onehot0(downstream_addr_size[i]))
+        `BR_ASSERT_INTG(downstream_addr_base_aligned_a,
+                        addr_valid |-> downstream_addr_range_disabled[i] ||
+                (downstream_addr_base[i] & (downstream_addr_size[i] - 1'b1)) == '0)
+        if (DownstreamAddrMask[i] != '1) begin : gen_downstream_addr_mask_check
+          `BR_ASSERT_INTG(downstream_addr_mask_preserves_offsets_a,
+                          addr_valid |-> downstream_addr_range_disabled[i] ||
+                  ((downstream_addr_size[i] - 1'b1) & ~DownstreamAddrMask[i]) == '0)
+        end
+      end
+    end
+  end
+
+  for (genvar i = 0; i < NumAddressRanges - 1; i++) begin : gen_range_overlap_check_i
+    for (genvar j = i + 1; j < NumAddressRanges; j++) begin : gen_range_overlap_check_j
+      `BR_ASSERT_INTG(downstream_addr_range_overlap_a,
+                      addr_valid |-> downstream_addr_range_disabled[i] ||
+                          downstream_addr_range_disabled[j] ||
+                          downstream_addr_limit[i] < downstream_addr_base[j] ||
+                          downstream_addr_base[i] > downstream_addr_limit[j])
+    end
+  end
+
+  // Implementation
+
+  logic [AddrWidth-1:0] upstream_addr_masked;
+
+  assign upstream_addr_masked = upstream_addr & UpstreamAddrMask;
+
+  // ri lint_check_off PARAM_BIT_SEL
+  for (genvar i = 0; i < NumAddressRanges; i++) begin : gen_downstream_addr_translate
+    assign select_onehot[i] = !downstream_addr_range_disabled[i] &&
+                              (upstream_addr_masked >= downstream_addr_base[i]) &&
+                              (upstream_addr_masked <= downstream_addr_limit[i]);
+
+    if (NormalizeDownstreamAddress[i]) begin : gen_normalize_downstream_address
+      assign downstream_addr_out[i] =
+          (downstream_addr_in[i] - downstream_addr_base[i]) & DownstreamAddrMask[i];
+    end else begin : gen_passthrough_downstream_address
+      assign downstream_addr_out[i] = downstream_addr_in[i] & DownstreamAddrMask[i];
+    end
+  end
+
+  if (HasDefaultDownstream) begin : gen_default_downstream_addr_translate
+    assign select_onehot[NumDownstreams-1] = !(|select_onehot[NumAddressRanges-1:0]);
+    assign downstream_addr_out[NumDownstreams-1] =
+        downstream_addr_in[NumDownstreams-1] & DownstreamAddrMask[NumDownstreams-1];
+  end
+  // ri lint_check_on PARAM_BIT_SEL
+
+endmodule : br_demux_addr_decode


### PR DESCRIPTION
# Summary

Adds an APB demux with shared address decoding, one-hot routing, optional retiming, and focused simulation coverage; refactors the CSR demux to reuse the address decoder.