### PR TITLE
[bazel] Add default-parameter elaboration and lint tests; fix some exposed bugs

### DIFF
--- a/amba/rtl/internal/br_amba_axi2axil_core.sv
+++ b/amba/rtl/internal/br_amba_axi2axil_core.sv
@@ -122,7 +122,9 @@ module br_amba_axi2axil_core #(
     logic [AddrWidth-1:0] wrap_mask;  // mask the wrap boundary
     logic [AddrWidth-1:0] align_mask;
 
-    incr_address = start_addr + (index << size);  // ri lint_check_waive VAR_SHIFT
+    // AXI bursts cannot cross a 4 KiB boundary. Since AddrWidth is at least 12, any bits
+    // truncated from this shifted beat offset are zero for legal transactions.
+    incr_address = start_addr + (index << size);  // ri lint_check_waive VAR_SHIFT TRUNC_LSHIFT
 
     unique case (br_amba::axi_burst_type_t'(burst_type))
       br_amba::AxiBurstIncr: begin

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -1698,12 +1698,16 @@ def verilog_elab_and_lint_test_suite(
         elab_tools = ["verific", "slang"],
         lint_tool = "ascentlint",
         disable_lint_rules = [],
+        tags = [],
         **kwargs):
     """Creates a suite of Verilog elaboration and lint tests for each combination of the provided parameters.
 
-    The function generates a wrapper covering all possible combinations of the provided parameters, creates a
-    verilog_elab_test for each elaboration tool, and creates one verilog_lint_test. Elaboration test names append
-    the tool name followed by "_elab_test"; the lint test name appends "_lint_test".
+    For each elaboration tool, the function creates one test of the original module's default parameters and one
+    test of a generated wrapper covering all possible combinations of the provided parameters. It also creates one
+    lint test of the original module's default parameters and one lint test of the generated wrapper.
+    Default-parameter test names append the tool name followed by "_default_params_elab_test" or
+    "_default_params_lint_test"; wrapper elaboration test names append the tool name followed by "_elab_test";
+    and the wrapper lint test name appends "_lint_test".
 
     Args:
         top (str): The top-level module to instantiate. Can be left undefined if there is only one dependency.
@@ -1714,6 +1718,7 @@ def verilog_elab_and_lint_test_suite(
         elab_tools (list of strings): The tools to use for elaboration. Defaults to Verific and Slang.
         lint_tool (str): The tool to use for linting.
         disable_lint_rules (list): A list of lint rules to disable in the generated files.
+        tags (list): A list of tags to add to generated tests.
         **kwargs: Additional common keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.
     """
     if not top:
@@ -1750,20 +1755,42 @@ def verilog_elab_and_lint_test_suite(
     )
 
     for elab_tool in elab_tools:
+        verilog_elab_test(
+            name = name + "_" + elab_tool + "_default_params_elab_test",
+            tool = elab_tool,
+            deps = deps,
+            defines = defines,
+            tags = tags + ["default-params"],
+            top = top,
+            **kwargs
+        )
+
         test_name = name + "_" + elab_tool + "_elab_test"
         verilog_elab_test(
             name = test_name,
             tool = elab_tool,
             deps = [":" + name + "_wrapper"],
             defines = defines,
+            tags = tags,
             **kwargs
         )
+
+    verilog_lint_test(
+        name = name + "_" + lint_tool + "_default_params_lint_test",
+        tool = lint_tool,
+        deps = deps,
+        defines = defines,
+        tags = tags + ["default-params"],
+        top = top,
+        **kwargs
+    )
 
     verilog_lint_test(
         name = name + "_lint_test",
         tool = lint_tool,
         deps = [":" + name + "_wrapper"],
         defines = defines,
+        tags = tags,
         **kwargs
     )
 

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -1695,16 +1695,18 @@ def verilog_elab_and_lint_test_suite(
         deps = [],
         defines = [],
         params = {},
+        include_default_params = True,
         elab_tools = ["verific", "slang"],
         lint_tool = "ascentlint",
         disable_lint_rules = [],
         **kwargs):
     """Creates a suite of Verilog elaboration and lint tests for each combination of the provided parameters.
 
-    The function generates a wrapper containing one instance with the module's default parameters and one instance
-    for every combination of the provided parameters. It creates one verilog_elab_test for each elaboration tool
-    and one verilog_lint_test. Elaboration test names append the tool name followed by "_elab_test"; the lint test
-    name appends "_lint_test".
+    The function generates a wrapper containing one instance for every combination of the provided parameters and,
+    by default, one instance with the module's default parameters. Set include_default_params to False when another
+    sweep already covers the defaults or the defaults are intentionally invalid. It creates one verilog_elab_test
+    for each elaboration tool and one verilog_lint_test. Elaboration test names append the tool name followed by
+    "_elab_test"; the lint test name appends "_lint_test".
 
     Args:
         top (str): The top-level module to instantiate. Can be left undefined if there is only one dependency.
@@ -1712,6 +1714,7 @@ def verilog_elab_and_lint_test_suite(
         name (str): The base name for the test suite.
         defines (list): A list of defines.
         params (dict): A dictionary where keys are parameter names and values are lists of possible values for those parameters.
+        include_default_params (bool): Whether to include an instance with the module's default parameters.
         elab_tools (list of strings): The tools to use for elaboration. Defaults to Verific and Slang.
         lint_tool (str): The tool to use for linting.
         disable_lint_rules (list): A list of lint rules to disable in the generated files.
@@ -1732,7 +1735,7 @@ def verilog_elab_and_lint_test_suite(
 
     generate_parameter_file(
         name = name + "_params",
-        include_default_params = True,
+        include_default_params = include_default_params,
         params = params,
     )
 

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -1698,16 +1698,13 @@ def verilog_elab_and_lint_test_suite(
         elab_tools = ["verific", "slang"],
         lint_tool = "ascentlint",
         disable_lint_rules = [],
-        tags = [],
         **kwargs):
     """Creates a suite of Verilog elaboration and lint tests for each combination of the provided parameters.
 
-    For each elaboration tool, the function creates one test of the original module's default parameters and one
-    test of a generated wrapper covering all possible combinations of the provided parameters. It also creates one
-    lint test of the original module's default parameters and one lint test of the generated wrapper.
-    Default-parameter test names append the tool name followed by "_default_params_elab_test" or
-    "_default_params_lint_test"; wrapper elaboration test names append the tool name followed by "_elab_test";
-    and the wrapper lint test name appends "_lint_test".
+    The function generates a wrapper containing one instance with the module's default parameters and one instance
+    for every combination of the provided parameters. It creates one verilog_elab_test for each elaboration tool
+    and one verilog_lint_test. Elaboration test names append the tool name followed by "_elab_test"; the lint test
+    name appends "_lint_test".
 
     Args:
         top (str): The top-level module to instantiate. Can be left undefined if there is only one dependency.
@@ -1718,7 +1715,6 @@ def verilog_elab_and_lint_test_suite(
         elab_tools (list of strings): The tools to use for elaboration. Defaults to Verific and Slang.
         lint_tool (str): The tool to use for linting.
         disable_lint_rules (list): A list of lint rules to disable in the generated files.
-        tags (list): A list of tags to add to generated tests.
         **kwargs: Additional common keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.
     """
     if not top:
@@ -1736,6 +1732,7 @@ def verilog_elab_and_lint_test_suite(
 
     generate_parameter_file(
         name = name + "_params",
+        include_default_params = True,
         params = params,
     )
 
@@ -1755,42 +1752,20 @@ def verilog_elab_and_lint_test_suite(
     )
 
     for elab_tool in elab_tools:
-        verilog_elab_test(
-            name = name + "_" + elab_tool + "_default_params_elab_test",
-            tool = elab_tool,
-            deps = deps,
-            defines = defines,
-            tags = tags + ["default-params"],
-            top = top,
-            **kwargs
-        )
-
         test_name = name + "_" + elab_tool + "_elab_test"
         verilog_elab_test(
             name = test_name,
             tool = elab_tool,
             deps = [":" + name + "_wrapper"],
             defines = defines,
-            tags = tags,
             **kwargs
         )
-
-    verilog_lint_test(
-        name = name + "_" + lint_tool + "_default_params_lint_test",
-        tool = lint_tool,
-        deps = deps,
-        defines = defines,
-        tags = tags + ["default-params"],
-        top = top,
-        **kwargs
-    )
 
     verilog_lint_test(
         name = name + "_lint_test",
         tool = lint_tool,
         deps = [":" + name + "_wrapper"],
         defines = defines,
-        tags = tags,
         **kwargs
     )
 
@@ -2013,6 +1988,8 @@ def _generate_parameter_file_impl(ctx):
         dict(zip(param_keys, [x for x in param_values]))
         for param_values in _cartesian_product(param_values_list)
     ]
+    if ctx.attr.include_default_params and len(params) > 0:
+        param_combinations = [{}] + param_combinations
 
     contents = json.encode({"param_sets": param_combinations})
     output_file = ctx.outputs.param_file
@@ -2028,6 +2005,10 @@ STITCH_TOOL_PATH = "//stitch:stitch_tool"
 generate_parameter_file = rule(
     implementation = _generate_parameter_file_impl,
     attrs = {
+        "include_default_params": attr.bool(
+            default = False,
+            doc = "Whether to include an empty parameter set that instantiates the module defaults.",
+        ),
         "params": attr.string_list_dict(mandatory = True),
     },
     outputs = {"param_file": "%{name}.json"},

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -566,16 +566,17 @@ True if the combination is legal, False if it is illegal.
 <pre>
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_elab_and_lint_test_suite")
 
-verilog_elab_and_lint_test_suite(<a href="#verilog_elab_and_lint_test_suite-name">name</a>, <a href="#verilog_elab_and_lint_test_suite-top">top</a>, <a href="#verilog_elab_and_lint_test_suite-deps">deps</a>, <a href="#verilog_elab_and_lint_test_suite-defines">defines</a>, <a href="#verilog_elab_and_lint_test_suite-params">params</a>, <a href="#verilog_elab_and_lint_test_suite-elab_tools">elab_tools</a>, <a href="#verilog_elab_and_lint_test_suite-lint_tool">lint_tool</a>,
-                                 <a href="#verilog_elab_and_lint_test_suite-disable_lint_rules">disable_lint_rules</a>, <a href="#verilog_elab_and_lint_test_suite-kwargs">**kwargs</a>)
+verilog_elab_and_lint_test_suite(<a href="#verilog_elab_and_lint_test_suite-name">name</a>, <a href="#verilog_elab_and_lint_test_suite-top">top</a>, <a href="#verilog_elab_and_lint_test_suite-deps">deps</a>, <a href="#verilog_elab_and_lint_test_suite-defines">defines</a>, <a href="#verilog_elab_and_lint_test_suite-params">params</a>, <a href="#verilog_elab_and_lint_test_suite-include_default_params">include_default_params</a>,
+                                 <a href="#verilog_elab_and_lint_test_suite-elab_tools">elab_tools</a>, <a href="#verilog_elab_and_lint_test_suite-lint_tool">lint_tool</a>, <a href="#verilog_elab_and_lint_test_suite-disable_lint_rules">disable_lint_rules</a>, <a href="#verilog_elab_and_lint_test_suite-kwargs">**kwargs</a>)
 </pre>
 
 Creates a suite of Verilog elaboration and lint tests for each combination of the provided parameters.
 
-The function generates a wrapper containing one instance with the module's default parameters and one instance
-for every combination of the provided parameters. It creates one verilog_elab_test for each elaboration tool
-and one verilog_lint_test. Elaboration test names append the tool name followed by "_elab_test"; the lint test
-name appends "_lint_test".
+The function generates a wrapper containing one instance for every combination of the provided parameters and,
+by default, one instance with the module's default parameters. Set include_default_params to False when another
+sweep already covers the defaults or the defaults are intentionally invalid. It creates one verilog_elab_test
+for each elaboration tool and one verilog_lint_test. Elaboration test names append the tool name followed by
+"_elab_test"; the lint test name appends "_lint_test".
 
 
 **PARAMETERS**
@@ -588,6 +589,7 @@ name appends "_lint_test".
 | <a id="verilog_elab_and_lint_test_suite-deps"></a>deps |  The dependencies of the test suite.   |  `[]` |
 | <a id="verilog_elab_and_lint_test_suite-defines"></a>defines |  A list of defines.   |  `[]` |
 | <a id="verilog_elab_and_lint_test_suite-params"></a>params |  A dictionary where keys are parameter names and values are lists of possible values for those parameters.   |  `{}` |
+| <a id="verilog_elab_and_lint_test_suite-include_default_params"></a>include_default_params |  Whether to include an instance with the module's default parameters.   |  `True` |
 | <a id="verilog_elab_and_lint_test_suite-elab_tools"></a>elab_tools |  The tools to use for elaboration. Defaults to Verific and Slang.   |  `["verific", "slang"]` |
 | <a id="verilog_elab_and_lint_test_suite-lint_tool"></a>lint_tool |  The tool to use for linting.   |  `"ascentlint"` |
 | <a id="verilog_elab_and_lint_test_suite-disable_lint_rules"></a>disable_lint_rules |  A list of lint rules to disable in the generated files.   |  `[]` |

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -566,14 +566,17 @@ True if the combination is legal, False if it is illegal.
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_elab_and_lint_test_suite")
 
 verilog_elab_and_lint_test_suite(<a href="#verilog_elab_and_lint_test_suite-name">name</a>, <a href="#verilog_elab_and_lint_test_suite-top">top</a>, <a href="#verilog_elab_and_lint_test_suite-deps">deps</a>, <a href="#verilog_elab_and_lint_test_suite-defines">defines</a>, <a href="#verilog_elab_and_lint_test_suite-params">params</a>, <a href="#verilog_elab_and_lint_test_suite-elab_tools">elab_tools</a>, <a href="#verilog_elab_and_lint_test_suite-lint_tool">lint_tool</a>,
-                                 <a href="#verilog_elab_and_lint_test_suite-disable_lint_rules">disable_lint_rules</a>, <a href="#verilog_elab_and_lint_test_suite-kwargs">**kwargs</a>)
+                                 <a href="#verilog_elab_and_lint_test_suite-disable_lint_rules">disable_lint_rules</a>, <a href="#verilog_elab_and_lint_test_suite-tags">tags</a>, <a href="#verilog_elab_and_lint_test_suite-kwargs">**kwargs</a>)
 </pre>
 
 Creates a suite of Verilog elaboration and lint tests for each combination of the provided parameters.
 
-The function generates a wrapper covering all possible combinations of the provided parameters, creates a
-verilog_elab_test for each elaboration tool, and creates one verilog_lint_test. Elaboration test names append
-the tool name followed by "_elab_test"; the lint test name appends "_lint_test".
+For each elaboration tool, the function creates one test of the original module's default parameters and one
+test of a generated wrapper covering all possible combinations of the provided parameters. It also creates one
+lint test of the original module's default parameters and one lint test of the generated wrapper.
+Default-parameter test names append the tool name followed by "_default_params_elab_test" or
+"_default_params_lint_test"; wrapper elaboration test names append the tool name followed by "_elab_test";
+and the wrapper lint test name appends "_lint_test".
 
 
 **PARAMETERS**
@@ -589,6 +592,7 @@ the tool name followed by "_elab_test"; the lint test name appends "_lint_test".
 | <a id="verilog_elab_and_lint_test_suite-elab_tools"></a>elab_tools |  The tools to use for elaboration. Defaults to Verific and Slang.   |  `["verific", "slang"]` |
 | <a id="verilog_elab_and_lint_test_suite-lint_tool"></a>lint_tool |  The tool to use for linting.   |  `"ascentlint"` |
 | <a id="verilog_elab_and_lint_test_suite-disable_lint_rules"></a>disable_lint_rules |  A list of lint rules to disable in the generated files.   |  `[]` |
+| <a id="verilog_elab_and_lint_test_suite-tags"></a>tags |  A list of tags to add to generated tests.   |  `[]` |
 | <a id="verilog_elab_and_lint_test_suite-kwargs"></a>kwargs |  Additional common keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.   |  none |
 
 

--- a/bazel/verilog_rules.md
+++ b/bazel/verilog_rules.md
@@ -36,7 +36,7 @@ generate_instantiation_wrapper(<a href="#generate_instantiation_wrapper-name">na
 <pre>
 load("@bedrock-rtl//bazel:verilog.bzl", "generate_parameter_file")
 
-generate_parameter_file(<a href="#generate_parameter_file-name">name</a>, <a href="#generate_parameter_file-params">params</a>)
+generate_parameter_file(<a href="#generate_parameter_file-name">name</a>, <a href="#generate_parameter_file-include_default_params">include_default_params</a>, <a href="#generate_parameter_file-params">params</a>)
 </pre>
 
 
@@ -47,6 +47,7 @@ generate_parameter_file(<a href="#generate_parameter_file-name">name</a>, <a hre
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="generate_parameter_file-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="generate_parameter_file-include_default_params"></a>include_default_params |  Whether to include an empty parameter set that instantiates the module defaults.   | Boolean | optional |  `False`  |
 | <a id="generate_parameter_file-params"></a>params |  -   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> List of strings</a> | required |  |
 
 
@@ -566,17 +567,15 @@ True if the combination is legal, False if it is illegal.
 load("@bedrock-rtl//bazel:verilog.bzl", "verilog_elab_and_lint_test_suite")
 
 verilog_elab_and_lint_test_suite(<a href="#verilog_elab_and_lint_test_suite-name">name</a>, <a href="#verilog_elab_and_lint_test_suite-top">top</a>, <a href="#verilog_elab_and_lint_test_suite-deps">deps</a>, <a href="#verilog_elab_and_lint_test_suite-defines">defines</a>, <a href="#verilog_elab_and_lint_test_suite-params">params</a>, <a href="#verilog_elab_and_lint_test_suite-elab_tools">elab_tools</a>, <a href="#verilog_elab_and_lint_test_suite-lint_tool">lint_tool</a>,
-                                 <a href="#verilog_elab_and_lint_test_suite-disable_lint_rules">disable_lint_rules</a>, <a href="#verilog_elab_and_lint_test_suite-tags">tags</a>, <a href="#verilog_elab_and_lint_test_suite-kwargs">**kwargs</a>)
+                                 <a href="#verilog_elab_and_lint_test_suite-disable_lint_rules">disable_lint_rules</a>, <a href="#verilog_elab_and_lint_test_suite-kwargs">**kwargs</a>)
 </pre>
 
 Creates a suite of Verilog elaboration and lint tests for each combination of the provided parameters.
 
-For each elaboration tool, the function creates one test of the original module's default parameters and one
-test of a generated wrapper covering all possible combinations of the provided parameters. It also creates one
-lint test of the original module's default parameters and one lint test of the generated wrapper.
-Default-parameter test names append the tool name followed by "_default_params_elab_test" or
-"_default_params_lint_test"; wrapper elaboration test names append the tool name followed by "_elab_test";
-and the wrapper lint test name appends "_lint_test".
+The function generates a wrapper containing one instance with the module's default parameters and one instance
+for every combination of the provided parameters. It creates one verilog_elab_test for each elaboration tool
+and one verilog_lint_test. Elaboration test names append the tool name followed by "_elab_test"; the lint test
+name appends "_lint_test".
 
 
 **PARAMETERS**
@@ -592,7 +591,6 @@ and the wrapper lint test name appends "_lint_test".
 | <a id="verilog_elab_and_lint_test_suite-elab_tools"></a>elab_tools |  The tools to use for elaboration. Defaults to Verific and Slang.   |  `["verific", "slang"]` |
 | <a id="verilog_elab_and_lint_test_suite-lint_tool"></a>lint_tool |  The tool to use for linting.   |  `"ascentlint"` |
 | <a id="verilog_elab_and_lint_test_suite-disable_lint_rules"></a>disable_lint_rules |  A list of lint rules to disable in the generated files.   |  `[]` |
-| <a id="verilog_elab_and_lint_test_suite-tags"></a>tags |  A list of tags to add to generated tests.   |  `[]` |
 | <a id="verilog_elab_and_lint_test_suite-kwargs"></a>kwargs |  Additional common keyword arguments to be passed to the verilog_elab_test and verilog_lint_test functions.   |  none |
 
 

--- a/csr/rtl/br_csr_mem_interface.sv
+++ b/csr/rtl/br_csr_mem_interface.sv
@@ -25,7 +25,7 @@ module br_csr_mem_interface #(
     // Depth of the backing memory. Must be at least 1 and <= (2 ** CsrAddrWidth) / (MemWidth / 8).
     parameter int MemDepth = 1,
     // Width of the backing memory. Must be <= CsrDataWidth, >= 8, and a power of 2.
-    parameter int MemWidth = 1,
+    parameter int MemWidth = 8,
     // If 1, register the downstream memory request interfaces
     // at the cost of an extra cycle of latency.
     parameter bit RegisterMemOutputs = 0,

--- a/fifo/rtl/br_fifo_shared_pop_ctrl.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl.sv
@@ -24,8 +24,8 @@
 module br_fifo_shared_pop_ctrl #(
     // Number of read ports. Must be >=1 and a power of 2.
     parameter int NumReadPorts = 1,
-    // Number of logical FIFOs. Must be >=1.
-    parameter int NumFifos = 1,
+    // Number of logical FIFOs. Must be >=2.
+    parameter int NumFifos = 2,
     // Total depth of the FIFO.
     // Must be greater than two times the number of write ports.
     parameter int Depth = 2,

--- a/fifo/rtl/br_fifo_shared_pop_ctrl_credit.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl_credit.sv
@@ -27,8 +27,8 @@
 module br_fifo_shared_pop_ctrl_credit #(
     // Number of read ports. Must be >=1 and a power of 2.
     parameter int NumReadPorts = 1,
-    // Number of logical FIFOs. Must be >=1.
-    parameter int NumFifos = 1,
+    // Number of logical FIFOs. Must be >=2.
+    parameter int NumFifos = 2,
     // Total depth of the FIFO.
     // Must be greater than two times the number of write ports.
     parameter int Depth = 2,

--- a/fifo/rtl/br_fifo_shared_pop_ctrl_credit_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl_credit_ext_arbiter.sv
@@ -33,8 +33,8 @@
 module br_fifo_shared_pop_ctrl_credit_ext_arbiter #(
     // Number of read ports. Must be >=1 and a power of 2.
     parameter int NumReadPorts = 1,
-    // Number of logical FIFOs. Must be >=1.
-    parameter int NumFifos = 1,
+    // Number of logical FIFOs. Must be >=2.
+    parameter int NumFifos = 2,
     // Total depth of the FIFO.
     // Must be greater than two times the number of write ports.
     parameter int Depth = 2,

--- a/fifo/rtl/br_fifo_shared_pop_ctrl_ext_arbiter.sv
+++ b/fifo/rtl/br_fifo_shared_pop_ctrl_ext_arbiter.sv
@@ -28,8 +28,8 @@
 module br_fifo_shared_pop_ctrl_ext_arbiter #(
     // Number of read ports. Must be >=1 and a power of 2.
     parameter int NumReadPorts = 1,
-    // Number of logical FIFOs. Must be >=1.
-    parameter int NumFifos = 1,
+    // Number of logical FIFOs. Must be >=2.
+    parameter int NumFifos = 2,
     // Total depth of the FIFO.
     // Must be greater than two times the number of write ports.
     parameter int Depth = 2,


### PR DESCRIPTION
# Problem

`verilog_elab_and_lint_test_suite` generated a Stitch wrapper containing only the explicit parameter sweep values. A module could therefore have invalid declaration defaults or default-only lint failures while every existing elaboration and lint target passed.

Adding default-parameter coverage exposed five modules with invalid defaults:

- `br_csr_mem_interface` defaulted `MemWidth` to 1 even though its static constraint requires at least 8
- four `br_fifo_shared_pop_ctrl*` variants defaulted `NumFifos` to 1 even though their shared read crossbar requires at least 2

The coverage also exposed an AscentLint failure shared by `br_amba_axi2axil` and `br_amba_axi2axil_core` at their legal `AddrWidth=12` default. Local root-cause analysis found one common `TRUNC_LSHIFT` warning on intentional address-width modular arithmetic. AXI bursts cannot cross a 4-KiB boundary and `AddrWidth` is constrained to at least 12, so the truncated bits are zero for legal transactions. The investigation and supporting analysis are recorded in [issue #1257](https://github.com/xlsynth/bedrock-rtl/issues/1257).

# Solution

Extend the existing generated-wrapper coverage instead of creating separate test targets:

- add an opt-in `include_default_params` setting to `generate_parameter_file`
- make `verilog_elab_and_lint_test_suite(include_default_params = True)` prepend an empty parameter set by default, causing Stitch to instantiate the original module defaults in the same wrapper as every existing sweep combination
- allow callers with multiple sweeps, or intentionally invalid defaults, to set `include_default_params = False` on redundant sweeps
- retain the existing elaboration/lint target names, tool configuration, tags, and parameter matrices unchanged
- document the combined default-and-sweep wrapper contract and its opt-out

Correct the invalid declaration defaults to their minimum legal values:

- set `br_csr_mem_interface.MemWidth` to 8
- set `NumFifos` to 2 in the four shared-pop FIFO variants and correct their parameter comments

Fix the AXI2AXIL lint failure with a narrowly scoped `TRUNC_LSHIFT` waiver alongside the existing variable-shift waiver. An inline RTL comment explains why the truncation cannot affect a legal AXI transaction. This keeps the documented `AddrWidth=12` default and does not weaken lint coverage elsewhere.

Validation:

- confirmed there are zero separate `*_default_params_*` targets
- confirmed the existing target expansion remains 942 Slang and 942 Verific elaboration targets
- inspected generated parameter files for both `include_default_params = True` and `False`, confirming the opt-out removes only the default instance
- passed all 942 existing Slang elaboration targets with combined default-and-sweep wrappers
- passed all 945 repository AscentLint targets locally with combined default-and-sweep wrappers
- built all 942 Verific elaboration targets locally; proprietary CI executes them
- passed 18/18 Bazel, Python, and generated-documentation regression tests
- passed the full pre-commit suite
