### PR TITLE
Fix CDC FIFO reset overlap check

### DIFF
--- a/cdc/rtl/internal/br_cdc_fifo_reset_overlap_checks.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_reset_overlap_checks.sv
@@ -42,7 +42,7 @@ module br_cdc_fifo_reset_overlap_checks #(
   localparam int MaxValue = 1 << 31;
   localparam int CounterWidth = $clog2(MaxValue + 1);
 
-  logic overlap_next, counter_rst, reset_active_push_d, reset_active_pop_d;
+  logic overlap_next, counter_rst, reset_active_push_d, reset_active_pop_d, reset_deasserted;
   logic [CounterWidth-1:0] overlap_cycles, overlap_cycles_next;
 
   `BR_REGN(reset_active_push_d, reset_active_push)
@@ -58,6 +58,13 @@ module br_cdc_fifo_reset_overlap_checks #(
       ((reset_active_push === 1'b1 && reset_active_push_d !== 1'b1) ||
       // ri lint_check_waive FOURSTATE_COMP
       (reset_active_pop === 1'b1 && reset_active_pop_d !== 1'b1));
+
+  // Only treat a known 1-to-0 transition as reset deassertion. $fell also detects
+  // X-to-0 transitions, which can cause a false failure at the start of simulation.
+  // ri lint_check_waive FOURSTATE_COMP
+  assign reset_deasserted = (reset_active_push_d === 1'b1 && reset_active_push === 1'b0) ||
+      // ri lint_check_waive FOURSTATE_COMP
+      (reset_active_pop_d === 1'b1 && reset_active_pop === 1'b0);
 
   // Not using br_counter_incr because it has implementation assertions
   // that assume we won't drive Xes into its inputs when it's not in reset.
@@ -80,8 +87,8 @@ module br_cdc_fifo_reset_overlap_checks #(
 `endif  // BR_DISABLE_INTG_CHECKS
 `endif  // BR_ASSERT_ON
 
-  `BR_ASSERT_CR_INTG(reset_overlap_a, $fell(reset_active_push) || $fell(reset_active_pop)
-                                      |-> overlap_cycles >= MinOverlapCycles, clk, 1'b0)
+  `BR_ASSERT_CR_INTG(reset_overlap_a, reset_deasserted |-> overlap_cycles >= MinOverlapCycles, clk,
+                     1'b0)
 
   `BR_UNUSED(reset_active_push)
   `BR_UNUSED(reset_active_pop)


### PR DESCRIPTION
## Summary

- replace `$fell` in `br_cdc_fifo_reset_overlap_checks` with explicit known `1` to known `0` reset-deassertion detection
- prevent unknown-to-zero reset transitions from triggering the overlap assertion

## Root cause and impact

SystemVerilog `$fell` evaluates true for `X` to `0` transitions. At simulation startup, an unknown reset value becoming deasserted could therefore falsely trigger `reset_overlap_a`, even though no known asserted-to-deasserted reset transition occurred.

The checker now evaluates reset deassertion using delayed reset values and case equality, so only a known `1` to known `0` transition checks the minimum overlap count.

## Validation

- all 9 focused `br_cdc_fifo_reset_overlap_checks` lint and elaboration targets
- `pre-commit run --all-files`