### PR TITLE
[fv] Exclude illegal FIFO external-arbiter latency configurations

### DIFF
--- a/fifo/fpv/br_fifo_ext_arb/BUILD.bazel
+++ b/fifo/fpv/br_fifo_ext_arb/BUILD.bazel
@@ -6,6 +6,18 @@ load("//bazel:verilog.bzl", "verilog_elab_test")
 
 package(default_visibility = ["//fifo/fpv:__subpackages__"])
 
+# A staging buffer is instantiated when DataRamReadLatency > 0 or
+# RegisterPopOutputs is set; its depth must not exceed DataRamReadLatency + 1.
+_EXT_ARB_LATENCY_ILLEGAL_PARAM_COMBINATIONS = {
+    (
+        "DataRamReadLatency",
+        "RegisterPopOutputs",
+        "StagingBufferDepth",
+    ): [
+        ("0", "1", "2"),
+    ],
+}
+
 verilog_library(
     name = "ext_arb_fv_monitor",
     srcs = ["ext_arb_fv_monitor.sv"],
@@ -64,16 +76,7 @@ br_verilog_fpv_test_tools_suite(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_fifo_shared_dynamic_ctrl_ext_arbiter_test_latency",
-    # StagingBufferDepth must not exceed DataRamReadLatency + 1.
-    illegal_param_combinations = {
-        (
-            "DataRamReadLatency",
-            "RegisterPopOutputs",
-            "StagingBufferDepth",
-        ): [
-            ("0", "1", "2"),
-        ],
-    },
+    illegal_param_combinations = _EXT_ARB_LATENCY_ILLEGAL_PARAM_COMBINATIONS,
     params = {
         "StagingBufferDepth": [
             "1",
@@ -192,16 +195,7 @@ br_verilog_fpv_test_tools_suite(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_test_latency",
-    # StagingBufferDepth must not exceed DataRamReadLatency + 1.
-    illegal_param_combinations = {
-        (
-            "DataRamReadLatency",
-            "RegisterPopOutputs",
-            "StagingBufferDepth",
-        ): [
-            ("0", "1", "2"),
-        ],
-    },
+    illegal_param_combinations = _EXT_ARB_LATENCY_ILLEGAL_PARAM_COMBINATIONS,
     params = {
         "StagingBufferDepth": [
             "1",

--- a/fifo/fpv/br_fifo_ext_arb/BUILD.bazel
+++ b/fifo/fpv/br_fifo_ext_arb/BUILD.bazel
@@ -64,6 +64,12 @@ br_verilog_fpv_test_tools_suite(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_fifo_shared_dynamic_ctrl_ext_arbiter_test_latency",
+    # StagingBufferDepth must not exceed DataRamReadLatency + 1.
+    illegal_param_combinations = {
+        ("DataRamReadLatency", "StagingBufferDepth"): [
+            ("0", "2"),
+        ],
+    },
     params = {
         "StagingBufferDepth": [
             "1",
@@ -182,6 +188,12 @@ br_verilog_fpv_test_tools_suite(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_test_latency",
+    # StagingBufferDepth must not exceed DataRamReadLatency + 1.
+    illegal_param_combinations = {
+        ("DataRamReadLatency", "StagingBufferDepth"): [
+            ("0", "2"),
+        ],
+    },
     params = {
         "StagingBufferDepth": [
             "1",

--- a/fifo/fpv/br_fifo_ext_arb/BUILD.bazel
+++ b/fifo/fpv/br_fifo_ext_arb/BUILD.bazel
@@ -66,8 +66,12 @@ br_verilog_fpv_test_tools_suite(
     name = "br_fifo_shared_dynamic_ctrl_ext_arbiter_test_latency",
     # StagingBufferDepth must not exceed DataRamReadLatency + 1.
     illegal_param_combinations = {
-        ("DataRamReadLatency", "StagingBufferDepth"): [
-            ("0", "2"),
+        (
+            "DataRamReadLatency",
+            "RegisterPopOutputs",
+            "StagingBufferDepth",
+        ): [
+            ("0", "1", "2"),
         ],
     },
     params = {
@@ -190,8 +194,12 @@ br_verilog_fpv_test_tools_suite(
     name = "br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_test_latency",
     # StagingBufferDepth must not exceed DataRamReadLatency + 1.
     illegal_param_combinations = {
-        ("DataRamReadLatency", "StagingBufferDepth"): [
-            ("0", "2"),
+        (
+            "DataRamReadLatency",
+            "RegisterPopOutputs",
+            "StagingBufferDepth",
+        ): [
+            ("0", "1", "2"),
         ],
     },
     params = {


### PR DESCRIPTION
### Changes
Exclude DataRamReadLatency=0 with StagingBufferDepth=2 from the following FPV latency suites:

- br_fifo_shared_dynamic_ctrl_ext_arbiter_test_latency
- br_fifo_shared_dynamic_ctrl_push_credit_ext_arbiter_test_latency

Document that StagingBufferDepth must not exceed DataRamReadLatency + 1.
These configurations violate the max_buffer_depth_a static assertion in br_fifo_staging_buffer.
### Validation
Ran the full local regression for fifo/fpv/br_fifo_ext_arb.
All tests passed.