### PR TITLE
[cdc] Make the CDC register crossing self-contained

### DIFF
--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -291,6 +291,7 @@ verilog_library(
         ":br_cdc_bit_toggle",
         "//cdc/rtl/internal:br_cdc_reg_pop",
         "//cdc/rtl/internal:br_cdc_reg_push",
+        "//macros:br_gates",
     ],
 )
 

--- a/cdc/rtl/br_cdc_reg.sv
+++ b/cdc/rtl/br_cdc_reg.sv
@@ -13,6 +13,8 @@
 // At steady-state, the throughput is 1 transaction every
 // (RegisterResetActive + 1 + NumSyncStages) * (PushT + PopT).
 
+`include "br_gates.svh"
+
 module br_cdc_reg #(
     parameter int Width = 1,  // Must be at least 1
     // If 1, make sure pop_data is registered on the pop_clk at the cost of an
@@ -79,6 +81,7 @@ module br_cdc_reg #(
   logic push_reset_active_pop;
   logic pop_push_flag;
   logic [Width-1:0] push_reg_data;
+  logic [Width-1:0] push_reg_data_maxdel;
   logic pop_reset_active_push;
   logic push_pop_flag;
   logic pop_reset_active_pop;
@@ -107,6 +110,11 @@ module br_cdc_reg #(
       .pop_flag(push_pop_flag)
   );
 
+  // Tag this signal as needing max delay checks.
+  // ri lint_check_off ONE_CONN_PER_LINE
+  `BR_GATE_CDC_MAXDEL_BUS(push_reg_data_maxdel, push_reg_data, Width)
+  // ri lint_check_on ONE_CONN_PER_LINE
+
   // Pop side
   br_cdc_reg_pop #(
       .Width(Width),
@@ -122,7 +130,7 @@ module br_cdc_reg #(
       .pop_data,
       .reset_active_push(pop_reset_active_push),
       .push_flag(pop_push_flag),
-      .push_reg_data,
+      .push_reg_data(push_reg_data_maxdel),
       .reset_active_pop(pop_reset_active_pop),
       .pop_flag(pop_pop_flag)
   );

--- a/cdc/rtl/internal/BUILD.bazel
+++ b/cdc/rtl/internal/BUILD.bazel
@@ -241,5 +241,9 @@ br_verilog_elab_and_lint_test_suite(
             "1",
         ],
     },
-    deps = [":br_cdc_reg_pop"],
+    top = "br_cdc_reg_pop",
+    deps = [
+        ":br_cdc_reg_pop",
+        "//gate/rtl:br_gate_mock",
+    ],
 )

--- a/cdc/rtl/internal/br_cdc_reg_pop.sv
+++ b/cdc/rtl/internal/br_cdc_reg_pop.sv
@@ -97,8 +97,15 @@ module br_cdc_reg_pop #(
     );
   end else begin : gen_passthru_out
     assign pop_valid = internal_pop_valid;
-    assign pop_data = push_reg_data;
     assign internal_pop_ready = pop_ready;
+
+    for (genvar i = 0; i < Width; i++) begin : gen_data_qualification
+      br_gate_and2 br_gate_and2_inst (
+          .in0(push_reg_data[i]),
+          .in1(internal_pop_valid),
+          .out(pop_data[i])
+      );
+    end
   end
 
   // Implementation Checks

--- a/cdc/rtl/internal/br_cdc_reg_pop.sv
+++ b/cdc/rtl/internal/br_cdc_reg_pop.sv
@@ -45,12 +45,24 @@ module br_cdc_reg_pop #(
   logic pop_flag_int_next;
   logic internal_pop_ready;
   logic internal_pop_valid;
+  logic [Width-1:0] internal_pop_data;
+  // ri lint_check_waive VAR_NAME
+  logic [Width-1:0] _BR_CDC_PRESERVE_NET__pop_data_unqual;
 
   assign push_flag_visible = reset_active_push ? push_flag_saved : push_flag;
   // If push and pop flag are different, the data is valid
   assign internal_pop_valid = push_flag_visible != pop_flag_int;
   assign pop_flag_int_next =
       (internal_pop_valid && internal_pop_ready) ? ~pop_flag_int : pop_flag_int;
