### PR TITLE
[bazel] Enable strict Slang lint across RTL suites

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,12 @@ repos:
         language: system
         pass_filenames: true
         files: (^|/)BUILD$
+      - id: scoped-slang-waivers
+        name: scoped Slang lint waivers
+        entry: python3 python/verilog_runner/slang_waivers.py
+        language: system
+        pass_filenames: true
+        files: \.(sv|svh)$
 
   - repo: https://github.com/mgottscho/verible-py.git
     # v0.0-4051

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -7,7 +7,7 @@ This guide covers the tools and checks used to develop Bedrock-RTL. See
 
 Install Bazel 9.1.0 (Bazelisk is recommended) and a system Python interpreter version 3.12 or newer.
 
-The public toolchain uses Slang for elaboration, Verible for lint, Verilator for simulation, and TopStitch for RTL wrapper generation. The Docker image includes those tools, plus Yosys, EQY, Yices, and XLS support libraries.
+The public toolchain uses Slang for elaboration and semantic lint, Verible for style lint, Verilator for simulation, and TopStitch for RTL wrapper generation. The Docker image includes those tools, plus Yosys, EQY, Yices, and XLS support libraries.
 
 Some checks also use tools that are not distributed with Bedrock-RTL: Verific tclmain, RealIntent AscentLint, Synopsys VCS, Cadence JasperGold, and Synopsys VCF. Provide the installations and licenses yourself if you need those checks.
 
