### PR TITLE
[testplanner] Count cached Bazel passes correctly

### DIFF
--- a/testplanner/generate_testreport.py
+++ b/testplanner/generate_testreport.py
@@ -57,7 +57,7 @@ def get_simulated_time(test_result: TestResult, testlogs_dir: Path) -> str:
 def create_test_entry(test_result, testlogs_dir) -> dict:
     """Convert one parsed Bazel result into a Testplanner result entry."""
 
-    passed = 1 if test_result.result == "PASSED" else 0
+    passed = 1 if test_result.result in ("PASSED", "(cached) PASSED") else 0
     simulated_time = get_simulated_time(test_result, testlogs_dir)
     return {
         "name": test_result.name,


### PR DESCRIPTION
# Problem

The GitHub Pages test dashboard treats Bazel's `(cached) PASSED` status as a failure because it only recognizes an exact `PASSED` result. Consequently, successful cached tests appear to be failing.

# Solution

Count both `PASSED` and `(cached) PASSED` as successful while continuing to classify actual failures as failures.

Validated by building `//testplanner:generate_testreport`, running `pre-commit run --all-files`, and checking uncached passes, cached passes, and failures directly.