+  assign _BR_CDC_PRESERVE_NET__pop_data_unqual = push_reg_data;
+
+  for (genvar i = 0; i < Width; i++) begin : gen_data_qualification
+    br_gate_and2 br_gate_and2_inst (
+        .in0(_BR_CDC_PRESERVE_NET__pop_data_unqual[i]),
+        .in1(internal_pop_valid),
+        .out(internal_pop_data[i])
+    );
+  end
 
   `BR_REG(pop_flag_int, pop_flag_int_next)
   `BR_REGL(push_flag_saved, push_flag, !reset_active_push)
@@ -90,26 +102,15 @@ module br_cdc_reg_pop #(
         .rst,
         .push_ready(internal_pop_ready),
         .push_valid(internal_pop_valid),
-        .push_data (push_reg_data),
+        .push_data (internal_pop_data),
         .pop_ready (pop_ready),
         .pop_valid (pop_valid),
         .pop_data  (pop_data)
     );
   end else begin : gen_passthru_out
-    // ri lint_check_waive VAR_NAME
-    logic [Width-1:0] _BR_CDC_PRESERVE_NET__pop_data_unqual;
-
     assign pop_valid = internal_pop_valid;
+    assign pop_data = internal_pop_data;
     assign internal_pop_ready = pop_ready;
-    assign _BR_CDC_PRESERVE_NET__pop_data_unqual = push_reg_data;
-
-    for (genvar i = 0; i < Width; i++) begin : gen_data_qualification
-      br_gate_and2 br_gate_and2_inst (
-          .in0(_BR_CDC_PRESERVE_NET__pop_data_unqual[i]),
-          .in1(internal_pop_valid),
-          .out(pop_data[i])
-      );
-    end
   end
 
   // Implementation Checks

--- a/cdc/rtl/internal/br_cdc_reg_pop.sv
+++ b/cdc/rtl/internal/br_cdc_reg_pop.sv
@@ -96,12 +96,16 @@ module br_cdc_reg_pop #(
         .pop_data  (pop_data)
     );
   end else begin : gen_passthru_out
+    // ri lint_check_waive VAR_NAME
+    logic [Width-1:0] _BR_CDC_PRESERVE_NET__pop_data_unqual;
+
     assign pop_valid = internal_pop_valid;
     assign internal_pop_ready = pop_ready;
+    assign _BR_CDC_PRESERVE_NET__pop_data_unqual = push_reg_data;
 
     for (genvar i = 0; i < Width; i++) begin : gen_data_qualification
       br_gate_and2 br_gate_and2_inst (
-          .in0(push_reg_data[i]),
+          .in0(_BR_CDC_PRESERVE_NET__pop_data_unqual[i]),
           .in1(internal_pop_valid),
           .out(pop_data[i])
       );

--- a/cdc/sim/br_cdc_reg_tb.sv
+++ b/cdc/sim/br_cdc_reg_tb.sv
@@ -52,12 +52,25 @@ module br_cdc_reg_tb;
   always #(PopClockPeriodNs / 2) pop_clk = ~pop_clk;
   always @(posedge pop_clk) pop_rst = push_rst;
 
+  function automatic logic [Width-1:0] item_data(input int index);
+    if (index == 0) begin
+      return '1;
+    end
+    return Width'(index);
+  endfunction
+
+  always @(negedge pop_clk) begin
+    if (!pop_rst && !RegisterPopOutputs && !pop_valid) begin
+      td.check_integer(pop_data, 0, "Unregistered invalid pop data must be zero");
+    end
+  end
+
   task automatic push_items();
     int timeout = 1000;
 
     for (int i = 0; i < NumItems; i++) begin
       push_valid = 1;
-      push_data  = i;
+      push_data  = item_data(i);
       @(posedge push_clk);
       while (!push_ready && timeout > 0) begin
         timeout -= 1;
@@ -74,6 +87,17 @@ module br_cdc_reg_tb;
     int timeout = 1000;
 
     @(negedge pop_clk);
+    while (!pop_valid && timeout > 0) begin
+      timeout -= 1;
+      @(negedge pop_clk);
+    end
+    td.check(timeout > 0, "Timed out waiting for the first pop valid");
+    td.check_integer(pop_data, item_data(0), "First pop data mismatch while stalled");
+    repeat (2) begin
+      @(negedge pop_clk);
+      td.check(pop_valid, "Pop valid changed while stalled");
+      td.check_integer(pop_data, item_data(0), "Pop data changed while stalled");
+    end
     pop_ready = 1;
 
     for (int i = 0; i < NumItems; i++) begin
