### PR TITLE
Avoid unreachable FIFO assertion precondition

### DIFF
--- a/fifo/rtl/internal/br_fifo_staging_buffer.sv
+++ b/fifo/rtl/internal/br_fifo_staging_buffer.sv
@@ -467,12 +467,10 @@ module br_fifo_staging_buffer #(
       // For bypass data, we can only do direct bypass when the buffer is empty
       assign internal_pop_valid = head_valid || ram_rd_data_valid || (empty && bypass_beat);
       assign internal_pop_data = head_valid ? mem_rd_data : push_data;
-      if (RamReadLatency >= InternalDepth) begin : gen_with_rd_data_bypass_check
-        `BR_ASSERT_IMPL(rd_data_to_pop_correct_address_a,
-                        (!head_valid && ram_rd_data_valid) |-> (wr_ptr_onehot_d == rd_ptr_onehot))
-      end else begin : gen_no_rd_data_bypass_check
-        `BR_ASSERT_IMPL(no_rd_data_when_buffer_empty_a, ram_rd_data_valid |-> head_valid)
-      end
+      // If RAM read data bypasses an invalid buffer head, check that its delayed
+      // allocation address matches the current read pointer.
+      `BR_ASSERT_IMPL(rd_data_to_pop_correct_address_a,
+                      head_valid || !ram_rd_data_valid || (wr_ptr_onehot_d == rd_ptr_onehot))
 
       // Only advance the read pointer if the write pointer was advanced
       // to provide the data currently being consumed.

--- a/fifo/rtl/internal/br_fifo_staging_buffer.sv
+++ b/fifo/rtl/internal/br_fifo_staging_buffer.sv
@@ -469,6 +469,8 @@ module br_fifo_staging_buffer #(
       assign internal_pop_data = head_valid ? mem_rd_data : push_data;
       // If RAM read data bypasses an invalid buffer head, check that its delayed
       // allocation address matches the current read pointer.
+      // Use a Boolean expression instead of an implication because its precondition
+      // is unreachable in some configurations.
       `BR_ASSERT_IMPL(rd_data_to_pop_correct_address_a,
                       head_valid || !ram_rd_data_valid || (wr_ptr_onehot_d == rd_ptr_onehot))
 


### PR DESCRIPTION
### Summary
The original `rd_data_to_pop_correct_address_a` assertion never produced a counterexample. The earlier regression failed because Jasper generated an implicit :precondition1 cover for the implication antecedent, and that cover was unreachable in some configurations.

Re-enabling the old `no_rd_data_when_buffer_empty_a` fallback caused 26 regression failures because returning RAM data may legally bypass an invalid buffer head. We therefore kept the original address-correctness check but rewrote the overlapping implication into its logically equivalent Boolean form:
```
head_valid || !ram_rd_data_valid || (wr_ptr_onehot_d == rd_ptr_onehot)
```
This preserves the assertion while preventing Jasper from generating the unreachable implication-precondition cover.

### Verification
FPV regression on entire fifo/fpv directory is clean.