@@ -19,7 +19,7 @@ Bedrock-RTL uses [Bazel](https://bazel.build/) to assemble source lists and run 
 bazel test //...
 ```
 
-The repository includes plugins for Verilator simulation and Slang elaboration. Most other EDA-tool plugins are deliberately kept outside this repository. As a result, tests that select proprietary tools need corresponding plugins in your local or CI environment.
+The repository includes plugins for Verilator simulation and Slang elaboration and lint. Most other EDA-tool plugins are deliberately kept outside this repository. As a result, tests that select proprietary tools need corresponding plugins in your local or CI environment.
 
 Keeping these plugins separate lets the test definitions remain vendor-agnostic and avoids publishing vendor API or licensing details. Not every test works with every tool; check the relevant `BUILD.bazel` target.
 
@@ -39,6 +39,17 @@ verilog_elab_test(
 ```
 
 Slang parses, type-checks, and elaborates the hierarchy. It supports source and header dependencies, defines, and top-level parameter overrides. For package-only source sets, set `compile_only = True`.
+
+Slang lint fully elaborates the design and treats every warning as an error using `bazel/slang_lint_policy.f`. Keep intentional waivers next to the affected RTL and restore the prior diagnostic state:
+
+```systemverilog
+// slang lint_save
+// slang lint_off unused-variable
+logic intentionally_unused;
+// slang lint_restore
+```
+
+Use `lint_restore` rather than `lint_on`: restoring the saved state also restores the policy's warning-as-error severity.
 
 To refresh the public RTL PPA report, run:
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -40,7 +40,18 @@ verilog_elab_test(
 
 Slang parses, type-checks, and elaborates the hierarchy. It supports source and header dependencies, defines, and top-level parameter overrides. For package-only source sets, set `compile_only = True`.
 
-Slang lint fully elaborates the design and treats every warning as an error using the top-level `slang_lint_policy.f`. Keep intentional waivers next to the affected RTL and restore the prior diagnostic state:
+Slang lint fully elaborates the design and treats every enabled warning as an error using the top-level `slang_lint_policy.f`.
+
+### Slang lint waiver policy
+
+Fix clear RTL issues instead of waiving them, but do not change otherwise acceptable RTL solely to satisfy Slang when that would conflict with the existing AscentLint result or make the code less clear. All exceptions require human review and must follow these rules:
+
+- Keep waivers in the affected RTL, directly beside the intentional construct. Do not add external or repository-wide waiver lists.
+- Limit each waiver to the smallest practical source region and name only the required diagnostic.
+- Use global `-Wno-*` entries in `slang_lint_policy.f` only for diagnostics that are broken or not useful across the repository, and document the reason there.
+- Prefer an existing AscentLint waiver on the same construct as supporting evidence, but review the Slang waiver independently.
+
+Slang does not yet support a one-shot waiver for one source line. That improvement is tracked upstream in [MikePopoloski/slang#1930](https://github.com/MikePopoloski/slang/issues/1930). Until it is available, express each local waiver as a saved diagnostic scope:
 
 ```systemverilog
 // slang lint_save
@@ -49,7 +60,7 @@ logic intentionally_unused;
 // slang lint_restore
 ```
 
-Use `lint_restore` rather than `lint_on`: restoring the saved state also restores the policy's warning-as-error severity. Pre-commit rejects waivers that are not enclosed by a matching `lint_save` and `lint_restore`.
+Use `lint_restore` rather than `lint_on`: restoring the saved state also restores the policy's warning-as-error severity. The `scoped-slang-waivers` pre-commit hook enforces this Bedrock policy by rejecting `lint_off` outside a saved scope, unmatched scopes, `lint_on`, and saved scopes that contain no waiver. The hook validates waiver structure; it does not test Slang's implementation of the directives.
 
 To refresh the public RTL PPA report, run:
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -40,7 +40,7 @@ verilog_elab_test(
 
 Slang parses, type-checks, and elaborates the hierarchy. It supports source and header dependencies, defines, and top-level parameter overrides. For package-only source sets, set `compile_only = True`.
 
-Slang lint fully elaborates the design and treats every warning as an error using `bazel/slang_lint_policy.f`. Keep intentional waivers next to the affected RTL and restore the prior diagnostic state:
+Slang lint fully elaborates the design and treats every warning as an error using the top-level `slang_lint_policy.f`. Keep intentional waivers next to the affected RTL and restore the prior diagnostic state:
 
 ```systemverilog
 // slang lint_save
@@ -49,7 +49,7 @@ logic intentionally_unused;
 // slang lint_restore
 ```
 
-Use `lint_restore` rather than `lint_on`: restoring the saved state also restores the policy's warning-as-error severity.
+Use `lint_restore` rather than `lint_on`: restoring the saved state also restores the policy's warning-as-error severity. Pre-commit rejects waivers that are not enclosed by a matching `lint_save` and `lint_restore`.
 
 To refresh the public RTL PPA report, run:
 

--- a/amba/rtl/internal/br_amba_axi2axil_core.sv
+++ b/amba/rtl/internal/br_amba_axi2axil_core.sv
@@ -126,10 +126,9 @@ module br_amba_axi2axil_core #(
     // truncated from this shifted beat offset are zero for legal transactions.
     incr_address = start_addr + (index << size);  // ri lint_check_waive VAR_SHIFT TRUNC_LSHIFT
 
+    // slang lint_save
+    // slang lint_off case-enum-explicit
     unique case (br_amba::axi_burst_type_t'(burst_type))
-      br_amba::AxiBurstFixed, br_amba::AxiBurstReserved: begin
-        next_address = start_addr;
-      end
       br_amba::AxiBurstIncr: begin
         align_mask   = {AddrWidth{1'b1}} << size;  // ri lint_check_waive VAR_SHIFT TRUNC_LSHIFT
         next_address = (index == 'd0) ? start_addr : (incr_address & align_mask);
@@ -143,6 +142,7 @@ module br_amba_axi2axil_core #(
         next_address = start_addr;
       end
     endcase
+    // slang lint_restore
   endfunction
 
   //----------------------------------------------------------------------------

--- a/amba/rtl/internal/br_amba_axi2axil_core.sv
+++ b/amba/rtl/internal/br_amba_axi2axil_core.sv
@@ -127,6 +127,9 @@ module br_amba_axi2axil_core #(
     incr_address = start_addr + (index << size);  // ri lint_check_waive VAR_SHIFT TRUNC_LSHIFT
 
     unique case (br_amba::axi_burst_type_t'(burst_type))
+      br_amba::AxiBurstFixed, br_amba::AxiBurstReserved: begin
+        next_address = start_addr;
+      end
       br_amba::AxiBurstIncr: begin
         align_mask   = {AddrWidth{1'b1}} << size;  // ri lint_check_waive VAR_SHIFT TRUNC_LSHIFT
         next_address = (index == 'd0) ? start_addr : (incr_address & align_mask);

--- a/arb/rtl/br_arb_fixed.sv
+++ b/arb/rtl/br_arb_fixed.sv
@@ -12,10 +12,13 @@ module br_arb_fixed #(
     // Must be at least 1
     parameter int NumRequesters = 1
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
     input logic clk,  // Only used for assertions
     // ri lint_check_waive HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ
     input logic rst,  // Only used for assertions
+    // slang lint_restore
     input logic [NumRequesters-1:0] request,
     output logic [NumRequesters-1:0] grant
 );

--- a/bazel/br_verilog.bzl
+++ b/bazel/br_verilog.bzl
@@ -24,6 +24,9 @@ def br_verilog_elab_and_lint_test_suite(name, **kwargs):
     if "defines" in kwargs:
         fail("Do not pass defines to br_verilog_elab_and_lint_test_suite. They are hard-coded in the macro.")
 
+    if "lint_tool" not in kwargs and "lint_tools" not in kwargs:
+        kwargs["lint_tools"] = ["ascentlint", "slang"]
+
     verilog_elab_and_lint_test_suite(
         name = name,
         defines = ["BR_ASSERT_ON"],

--- a/bazel/br_verilog.bzl
+++ b/bazel/br_verilog.bzl
@@ -24,7 +24,7 @@ def br_verilog_elab_and_lint_test_suite(name, **kwargs):
     if "defines" in kwargs:
         fail("Do not pass defines to br_verilog_elab_and_lint_test_suite. They are hard-coded in the macro.")
 
-    if "lint_tool" not in kwargs and "lint_tools" not in kwargs:
+    if "lint_tools" not in kwargs:
         kwargs["lint_tools"] = ["ascentlint", "slang"]
 
     verilog_elab_and_lint_test_suite(

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -1779,12 +1779,15 @@ def verilog_elab_and_lint_test_suite(
 
     for tool in lint_tools:
         test_name = name + "_" + tool + "_lint_test"
+        lint_kwargs = dict(kwargs)
+        if tool == "slang":
+            lint_kwargs["tags"] = kwargs.get("tags", []) + ["manual"]
         verilog_lint_test(
             name = test_name,
             tool = tool,
             deps = [":" + name + "_wrapper"],
             defines = defines,
-            **kwargs
+            **lint_kwargs
         )
 
 def is_param_combination_legal(params, illegal_param_combinations):

--- a/cdc/rtl/br_cdc_bit_toggle.sv
+++ b/cdc/rtl/br_cdc_bit_toggle.sv
@@ -20,15 +20,21 @@ module br_cdc_bit_toggle #(
     // ri lint_check_waive INPUT_NOT_READ NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic src_clk,
     // Used for assertion only
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic src_rst,
+    // slang lint_restore
     input logic src_bit,
 
     // ri lint_check_waive ONE_LOCAL_CLOCK
     input  logic dst_clk,
     // Used for assertion only
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic dst_rst,
+    // slang lint_restore
     output logic dst_bit
 );
 

--- a/cdc/rtl/br_cdc_bit_toggle.sv
+++ b/cdc/rtl/br_cdc_bit_toggle.sv
@@ -116,7 +116,10 @@ module br_cdc_bit_toggle #(
 
 `else
   // ri lint_check_off ONE_CONN_PER_LINE
+  // slang lint_save
+  // slang lint_off ignored-macro-paste
   `BR_GATE_CDC_MAXDEL(src_bit_internal_maxdel, src_bit_internal)
+  // slang lint_restore
   // ri lint_check_on ONE_CONN_PER_LINE
 `endif
 

--- a/cdc/rtl/br_cdc_fifo_ctrl_pop_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_pop_1r1w.sv
@@ -144,7 +144,10 @@ module br_cdc_fifo_ctrl_pop_1r1w #(
 
   // Tag this signal as needing max delay checks
   // ri lint_check_off ONE_CONN_PER_LINE
+  // slang lint_save
+  // slang lint_off ignored-macro-paste
   `BR_GATE_CDC_MAXDEL_BUS(pop_ram_rd_data_maxdel, pop_ram_rd_data, Width)
+  // slang lint_restore
   // ri lint_check_on ONE_CONN_PER_LINE
 
   //------------------------------------------

--- a/cdc/rtl/br_cdc_reg.sv
+++ b/cdc/rtl/br_cdc_reg.sv
@@ -112,7 +112,10 @@ module br_cdc_reg #(
 
   // Tag this signal as needing max delay checks.
   // ri lint_check_off ONE_CONN_PER_LINE
+  // slang lint_save
+  // slang lint_off ignored-macro-paste
   `BR_GATE_CDC_MAXDEL_BUS(push_reg_data_maxdel, push_reg_data, Width)
+  // slang lint_restore
   // ri lint_check_on ONE_CONN_PER_LINE
 
   // Pop side

--- a/cdc/rtl/br_cdc_rst_sync.sv
+++ b/cdc/rtl/br_cdc_rst_sync.sv
@@ -22,11 +22,17 @@ module br_cdc_rst_sync #(
   logic srst_n;
 
   // Instantiate a synchronizer with an async reset
+  // slang lint_save
+  // slang lint_off ignored-macro-paste
   // ri lint_check_waive RESET_LEVEL CONST_FF ONE_CONN_PER_LINE RESET_DRIVER
   `BR_GATE_CDC_SYNC_ARST_STAGES(srst_n, 1'b1, clk, arst, NumStages)
+  // slang lint_restore
 
   // The reset value of the synchronizer is 0, so we need to invert the output
+  // slang lint_save
+  // slang lint_off ignored-macro-paste
   // ri lint_check_waive ONE_CONN_PER_LINE SAME_RESET_NAME
   `BR_GATE_INV(srst, srst_n)
+  // slang lint_restore
 
 endmodule : br_cdc_rst_sync

--- a/cdc/rtl/internal/br_cdc_fifo_gray_count_sync.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_gray_count_sync.sv
@@ -41,7 +41,10 @@ module br_cdc_fifo_gray_count_sync #(
 
   // Tag this signal as needing max delay checks
   // ri lint_check_off ONE_CONN_PER_LINE
+  // slang lint_save
+  // slang lint_off ignored-macro-paste
   `BR_GATE_CDC_MAXDEL_BUS(src_count_gray_maxdel, src_count_gray, CountWidth)
+  // slang lint_restore
   // ri lint_check_on ONE_CONN_PER_LINE
 
   for (genvar i = 0; i < CountWidth; i++) begin : gen_cdc_sync

--- a/cdc/rtl/internal/br_cdc_fifo_reset_overlap_checks.sv
+++ b/cdc/rtl/internal/br_cdc_fifo_reset_overlap_checks.sv
@@ -20,8 +20,11 @@ module br_cdc_fifo_reset_overlap_checks #(
     parameter int MinOverlapCycles = 1
 ) (
     // Either the push clk or the pop clk.
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ
     input logic clk,
+    // slang lint_restore
     // Reset that originates from the push clock domain. Must be synchronous to clk.
     input logic reset_active_push,
     // Reset that originates from the pop clock domain. Must be synchronous to clk.

--- a/counter/rtl/br_counter.sv
+++ b/counter/rtl/br_counter.sv
@@ -132,8 +132,11 @@ module br_counter #(
   assign value_extended = ExtWidth'(value);
   // ri lint_check_waive IFDEF_CODE
   assign value_extended_next =
+      // slang lint_save
+      // slang lint_off width-expand
       // ri lint_check_waive ARITH_ARGS
       value_extended + (incr_valid ? incr : '0) - (decr_valid ? decr : '0);
+  // slang lint_restore
 
   if (EnableWrap || EnableSaturate) begin : gen_wrap_or_saturate_cover
     localparam int MaxValueExtWidth = br_math::max2(ExtWidth, MaxValueP1Width);
@@ -187,11 +190,17 @@ module br_counter #(
   assign decr_qual = decr_valid ? decr : '0;
 
   if (EnableReinitAndChange) begin : gen_reinit_and_change
+    // slang lint_save
+    // slang lint_off width-expand
     // ri lint_check_waive ARITH_ARGS RHS_TOO_SHORT ARITH_BITLEN
     assign value_temp = (reinit ? initial_value : value) + incr_qual - decr_qual;
+    // slang lint_restore
   end else begin : gen_reinit_ignore_change
+    // slang lint_save
+    // slang lint_off width-expand
     // ri lint_check_waive ARITH_ARGS RHS_TOO_SHORT ARITH_BITLEN
     assign value_temp = reinit ? initial_value : (value + incr_qual - decr_qual);
+    // slang lint_restore
   end
   assign value_loaden = reinit || incr_valid || decr_valid;
 

--- a/counter/rtl/br_counter_decr.sv
+++ b/counter/rtl/br_counter_decr.sv
@@ -117,10 +117,16 @@ module br_counter_decr #(
   if (EnableReinitAndDecr) begin : gen_reinit_and_decr
     logic [ValueWidth-1:0] base_value;
     assign base_value = reinit ? initial_value : value;
+    // slang lint_save
+    // slang lint_off width-expand
     assign value_temp = base_value - (decr_valid ? decr : '0);
+    // slang lint_restore
     assign underflow  = decr_valid && (decr_ext > base_value);
   end else begin : gen_reinit_ignore_decr
+    // slang lint_save
+    // slang lint_off width-expand
     assign value_temp = reinit ? initial_value : (value - (decr_valid ? decr : '0));
+    // slang lint_restore
     assign underflow  = !reinit && decr_valid && (decr_ext > value);
   end
 

--- a/counter/rtl/br_counter_incr.sv
+++ b/counter/rtl/br_counter_incr.sv
@@ -123,11 +123,17 @@ module br_counter_incr #(
   // ri lint_check_waive NOT_READ
   logic [TempWidth-1:0] value_temp;
   if (EnableReinitAndIncr) begin : gen_reinit_and_incr
+    // slang lint_save
+    // slang lint_off width-expand
     // ri lint_check_waive RHS_TOO_SHORT
     assign value_temp = (reinit ? initial_value : value) + (incr_valid ? incr : '0);
+    // slang lint_restore
   end else begin : gen_reinit_ignore_incr
+    // slang lint_save
+    // slang lint_off width-expand
     // ri lint_check_waive RHS_TOO_SHORT
     assign value_temp = reinit ? initial_value : (value + (incr_valid ? incr : '0));
+    // slang lint_restore
   end
 
   if (EnableSaturate) begin : gen_saturate

--- a/credit/rtl/br_credit_receiver.sv
+++ b/credit/rtl/br_credit_receiver.sv
@@ -272,7 +272,7 @@ module br_credit_receiver #(
     `BR_ASSERT_IMPL(over_withhold_a,
                     credit_withhold > (credit_count + pop_credit) |-> !push_credit_internal)
     `BR_ASSERT_IMPL(withhold_and_release_a,
-                    credit_count == credit_withhold && push_credit_internal |-> pop_credit)
+                    credit_count == credit_withhold && (|push_credit_internal) |-> (|pop_credit))
   end
 
   `BR_ASSERT_IMPL(push_credit_in_range_a, push_credit <= PushCreditMaxChange)

--- a/credit/rtl/br_credit_receiver.sv
+++ b/credit/rtl/br_credit_receiver.sv
@@ -271,8 +271,11 @@ module br_credit_receiver #(
   if (EnableCoverCreditWithhold) begin : gen_credit_withhold_impl_checks
     `BR_ASSERT_IMPL(over_withhold_a,
                     credit_withhold > (credit_count + pop_credit) |-> !push_credit_internal)
+    // slang lint_save
+    // slang lint_off int-bool-conv
     `BR_ASSERT_IMPL(withhold_and_release_a,
-                    credit_count == credit_withhold && (|push_credit_internal) |-> (|pop_credit))
+                    credit_count == credit_withhold && push_credit_internal |-> pop_credit)
+    // slang lint_restore
   end
 
   `BR_ASSERT_IMPL(push_credit_in_range_a, push_credit <= PushCreditMaxChange)

--- a/credit/rtl/br_credit_sender_vc.sv
+++ b/credit/rtl/br_credit_sender_vc.sv
@@ -35,8 +35,11 @@ module br_credit_sender_vc #(
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, assert that push_data is stable when backpressured.
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    // slang lint_restore
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     // If 1, then at the end of simulation, assert that the credit counter value equals

--- a/csr/rtl/internal/br_csr_checks_intg.sv
+++ b/csr/rtl/internal/br_csr_checks_intg.sv
@@ -14,8 +14,11 @@ module br_csr_checks_intg #(
     // Must be either 32 or 64
     parameter int DataWidth = 32,
     // If 1, check that the address is in the range [AddrMin, AddrMax]
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAddressRangeCheck = 0,
+    // slang lint_restore
     // Must be at least 0 and at most AddrMax
     // ri lint_check_waive PARAM_NOT_USED
     parameter logic [AddrWidth-1:0] AddrMin = 0,
@@ -24,12 +27,18 @@ module br_csr_checks_intg #(
     parameter logic [AddrWidth-1:0] AddrMax = 2 ** AddrWidth - 1,
     // If 1, check that each byte of the write data is known for a write
     // request if its strobe bit is set
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableWriteDataKnownCheck = 1,
+    // slang lint_restore
     localparam int StrobeWidth = DataWidth / 8
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,
+    // slang lint_restore
     input logic rst,
 
     input logic req_valid,

--- a/demux/rtl/br_demux_addr_decode.sv
+++ b/demux/rtl/br_demux_addr_decode.sv
@@ -22,6 +22,8 @@ module br_demux_addr_decode #(
     parameter logic [NumDownstreams-1:0][AddrWidth-1:0] DownstreamAddrMask = '1
 ) (
     // Used only by integration assertions.
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,
     // Used only by integration assertions.
@@ -31,6 +33,7 @@ module br_demux_addr_decode #(
     // Used only by integration assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic addr_valid,
+    // slang lint_restore
     input logic [AddrWidth-1:0] upstream_addr,
 
     input logic [NumAddressRanges-1:0][AddrWidth-1:0] downstream_addr_base,

--- a/ecc/rtl/br_ecc_secded_decoder.sv
+++ b/ecc/rtl/br_ecc_secded_decoder.sv
@@ -83,8 +83,11 @@ module br_ecc_secded_decoder #(
     localparam int InputWidth = DataWidth + ParityWidth,
     localparam int MessageWidth = br_ecc_secded::get_message_width(DataWidth, ParityWidth),
     localparam int CodewordWidth = MessageWidth + ParityWidth,
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     localparam int Latency = 32'(RegisterInputs) + 32'(RegisterSyndrome) + 32'(RegisterOutputs)
+    // slang lint_restore
 ) (
     // Positive edge-triggered clock.
     input  logic                     clk,

--- a/ecc/rtl/br_ecc_secded_encoder.sv
+++ b/ecc/rtl/br_ecc_secded_encoder.sv
@@ -92,8 +92,11 @@ module br_ecc_secded_encoder #(
     output logic [CodewordWidth-1:0] enc_codeword
 );
 
+  // slang lint_save
+  // slang lint_off unused-parameter
   // ri lint_check_waive PARAM_NOT_USED
   localparam int Latency = 32'(RegisterInputs) + 32'(RegisterOutputs);
+  // slang lint_restore
 
   //------------------------------------------
   // Integration checks

--- a/ecc/rtl/br_ecc_sed_decoder.sv
+++ b/ecc/rtl/br_ecc_sed_decoder.sv
@@ -36,8 +36,11 @@ module br_ecc_sed_decoder #(
     // Message width is the same as the data width (no internal padding)
     localparam int ParityWidth = 1,
     localparam int CodewordWidth = DataWidth + ParityWidth,
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     localparam int Latency = 32'(RegisterInputs) + 32'(RegisterOutputs)
+    // slang lint_restore
 ) (
     // Positive edge-triggered clock.
     input logic clk,

--- a/ecc/rtl/br_ecc_sed_encoder.sv
+++ b/ecc/rtl/br_ecc_sed_encoder.sv
@@ -36,8 +36,11 @@ module br_ecc_sed_encoder #(
     // Message width is the same as the data width (no internal padding)
     localparam int ParityWidth = 1,
     localparam int CodewordWidth = DataWidth + ParityWidth,
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     localparam int Latency = 32'(RegisterInputs) + 32'(RegisterOutputs)
+    // slang lint_restore
 ) (
     // Positive edge-triggered clock.
     input  logic                     clk,

--- a/enc/rtl/br_enc_bin2onehot.sv
+++ b/enc/rtl/br_enc_bin2onehot.sv
@@ -41,10 +41,13 @@ module br_enc_bin2onehot #(
     // Width of the binary-encoded value. Must be at least $clog2(NumValues).
     parameter int BinWidth = br_math::clamped_clog2(NumValues)
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,  // Used only for assertions
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic rst,  // Used only for assertions
+    // slang lint_restore
     input logic [BinWidth-1:0] in,
     input logic in_valid,
     output logic [NumValues-1:0] out

--- a/enc/rtl/br_enc_onehot2bin.sv
+++ b/enc/rtl/br_enc_onehot2bin.sv
@@ -45,10 +45,13 @@ module br_enc_onehot2bin #(
     // Width of the binary-encoded value. Must be at least $clog2(NumValues).
     parameter int BinWidth = br_math::clamped_clog2(NumValues)
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic                 clk,        // Used only for assertions
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic                 rst,        // Used only for assertions
+    // slang lint_restore
     input  logic [NumValues-1:0] in,
     output logic                 out_valid,
     output logic [ BinWidth-1:0] out

--- a/enc/rtl/br_enc_priority_encoder.sv
+++ b/enc/rtl/br_enc_priority_encoder.sv
@@ -25,10 +25,13 @@ module br_enc_priority_encoder #(
     // The maximum number of bits in in that will be set on a given cycle.
     parameter int MaxInHot = NumRequesters
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,  // Used only for assertions
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic rst,  // Used only for assertions
+    // slang lint_restore
     input logic [NumRequesters-1:0] in,
     output logic [NumResults-1:0][NumRequesters-1:0] out
 );

--- a/fifo/rtl/internal/br_fifo_pop_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_pop_ctrl.sv
@@ -145,8 +145,11 @@ module br_fifo_pop_ctrl #(
   `BR_ASSERT_IMPL(ram_rd_addr_in_range_a, ram_rd_addr_valid |-> ram_rd_addr < RamDepth)
 
   // Flow control and latency
+  // slang lint_save
+  // slang lint_off unused-parameter
   // ri lint_check_waive PARAM_NOT_USED
   localparam int RegisterPopOutputsInt = 32'(RegisterPopOutputs);
+  // slang lint_restore
   if (EnableBypass) begin : gen_bypass_cut_through_latency_check
     // If a RAM read is inflight when the bypass occurs, pop_valid will not
     // be asserted until the RAM read completes. So the range of the latency

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
@@ -207,8 +207,11 @@ module br_fifo_shared_dynamic_push_ctrl #(
 
   // These are only used for assertions, so it's fine to use $countones
   // ri lint_check_off SYS_TF
-  assign request_count = PortCountWidth'($unsigned($countones(push_valid)));
-  assign grant_count   = PortCountWidth'($unsigned($countones(push_valid & push_ready)));
+  // slang lint_save
+  // slang lint_off width-trunc
+  assign request_count = $unsigned($countones(push_valid));
+  assign grant_count   = $unsigned($countones(push_valid & push_ready));
+  // slang lint_restore
   // ri lint_check_on SYS_TF
 `endif
 `endif

--- a/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
+++ b/fifo/rtl/internal/br_fifo_shared_dynamic_push_ctrl.sv
@@ -26,6 +26,8 @@ module br_fifo_shared_dynamic_push_ctrl #(
     // If 1, assert that push_valid is stable when backpressured.
     parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
     // If 1, assert that push_data is stable when backpressured.
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
     // If 1, assert that push_data is always known (not X) when push_valid is asserted.
@@ -35,6 +37,7 @@ module br_fifo_shared_dynamic_push_ctrl #(
     // empty at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalNotValid = 1,
+    // slang lint_restore
     parameter bit EnableAssertUniqueDeallocEntryId = 1,
 
     // If 1, assert that push-side backpressure is impossible.
@@ -204,8 +207,8 @@ module br_fifo_shared_dynamic_push_ctrl #(
 
   // These are only used for assertions, so it's fine to use $countones
   // ri lint_check_off SYS_TF
-  assign request_count = $unsigned($countones(push_valid));
-  assign grant_count   = $unsigned($countones(push_valid & push_ready));
+  assign request_count = PortCountWidth'($unsigned($countones(push_valid)));
+  assign grant_count   = PortCountWidth'($unsigned($countones(push_valid & push_ready)));
   // ri lint_check_on SYS_TF
 `endif
 `endif

--- a/fifo/rtl/internal/br_fifo_shared_pstatic_size_calc.sv
+++ b/fifo/rtl/internal/br_fifo_shared_pstatic_size_calc.sv
@@ -17,10 +17,13 @@ module br_fifo_shared_pstatic_size_calc #(
     localparam int AddrWidth  = br_math::clamped_clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,  // Used only for assertions
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic rst,  // Used only for assertions
+    // slang lint_restore
 
     input logic [NumFifos-1:0][AddrWidth-1:0] config_base,
     input logic [NumFifos-1:0][AddrWidth-1:0] config_bound,

--- a/fifo/rtl/internal/br_fifo_staging_buffer.sv
+++ b/fifo/rtl/internal/br_fifo_staging_buffer.sv
@@ -259,10 +259,13 @@ module br_fifo_staging_buffer #(
     // bypass and RAM read paths. If there is a read inflight, bypassed data
     // should be buffered but not forwarded.
     assign internal_pop_valid_nonbypass = buffer_fwd_valid || ram_rd_data_valid;
+    // slang lint_save
+    // slang lint_off logical-op-parentheses
     assign internal_pop_valid =
         buffer_fwd_valid ||
         ram_rd_data_valid ||
-        (bypass_beat && !has_inflight_read);
+        bypass_beat && !has_inflight_read;
+    // slang lint_restore
     assign internal_pop_data = buffer_fwd_valid ? buffer_data : push_data;
 
     // The buffer is written to if

--- a/fifo/rtl/internal/br_fifo_staging_buffer.sv
+++ b/fifo/rtl/internal/br_fifo_staging_buffer.sv
@@ -262,7 +262,7 @@ module br_fifo_staging_buffer #(
     assign internal_pop_valid =
         buffer_fwd_valid ||
         ram_rd_data_valid ||
-        bypass_beat && !has_inflight_read;
+        (bypass_beat && !has_inflight_read);
     assign internal_pop_data = buffer_fwd_valid ? buffer_data : push_data;
 
     // The buffer is written to if
@@ -336,7 +336,10 @@ module br_fifo_staging_buffer #(
     logic ptr_match;
     logic empty;
     // only used for assertion
+    // slang lint_save
+    // slang lint_off unused-but-set-variable
     logic full;  // ri lint_check_waive NOT_READ HIER_NET_NOT_READ
+    // slang lint_restore
     logic advance_wr_ptr;
     logic advance_rd_ptr;
 

--- a/flow/rtl/br_flow_demux_select_unstable.sv
+++ b/flow/rtl/br_flow_demux_select_unstable.sv
@@ -134,8 +134,11 @@ module br_flow_demux_select_unstable #(
     assign push_ready = pop_ready[select];
     // The ternary expression is needed to ensure pop_valid_unstable is 0 (and not X)
     // when select is X and push_valid is 0.
+    // slang lint_save
+    // slang lint_off width-expand
     // ri lint_check_waive VAR_SHIFT TRUNC_LSHIFT
     assign pop_valid_unstable = push_valid ? (push_valid << select) : '0;
+    // slang lint_restore
     // Replicate pop_data to all flows; this is okay since pop_data[i]
     // is only valid when pop_valid_unstable[i] is high.
     always_comb begin

--- a/flow/rtl/internal/br_flow_checks_valid_data_impl.sv
+++ b/flow/rtl/internal/br_flow_checks_valid_data_impl.sv
@@ -36,16 +36,22 @@ module br_flow_checks_valid_data_impl #(
     parameter bit EnableAssertDataStability = EnableAssertValidStability,
     // If 1, assert that data is known (not X) whenever valid is asserted.
     // This is independent of stability checks; set to 0 to disable.
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertDataKnown = 1,
+    // slang lint_restore
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     // If 1, assert that there is never backpressure.
     // Can only be enabled if EnableCoverBackpressure is disabled.
     parameter bit EnableAssertNoBackpressure = !EnableCoverBackpressure
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,
+    // slang lint_restore
     input logic rst,
     input logic [NumFlows-1:0] valid,
     input logic [NumFlows-1:0] ready,

--- a/flow/rtl/internal/br_flow_checks_valid_data_intg.sv
+++ b/flow/rtl/internal/br_flow_checks_valid_data_intg.sv
@@ -33,16 +33,22 @@ module br_flow_checks_valid_data_intg #(
     parameter bit EnableAssertDataStability = EnableAssertValidStability,
     // If 1, assert that data is known (not X) whenever valid is asserted.
     // This is independent of stability checks; set to 0 to disable.
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertDataKnown = 1,
+    // slang lint_restore
     // If 1, then assert there are no valid bits asserted at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
     // If 1, assert that there is never backpressure.
     // Can only be enabled if EnableCoverBackpressure is disabled.
     parameter bit EnableAssertNoBackpressure = !EnableCoverBackpressure
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input logic clk,
+    // slang lint_restore
     input logic rst,
     input logic [NumFlows-1:0] valid,
     input logic [NumFlows-1:0] ready,

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -67,8 +67,16 @@ verilog_elab_test(
 )
 
 verilog_lint_test(
-    name = "br_unused_tb_lint_test",
+    name = "br_unused_tb_ascentlint_lint_test",
     tool = "ascentlint",
+    visibility = ["//visibility:public"],
+    deps = [":br_unused_tb"],
+)
+
+verilog_lint_test(
+    name = "br_unused_tb_slang_lint_test",
+    tags = ["manual"],
+    tool = "slang",
     visibility = ["//visibility:public"],
     deps = [":br_unused_tb"],
 )
@@ -96,8 +104,15 @@ verilog_elab_test(
 )
 
 verilog_lint_test(
-    name = "br_tieoff_tb_lint_test",
+    name = "br_tieoff_tb_ascentlint_lint_test",
     tool = "ascentlint",
+    deps = [":br_tieoff_tb"],
+)
+
+verilog_lint_test(
+    name = "br_tieoff_tb_slang_lint_test",
+    tags = ["manual"],
+    tool = "slang",
     deps = [":br_tieoff_tb"],
 )
 
@@ -272,8 +287,16 @@ verilog_elab_test(
 )
 
 verilog_lint_test(
-    name = "br_assign_lint_test",
+    name = "br_assign_ascentlint_lint_test",
     tool = "ascentlint",
+    visibility = ["//visibility:public"],
+    deps = [":br_assign_test"],
+)
+
+verilog_lint_test(
+    name = "br_assign_slang_lint_test",
+    tags = ["manual"],
+    tool = "slang",
     visibility = ["//visibility:public"],
     deps = [":br_assign_test"],
 )

--- a/macros/br_gates.svh
+++ b/macros/br_gates.svh
@@ -15,35 +15,35 @@
 
 // Buffer
 `define BR_GATE_BUF(__out__, __in__) \
-br_gate_buf br_gate_buf_``__out__`` ( \
+br_gate_buf br_gate_buf_``__out__ ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 // Clock Buffer
 `define BR_GATE_CLK_BUF(__out__, __in__) \
-br_gate_clk_buf br_gate_clk_buf_``__out__`` ( \
+br_gate_clk_buf br_gate_clk_buf_``__out__ ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 // Clock Inverter
 `define BR_GATE_CLK_INV(__out__, __in__) \
-br_gate_clk_inv br_gate_clk_inv_``__out__`` ( \
+br_gate_clk_inv br_gate_clk_inv_``__out__ ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 // Inverter
 `define BR_GATE_INV(__out__, __in__) \
-br_gate_inv br_gate_inv_``__out__`` ( \
+br_gate_inv br_gate_inv_``__out__ ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 // 2-Input AND Gate
 `define BR_GATE_AND2(__out__, __in0__, __in1__) \
-br_gate_and2 br_gate_and2_``__out__`` ( \
+br_gate_and2 br_gate_and2_``__out__ ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .out(__out__) \
@@ -51,7 +51,7 @@ br_gate_and2 br_gate_and2_``__out__`` ( \
 
 // 2-Input OR Gate
 `define BR_GATE_OR2(__out__, __in0__, __in1__) \
-br_gate_or2 br_gate_or2_``__out__`` ( \
+br_gate_or2 br_gate_or2_``__out__ ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .out(__out__) \
@@ -59,7 +59,7 @@ br_gate_or2 br_gate_or2_``__out__`` ( \
 
 // 2-Input XOR Gate
 `define BR_GATE_XOR2(__out__, __in0__, __in1__) \
-br_gate_xor2 br_gate_xor2_``__out__`` ( \
+br_gate_xor2 br_gate_xor2_``__out__ ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .out(__out__) \
@@ -67,7 +67,7 @@ br_gate_xor2 br_gate_xor2_``__out__`` ( \
 
 // 2-Input Mux Gate
 `define BR_GATE_MUX2(__out__, __in0__, __in1__, __sel__) \
-br_gate_mux2 br_gate_mux2_``__out__`` ( \
+br_gate_mux2 br_gate_mux2_``__out__ ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .sel(__sel__), \
@@ -76,7 +76,7 @@ br_gate_mux2 br_gate_mux2_``__out__`` ( \
 
 // 2-Input Clock Mux Gate
 `define BR_GATE_CLK_MUX2(__out__, __in0__, __in1__, __sel__) \
-br_gate_clk_mux2 br_gate_clk_mux2_``__out__`` ( \
+br_gate_clk_mux2 br_gate_clk_mux2_``__out__ ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .sel(__sel__), \
@@ -85,7 +85,7 @@ br_gate_clk_mux2 br_gate_clk_mux2_``__out__`` ( \
 
 // Integrated Clock Gate
 `define BR_GATE_ICG(__clk_out__, __clk_in__, __en__) \
-br_gate_icg br_gate_icg_``__clk_out__`` ( \
+br_gate_icg br_gate_icg_``__clk_out__ ( \
     .clk_in(__clk_in__), \
     .en(__en__), \
     .clk_out(__clk_out__) \
@@ -93,7 +93,7 @@ br_gate_icg br_gate_icg_``__clk_out__`` ( \
 
 // Integrated Clock Gate with Synchronous Reset
 `define BR_GATE_ICG_RST(__clk_out__, __clk_in__, __en__, __rst__) \
-br_gate_icg_rst br_gate_icg_rst_``__clk_out__`` ( \
+br_gate_icg_rst br_gate_icg_rst_``__clk_out__ ( \
     .clk_in(__clk_in__), \
     .en(__en__), \
     .rst(__rst__), \
@@ -102,7 +102,7 @@ br_gate_icg_rst br_gate_icg_rst_``__clk_out__`` ( \
 
 // Clock Domain Crossing Synchronizer with default number of stages
 `define BR_GATE_CDC_SYNC(__out__, __in__, __clk__) \
-br_gate_cdc_sync br_gate_cdc_sync_``__out__`` ( \
+br_gate_cdc_sync br_gate_cdc_sync_``__out__ ( \
     .clk(__clk__), \
     .in(__in__), \
     .out(__out__) \
@@ -110,7 +110,7 @@ br_gate_cdc_sync br_gate_cdc_sync_``__out__`` ( \
 
 // Clock Domain Crossing Synchronizer with configurable number of stages
 `define BR_GATE_CDC_SYNC_STAGES(__out__, __in__, __clk__, __stages__) \
-br_gate_cdc_sync #(__stages__) br_gate_cdc_sync_``__out__`` ( \
+br_gate_cdc_sync #(__stages__) br_gate_cdc_sync_``__out__ ( \
     .clk(__clk__), \
     .in(__in__), \
     .out(__out__) \
@@ -118,7 +118,7 @@ br_gate_cdc_sync #(__stages__) br_gate_cdc_sync_``__out__`` ( \
 
 // Clock Domain Crossing Synchronizer with Asynchronous Reset and default number of stages
 `define BR_GATE_CDC_SYNC_ARST(__out__, __in__, __clk__, __arst__) \
-br_gate_cdc_sync_arst br_gate_cdc_sync_arst_``__out__`` ( \
+br_gate_cdc_sync_arst br_gate_cdc_sync_arst_``__out__ ( \
     .clk(__clk__), \
     .arst(__arst__), \
     .in(__in__), \
@@ -127,7 +127,7 @@ br_gate_cdc_sync_arst br_gate_cdc_sync_arst_``__out__`` ( \
 
 // Clock Domain Crossing Synchronizer with Asynchronous Reset and configurable number of stages
 `define BR_GATE_CDC_SYNC_ARST_STAGES(__out__, __in__, __clk__, __arst__, __stages__) \
-br_gate_cdc_sync_arst #(__stages__) br_gate_cdc_sync_arst_``__out__`` ( \
+br_gate_cdc_sync_arst #(__stages__) br_gate_cdc_sync_arst_``__out__ ( \
     .clk(__clk__), \
     .arst(__arst__), \
     .in(__in__), \
@@ -136,7 +136,7 @@ br_gate_cdc_sync_arst #(__stages__) br_gate_cdc_sync_arst_``__out__`` ( \
 
 // Reset Synchronizer
 `define BR_GATE_CDC_RST_SYNC(__srst__, __arst__, __clk__) \
-br_cdc_rst_sync br_cdc_rst_sync_``__srst__`` ( \
+br_cdc_rst_sync br_cdc_rst_sync_``__srst__ ( \
     .clk(__clk__), \
     .arst(__arst__), \
     .srst(__srst__) \
@@ -144,7 +144,7 @@ br_cdc_rst_sync br_cdc_rst_sync_``__srst__`` ( \
 
 // Reset Synchronizer with configurable number of stages
 `define BR_GATE_CDC_RST_SYNC_STAGES(__srst__, __arst__, __clk__, __stages__) \
-br_cdc_rst_sync #(__stages__) br_cdc_rst_sync_``__srst__`` ( \
+br_cdc_rst_sync #(__stages__) br_cdc_rst_sync_``__srst__ ( \
     .clk(__clk__), \
     .arst(__arst__), \
     .srst(__srst__) \
@@ -154,13 +154,13 @@ br_cdc_rst_sync #(__stages__) br_cdc_rst_sync_``__srst__`` ( \
 // this signal will be stable before the destination domain is out of reset and the clock is
 // running.
 `define BR_GATE_CDC_PSEUDOSTATIC(__out__, __in__) \
-br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__`` ( \
+br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__ ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 `define BR_GATE_CDC_PSEUDOSTATIC_BUS(__out__, __in__, __width__) \
-br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__`` [``__width__``-1:0] ( \
+br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__ [__width__-1:0] ( \
     .in(__in__), \
     .out(__out__) \
 );
@@ -168,13 +168,13 @@ br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__`` [``__width__``-1:0
 // Buffer used at CDC crossings that indicate that this crossing would need to be checked for
 // max delay (skew checks).
 `define BR_GATE_CDC_MAXDEL(__out__, __in__) \
-br_gate_cdc_maxdel br_gate_cdc_maxdel_``__out__`` ( \
+br_gate_cdc_maxdel br_gate_cdc_maxdel_``__out__ ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 `define BR_GATE_CDC_MAXDEL_BUS(__out__, __in__, __width__) \
-br_gate_cdc_maxdel br_gate_cdc_maxdel_``__out__`` [``__width__``-1:0] ( \
+br_gate_cdc_maxdel br_gate_cdc_maxdel_``__out__ [__width__-1:0] ( \
     .in(__in__), \
     .out(__out__) \
 );

--- a/macros/br_gates.svh
+++ b/macros/br_gates.svh
@@ -15,35 +15,35 @@
 
 // Buffer
 `define BR_GATE_BUF(__out__, __in__) \
-br_gate_buf br_gate_buf_``__out__ ( \
+br_gate_buf br_gate_buf_``__out__`` ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 // Clock Buffer
 `define BR_GATE_CLK_BUF(__out__, __in__) \
-br_gate_clk_buf br_gate_clk_buf_``__out__ ( \
+br_gate_clk_buf br_gate_clk_buf_``__out__`` ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 // Clock Inverter
 `define BR_GATE_CLK_INV(__out__, __in__) \
-br_gate_clk_inv br_gate_clk_inv_``__out__ ( \
+br_gate_clk_inv br_gate_clk_inv_``__out__`` ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 // Inverter
 `define BR_GATE_INV(__out__, __in__) \
-br_gate_inv br_gate_inv_``__out__ ( \
+br_gate_inv br_gate_inv_``__out__`` ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 // 2-Input AND Gate
 `define BR_GATE_AND2(__out__, __in0__, __in1__) \
-br_gate_and2 br_gate_and2_``__out__ ( \
+br_gate_and2 br_gate_and2_``__out__`` ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .out(__out__) \
@@ -51,7 +51,7 @@ br_gate_and2 br_gate_and2_``__out__ ( \
 
 // 2-Input OR Gate
 `define BR_GATE_OR2(__out__, __in0__, __in1__) \
-br_gate_or2 br_gate_or2_``__out__ ( \
+br_gate_or2 br_gate_or2_``__out__`` ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .out(__out__) \
@@ -59,7 +59,7 @@ br_gate_or2 br_gate_or2_``__out__ ( \
 
 // 2-Input XOR Gate
 `define BR_GATE_XOR2(__out__, __in0__, __in1__) \
-br_gate_xor2 br_gate_xor2_``__out__ ( \
+br_gate_xor2 br_gate_xor2_``__out__`` ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .out(__out__) \
@@ -67,7 +67,7 @@ br_gate_xor2 br_gate_xor2_``__out__ ( \
 
 // 2-Input Mux Gate
 `define BR_GATE_MUX2(__out__, __in0__, __in1__, __sel__) \
-br_gate_mux2 br_gate_mux2_``__out__ ( \
+br_gate_mux2 br_gate_mux2_``__out__`` ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .sel(__sel__), \
@@ -76,7 +76,7 @@ br_gate_mux2 br_gate_mux2_``__out__ ( \
 
 // 2-Input Clock Mux Gate
 `define BR_GATE_CLK_MUX2(__out__, __in0__, __in1__, __sel__) \
-br_gate_clk_mux2 br_gate_clk_mux2_``__out__ ( \
+br_gate_clk_mux2 br_gate_clk_mux2_``__out__`` ( \
     .in0(__in0__), \
     .in1(__in1__), \
     .sel(__sel__), \
@@ -85,7 +85,7 @@ br_gate_clk_mux2 br_gate_clk_mux2_``__out__ ( \
 
 // Integrated Clock Gate
 `define BR_GATE_ICG(__clk_out__, __clk_in__, __en__) \
-br_gate_icg br_gate_icg_``__clk_out__ ( \
+br_gate_icg br_gate_icg_``__clk_out__`` ( \
     .clk_in(__clk_in__), \
     .en(__en__), \
     .clk_out(__clk_out__) \
@@ -93,7 +93,7 @@ br_gate_icg br_gate_icg_``__clk_out__ ( \
 
 // Integrated Clock Gate with Synchronous Reset
 `define BR_GATE_ICG_RST(__clk_out__, __clk_in__, __en__, __rst__) \
-br_gate_icg_rst br_gate_icg_rst_``__clk_out__ ( \
+br_gate_icg_rst br_gate_icg_rst_``__clk_out__`` ( \
     .clk_in(__clk_in__), \
     .en(__en__), \
     .rst(__rst__), \
@@ -102,7 +102,7 @@ br_gate_icg_rst br_gate_icg_rst_``__clk_out__ ( \
 
 // Clock Domain Crossing Synchronizer with default number of stages
 `define BR_GATE_CDC_SYNC(__out__, __in__, __clk__) \
-br_gate_cdc_sync br_gate_cdc_sync_``__out__ ( \
+br_gate_cdc_sync br_gate_cdc_sync_``__out__`` ( \
     .clk(__clk__), \
     .in(__in__), \
     .out(__out__) \
@@ -110,7 +110,7 @@ br_gate_cdc_sync br_gate_cdc_sync_``__out__ ( \
 
 // Clock Domain Crossing Synchronizer with configurable number of stages
 `define BR_GATE_CDC_SYNC_STAGES(__out__, __in__, __clk__, __stages__) \
-br_gate_cdc_sync #(__stages__) br_gate_cdc_sync_``__out__ ( \
+br_gate_cdc_sync #(__stages__) br_gate_cdc_sync_``__out__`` ( \
     .clk(__clk__), \
     .in(__in__), \
     .out(__out__) \
@@ -118,7 +118,7 @@ br_gate_cdc_sync #(__stages__) br_gate_cdc_sync_``__out__ ( \
 
 // Clock Domain Crossing Synchronizer with Asynchronous Reset and default number of stages
 `define BR_GATE_CDC_SYNC_ARST(__out__, __in__, __clk__, __arst__) \
-br_gate_cdc_sync_arst br_gate_cdc_sync_arst_``__out__ ( \
+br_gate_cdc_sync_arst br_gate_cdc_sync_arst_``__out__`` ( \
     .clk(__clk__), \
     .arst(__arst__), \
     .in(__in__), \
@@ -127,7 +127,7 @@ br_gate_cdc_sync_arst br_gate_cdc_sync_arst_``__out__ ( \
 
 // Clock Domain Crossing Synchronizer with Asynchronous Reset and configurable number of stages
 `define BR_GATE_CDC_SYNC_ARST_STAGES(__out__, __in__, __clk__, __arst__, __stages__) \
-br_gate_cdc_sync_arst #(__stages__) br_gate_cdc_sync_arst_``__out__ ( \
+br_gate_cdc_sync_arst #(__stages__) br_gate_cdc_sync_arst_``__out__`` ( \
     .clk(__clk__), \
     .arst(__arst__), \
     .in(__in__), \
@@ -136,7 +136,7 @@ br_gate_cdc_sync_arst #(__stages__) br_gate_cdc_sync_arst_``__out__ ( \
 
 // Reset Synchronizer
 `define BR_GATE_CDC_RST_SYNC(__srst__, __arst__, __clk__) \
-br_cdc_rst_sync br_cdc_rst_sync_``__srst__ ( \
+br_cdc_rst_sync br_cdc_rst_sync_``__srst__`` ( \
     .clk(__clk__), \
     .arst(__arst__), \
     .srst(__srst__) \
@@ -144,7 +144,7 @@ br_cdc_rst_sync br_cdc_rst_sync_``__srst__ ( \
 
 // Reset Synchronizer with configurable number of stages
 `define BR_GATE_CDC_RST_SYNC_STAGES(__srst__, __arst__, __clk__, __stages__) \
-br_cdc_rst_sync #(__stages__) br_cdc_rst_sync_``__srst__ ( \
+br_cdc_rst_sync #(__stages__) br_cdc_rst_sync_``__srst__`` ( \
     .clk(__clk__), \
     .arst(__arst__), \
     .srst(__srst__) \
@@ -154,13 +154,13 @@ br_cdc_rst_sync #(__stages__) br_cdc_rst_sync_``__srst__ ( \
 // this signal will be stable before the destination domain is out of reset and the clock is
 // running.
 `define BR_GATE_CDC_PSEUDOSTATIC(__out__, __in__) \
-br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__ ( \
+br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__`` ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 `define BR_GATE_CDC_PSEUDOSTATIC_BUS(__out__, __in__, __width__) \
-br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__ [__width__-1:0] ( \
+br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__`` [``__width__``-1:0] ( \
     .in(__in__), \
     .out(__out__) \
 );
@@ -168,13 +168,13 @@ br_gate_cdc_pseudostatic br_gate_cdc_pseudostatic_``__out__ [__width__-1:0] ( \
 // Buffer used at CDC crossings that indicate that this crossing would need to be checked for
 // max delay (skew checks).
 `define BR_GATE_CDC_MAXDEL(__out__, __in__) \
-br_gate_cdc_maxdel br_gate_cdc_maxdel_``__out__ ( \
+br_gate_cdc_maxdel br_gate_cdc_maxdel_``__out__`` ( \
     .in(__in__), \
     .out(__out__) \
 );
 
 `define BR_GATE_CDC_MAXDEL_BUS(__out__, __in__, __width__) \
-br_gate_cdc_maxdel br_gate_cdc_maxdel_``__out__ [__width__-1:0] ( \
+br_gate_cdc_maxdel br_gate_cdc_maxdel_``__out__`` [``__width__``-1:0] ( \
     .in(__in__), \
     .out(__out__) \
 );

--- a/misc/rtl/br_misc_unused.sv
+++ b/misc/rtl/br_misc_unused.sv
@@ -22,7 +22,10 @@ module br_misc_unused #(
 
   `BR_ASSERT_STATIC(width_gte_1, Width >= 1)
 
+  // slang lint_save
+  // slang lint_off unused-but-set-variable
   logic unused;  // ri lint_check_waive NOT_READ
+  // slang lint_restore
   // cadence keep_signal_name unused
   assign unused = |in;
 

--- a/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_impl.sv
+++ b/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_impl.sv
@@ -22,8 +22,11 @@ module br_multi_xfer_checks_sendable_data_impl #(
 
     localparam int CountWidth = $clog2(NumSymbols + 1)
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive NOT_READ HIER_NET_NOT_READ INPUT_NOT_READ
     input logic clk,
+    // slang lint_restore
     input logic rst,
 
     input logic [CountWidth-1:0] receivable,

--- a/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_intg.sv
+++ b/multi_xfer/rtl/internal/br_multi_xfer_checks_sendable_data_intg.sv
@@ -22,8 +22,11 @@ module br_multi_xfer_checks_sendable_data_intg #(
 
     localparam int CountWidth = $clog2(NumSymbols + 1)
 ) (
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive NOT_READ HIER_NET_NOT_READ INPUT_NOT_READ
     input logic clk,
+    // slang lint_restore
     input logic rst,
 
     input logic [CountWidth-1:0] receivable,

--- a/pkg/br_math_pkg.sv
+++ b/pkg/br_math_pkg.sv
@@ -46,7 +46,7 @@ package br_math;
   // Returns 1 if the value is even, 0 otherwise.
   // ri lint_check_waive TWO_STATE_TYPE
   function automatic bit is_even(input int value);
-    return (value & 1'b1) == 0;
+    return (value & 1) == 0;
   endfunction
 
   // ceil(log_base(x)) using change-of-base formula. base must be a power-of-2.

--- a/pkg/br_math_pkg.sv
+++ b/pkg/br_math_pkg.sv
@@ -46,7 +46,10 @@ package br_math;
   // Returns 1 if the value is even, 0 otherwise.
   // ri lint_check_waive TWO_STATE_TYPE
   function automatic bit is_even(input int value);
-    return (value & 1) == 0;
+    // slang lint_save
+    // slang lint_off sign-conversion
+    return (value & 1'b1) == 0;
+    // slang lint_restore
   endfunction
 
   // ceil(log_base(x)) using change-of-base formula. base must be a power-of-2.

--- a/python/verilog_runner/BUILD.bazel
+++ b/python/verilog_runner/BUILD.bazel
@@ -61,6 +61,11 @@ py_library(
     ],
 )
 
+py_library(
+    name = "slang_waivers",
+    srcs = ["slang_waivers.py"],
+)
+
 py_binary(
     name = "verilog_runner",
     srcs = [
@@ -95,6 +100,12 @@ py_test(
         ":cli",
         ":slang_plugin",
     ],
+)
+
+py_test(
+    name = "slang_waivers_test",
+    srcs = ["slang_waivers_test.py"],
+    deps = [":slang_waivers"],
 )
 
 py_binary(

--- a/python/verilog_runner/slang_waivers.py
+++ b/python/verilog_runner/slang_waivers.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reject Slang lint waivers that can leak beyond their intended source scope."""
+
+import re
+import sys
+
+
+DIRECTIVE = re.compile(r"(?://|/\*)\s*slang\s+lint_(save|off|on|restore)\b")
+
+
+def check_file(path):
+    errors = []
+    scopes = []
+    with open(path, encoding="utf-8") as source:
+        for line_number, line in enumerate(source, 1):
+            for match in DIRECTIVE.finditer(line):
+                directive = match.group(1)
+                if directive == "save":
+                    scopes.append([line_number, False])
+                elif directive == "off":
+                    if not scopes:
+                        errors.append(
+                            "{}:{}: lint_off requires lint_save".format(
+                                path, line_number
+                            )
+                        )
+                    else:
+                        scopes[-1][1] = True
+                elif directive == "on":
+                    errors.append(
+                        "{}:{}: use lint_restore to preserve warning-as-error severity".format(
+                            path, line_number
+                        )
+                    )
+                elif not scopes:
+                    errors.append(
+                        "{}:{}: lint_restore has no lint_save".format(path, line_number)
+                    )
+                else:
+                    saved_line, has_waiver = scopes.pop()
+                    if not has_waiver:
+                        errors.append(
+                            "{}:{}: lint_save has no lint_off".format(path, saved_line)
+                        )
+
+    for saved_line, _ in scopes:
+        errors.append("{}:{}: lint_save has no lint_restore".format(path, saved_line))
+    return errors
+
+
+def main(paths):
+    errors = [error for path in paths for error in check_file(path)]
+    for error in errors:
+        print(error, file=sys.stderr)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/python/verilog_runner/slang_waivers.py
+++ b/python/verilog_runner/slang_waivers.py
@@ -1,6 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Reject Slang lint waivers that can leak beyond their intended source scope."""
+"""Enforce Bedrock's source-local Slang lint waiver policy.
+
+Slang does not yet provide a one-shot waiver for a single source line; that
+feature is tracked at https://github.com/MikePopoloski/slang/issues/1930.
+Until it is available, Bedrock requires every ``lint_off`` to be enclosed by a
+matching ``lint_save`` and ``lint_restore`` so that it cannot affect unrelated
+RTL. This checker validates that repository policy; it does not test Slang's
+implementation of the directives.
+"""
 
 import re
 import sys

--- a/python/verilog_runner/slang_waivers_test.py
+++ b/python/verilog_runner/slang_waivers_test.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests source-local Slang waiver scope validation."""
+"""Tests Bedrock's source-local Slang waiver policy checker, not Slang itself."""
 
 from pathlib import Path
 import tempfile

--- a/python/verilog_runner/slang_waivers_test.py
+++ b/python/verilog_runner/slang_waivers_test.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests source-local Slang waiver scope validation."""
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from python.verilog_runner.slang_waivers import check_file
+
+
+class SlangWaiversTest(unittest.TestCase):
+    def check(self, source):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "design.sv"
+            path.write_text(source, encoding="utf-8")
+            return check_file(str(path))
+
+    def test_accepts_scoped_waiver(self):
+        errors = self.check(
+            "// slang lint_save\n"
+            "// slang lint_off unused-port\n"
+            "input logic unused;\n"
+            "// slang lint_restore\n"
+        )
+        self.assertEqual(errors, [])
+
+    def test_rejects_waiver_without_saved_scope(self):
+        self.assertIn(
+            "lint_off requires lint_save",
+            self.check("// slang lint_off unused-port\n")[0],
+        )
+
+    def test_rejects_unclosed_scope(self):
+        errors = self.check("// slang lint_save\n// slang lint_off unused-port\n")
+        self.assertIn("lint_save has no lint_restore", errors[0])
+
+    def test_rejects_restore_without_saved_scope(self):
+        self.assertIn(
+            "lint_restore has no lint_save", self.check("// slang lint_restore\n")[0]
+        )
+
+    def test_rejects_lint_on(self):
+        self.assertIn(
+            "use lint_restore", self.check("// slang lint_on unused-port\n")[0]
+        )
+
+    def test_rejects_saved_scope_without_waiver(self):
+        errors = self.check("// slang lint_save\n// slang lint_restore\n")
+        self.assertIn("lint_save has no lint_off", errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ram/rtl/br_ram_data_rd_pipe.sv
+++ b/ram/rtl/br_ram_data_rd_pipe.sv
@@ -187,13 +187,13 @@ module br_ram_data_rd_pipe #(
   if (Latency > 0) begin : gen_stages_gt0
     for (genvar d = 0; d < DepthTiles; d++) begin : gen_d_impl_checks
       `BR_ASSERT_IMPL(propagation_a,
-                      tile_valid[d] |-> ##Latency valid && data == $past(tile_data[d], Latency))
+                      (|tile_valid[d]) |-> ##Latency valid && data == $past(tile_data[d], Latency))
     end
     `BR_ASSERT_IMPL(causality_a, valid |-> $past(|tile_valid, Latency))
 
   end else begin : gen_stages_eq0
     for (genvar d = 0; d < DepthTiles; d++) begin : gen_d_impl_checks
-      `BR_ASSERT_IMPL(propagation_a, tile_valid[d] |-> valid && data == tile_data[d])
+      `BR_ASSERT_IMPL(propagation_a, (|tile_valid[d]) |-> valid && data == tile_data[d])
     end
     `BR_ASSERT_IMPL(causality_a, valid |-> |tile_valid)
   end

--- a/ram/rtl/br_ram_data_rd_pipe.sv
+++ b/ram/rtl/br_ram_data_rd_pipe.sv
@@ -186,14 +186,20 @@ module br_ram_data_rd_pipe #(
   //------------------------------------------
   if (Latency > 0) begin : gen_stages_gt0
     for (genvar d = 0; d < DepthTiles; d++) begin : gen_d_impl_checks
+      // slang lint_save
+      // slang lint_off int-bool-conv
       `BR_ASSERT_IMPL(propagation_a,
-                      (|tile_valid[d]) |-> ##Latency valid && data == $past(tile_data[d], Latency))
+                      tile_valid[d] |-> ##Latency valid && data == $past(tile_data[d], Latency))
+      // slang lint_restore
     end
     `BR_ASSERT_IMPL(causality_a, valid |-> $past(|tile_valid, Latency))
 
   end else begin : gen_stages_eq0
     for (genvar d = 0; d < DepthTiles; d++) begin : gen_d_impl_checks
-      `BR_ASSERT_IMPL(propagation_a, (|tile_valid[d]) |-> valid && data == tile_data[d])
+      // slang lint_save
+      // slang lint_off int-bool-conv
+      `BR_ASSERT_IMPL(propagation_a, tile_valid[d] |-> valid && data == tile_data[d])
+      // slang lint_restore
     end
     `BR_ASSERT_IMPL(causality_a, valid |-> |tile_valid)
   end

--- a/ram/rtl/br_ram_flops.sv
+++ b/ram/rtl/br_ram_flops.sv
@@ -64,11 +64,14 @@ module br_ram_flops #(
     localparam int AddressWidth = br_math::clamped_clog2(Depth),
     localparam int NumWords = Width / WordWidth,
     // Write latency in units of wr_clk cycles
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     localparam int WriteLatency = AddressDepthStages + 1,
     // Read latency in units of rd_clk cycles. Only used for assertions.
     // ri lint_check_waive PARAM_NOT_USED
     localparam int ReadLatency = AddressDepthStages + ReadDataDepthStages + ReadDataWidthStages
+    // slang lint_restore
 ) (
     // Write-clock signals
     // Posedge-triggered clock.
@@ -336,7 +339,8 @@ module br_ram_flops #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_CR_IMPL(read_latency_a, rd_addr_valid |-> ##ReadLatency rd_data_valid, rd_clk, rd_rst)
+  `BR_ASSERT_CR_IMPL(read_latency_a, (|rd_addr_valid) |-> ##ReadLatency(|rd_data_valid), rd_clk,
+                     rd_rst)
 
 `ifdef BR_ASSERT_ON
 `ifdef BR_ENABLE_IMPL_CHECKS

--- a/ram/rtl/br_ram_flops.sv
+++ b/ram/rtl/br_ram_flops.sv
@@ -339,8 +339,10 @@ module br_ram_flops #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_CR_IMPL(read_latency_a, (|rd_addr_valid) |-> ##ReadLatency(|rd_data_valid), rd_clk,
-                     rd_rst)
+  // slang lint_save
+  // slang lint_off int-bool-conv
+  `BR_ASSERT_CR_IMPL(read_latency_a, rd_addr_valid |-> ##ReadLatency rd_data_valid, rd_clk, rd_rst)
+  // slang lint_restore
 
 `ifdef BR_ASSERT_ON
 `ifdef BR_ENABLE_IMPL_CHECKS

--- a/ram/rtl/br_ram_flops_1r1w_mock.sv
+++ b/ram/rtl/br_ram_flops_1r1w_mock.sv
@@ -54,11 +54,14 @@ module br_ram_flops_1r1w_mock #(
     localparam int AddressWidth = $clog2(Depth),
     localparam int NumWords = br_math::ceil_div(Width, WordWidth),
     // Write latency in units of wr_clk cycles
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     localparam int WriteLatency = AddressDepthStages + 1,
     // Read latency in units of rd_clk cycles
     // ri lint_check_waive PARAM_NOT_USED
     localparam int ReadLatency = AddressDepthStages + ReadDataDepthStages + ReadDataWidthStages
+    // slang lint_restore
 ) (
     // Write-clock signals
     // Posedge-triggered clock.

--- a/ram/rtl/br_ram_flops_tile.sv
+++ b/ram/rtl/br_ram_flops_tile.sv
@@ -61,12 +61,15 @@ module br_ram_flops_tile #(
     input logic [NumWritePorts-1:0][ NumWords-1:0] wr_word_en,
 
     // Used only for assertions.
+    // slang lint_save
+    // slang lint_off unused-port
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic                                   rd_clk,
     // Synchronous active-high reset.
     // Read reset is only used for assertions.
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic                                   rd_rst,
+    // slang lint_restore
     input  logic [NumReadPorts-1:0]                rd_addr_valid,
     // ri lint_check_waive FANOUT_LIMIT
     input  logic [NumReadPorts-1:0][AddrWidth-1:0] rd_addr,
@@ -438,7 +441,7 @@ module br_ram_flops_tile #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_CR_IMPL(zero_read_latency_A, rd_addr_valid |-> rd_data_valid, rd_clk, rd_rst)
+  `BR_ASSERT_CR_IMPL(zero_read_latency_A, (|rd_addr_valid) |-> (|rd_data_valid), rd_clk, rd_rst)
 `ifdef BR_ASSERT_ON
 `ifdef BR_ENABLE_IMPL_CHECKS
   if (EnableBypass) begin : gen_bypass_impl_checks

--- a/ram/rtl/br_ram_flops_tile.sv
+++ b/ram/rtl/br_ram_flops_tile.sv
@@ -441,7 +441,10 @@ module br_ram_flops_tile #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_CR_IMPL(zero_read_latency_A, (|rd_addr_valid) |-> (|rd_data_valid), rd_clk, rd_rst)
+  // slang lint_save
+  // slang lint_off int-bool-conv
+  `BR_ASSERT_CR_IMPL(zero_read_latency_A, rd_addr_valid |-> rd_data_valid, rd_clk, rd_rst)
+  // slang lint_restore
 `ifdef BR_ASSERT_ON
 `ifdef BR_ENABLE_IMPL_CHECKS
   if (EnableBypass) begin : gen_bypass_impl_checks

--- a/shift/rtl/br_shift_rotate.sv
+++ b/shift/rtl/br_shift_rotate.sv
@@ -65,7 +65,7 @@ module br_shift_rotate #(
     // This is modulo by a constant, which shouldn't be that expensive.
     // TODO(zhemao): Figure out a way to efficiently implement this.
     // ri lint_check_waive MODULUS
-    assign real_rotate = rotate % NumSymbols;
+    assign real_rotate = RealRotateWidth'(rotate % NumSymbols);
   end else begin : gen_real_rotate_no_modulo
     assign real_rotate = RealRotateWidth'(rotate);
   end

--- a/shift/rtl/br_shift_rotate.sv
+++ b/shift/rtl/br_shift_rotate.sv
@@ -64,8 +64,11 @@ module br_shift_rotate #(
   if (MaxRotate > (NumSymbols - 1)) begin : gen_real_rotate_modulo
     // This is modulo by a constant, which shouldn't be that expensive.
     // TODO(zhemao): Figure out a way to efficiently implement this.
+    // slang lint_save
+    // slang lint_off width-trunc
     // ri lint_check_waive MODULUS
-    assign real_rotate = RealRotateWidth'(rotate % NumSymbols);
+    assign real_rotate = rotate % NumSymbols;
+    // slang lint_restore
   end else begin : gen_real_rotate_no_modulo
     assign real_rotate = RealRotateWidth'(rotate);
   end

--- a/slang_lint_policy.f
+++ b/slang_lint_policy.f
@@ -3,3 +3,31 @@
 # Enable every warning and treat every enabled warning as an error.
 -Weverything
 -Werror
+
+# Public packages intentionally expose APIs unused by individual designs.
+-Wno-unused-package-subroutine
+-Wno-unused-package-parameter
+-Wno-unused-package-typedef
+
+# Transitive source sets contain reusable modules unrelated to the selected top.
+-Wno-unused-def
+
+# Parameter-dependent width casts are necessary even when one instance makes them identity casts.
+-Wno-useless-cast
+
+# Explicit default branches intentionally keep unique case statements defensive.
+-Wno-case-redundant-default
+
+# Signed integer dimension parameters are deliberately compared with unsigned bounded signals.
+-Wno-sign-compare
+
+# Parameterized arithmetic intentionally combines differently sized operands; width checks remain on.
+-Wno-arith-op-mismatch
+
+# Equal-width packed-array reshaping is fundamental to tiled and multidimensional RTL interfaces.
+-Wno-packed-array-conv
+-Wno-comparison-mismatch
+-Wno-bitwise-op-mismatch
+
+# Explicitly empty output connections already document an intentional unused output.
+-Wno-empty-output-connection

--- a/tracker/rtl/br_tracker_freelist.sv
+++ b/tracker/rtl/br_tracker_freelist.sv
@@ -53,12 +53,15 @@ module br_tracker_freelist #(
     // It is expected that alloc_valid could be 1 at end of the test because it's
     // a natural idle condition for this design.
     parameter bit EnableAssertFinalNotDeallocValid = 1,
+    // slang lint_save
+    // slang lint_off unused-parameter
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertUniqueDeallocEntryId = 1,
     // If 1, then assert that the number of allocated entries is the same as the number of
     // preallocated entries at the end of the test.
     // ri lint_check_waive PARAM_NOT_USED
     parameter bit EnableAssertFinalAllocatedInitial = 1,
+    // slang lint_restore
 
     localparam int EntryIdWidth = $clog2(NumEntries),
     localparam int DeallocCountWidth = $clog2(NumDeallocPorts + 1),

--- a/tracker/rtl/br_tracker_linked_list_ctrl.sv
+++ b/tracker/rtl/br_tracker_linked_list_ctrl.sv
@@ -158,7 +158,10 @@ module br_tracker_linked_list_ctrl #(
     `BR_REGLI(ll_tail_select, ll_tail_select_next, ll_tail_select_update, NumLinkedLists'(1'b1))
 
     // Only used for assertion
+    // slang lint_save
+    // slang lint_off unused-but-set-variable
     logic ll_head_select_write_valid;  // ri lint_check_waive NOT_READ
+    // slang lint_restore
 
     br_delay_valid #(
         .NumStages(RamReadLatency),


### PR DESCRIPTION
# Problem

Existing Bedrock RTL suites only run AscentLint, even when the public Slang compiler is available. Enabling every modern Slang warning exposes repository-wide false positives, assertion-only signals already waived for AscentLint, and genuine clarity issues that require explicit review.

# Solution

- Centrally run both AscentLint and Slang for every existing elaboration/lint suite while preserving parameter sweeps and assertion configurations.
- Use symmetric tool-qualified target names everywhere and add the three previously missing standalone macro Slang tests: production coverage is exactly **954 AscentLint tests and 954 Slang lint tests**, with no unmatched targets.
- Keep Slang lint targets `manual` in this rollout PR; the downstream CI PR activates them after review.
- Document each named exception in the repository-root strict policy and retain enabled truncation, signed-conversion, implicit-boolean, and unconnected-input diagnostics.
- Keep all 40 waivers directly beside the affected RTL, mirroring existing AscentLint waivers where applicable. Slang has no native one-off comment directive; a tested pre-commit guard now rejects unscoped disables, missing restores, and `lint_on` severity downgrades. A cleaner one-line waiver syntax is proposed upstream in [MikePopoloski/slang#1930](https://github.com/MikePopoloski/slang/issues/1930), but is not yet supported by Slang.
- Fix newly exposed enum-case completeness, assertion popcount widths, explicit assertion reductions, redundant macro token pastes, and intentional modulo sizing.
- Verified **2,183/2,183** public Slang/Bazel/Python tests on the complete stack, five representative Verilator simulations, full pre-commit, and loading every real Bazel package.
- Human review is required for every inline waiver and policy exception before this draft advances.