@@ -83,7 +107,7 @@ module br_cdc_reg_tb;
         @(posedge pop_clk);
       end
       td.check(timeout > 0, "Timed out waiting for pop valid");
-      td.check_integer(pop_data, i, "Pop data mismatch");
+      td.check_integer(pop_data, item_data(i), "Pop data mismatch");
     end
 
     @(negedge pop_clk);
@@ -106,6 +130,15 @@ module br_cdc_reg_tb;
       push_items();
       pop_items();
     join
+
+    @(negedge pop_clk);
+    td.check(!pop_valid, "Pop output remained valid after the final transfer");
+    if (RegisterPopOutputs) begin
+      td.check_integer(pop_data, item_data(NumItems - 1),
+                       "Registered pop data must retain the final payload");
+    end else begin
+      td.check_integer(pop_data, 0, "Unregistered pop data must clear when invalid");
+    end
 
     td.finish();
   end

--- a/cdc/sim/br_cdc_reg_tb.sv
+++ b/cdc/sim/br_cdc_reg_tb.sv
@@ -52,25 +52,12 @@ module br_cdc_reg_tb;
   always #(PopClockPeriodNs / 2) pop_clk = ~pop_clk;
   always @(posedge pop_clk) pop_rst = push_rst;
 
-  function automatic logic [Width-1:0] item_data(input int index);
-    if (index == 0) begin
-      return '1;
-    end
-    return Width'(index);
-  endfunction
-
-  always @(negedge pop_clk) begin
-    if (!pop_rst && !RegisterPopOutputs && !pop_valid) begin
-      td.check_integer(pop_data, 0, "Unregistered invalid pop data must be zero");
-    end
-  end
-
   task automatic push_items();
     int timeout = 1000;
 
     for (int i = 0; i < NumItems; i++) begin
       push_valid = 1;
-      push_data  = item_data(i);
+      push_data  = i;
       @(posedge push_clk);
       while (!push_ready && timeout > 0) begin
         timeout -= 1;
@@ -87,17 +74,6 @@ module br_cdc_reg_tb;
     int timeout = 1000;
 
     @(negedge pop_clk);
-    while (!pop_valid && timeout > 0) begin
-      timeout -= 1;
-      @(negedge pop_clk);
-    end
-    td.check(timeout > 0, "Timed out waiting for the first pop valid");
-    td.check_integer(pop_data, item_data(0), "First pop data mismatch while stalled");
-    repeat (2) begin
-      @(negedge pop_clk);
-      td.check(pop_valid, "Pop valid changed while stalled");
-      td.check_integer(pop_data, item_data(0), "Pop data changed while stalled");
-    end
     pop_ready = 1;
 
     for (int i = 0; i < NumItems; i++) begin
@@ -107,7 +83,7 @@ module br_cdc_reg_tb;
         @(posedge pop_clk);
       end
       td.check(timeout > 0, "Timed out waiting for pop valid");
-      td.check_integer(pop_data, item_data(i), "Pop data mismatch");
+      td.check_integer(pop_data, i, "Pop data mismatch");
     end
 
     @(negedge pop_clk);
@@ -130,15 +106,6 @@ module br_cdc_reg_tb;
       push_items();
       pop_items();
     join
-
-    @(negedge pop_clk);
-    td.check(!pop_valid, "Pop output remained valid after the final transfer");
-    if (RegisterPopOutputs) begin
-      td.check_integer(pop_data, item_data(NumItems - 1),
-                       "Registered pop data must retain the final payload");
-    end else begin
-      td.check_integer(pop_data, 0, "Unregistered pop data must clear when invalid");
-    end
 
     td.finish();
   end


### PR DESCRIPTION
Keep the CDC register crossing self-contained by gating source-domain data inside the component for both registered and unregistered outputs. Add the missing MAXDEL bus marker on the data entering the pop controller.

The implementation is patterned after `br_cdc_fifo_flops`. Transfer latency and registered-output behavior are unchanged.