### PR TITLE
[tooling] Fix packaged source archive layout

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,6 +46,11 @@ py_test(
     tags = ["local"],
 )
 
+py_test(
+    name = "package_sources_test",
+    srcs = ["package_sources_test.py"],
+)
+
 verilog_sim_coverage_aggregate(
     name = "br_verilator_coverage",
     all_srcs = ":rtl_srcs",

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ git checkout <pinned-commit>
 ./package_sources.py //arb/rtl:br_arb_fixed
 ```
 
-The generated `.tar` contains a `.f` file and the target's transitive SystemVerilog sources and headers. Extract it, then run your simulator or synthesis tool from the extraction directory. The file list starts with the required `macros` include directory. Choose the library target for the module you use; its name is listed in the library's `BUILD.bazel` file.
+The generated `.tar` contains a root-level `project.f` file and the target's transitive SystemVerilog sources and headers. `project.f` declares the selected target as the top module and starts with the required `macros` include directory. Extract it, then run your simulator or synthesis tool from the extraction directory. Choose the library target for the module you use; its name is listed in the library's `BUILD.bazel` file.
 
 Pass `--filelist-only` to generate just the checkout-relative `.f` file.
 

--- a/package_sources.py
+++ b/package_sources.py
@@ -70,16 +70,42 @@ def query_source_paths(target: str) -> list[str]:
     ]
 
 
-def write_filelist(path: Path, source_paths: list[str]) -> None:
+def top_module(target: str) -> str:
+    return target.rsplit(":", 1)[-1]
+
+
+def write_filelist(path: Path, source_paths: list[str], top: str) -> None:
     path.write_text(
+        f"--top {top}\n"
         "+incdir+./macros\n" + "\n".join(source_paths) + ("\n" if source_paths else ""),
         encoding="utf-8",
     )
 
 
+def create_package(
+    package_path: Path,
+    source_root: Path,
+    source_paths: list[str],
+    top: str,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="package_sources_") as staging_directory:
+        staging_path = Path(staging_directory)
+        write_filelist(staging_path / "project.f", source_paths, top)
+        for source_path in source_paths:
+            relative_path = Path(source_path).relative_to(".")
+            destination = staging_path / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_root / relative_path, destination)
+
+        with tarfile.open(package_path, "w") as archive:
+            for path in sorted(staging_path.iterdir()):
+                archive.add(path, arcname=path.name)
+
+
 def main() -> None:
     args = parse_args()
     target_name = sanitized_target(args.target)
+    top = top_module(args.target)
     output_directory = args.output_path or Path(".")
     filelist_name = f"filelist_paths_{target_name}.f"
     source_paths = query_source_paths(args.target)
@@ -87,7 +113,7 @@ def main() -> None:
     if args.filelist_only:
         filelist_path = args.output_file or output_directory / filelist_name
         filelist_path.parent.mkdir(parents=True, exist_ok=True)
-        write_filelist(filelist_path, source_paths)
+        write_filelist(filelist_path, source_paths, top)
         print(f"File list generated and saved to {filelist_path}")
         return
 
@@ -95,17 +121,7 @@ def main() -> None:
         args.output_file or output_directory / f"package_sources_{target_name}.tar"
     )
     package_path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix="package_sources_") as staging_directory:
-        staging_path = Path(staging_directory)
-        write_filelist(staging_path / filelist_name, source_paths)
-        for source_path in source_paths:
-            relative_path = Path(source_path).relative_to(".")
-            destination = staging_path / relative_path
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(relative_path, destination)
-
-        with tarfile.open(package_path, "w") as archive:
-            archive.add(staging_path, arcname=".")
+    create_package(package_path, Path.cwd(), source_paths, top)
 
     print(f"Source package generated and saved to {package_path}")
 

--- a/package_sources_test.py
+++ b/package_sources_test.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+import package_sources
+
+
+class PackageSourcesTest(unittest.TestCase):
+    def test_create_package_has_root_project_filelist_and_top(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "rtl").mkdir()
+            (root / "rtl" / "top.sv").write_text(
+                "module top; endmodule\n", encoding="utf-8"
+            )
+            package = root / "sources.tar"
+
+            package_sources.create_package(
+                package,
+                root,
+                ["./rtl/top.sv"],
+                "top",
+            )
+
+            with tarfile.open(package) as archive:
+                self.assertEqual(
+                    sorted(archive.getnames()),
+                    ["project.f", "rtl", "rtl/top.sv"],
+                )
+                project_filelist = archive.extractfile("project.f")
+                self.assertIsNotNone(project_filelist)
+                assert project_filelist is not None
+                self.assertEqual(
+                    project_filelist.read().decode(),
+                    "--top top\n+incdir+./macros\n./rtl/top.sv\n",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Problem

`package_sources.py` generated a dynamically named filelist without a `--top` declaration. Its archive layout was also not explicit about the root filelist contract required by Nettle hosted source uploads.

# Solution

Generate a root-level `project.f` containing the selected Bazel target as `--top`, add archive entries without a synthetic `.` root entry, and add a regression test and documentation for the archive contract.

Validation: `python3 package_sources_test.py`; `bazel --output_user_root=/tmp/bedrock-rtl-bazel-package-sources test //:package_sources_test`; focused `pre-commit` checks.