### PR TITLE
Cast AXI isolate response parameter to enum

### DIFF
--- a/amba/rtl/internal/br_amba_iso_resp_tracker.sv
+++ b/amba/rtl/internal/br_amba_iso_resp_tracker.sv
@@ -680,7 +680,7 @@ module br_amba_iso_resp_tracker #(
   always_comb begin
     if (isolate_req) begin
       // Ignore downstream responses if isolating, use fixed IsolateResp and IsolateData.
-      downstream_iso_xresp = IsolateResp;
+      downstream_iso_xresp = br_amba::axi_resp_t'(IsolateResp);
       downstream_iso_xdata = IsolateData;
       // When isolating, use the arbiter to pick the next transaction to generate (error) responses
       // for from the resp_tracker FIFO, since there's no downstream responses arriving anymore that


### PR DESCRIPTION
## Summary

- Explicitly cast `IsolateResp` to `br_amba::axi_resp_t` before assigning it to `downstream_iso_xresp`.
- Silence the Genus `VLOGPT-702` enum strong-typing warning without changing the AXI response encoding or behavior.

## Root cause

Genus loses the enum type of the `IsolateResp` parameter during HDL analysis and treats the parameter as its raw integral value when assigning it back to an enum-typed signal.

## Validation

- `pre-commit run --all-files`
- Genus 25.11 A/B experiment over the full 72-file AXI-isolation source list:
  - original assignment reproduced `VLOGPT-702` at line 683
  - explicit cast produced no `VLOGPT-702` diagnostic and exited normally
- Focused Bazel lint/elaboration runners were attempted but stopped before RTL parsing because the configured Python environment lacks the `dataclasses` module.