### PR TITLE
Add rules generating coverage data

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,7 @@
 
 load("@python_versions//3.12:defs.bzl", compile_pip_requirements_3_12 = "compile_pip_requirements")
 load("@rules_python//python:defs.bzl", "py_test")
+load("//bazel:verilog.bzl", "verilog_sim_coverage_aggregate")
 
 compile_pip_requirements_3_12(
     name = "requirements_3_12",
@@ -14,4 +15,30 @@ py_test(
     srcs = ["check_env.py"],
     env_inherit = ["PATH"],
     tags = ["local"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_verilator_coverage",
+    coverage_reports = [
+        "//amba/sim:br_amba_verilator_coverage",
+        "//arb/sim:br_arb_verilator_coverage",
+        "//counter/sim:br_counter_verilator_coverage",
+        "//credit/sim:br_credit_verilator_coverage",
+        "//cdc/sim:br_cdc_verilator_coverage",
+        "//csr/sim:br_csr_verilator_coverage",
+        "//delay/sim:br_delay_verilator_coverage",
+        "//demux/sim:br_demux_verilator_coverage",
+        "//ecc/sim:br_ecc_verilator_coverage",
+        "//enc/sim:br_enc_verilator_coverage",
+        "//flow/sim:br_flow_verilator_coverage",
+        "//fifo/sim:br_fifo_verilator_coverage",
+        "//lfsr/sim:br_lfsr_verilator_coverage",
+        "//macros:br_macros_verilator_coverage",
+        "//misc/sim:br_misc_verilator_coverage",
+        "//multi_xfer/sim:br_multi_xfer_verilator_coverage",
+        "//mux/sim:br_mux_verilator_coverage",
+        "//ram/sim:br_ram_verilator_coverage",
+        "//shift/sim:br_shift_verilator_coverage",
+        "//tracker/sim:br_tracker_verilator_coverage",
+    ],
 )

--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 BR_AMBA_SIM_MAX_CHECK_WIDTH_64 = "BR_AMBA_SIM_MAX_CHECK_WIDTH=64"
 
@@ -615,4 +615,17 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_amba_atb_funnel_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_amba_verilator_coverage",
+    coverage_reports = [
+        ":br_amba_apb_timing_slice_sim_test_tools_suite_verilator_coverage",
+        ":br_amba_atb_funnel_sim_test_tools_suite_verilator_coverage",
+        ":br_amba_axi_isolate_sub_tb_sim_test_tools_suite_verilator_coverage",
+        ":br_amba_axi_isolate_mgr_tb_sim_test_tools_suite_verilator_coverage",
+        ":br_amba_axi_demux_tb_sim_test_tools_suite_verilator_coverage",
+        ":br_amba_axil_default_target_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/arb/sim/BUILD.bazel
+++ b/arb/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -251,4 +251,18 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_arb_weighted_rr_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_arb_verilator_coverage",
+    coverage_reports = [
+        ":br_arb_fixed_tb_sim_test_tools_suite_verilator_coverage",
+        ":br_arb_lru_tb_sim_test_tools_suite_verilator_coverage",
+        ":br_arb_rr_tb_sim_test_tools_suite_verilator_coverage",
+        ":br_arb_grant_hold_tb_sim_test_tools_suite_verilator_coverage",
+        ":br_arb_pri_rr_tb_sim_test_tools_suite_verilator_coverage",
+        ":br_arb_weighted_lru_tb_sim_test_tools_suite_verilator_coverage",
+        ":br_arb_weighted_rr_tb_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/bazel/br_verilog.bzl
+++ b/bazel/br_verilog.bzl
@@ -76,20 +76,31 @@ def br_verilog_sim_test_suite(name, tool, defines = None, elab_opts = [], sim_op
         **kwargs
     )
 
-def br_verilog_sim_test_tools_suite(name, tools = [], **kwargs):
+def br_verilog_sim_test_tools_suite(name, tools = [], coverage = None, **kwargs):
     """Wraps br_verilog_sim_test_suite with multiple simulation tools.
 
     Args:
         name (str): The base name of the test suite.
         tools (list of strings): simulator tools to use.
+        coverage (bool or None): If true, gathers coverage data from all tests in the test suite.
+            If None, the coverage will be enabled if Verilator is used.
         **kwargs: Additional keyword arguments passed to br_verilog_sim_test_suite.
     """
+    if coverage and "verilator" not in tools:
+        fail("coverage = True is currently supported only by Verilator.")
+
+    if coverage == None and "verilator" in tools and not kwargs.get("elab_only", False):
+        coverage = True
 
     for tool in tools:
+        tool_kwargs = {}
+        tool_kwargs.update(kwargs)
+        tool_kwargs["coverage"] = coverage and tool == "verilator"
+
         br_verilog_sim_test_suite(
             name = name + "_" + tool,
             tool = tool,
-            **kwargs
+            **tool_kwargs
         )
 
 def br_verilog_synth_suite(

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -11,6 +11,15 @@ TOOLS_THAT_NEED_LICENSES = [
     "vcs",
     "xrun",
 ]
+COVERAGE_TYPES = [
+    "toggle",
+    "line",
+    "branch",
+    "expr",
+    "covergroup",
+    "user",
+]
+COVERAGE_DATA_FILENAME = "coverage.dat"
 
 def extra_tags(kind, tool):
     """Returns a list of extra tags that should be added to a target.
@@ -32,6 +41,12 @@ def extra_tags(kind, tool):
     if tool in TOOLS_THAT_NEED_LICENSES:
         extra_tags.append("resources:verilog_test_tool_licenses_" + tool + ":1")
     return extra_tags
+
+def _with_manual_tag(tags):
+    """Returns tags with the manual tag included."""
+    if "manual" in tags:
+        return tags
+    return tags + ["manual"]
 
 def get_transitive(ctx, srcs_not_hdrs):
     """Returns a depset of all Verilog source or header files in the transitive closure of the deps attribute."""
@@ -101,9 +116,24 @@ def _write_executable_shell_script(ctx, executable_file, cmd, verbose = True, en
         is_executable = True,
     )
 
+def _cov_type_to_provider(cov_type):
+    return cov_type + "_info"
+
+_VERILOG_COVERAGE_DATA_FIELDS = [_cov_type_to_provider(t) for t in COVERAGE_TYPES] + ["coverage_data", "coverage_failures"]
+
 VerilogRunnerFlagsInfo = provider(
     fields = ["name", "runner_flags"],
     doc = "Verilog Runner flags provider",
+)
+
+VerilogCoverageDataInfo = provider(
+    fields = _VERILOG_COVERAGE_DATA_FIELDS,
+    doc = "Verilator raw coverage data and info artifacts.",
+)
+
+VerilogCoverageReportInfo = provider(
+    fields = _VERILOG_COVERAGE_DATA_FIELDS + ["srcs"],
+    doc = "Aggregated Verilator coverage data and info artifacts.",
 )
 
 def _runner_flags_impl(ctx):
@@ -414,6 +444,255 @@ def _verilog_synth_sandbox_impl(ctx):
         extra_args = extra_args,
         extra_runfiles = extra_runfiles,
     )
+
+def _coverage_report_info(coverage_infos_by_type, coverage_data, coverage_failures, srcs):
+    return VerilogCoverageReportInfo(
+        toggle_info = coverage_infos_by_type.get("toggle", []),
+        line_info = coverage_infos_by_type.get("line", []),
+        branch_info = coverage_infos_by_type.get("branch", []),
+        expr_info = coverage_infos_by_type.get("expr", []),
+        covergroup_info = coverage_infos_by_type.get("covergroup", []),
+        user_info = coverage_infos_by_type.get("user", []),
+        coverage_data = coverage_data,
+        coverage_failures = coverage_failures,
+        srcs = srcs,
+    )
+
+def _coverage_data_info(coverage_infos_by_type, coverage_data, coverage_failures):
+    return VerilogCoverageDataInfo(
+        toggle_info = coverage_infos_by_type.get("toggle", []),
+        line_info = coverage_infos_by_type.get("line", []),
+        branch_info = coverage_infos_by_type.get("branch", []),
+        expr_info = coverage_infos_by_type.get("expr", []),
+        covergroup_info = coverage_infos_by_type.get("covergroup", []),
+        user_info = coverage_infos_by_type.get("user", []),
+        coverage_data = coverage_data,
+        coverage_failures = coverage_failures,
+    )
+
+def _append_coverage_infos(coverage_infos_by_type, coverage_provider):
+    for coverage_type in COVERAGE_TYPES:
+        coverage_infos = getattr(coverage_provider, _cov_type_to_provider(coverage_type), [])
+        if len(coverage_infos) == 0:
+            continue
+        coverage_infos_by_type[coverage_type] += coverage_infos
+
+def _source_verilog_runner_eda_tools_env_setup():
+    return [
+        'if [[ -n "$VERILOG_RUNNER_EDA_TOOLS_ENV_SETUP" ]]; then',
+        '  source "$VERILOG_RUNNER_EDA_TOOLS_ENV_SETUP"',
+        "fi",
+    ]
+
+def _declare_coverage_info_files(ctx, coverage_data, name, coverage_dat_path = None):
+    coverage_infos = []
+    if coverage_dat_path == None:
+        coverage_dat_path = coverage_data.path
+    for coverage_type in COVERAGE_TYPES:
+        coverage_info = ctx.actions.declare_file("coverage_{}_{}.info".format(coverage_type, name))
+
+        command_prefix = ["set -e"] + _source_verilog_runner_eda_tools_env_setup()
+        ctx.actions.run_shell(
+            inputs = [coverage_data],
+            outputs = [coverage_info],
+            command = "\n".join(command_prefix + [
+                "if test -s {coverage_dat_path}; then",
+                "  " + " ".join([
+                    "\"${{VERILATOR_COVERAGE_CMD:-verilator_coverage}}\"",
+                    "--filter-type {coverage_type}",
+                    "--write-info {coverage_info_path} {coverage_dat_path}",
+                ]),
+                "else",
+                "  : > {coverage_info_path}",
+                "fi",
+            ]).format(
+                coverage_dat_path = _shell_quote(coverage_dat_path),
+                coverage_type = _shell_quote(coverage_type),
+                coverage_info_path = _shell_quote(coverage_info.path),
+            ),
+            mnemonic = "VerilatorCoverageInfo",
+            progress_message = "Creating Verilator coverage info for %{label}",
+            use_default_shell_env = True,
+        )
+
+        coverage_infos.append(coverage_info)
+
+    return coverage_infos
+
+def _verilog_sim_coverage_data_impl(ctx):
+    """Implementation of the Verilator coverage info and description rule."""
+    extra_args = []
+    if ctx.attr.opts and ctx.attr.tool != "vcs":
+        fail("'opts' is a deprecated VCS-only simulation option. Use 'elab_opts' or 'sim_opts' instead.")
+    if ctx.attr.tool != "verilator":
+        fail("'coverage' is only supported with tool = 'verilator'.")
+    if ctx.attr.elab_only:
+        fail("'coverage' cannot be combined with 'elab_only'.")
+    if ctx.attr.uvm:
+        extra_args.append("--uvm")
+    extra_args.append("--seed='" + str(ctx.attr.seed) + "'")
+    if ctx.attr.waves:
+        extra_args.append("--waves")
+    raw_coverage_data = ctx.actions.declare_directory(ctx.attr.name + "_coverage")
+    coverage_log = ctx.actions.declare_file(ctx.attr.name + ".log")
+    coverage_failure = ctx.actions.declare_file(ctx.attr.name + "_coverage_failures.txt")
+    coverage_dat_path = raw_coverage_data.path + "/" + COVERAGE_DATA_FILENAME
+    coverage_dat = _shell_quote(coverage_dat_path)
+    extra_args.extend(["--coverage", coverage_dat])
+    for opt in ctx.attr.opts:
+        extra_args.append("--opt='" + opt + "'")
+    for opt in ctx.attr.elab_opts:
+        extra_args.append("--elab_opt='" + opt + "'")
+    for opt in ctx.attr.sim_opts:
+        extra_args.append("--sim_opt='" + opt + "'")
+    verilog_test = _verilog_base_impl(ctx = ctx, subcmd = "sim", extra_args = extra_args)
+
+    runner_cmd = " ".join([verilog_test.files.to_list()[0].path])
+    command = "\n".join([
+        "set -e",
+        "rm -rf {raw_coverage_data}",
+        "mkdir -p {raw_coverage_data}",
+        ": > {coverage_failure}",
+        "set +e",
+        "{runner_cmd} > {coverage_log} 2>&1",
+        "status=$?",
+        "set -e",
+        "if [[ $status -ne 0 ]] ; then",
+        "  rm -f {coverage_dat}",
+        "  cat {coverage_log} >&2",
+        "  printf '%s\\n' '{label} failed with exit status '\"${{status}}\" > {coverage_failure}",
+        "  echo '  log: {coverage_log}' >> {coverage_failure}",
+        "fi",
+    ]).format(
+        label = str(ctx.label),
+        runner_cmd = runner_cmd,
+        raw_coverage_data = _shell_quote(raw_coverage_data.path),
+        coverage_failure = _shell_quote(coverage_failure.path),
+        coverage_log = _shell_quote(coverage_log.path),
+        coverage_dat = coverage_dat,
+    )
+
+    ctx.actions.run_shell(
+        inputs = verilog_test.files.to_list() + ctx.files.verilog_runner_plugins,
+        tools = [verilog_test.default_runfiles.files],
+        outputs = [raw_coverage_data, coverage_log, coverage_failure],
+        command = command,
+        mnemonic = "VerilatorCoverageData",
+        progress_message = "Generating Verilator coverage data for %{label}",
+        use_default_shell_env = True,
+    )
+
+    coverage_infos = _declare_coverage_info_files(
+        ctx = ctx,
+        coverage_data = raw_coverage_data,
+        coverage_dat_path = coverage_dat_path,
+        name = ctx.attr.name,
+    )
+    coverage_infos_by_type = {}
+    for index, coverage_type in enumerate(COVERAGE_TYPES):
+        coverage_infos_by_type[coverage_type] = [coverage_infos[index]]
+
+    return [
+        DefaultInfo(files = depset(coverage_infos + [raw_coverage_data, coverage_log, coverage_failure])),
+        _coverage_data_info(
+            coverage_infos_by_type = coverage_infos_by_type,
+            coverage_data = [raw_coverage_data],
+            coverage_failures = [coverage_failure],
+        ),
+    ]
+
+def _verilog_sim_coverage_aggregate_impl(ctx):
+    """Implementation of the Verilator coverage aggregation rule."""
+    srcs = get_transitive(ctx = ctx, srcs_not_hdrs = True).to_list()
+    coverage_targets = ctx.attr.coverage_data + ctx.attr.coverage_reports
+    s = []
+    for coverage_report in ctx.attr.coverage_reports:
+        s += coverage_report[VerilogCoverageReportInfo].srcs
+    srcs += depset(s).to_list()
+
+    if len(coverage_targets) == 0:
+        fail("At least one entry must be provided in 'coverage_data' or 'coverage_reports'.")
+
+    coverage_infos_by_type = {}
+    for coverage_type in COVERAGE_TYPES:
+        coverage_infos_by_type[coverage_type] = []
+    coverage_data_inputs = []
+    coverage_dat_paths = []
+    coverage_failures = []
+
+    for coverage_target in ctx.attr.coverage_data:
+        coverage_info = coverage_target[VerilogCoverageDataInfo]
+        coverage_data_inputs += coverage_info.coverage_data
+        coverage_dat_paths += [coverage_data.path + "/" + COVERAGE_DATA_FILENAME for coverage_data in coverage_info.coverage_data]
+        coverage_failures += coverage_info.coverage_failures
+        _append_coverage_infos(coverage_infos_by_type, coverage_info)
+
+    for coverage_target in ctx.attr.coverage_reports:
+        coverage_report = coverage_target[VerilogCoverageReportInfo]
+        coverage_data_inputs += coverage_report.coverage_data
+        coverage_dat_paths += [coverage_data.path for coverage_data in coverage_report.coverage_data]
+        coverage_failures += coverage_report.coverage_failures
+        _append_coverage_infos(coverage_infos_by_type, coverage_report)
+
+    merged_coverage_data = ctx.outputs.coverage_data
+    merged_coverage_failures = ctx.actions.declare_file(ctx.attr.name + "_coverage_failures.txt")
+    coverage_dat_paths = [_shell_quote(coverage_dat_path) for coverage_dat_path in coverage_dat_paths]
+    coverage_failure_paths = [_shell_quote(coverage_failure.path) for coverage_failure in coverage_failures]
+    command_prefix = ["set -e"] + _source_verilog_runner_eda_tools_env_setup()
+    ctx.actions.run_shell(
+        inputs = coverage_data_inputs + coverage_failures,
+        outputs = [merged_coverage_data, merged_coverage_failures],
+        command = "\n".join(command_prefix + [
+            # Gather failed coverages
+            ": > {merged_coverage_failures}",
+            "for failure in {coverage_failure_paths}; do",
+            "  if test -s \"${{failure}}\"; then",
+            "    cat \"${{failure}}\" >> {merged_coverage_failures}",
+            "    echo >> {merged_coverage_failures}",
+            "  fi",
+            "done",
+            "if test -s {merged_coverage_failures}; then",
+            # Exit when one of coverage data was not collected
+            "  exit 1",
+            "fi",
+            # Create list of coverage .dat files
+            "coverage_data=()",
+            "for coverage_dat in {coverage_dat_paths}; do",
+            "  if test -s \"${{coverage_dat}}\"; then",
+            "    coverage_data+=(\"${{coverage_dat}}\")",
+            "  fi",
+            "done",
+            # Merge coverage data
+            "if (( ${{#coverage_data[@]}} )); then",
+            "  \"${{VERILATOR_COVERAGE_CMD:-verilator_coverage}}\" -write {merged_coverage_data} \"${{coverage_data[@]}}\"",
+            "else",
+            "  echo 'No Verilator coverage data files were produced.' >&2",
+            "  : > {merged_coverage_data}",
+            "fi",
+        ]).format(
+            coverage_failure_paths = " ".join(coverage_failure_paths),
+            merged_coverage_failures = _shell_quote(merged_coverage_failures.path),
+            coverage_dat_paths = " ".join(coverage_dat_paths),
+            merged_coverage_data = _shell_quote(merged_coverage_data.path),
+        ),
+        mnemonic = "VerilatorCoverageDataMerge",
+        progress_message = "Merging Verilator coverage data for %{label}",
+        use_default_shell_env = True,
+    )
+
+    coverage_infos = []
+    for coverage_type in COVERAGE_TYPES:
+        coverage_infos += coverage_infos_by_type[coverage_type]
+
+    return [
+        DefaultInfo(files = depset([merged_coverage_data, merged_coverage_failures])),
+        _coverage_report_info(
+            coverage_infos_by_type = coverage_infos_by_type,
+            coverage_data = [merged_coverage_data],
+            coverage_failures = [merged_coverage_failures],
+            srcs = srcs,
+        ),
+    ]
 
 def _verilog_fpv_args(ctx):
     extra_args = []
@@ -746,12 +1025,8 @@ def verilog_synth_sandbox(name, tool, tags = [], **kwargs):
         **kwargs
     )
 
-rule_verilog_sim_test = rule(
-    doc = """
-    Runs Verilog/SystemVerilog compilation and simulation in one command. This rule should be used for simple unit tests that do not require multi-step compilation, elaboration, and simulation. Needs VERILOG_RUNNER_PLUGIN_PATH environment variable to be set correctly.
-    """,
-    implementation = _verilog_sim_test_impl,
-    attrs = {
+def _verilog_sim_attrs(verilog_runner_tool_default = "//python/verilog_runner:verilog_runner.py"):
+    return {
         "deps": attr.label_list(
             doc = "The dependencies of the test.",
             allow_files = False,
@@ -827,9 +1102,114 @@ rule_verilog_sim_test = rule(
             providers = [VerilogRunnerFlagsInfo],
             default = "//bazel:runner_flags",
         ),
-    },
+    }
+
+rule_verilog_sim_test = rule(
+    doc = """
+    Runs Verilog/SystemVerilog compilation and simulation in one command. This rule should be used for simple unit tests that do not require multi-step compilation, elaboration, and simulation. Needs VERILOG_RUNNER_PLUGIN_PATH environment variable to be set correctly.
+    """,
+    implementation = _verilog_sim_test_impl,
+    attrs = _verilog_sim_attrs(),
     test = True,
 )
+
+rule_verilog_sim_coverage_data = rule(
+    doc = """
+    Runs a Verilator simulation test target and emits coverage info and description files.
+    """,
+    implementation = _verilog_sim_coverage_data_impl,
+    attrs = _verilog_sim_attrs(),
+    provides = [VerilogCoverageDataInfo],
+)
+
+rule_verilog_sim_coverage_aggregate = rule(
+    doc = """
+    Merges Verilator coverage data as a declared Bazel output.
+    """,
+    implementation = _verilog_sim_coverage_aggregate_impl,
+    attrs = {
+        "coverage_data": attr.label_list(
+            doc = "Coverage data targets whose data and info files should be merged.",
+            default = [],
+            providers = [VerilogCoverageDataInfo],
+        ),
+        "coverage_reports": attr.label_list(
+            doc = "Coverage report targets whose transitive data and info files should be merged.",
+            default = [],
+            providers = [VerilogCoverageReportInfo],
+        ),
+        "deps": attr.label_list(
+            doc = "The dependencies of the testbench whose design sources should be tracked transitively.",
+            allow_files = False,
+            providers = [VerilogInfo],
+            default = [],
+        ),
+    },
+    outputs = {
+        "coverage_data": "%{name}.dat",
+    },
+)
+
+def verilog_sim_coverage_data(tool, opts = [], elab_opts = [], sim_opts = [], tags = [], waves = False, **kwargs):
+    """Wraps rule_verilog_sim_coverage_data.
+
+    Args:
+        name: The name of the coverage info and description target.
+        tool: The simulation tool to use. Must be "verilator".
+        opts: Deprecated VCS-only simulation options.
+        elab_opts: Tool-specific compile/elaboration options not covered by other arguments.
+        sim_opts: Tool-specific simulation runtime options, such as simulator plusargs.
+        waves: Enable waveform dumping.
+        **kwargs: Other arguments to pass to the rule_verilog_sim_coverage_data rule.
+    """
+    if opts and tool != "vcs":
+        fail("'opts' is a deprecated VCS-only simulation option. Use 'elab_opts' or 'sim_opts' instead.")
+    if tool != "verilator":
+        fail("'coverage' is only supported with tool = 'verilator'.")
+    if kwargs.get("elab_only", False):
+        fail("'coverage' cannot be combined with 'elab_only'.")
+
+    # Make sure we fail the test ASAP after any error occurs (assertion or otherwise).
+    extra_elab_opts = []
+    extra_sim_opts = []
+    tags = _with_manual_tag(tags + extra_tags("sim", tool))
+    if tool == "vcs":
+        # Make sure we fail the test if any assertions fail.
+        extra_elab_opts = ["-assert global_finish_maxfail=1+offending_values -error=TFIPC -error=PCWM-W -error=PCWM-L"]
+    elif tool == "dsim":
+        extra_sim_opts.append("-exit-on-error 1")
+
+    rule_verilog_sim_coverage_data(
+        tool = tool,
+        opts = opts,
+        elab_opts = elab_opts + extra_elab_opts,
+        sim_opts = sim_opts + extra_sim_opts,
+        tags = tags,
+        waves = waves,
+        **kwargs
+    )
+
+def verilog_sim_coverage_aggregate(name, coverage_data = [], coverage_reports = [], deps = [], **kwargs):
+    """Wraps rule_verilog_sim_coverage_aggregate.
+
+    Args:
+        name: The name of the aggregate coverage target.
+        coverage_data: Coverage data targets whose data and info files should be merged.
+        coverage_reports: Coverage report targets whose transitive data and info files should be merged.
+        deps: The dependencies of the testbench whose design sources should be tracked transitively.
+        **kwargs: Other arguments to pass to the rule_verilog_sim_coverage_aggregate rule.
+    """
+
+    tags = _with_manual_tag(kwargs.pop("tags", []))
+
+    rule_verilog_sim_coverage_aggregate(
+        name = name,
+        coverage_data = coverage_data,
+        coverage_reports = coverage_reports,
+        deps = deps,
+        tags = tags,
+        **kwargs
+    )
 
 def verilog_sim_test(tool, opts = [], elab_opts = [], sim_opts = [], tags = [], waves = False, **kwargs):
     """Wraps rule_verilog_sim_test with a default tool and appends extra tags.
@@ -1253,6 +1633,7 @@ def verilog_sim_test_suite(
         defines = [],
         params = {},
         illegal_param_combinations = {},
+        coverage = False,
         **kwargs):
     """Creates a suite of Verilog sim tests for each combination of the provided parameters.
 
@@ -1265,22 +1646,48 @@ def verilog_sim_test_suite(
         defines (list): A list of defines.
         params (dict): A dictionary where keys are parameter names and values are lists of possible values for those parameters.
         illegal_param_combinations (dict): A dictionary where keys are parameter tuples and values are lists of tuples of illegal values for those parameters.
+        coverage (bool): Value enabling and disabling coverage data.
         **kwargs: Additional keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.
     """
     param_keys = sorted(params.keys())
     param_values_list = [params[key] for key in param_keys]
     param_combinations = _cartesian_product(param_values_list)
+    tool = kwargs.get("tool", False)
+    coverage_data = []
+
+    if coverage and tool != "verilator":
+        fail("'coverage' is only supported with tool = 'verilator'.")
 
     # Create a verilog_sim_test for each legal combination of parameters
     for param_combination in param_combinations:
         params = dict(zip(param_keys, param_combination))
-        if is_param_combination_legal(params, illegal_param_combinations):
-            verilog_sim_test(
-                name = _make_test_name(name, "sim_test", param_keys, param_combination),
+        if not is_param_combination_legal(params, illegal_param_combinations):
+            continue
+        test_name = _make_test_name(name, "sim_test", param_keys, param_combination)
+        verilog_sim_test(
+            name = test_name,
+            defines = defines,
+            params = params,
+            **kwargs
+        )
+        if coverage and tool == "verilator":
+            coverage_data_name = _make_test_name(name, "coverage_data", param_keys, param_combination)
+            verilog_sim_coverage_data(
+                name = coverage_data_name,
                 defines = defines,
                 params = params,
                 **kwargs
             )
+            coverage_data.append(":" + coverage_data_name)
+
+    if coverage:
+        if "deps" not in kwargs:
+            fail("'deps' must be provided when 'coverage' is enabled.")
+        verilog_sim_coverage_aggregate(
+            name = name + "_coverage",
+            coverage_data = coverage_data,
+            deps = kwargs["deps"],
+        )
 
 def verilog_synth_suite(
         name,

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -205,6 +205,71 @@ Tests that a Verilog or SystemVerilog design passes a set of static lint checks.
 | <a id="rule_verilog_lint_test-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
 
 
+<a id="rule_verilog_sim_coverage_aggregate"></a>
+
+## rule_verilog_sim_coverage_aggregate
+
+<pre>
+load("@bedrock-rtl//bazel:verilog.bzl", "rule_verilog_sim_coverage_aggregate")
+
+rule_verilog_sim_coverage_aggregate(<a href="#rule_verilog_sim_coverage_aggregate-name">name</a>, <a href="#rule_verilog_sim_coverage_aggregate-deps">deps</a>, <a href="#rule_verilog_sim_coverage_aggregate-coverage_data">coverage_data</a>, <a href="#rule_verilog_sim_coverage_aggregate-coverage_reports">coverage_reports</a>)
+</pre>
+
+Merges Verilator coverage data as a declared Bazel output.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rule_verilog_sim_coverage_aggregate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="rule_verilog_sim_coverage_aggregate-deps"></a>deps |  The dependencies of the testbench whose design sources should be tracked transitively.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="rule_verilog_sim_coverage_aggregate-coverage_data"></a>coverage_data |  Coverage data targets whose data and info files should be merged.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="rule_verilog_sim_coverage_aggregate-coverage_reports"></a>coverage_reports |  Coverage report targets whose transitive data and info files should be merged.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+
+<a id="rule_verilog_sim_coverage_data"></a>
+
+## rule_verilog_sim_coverage_data
+
+<pre>
+load("@bedrock-rtl//bazel:verilog.bzl", "rule_verilog_sim_coverage_data")
+
+rule_verilog_sim_coverage_data(<a href="#rule_verilog_sim_coverage_data-name">name</a>, <a href="#rule_verilog_sim_coverage_data-deps">deps</a>, <a href="#rule_verilog_sim_coverage_data-custom_tcl_body">custom_tcl_body</a>, <a href="#rule_verilog_sim_coverage_data-custom_tcl_header">custom_tcl_header</a>, <a href="#rule_verilog_sim_coverage_data-defines">defines</a>, <a href="#rule_verilog_sim_coverage_data-elab_only">elab_only</a>,
+                               <a href="#rule_verilog_sim_coverage_data-elab_opts">elab_opts</a>, <a href="#rule_verilog_sim_coverage_data-opts">opts</a>, <a href="#rule_verilog_sim_coverage_data-params">params</a>, <a href="#rule_verilog_sim_coverage_data-runner_flags">runner_flags</a>, <a href="#rule_verilog_sim_coverage_data-seed">seed</a>, <a href="#rule_verilog_sim_coverage_data-sim_opts">sim_opts</a>, <a href="#rule_verilog_sim_coverage_data-tool">tool</a>, <a href="#rule_verilog_sim_coverage_data-top">top</a>, <a href="#rule_verilog_sim_coverage_data-uvm">uvm</a>,
+                               <a href="#rule_verilog_sim_coverage_data-verilog_runner_data">verilog_runner_data</a>, <a href="#rule_verilog_sim_coverage_data-verilog_runner_env">verilog_runner_env</a>, <a href="#rule_verilog_sim_coverage_data-verilog_runner_plugins">verilog_runner_plugins</a>,
+                               <a href="#rule_verilog_sim_coverage_data-verilog_runner_tool">verilog_runner_tool</a>, <a href="#rule_verilog_sim_coverage_data-waves">waves</a>)
+</pre>
+
+Runs a Verilator simulation test target and emits coverage info and description files.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rule_verilog_sim_coverage_data-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="rule_verilog_sim_coverage_data-deps"></a>deps |  The dependencies of the test.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="rule_verilog_sim_coverage_data-custom_tcl_body"></a>custom_tcl_body |  Tcl script file containing custom tool-specific commands to insert in the middle of the generated tcl script after the elaboration step.The tcl body (custom or not) is unconditionally followed by the tcl footer.Do not include Tcl commands that manipulate sources, headers, defines, or parameters, as those will be handled by the rule implementation.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="rule_verilog_sim_coverage_data-custom_tcl_header"></a>custom_tcl_header |  Tcl script file containing custom tool-specific commands to insert at the beginning of the generated tcl script.The tcl header (custom or not) is unconditionally followed by analysis and elaborate commands, and then the tcl body.Do not include Tcl commands that manipulate sources, headers, defines, or parameters, as those will be handled by the rule implementation.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="rule_verilog_sim_coverage_data-defines"></a>defines |  Preprocessor defines to pass to the Verilog compiler.   | List of strings | optional |  `[]`  |
+| <a id="rule_verilog_sim_coverage_data-elab_only"></a>elab_only |  Only run elaboration.   | Boolean | optional |  `False`  |
+| <a id="rule_verilog_sim_coverage_data-elab_opts"></a>elab_opts |  Tool-specific compile/elaboration options not covered by other arguments.   | List of strings | optional |  `[]`  |
+| <a id="rule_verilog_sim_coverage_data-opts"></a>opts |  Deprecated VCS-only simulation options. Prefer 'elab_opts' or 'sim_opts'.   | List of strings | optional |  `[]`  |
+| <a id="rule_verilog_sim_coverage_data-params"></a>params |  Verilog module parameters to set in the instantiation of the top-level module.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="rule_verilog_sim_coverage_data-runner_flags"></a>runner_flags |  command line flags   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//bazel:runner_flags"`  |
+| <a id="rule_verilog_sim_coverage_data-seed"></a>seed |  Random seed to use in simulation.   | Integer | optional |  `0`  |
+| <a id="rule_verilog_sim_coverage_data-sim_opts"></a>sim_opts |  Tool-specific simulation runtime options, such as simulator plusargs.   | List of strings | optional |  `[]`  |
+| <a id="rule_verilog_sim_coverage_data-tool"></a>tool |  Simulator tool to use.   | String | required |  |
+| <a id="rule_verilog_sim_coverage_data-top"></a>top |  The top-level module; if not provided and there exists one dependency, then defaults to that dep's label name.   | String | optional |  `""`  |
+| <a id="rule_verilog_sim_coverage_data-uvm"></a>uvm |  Run UVM test.   | Boolean | optional |  `False`  |
+| <a id="rule_verilog_sim_coverage_data-verilog_runner_data"></a>verilog_runner_data |  Additional Verilog Runner files needed at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner:verilog_runner_data"]`  |
+| <a id="rule_verilog_sim_coverage_data-verilog_runner_env"></a>verilog_runner_env |  Optional shell script sourced immediately before each Verilog Runner invocation.<br><br>The wrapper does not change directories before sourcing the hook, so it inherits the wrapper's existing working directory. Direct wrappers add the hook to runfiles and source its runfiles path; sandbox generator actions declare it as an input and source its execroot path. A direct hook is sourced before the wrapper unsets any inherited `rlocation` function, but callers needing runfiles lookup must initialize a working runfiles library rather than assume that Bazel exports a usable `rlocation` implementation. Bedrock appends its `verilog_runner_plugins` directories to `VERILOG_RUNNER_PLUGIN_PATH` after the hook runs. The hook is not included in sandbox archives or sourced by their final runners.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="rule_verilog_sim_coverage_data-verilog_runner_plugins"></a>verilog_runner_plugins |  Verilog runner plugins to load from this workspace, in addition to those loaded from VERILOG_RUNNER_PLUGIN_PATH.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `["@bedrock-rtl//python/verilog_runner/plugins:verilator.py"]`  |
+| <a id="rule_verilog_sim_coverage_data-verilog_runner_tool"></a>verilog_runner_tool |  The Verilog Runner tool to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@bedrock-rtl//python/verilog_runner:verilog_runner.py"`  |
+| <a id="rule_verilog_sim_coverage_data-waves"></a>waves |  Enable waveform dumping.   | Boolean | optional |  `False`  |
+
+
 <a id="rule_verilog_sim_test"></a>
 
 ## rule_verilog_sim_test
@@ -341,6 +406,61 @@ Build configuration for Verilog Runner flags from command line
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="runner_flags-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+
+
+<a id="VerilogCoverageDataInfo"></a>
+
+## VerilogCoverageDataInfo
+
+<pre>
+load("@bedrock-rtl//bazel:verilog.bzl", "VerilogCoverageDataInfo")
+
+VerilogCoverageDataInfo(<a href="#VerilogCoverageDataInfo-toggle_info">toggle_info</a>, <a href="#VerilogCoverageDataInfo-line_info">line_info</a>, <a href="#VerilogCoverageDataInfo-branch_info">branch_info</a>, <a href="#VerilogCoverageDataInfo-expr_info">expr_info</a>, <a href="#VerilogCoverageDataInfo-covergroup_info">covergroup_info</a>, <a href="#VerilogCoverageDataInfo-user_info">user_info</a>,
+                        <a href="#VerilogCoverageDataInfo-coverage_data">coverage_data</a>, <a href="#VerilogCoverageDataInfo-coverage_failures">coverage_failures</a>)
+</pre>
+
+Verilator raw coverage data and info artifacts.
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="VerilogCoverageDataInfo-toggle_info"></a>toggle_info |  -    |
+| <a id="VerilogCoverageDataInfo-line_info"></a>line_info |  -    |
+| <a id="VerilogCoverageDataInfo-branch_info"></a>branch_info |  -    |
+| <a id="VerilogCoverageDataInfo-expr_info"></a>expr_info |  -    |
+| <a id="VerilogCoverageDataInfo-covergroup_info"></a>covergroup_info |  -    |
+| <a id="VerilogCoverageDataInfo-user_info"></a>user_info |  -    |
+| <a id="VerilogCoverageDataInfo-coverage_data"></a>coverage_data |  -    |
+| <a id="VerilogCoverageDataInfo-coverage_failures"></a>coverage_failures |  -    |
+
+
+<a id="VerilogCoverageReportInfo"></a>
+
+## VerilogCoverageReportInfo
+
+<pre>
+load("@bedrock-rtl//bazel:verilog.bzl", "VerilogCoverageReportInfo")
+
+VerilogCoverageReportInfo(<a href="#VerilogCoverageReportInfo-toggle_info">toggle_info</a>, <a href="#VerilogCoverageReportInfo-line_info">line_info</a>, <a href="#VerilogCoverageReportInfo-branch_info">branch_info</a>, <a href="#VerilogCoverageReportInfo-expr_info">expr_info</a>, <a href="#VerilogCoverageReportInfo-covergroup_info">covergroup_info</a>,
+                          <a href="#VerilogCoverageReportInfo-user_info">user_info</a>, <a href="#VerilogCoverageReportInfo-coverage_data">coverage_data</a>, <a href="#VerilogCoverageReportInfo-coverage_failures">coverage_failures</a>, <a href="#VerilogCoverageReportInfo-srcs">srcs</a>)
+</pre>
+
+Aggregated Verilator coverage data and info artifacts.
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="VerilogCoverageReportInfo-toggle_info"></a>toggle_info |  -    |
+| <a id="VerilogCoverageReportInfo-line_info"></a>line_info |  -    |
+| <a id="VerilogCoverageReportInfo-branch_info"></a>branch_info |  -    |
+| <a id="VerilogCoverageReportInfo-expr_info"></a>expr_info |  -    |
+| <a id="VerilogCoverageReportInfo-covergroup_info"></a>covergroup_info |  -    |
+| <a id="VerilogCoverageReportInfo-user_info"></a>user_info |  -    |
+| <a id="VerilogCoverageReportInfo-coverage_data"></a>coverage_data |  -    |
+| <a id="VerilogCoverageReportInfo-coverage_failures"></a>coverage_failures |  -    |
+| <a id="VerilogCoverageReportInfo-srcs"></a>srcs |  -    |
 
 
 <a id="VerilogRunnerFlagsInfo"></a>
@@ -592,6 +712,56 @@ The following extra tags are unconditionally appended to the list of tags:
 | <a id="verilog_lint_test-kwargs"></a>kwargs |  Other arguments to pass to the rule_verilog_lint_test rule.   |  none |
 
 
+<a id="verilog_sim_coverage_aggregate"></a>
+
+## verilog_sim_coverage_aggregate
+
+<pre>
+load("@bedrock-rtl//bazel:verilog.bzl", "verilog_sim_coverage_aggregate")
+
+verilog_sim_coverage_aggregate(<a href="#verilog_sim_coverage_aggregate-name">name</a>, <a href="#verilog_sim_coverage_aggregate-coverage_data">coverage_data</a>, <a href="#verilog_sim_coverage_aggregate-coverage_reports">coverage_reports</a>, <a href="#verilog_sim_coverage_aggregate-deps">deps</a>, <a href="#verilog_sim_coverage_aggregate-kwargs">**kwargs</a>)
+</pre>
+
+Wraps rule_verilog_sim_coverage_aggregate.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="verilog_sim_coverage_aggregate-name"></a>name |  The name of the aggregate coverage target.   |  none |
+| <a id="verilog_sim_coverage_aggregate-coverage_data"></a>coverage_data |  Coverage data targets whose data and info files should be merged.   |  `[]` |
+| <a id="verilog_sim_coverage_aggregate-coverage_reports"></a>coverage_reports |  Coverage report targets whose transitive data and info files should be merged.   |  `[]` |
+| <a id="verilog_sim_coverage_aggregate-deps"></a>deps |  The dependencies of the testbench whose design sources should be tracked transitively.   |  `[]` |
+| <a id="verilog_sim_coverage_aggregate-kwargs"></a>kwargs |  Other arguments to pass to the rule_verilog_sim_coverage_aggregate rule.   |  none |
+
+
+<a id="verilog_sim_coverage_data"></a>
+
+## verilog_sim_coverage_data
+
+<pre>
+load("@bedrock-rtl//bazel:verilog.bzl", "verilog_sim_coverage_data")
+
+verilog_sim_coverage_data(<a href="#verilog_sim_coverage_data-tool">tool</a>, <a href="#verilog_sim_coverage_data-opts">opts</a>, <a href="#verilog_sim_coverage_data-elab_opts">elab_opts</a>, <a href="#verilog_sim_coverage_data-sim_opts">sim_opts</a>, <a href="#verilog_sim_coverage_data-tags">tags</a>, <a href="#verilog_sim_coverage_data-waves">waves</a>, <a href="#verilog_sim_coverage_data-kwargs">**kwargs</a>)
+</pre>
+
+Wraps rule_verilog_sim_coverage_data.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="verilog_sim_coverage_data-tool"></a>tool |  The simulation tool to use. Must be "verilator".   |  none |
+| <a id="verilog_sim_coverage_data-opts"></a>opts |  Deprecated VCS-only simulation options.   |  `[]` |
+| <a id="verilog_sim_coverage_data-elab_opts"></a>elab_opts |  Tool-specific compile/elaboration options not covered by other arguments.   |  `[]` |
+| <a id="verilog_sim_coverage_data-sim_opts"></a>sim_opts |  Tool-specific simulation runtime options, such as simulator plusargs.   |  `[]` |
+| <a id="verilog_sim_coverage_data-tags"></a>tags |  <p align="center"> - </p>   |  `[]` |
+| <a id="verilog_sim_coverage_data-waves"></a>waves |  Enable waveform dumping.   |  `False` |
+| <a id="verilog_sim_coverage_data-kwargs"></a>kwargs |  Other arguments to pass to the rule_verilog_sim_coverage_data rule.   |  none |
+
+
 <a id="verilog_sim_test"></a>
 
 ## verilog_sim_test
@@ -632,7 +802,7 @@ The following extra tags are unconditionally appended to the list of tags:
 <pre>
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_sim_test_suite")
 
-verilog_sim_test_suite(<a href="#verilog_sim_test_suite-name">name</a>, <a href="#verilog_sim_test_suite-defines">defines</a>, <a href="#verilog_sim_test_suite-params">params</a>, <a href="#verilog_sim_test_suite-illegal_param_combinations">illegal_param_combinations</a>, <a href="#verilog_sim_test_suite-kwargs">**kwargs</a>)
+verilog_sim_test_suite(<a href="#verilog_sim_test_suite-name">name</a>, <a href="#verilog_sim_test_suite-defines">defines</a>, <a href="#verilog_sim_test_suite-params">params</a>, <a href="#verilog_sim_test_suite-illegal_param_combinations">illegal_param_combinations</a>, <a href="#verilog_sim_test_suite-coverage">coverage</a>, <a href="#verilog_sim_test_suite-kwargs">**kwargs</a>)
 </pre>
 
 Creates a suite of Verilog sim tests for each combination of the provided parameters.
@@ -651,6 +821,7 @@ to the base name followed by the parameter key-values.
 | <a id="verilog_sim_test_suite-defines"></a>defines |  A list of defines.   |  `[]` |
 | <a id="verilog_sim_test_suite-params"></a>params |  A dictionary where keys are parameter names and values are lists of possible values for those parameters.   |  `{}` |
 | <a id="verilog_sim_test_suite-illegal_param_combinations"></a>illegal_param_combinations |  A dictionary where keys are parameter tuples and values are lists of tuples of illegal values for those parameters.   |  `{}` |
+| <a id="verilog_sim_test_suite-coverage"></a>coverage |  Value enabling and disabling coverage data.   |  `False` |
 | <a id="verilog_sim_test_suite-kwargs"></a>kwargs |  Additional keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.   |  none |
 
 

--- a/cdc/sim/BUILD.bazel
+++ b/cdc/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -192,6 +192,13 @@ verilog_elab_test(
     ],
 )
 
+CDC_DELAY_MODES = [
+    "0",
+    "1",
+    "2",
+    "3",
+]
+
 [
     br_verilog_sim_test_tools_suite(
         name = "br_cdc_fifo_flops_sim_test_tools_suite" + cdc_delay_mode,
@@ -233,12 +240,7 @@ verilog_elab_test(
             "//mux/rtl:br_mux_bin_structured_gates_mock",
         ],
     )
-    for cdc_delay_mode in [
-        "0",
-        "1",
-        "2",
-        "3",
-    ]
+    for cdc_delay_mode in CDC_DELAY_MODES
 ]
 
 verilog_library(
@@ -388,12 +390,7 @@ verilog_elab_test(
             "//mux/rtl:br_mux_bin_structured_gates_mock",
         ],
     )
-    for cdc_delay_mode in [
-        "0",
-        "1",
-        "2",
-        "3",
-    ]
+    for cdc_delay_mode in CDC_DELAY_MODES
 ]
 
 verilog_library(
@@ -477,6 +474,7 @@ verilog_elab_test(
 [
     br_verilog_sim_test_tools_suite(
         name = "br_cdc_bit_pulse_sim_test_tools_suite_" + cdc_delay_mode,
+        coverage = True,
         params = {
             "NumStages": [
                 "2",
@@ -505,12 +503,7 @@ verilog_elab_test(
         ],
         deps = [":br_cdc_bit_pulse_tb"],
     )
-    for cdc_delay_mode in [
-        "0",
-        "1",
-        "2",
-        "3",
-    ]
+    for cdc_delay_mode in CDC_DELAY_MODES
 ]
 
 verilog_library(
@@ -675,4 +668,23 @@ br_verilog_sim_test_tools_suite(
         ":br_cdc_stable_data_autoupdate_tb",
         "//gate/rtl:br_gate_mock",
     ],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_cdc_verilator_coverage",
+    coverage_reports = [
+        ":br_cdc_reg_sim_test_tools_suite_verilator_coverage",
+        ":br_cdc_stable_data_sim_test_tools_suite_verilator_coverage",
+        ":br_cdc_stable_data_autoupdate_sim_test_tools_suite_verilator_coverage",
+    ] + [
+        ":br_cdc_fifo_flops_sim_test_tools_suite" + cdc_delay_mode + "_verilator_coverage"
+        for cdc_delay_mode in CDC_DELAY_MODES
+    ] + [
+        ":br_cdc_fifo_flops_push_credit_sim_test_tools_suite" + cdc_delay_mode + "_verilator_coverage"
+        for cdc_delay_mode in CDC_DELAY_MODES
+    ] + [
+        ":br_cdc_bit_pulse_sim_test_tools_suite_" + cdc_delay_mode + "_verilator_coverage"
+        for cdc_delay_mode in CDC_DELAY_MODES
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/check_env.py
+++ b/check_env.py
@@ -26,31 +26,32 @@ REQUIRED_BINARIES = [
     "xrun",
 ]
 
-all_ok = True
+if __name__ == "__main__":
+    all_ok = True
 
-print("Checking environment variables...", end="", flush=True)
-ok = True
-for var in REQUIRED_ENV_VARS:
-    if not os.environ.get(var):
-        if ok:
-            print("FAIL")  # Go to a new line before printing first error
-        ok = False
-        print(f"--> {var} is not set")
-if ok:
-    print("Ok")
-all_ok = all_ok and ok
+    print("Checking environment variables...", end="", flush=True)
+    ok = True
+    for var in REQUIRED_ENV_VARS:
+        if not os.environ.get(var):
+            if ok:
+                print("FAIL")  # Go to a new line before printing first error
+            ok = False
+            print(f"--> {var} is not set")
+    if ok:
+        print("Ok")
+    all_ok = all_ok and ok
 
-print("Checking binaries exist...", end="", flush=True)
-ok = True
-for binary in REQUIRED_BINARIES:
-    if which(binary) is None:
-        if ok:
-            print("FAIL")  # Go to a new line before printing first error
-        ok = False
-        print(f"--> Required binary '{binary}' is not found in PATH")
-if ok:
-    print("Ok")
-all_ok = all_ok and ok
+    print("Checking binaries exist...", end="", flush=True)
+    ok = True
+    for binary in REQUIRED_BINARIES:
+        if which(binary) is None:
+            if ok:
+                print("FAIL")  # Go to a new line before printing first error
+            ok = False
+            print(f"--> Required binary '{binary}' is not found in PATH")
+    if ok:
+        print("Ok")
+    all_ok = all_ok and ok
 
-if not all_ok:
-    sys.exit(1)
+    if not all_ok:
+        sys.exit(1)

--- a/counter/sim/BUILD.bazel
+++ b/counter/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -127,4 +127,14 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_counter_decr_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_counter_verilator_coverage",
+    coverage_reports = [
+        ":br_counter_incr_sim_test_tools_suite_verilator_coverage",
+        ":br_counter_sim_test_tools_suite_verilator_coverage",
+        ":br_counter_decr_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/credit/sim/BUILD.bazel
+++ b/credit/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -88,4 +88,14 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_credit_sender_vc_rr_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_credit_verilator_coverage",
+    coverage_reports = [
+        ":br_credit_receiver_sim_test_tools_suite_verilator_coverage",
+        # Re-enable after confirming that test suite with coverage gathering passes
+        # ":br_credit_sender_vc_rr_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/csr/sim/BUILD.bazel
+++ b/csr/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -121,4 +121,13 @@ br_verilog_sim_test_tools_suite(
         #"verilator",
     ],
     deps = [":br_csr_mem_interface_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_csr_verilator_coverage",
+    coverage_reports = [
+        ":br_csr_axil_widget_sim_test_tools_suite_verilator_coverage",
+        ":br_csr_demux_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/delay/sim/BUILD.bazel
+++ b/delay/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -321,4 +321,20 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_delay_valid_nr_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_delay_verilator_coverage",
+    coverage_reports = [
+        ":br_delay_sim_test_tools_suite_verilator_coverage",
+        ":br_delay_nr_sim_test_tools_suite_verilator_coverage",
+        ":br_delay_shift_reg_sim_test_tools_suite_verilator_coverage",
+        ":br_delay_deskew_sim_test_tools_suite_verilator_coverage",
+        ":br_delay_skew_sim_test_tools_suite_verilator_coverage",
+        ":br_delay_valid_next_sim_test_tools_suite_verilator_coverage",
+        ":br_delay_valid_next_nr_sim_test_tools_suite_verilator_coverage",
+        ":br_delay_valid_sim_test_tools_suite_verilator_coverage",
+        ":br_delay_valid_nr_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/demux/sim/BUILD.bazel
+++ b/demux/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -43,4 +43,12 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_demux_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_demux_verilator_coverage",
+    coverage_reports = [
+        ":br_demux_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/ecc/sim/BUILD.bazel
+++ b/ecc/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -83,16 +83,23 @@ K = [
     "68",
 ]
 
-[
-    br_verilog_sim_test_tools_suite(
-        name = "br_ecc_secded_encoder_decoder_sim_test_tools_suite",
-        params = {"DataWidth": [k]},
-        seed = 42,
-        tools = [
-            "vcs",
-            "verilator",
-        ],
-        deps = [":br_ecc_secded_encoder_decoder_tb"],
-    )
-    for k in K
-]
+br_verilog_sim_test_tools_suite(
+    name = "br_ecc_secded_encoder_decoder_sim_test_tools_suite",
+    coverage = True,
+    params = {"DataWidth": K},
+    seed = 42,
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_ecc_secded_encoder_decoder_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_ecc_verilator_coverage",
+    coverage_reports = [
+        ":br_ecc_sed_encoder_decoder_sim_test_tools_suite_verilator_coverage",
+        ":br_ecc_secded_encoder_decoder_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/enc/sim/BUILD.bazel
+++ b/enc/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -178,4 +178,17 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_enc_onehot2bin_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_enc_verilator_coverage",
+    coverage_reports = [
+        ":br_enc_bin2onehot_sim_test_tools_suite_verilator_coverage",
+        ":br_enc_gray_sim_test_tools_suite_verilator_coverage",
+        ":br_enc_priority_encoder_sim_test_tools_suite_verilator_coverage",
+        ":br_enc_priority_dynamic_sim_test_tools_suite_verilator_coverage",
+        ":br_enc_countones_tb_sim_test_suite_verilator_coverage",
+        ":br_enc_onehot2bin_tb_sim_test_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -616,4 +616,14 @@ br_verilog_sim_test_tools_suite(
         #"verilator",
     ],
     deps = [":br_fifo_shared_dynamic_flops_push_credit_pop_credit_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_fifo_verilator_coverage",
+    coverage_reports = [
+        ":br_fifo_ctrl_1r1w_sim_test_tools_suite_verilator_coverage",
+        ":br_fifo_ctrl_1r1w_push_credit_sim_test_tools_suite_verilator_coverage",
+        ":br_fifo_ctrl_1r1w_push_credit_min_depth_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/flow/sim/BUILD.bazel
+++ b/flow/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -879,4 +879,44 @@ br_verilog_sim_test_tools_suite(
     elab_opts = ["-Wno-BLKANDNBLK"],
     tools = ["verilator"],
     deps = [":br_flow_xbar_lru_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_flow_verilator_coverage",
+    coverage_reports = [
+        ":br_flow_reg_fwd_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_reg_rev_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_reg_none_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_reg_both_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_fork_select_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_join_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_valve_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_mux_select_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_demux_select_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_buffer_depth_0_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_buffer_depth_1_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_buffer_depth_1_fwd_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_buffer_depth_2_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_buffer_depth_3_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_arb_fixed_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_arb_rr_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_arb_lru_sim_test_tools_suite_verilator_verilator_coverage",
+        ":br_flow_mux_fixed_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_mux_rr_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_mux_lru_sim_test_tools_suite_verilator_verilator_coverage",
+        ":br_flow_mux_fixed_stable_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_mux_rr_stable_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_mux_lru_stable_sim_test_tools_suite_verilator_verilator_coverage",
+        ":br_flow_burst_mux_fixed_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_burst_mux_rr_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_burst_mux_lru_sim_test_tools_suite_verilator_verilator_coverage",
+        ":br_flow_burst_mux_fixed_stable_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_burst_mux_rr_stable_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_burst_mux_lru_stable_sim_test_tools_suite_verilator_verilator_coverage",
+        ":br_flow_serializer_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_xbar_fixed_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_xbar_rr_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_xbar_lru_sim_test_tools_suite_verilator_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/lfsr/sim/BUILD.bazel
+++ b/lfsr/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -68,4 +68,13 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_lfsr_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_lfsr_verilator_coverage",
+    coverage_reports = [
+        ":br_lfsr_sim_test_tools_suite_verilator_coverage",
+        ":br_lfsr_advance_steps_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_lint_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_lint_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -267,4 +267,13 @@ verilog_lint_test(
     tool = "ascentlint",
     visibility = ["//visibility:public"],
     deps = [":br_assign_test"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_macros_verilator_coverage",
+    coverage_reports = [
+        ":br_asserts_sim_test_tools_suite_verilator_coverage",
+        ":br_asserts_sim_noassert_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/misc/sim/BUILD.bazel
+++ b/misc/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -128,4 +128,14 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_misc_unused_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_misc_verilator_coverage",
+    coverage_reports = [
+        ":br_misc_tieoff_one_sim_test_tools_suite_verilator_coverage",
+        ":br_misc_tieoff_zero_sim_test_tools_suite_verilator_coverage",
+        ":br_misc_unused_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/multi_xfer/sim/BUILD.bazel
+++ b/multi_xfer/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -74,4 +74,13 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_multi_xfer_distributor_rr_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_multi_xfer_verilator_coverage",
+    coverage_reports = [
+        ":br_multi_xfer_reg_fwd_sim_test_tools_suite_verilator_coverage",
+        ":br_multi_xfer_distributor_rr_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/mux/sim/BUILD.bazel
+++ b/mux/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -206,4 +206,16 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_mux_onehot_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_mux_verilator_coverage",
+    coverage_reports = [
+        ":br_mux_bin_sim_test_tools_suite_verilator_coverage",
+        ":br_mux_bin_array_sim_test_tools_suite_verilator_coverage",
+        ":br_mux_bin_structured_gates_sim_test_tools_suite_verilator_coverage",
+        ":br_mux_bin_structured_gates_mock_sim_test_tools_suite_verilator_coverage",
+        ":br_mux_onehot_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/python/verilog_runner/cli.py
+++ b/python/verilog_runner/cli.py
@@ -286,6 +286,12 @@ class Sim(Subcommand):
             action="store_true",
             help="Enable waveform dumping.",
         )
+        parser.add_argument(
+            "--coverage",
+            type=str,
+            default=None,
+            help="Path where coverage data will be saved, if None the coverage is not enabled",
+        )
 
 
 class Fpv(Subcommand):

--- a/python/verilog_runner/plugins/verilator.py
+++ b/python/verilog_runner/plugins/verilator.py
@@ -5,6 +5,7 @@
 import argparse
 from dataclasses import dataclass
 from typing import Dict, Type
+from pathlib import Path
 
 from cli import Sim, Subcommand, common_args
 from eda_tool import EdaTool
@@ -28,6 +29,7 @@ class Verilator(EdaTool):
     help: str = "Simulate a Verilog/SystemVerilog design using Verilator"
     elab_only: bool = False
     waves: bool = False
+    coverage: bool = False
 
     def __post_init__(self):
         self.logger = get_class_logger("sim", "verilator")
@@ -38,9 +40,12 @@ class Verilator(EdaTool):
 
     @classmethod
     def from_args(cls, args):
+        if args.coverage and args.elab_only:
+            raise ValueError("Coverage cannot be combined with elab_only.")
         sim_args = {
             "elab_only": args.elab_only,
             "waves": args.waves,
+            "coverage": args.coverage,
         }
         return cls(**common_args(args), **sim_args)
 
@@ -62,7 +67,7 @@ class Verilator(EdaTool):
     def cmd(self) -> str:
         """Returns a default shell script to run Verilator."""
         self.logger.info("Generating shell script.")
-        obj_dir = "obj_dir"
+        obj_dir = f"obj_dir_{Path(self.filelist).stem}"
         executable = "simv"
 
         cmd = ["#!/bin/bash"]
@@ -98,6 +103,8 @@ class Verilator(EdaTool):
         ]
         if self.waves:
             verilator_cmd += ["--trace"]
+        if self.coverage:
+            verilator_cmd += ["--coverage"]
         verilator_cmd += [f"-I{dir}" for dir in include_dirs(self.hdrs)]
         verilator_cmd += ["-DBR_VERILATOR"]
         verilator_cmd += [f"-D{define}" for define in self.defines]
@@ -108,7 +115,10 @@ class Verilator(EdaTool):
         if self.elab_only:
             cmd += [verilator_cmd]
         else:
-            sim_cmd = " ".join([f"./{obj_dir}/{executable}"] + self.sim_opts)
+            sim_cmd = [f"./{obj_dir}/{executable}"] + self.sim_opts
+            if self.coverage:
+                sim_cmd.append(f"'+verilator+coverage+file+{self.coverage}'")
+            sim_cmd = " ".join(sim_cmd)
             cmd += [" && ".join([verilator_cmd, sim_cmd])]
         cmd += [""]
         return "\n".join(cmd)

--- a/ram/sim/BUILD.bazel
+++ b/ram/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -196,4 +196,18 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_ram_initializer_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_ram_verilator_coverage",
+    coverage_reports = [
+        ":br_ram_flops_1r1w_sim_test_tools_suite_basic_verilator_coverage",
+        ":br_ram_flops_1r1w_sim_test_tools_suite_evenshape_verilator_coverage",
+        ":br_ram_flops_1r1w_sim_test_tools_suite_oddshape_verilator_coverage",
+        ":br_ram_flops_1r1w_sim_test_tools_suite_latency1a_verilator_coverage",
+        ":br_ram_flops_1r1w_sim_test_tools_suite_latency1b_verilator_coverage",
+        ":br_ram_flops_1r1w_sim_test_tools_suite_latency1c_verilator_coverage",
+        ":br_ram_initializer_sim_test_tools_suite_basic_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/shift/sim/BUILD.bazel
+++ b/shift/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -104,4 +104,14 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_shift_left_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_shift_verilator_coverage",
+    coverage_reports = [
+        ":br_shift_rotate_sim_test_tools_suite_verilator_coverage",
+        ":br_shift_right_sim_test_tools_suite_verilator_coverage",
+        ":br_shift_left_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/tracker/sim/BUILD.bazel
+++ b/tracker/sim/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
-load("//bazel:verilog.bzl", "verilog_elab_test")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -118,4 +118,13 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_tracker_reorder_buffer_flops_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_tracker_verilator_coverage",
+    coverage_reports = [
+        ":br_tracker_linked_list_ctrl_sim_test_tools_suite_verilator_coverage",
+        ":br_tracker_reorder_buffer_flops_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
This PR extends Bazel rules with option to generate coverage data using Verilator flow and aggregate them into one target