### PR TITLE
Fix CSR memory interface testbench race

### DIFF
--- a/csr/sim/BUILD.bazel
+++ b/csr/sim/BUILD.bazel
@@ -147,12 +147,9 @@ br_verilog_sim_test_tools_suite(
             "1",
         ],
     },
-    # TODO(mgottscho): Enable Verilator once this suite no longer fails due to
-    # the runtime memory write address mismatch (`Got 8, Expected 16`) seen with
-    # `RegisterMemOutputs=1` and `RegisterResponseOutputs=0`.
     tools = [
         "vcs",
-        #"verilator",
+        "verilator",
     ],
     deps = [":br_csr_mem_interface_tb"],
 )
@@ -163,6 +160,7 @@ verilog_sim_coverage_aggregate(
         ":br_csr_axil_widget_sim_test_tools_suite_verilator_coverage",
         ":br_csr_default_responder_sim_test_tools_suite_verilator_coverage",
         ":br_csr_demux_sim_test_tools_suite_verilator_coverage",
+        ":br_csr_mem_interface_sim_test_tools_suite_verilator_coverage",
     ],
     visibility = ["//:__pkg__"],
 )

--- a/csr/sim/br_csr_mem_interface_tb.sv
+++ b/csr/sim/br_csr_mem_interface_tb.sv
@@ -84,6 +84,11 @@ module br_csr_mem_interface_tb;
       .rst
   );
 
+  // Synchronize readiness changes to rising edges without racing DUT sampling.
+  clocking mem_access_cb @(posedge clk);
+    output mem_access_ready;
+  endclocking
+
   task automatic send_write_req(input logic [CsrAddrWidth-1:0] addr,
                                 input logic [CsrDataWidth-1:0] wdata,
                                 input logic [CsrStrobeWidth-1:0] wstrb);
@@ -200,7 +205,7 @@ module br_csr_mem_interface_tb;
     td.wait_cycles(2);
 
     $display("Checking immediate write request and response");
-    mem_access_ready = 1'b1;
+    mem_access_cb.mem_access_ready <= 1'b1;
     fork
       send_write_req(16'h0010, 32'h12345678, 4'b1100);
       wait_for_write_req(15'h0008, 16'h1234, 2'b11);
@@ -208,7 +213,7 @@ module br_csr_mem_interface_tb;
     join
 
     $display("Checking buffered write request, then release");
-    mem_access_ready = 1'b0;
+    mem_access_cb.mem_access_ready <= 1'b0;
     fork
       send_write_req(16'h0020, 32'h89ABCDEF, 4'b0011);
       wait_for_write_req(15'h0010, 16'hCDEF, 2'b11);
@@ -219,11 +224,11 @@ module br_csr_mem_interface_tb;
     td.check_integer(mem_access_addr, 15'h0010, "Buffered write address mismatch");
     td.check_integer(mem_access_wr_data, 16'hCDEF, "Buffered write data mismatch");
     td.check_integer(mem_access_wr_strb, 2'b11, "Buffered write strobe mismatch");
-    mem_access_ready = 1'b1;
+    mem_access_cb.mem_access_ready <= 1'b1;
     wait_for_resp('0, 1'b0);
 
     $display("Checking buffered write request abort");
-    mem_access_ready = 1'b0;
+    mem_access_cb.mem_access_ready <= 1'b0;
     fork
       send_write_req(16'h0030, 32'hCAFEBABE, 4'b1100);
       wait_for_write_req(15'h0018, 16'hCAFE, 2'b11);
@@ -237,7 +242,7 @@ module br_csr_mem_interface_tb;
     td.check(!resp_valid, "Abort should not generate a write response");
 
     $display("Checking immediate read request and error response");
-    mem_access_ready = 1'b1;
+    mem_access_cb.mem_access_ready <= 1'b1;
     fork
       send_read_req(16'h0040);
       wait_for_read_req(15'h0020);
@@ -248,7 +253,7 @@ module br_csr_mem_interface_tb;
     join
 
     $display("Checking buffered read request, then release");
-    mem_access_ready = 1'b0;
+    mem_access_cb.mem_access_ready <= 1'b0;
     fork
       send_read_req(16'h0050);
       wait_for_read_req(15'h0028);
@@ -257,7 +262,7 @@ module br_csr_mem_interface_tb;
     td.check(mem_access_valid, "Buffered read request should remain valid while backpressured");
     td.check(!mem_access_wr_en, "Memory write enable should be 0");
     td.check_integer(mem_access_addr, 15'h0028, "Buffered read address mismatch");
-    mem_access_ready = 1'b1;
+    mem_access_cb.mem_access_ready <= 1'b1;
     td.wait_cycles(1);
     fork
       pulse_read_data(16'h0BAD, 1'b0);
@@ -265,7 +270,7 @@ module br_csr_mem_interface_tb;
     join
 
     $display("Checking buffered read request abort");
-    mem_access_ready = 1'b0;
+    mem_access_cb.mem_access_ready <= 1'b0;
     fork
       send_read_req(16'h0060);
       wait_for_read_req(15'h0030);


### PR DESCRIPTION
Fix a race condition in the br_csr_mem_interface simulation testbench and enable its Verilator regression and coverage targets.

## Issue prior to the fix

The Verilator test previously failed for `RegisterMemOutputs=1` and `RegisterResponseOutputs=0` with a stale memory-request address:
```
Memory write address mismatch: Got 8, Expected 16
```

For this configuration, the write response is generated combinationally from the memory handshake:
```
assign write_resp_valid = mem_access_valid && mem_access_ready && mem_access_wr_en;
```

`wait_for_resp()` detects that response on a positive clock edge and returns from the fork. The testbench then used a blocking assignment to deassert mem_access_ready in the same simulation time slot.
This created a scheduling race between the testbench and the DUT. Depending on active-region evaluation order, the DUT could observe `mem_access_ready == 0` on the edge where the testbench had already observed the response and considered the request accepted. The buffered request would therefore remain pending, and the following transaction could observe its stale address.