### PR TITLE
[ci] Enable strict Slang lint in public CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,38 +79,38 @@ jobs:
             suite: python-stardoc
             shard_index: 0
             shard_count: 1
-          - name: slang-1-of-8
-            suite: slang
+          - name: slang-elab-1-of-4
+            suite: slang_elab
             shard_index: 0
-            shard_count: 8
-          - name: slang-2-of-8
-            suite: slang
+            shard_count: 4
+          - name: slang-elab-2-of-4
+            suite: slang_elab
             shard_index: 1
-            shard_count: 8
-          - name: slang-3-of-8
-            suite: slang
+            shard_count: 4
+          - name: slang-elab-3-of-4
+            suite: slang_elab
             shard_index: 2
-            shard_count: 8
-          - name: slang-4-of-8
-            suite: slang
+            shard_count: 4
+          - name: slang-elab-4-of-4
+            suite: slang_elab
             shard_index: 3
-            shard_count: 8
-          - name: slang-5-of-8
-            suite: slang
-            shard_index: 4
-            shard_count: 8
-          - name: slang-6-of-8
-            suite: slang
-            shard_index: 5
-            shard_count: 8
-          - name: slang-7-of-8
-            suite: slang
-            shard_index: 6
-            shard_count: 8
-          - name: slang-8-of-8
-            suite: slang
-            shard_index: 7
-            shard_count: 8
+            shard_count: 4
+          - name: slang-lint-1-of-4
+            suite: slang_lint
+            shard_index: 0
+            shard_count: 4
+          - name: slang-lint-2-of-4
+            suite: slang_lint
+            shard_index: 1
+            shard_count: 4
+          - name: slang-lint-3-of-4
+            suite: slang_lint
+            shard_index: 2
+            shard_count: 4
+          - name: slang-lint-4-of-4
+            suite: slang_lint
+            shard_index: 3
+            shard_count: 4
           - name: verilator-1-of-8
             suite: verilator
             shard_index: 0
@@ -290,9 +290,13 @@ jobs:
                 > /tmp/discovered-stardoc.txt
               run_discovered_suite stardoc 0 1 /tmp/discovered-stardoc.txt
               ;;
-            slang)
-              query_and_run_suite slang "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
-                '(tests(//...) intersect attr(tags, "slang", //...)) except attr(tags, "manual", //...)'
+            slang_elab)
+              query_and_run_suite slang_elab "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
+                '(tests(//...) intersect attr(tags, "slang", //...) intersect attr(tags, "elab", //...)) except attr(tags, "manual", //...)'
+              ;;
+            slang_lint)
+              query_and_run_suite slang_lint "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
+                '(tests(//...) intersect attr(tags, "slang", //...) intersect attr(tags, "lint", //...)) except attr(tags, "manual", //...)'
               ;;
             verilator)
               query_and_run_suite verilator "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
@@ -550,6 +554,12 @@ jobs:
       stardoc_total_tests: ${{ steps.results.outputs.stardoc_total_tests }}
       stardoc_passing_tests: ${{ steps.results.outputs.stardoc_passing_tests }}
       stardoc_exit_code: ${{ steps.results.outputs.stardoc_exit_code }}
+      slang_elab_total_tests: ${{ steps.results.outputs.slang_elab_total_tests }}
+      slang_elab_passing_tests: ${{ steps.results.outputs.slang_elab_passing_tests }}
+      slang_elab_exit_code: ${{ steps.results.outputs.slang_elab_exit_code }}
+      slang_lint_total_tests: ${{ steps.results.outputs.slang_lint_total_tests }}
+      slang_lint_passing_tests: ${{ steps.results.outputs.slang_lint_passing_tests }}
+      slang_lint_exit_code: ${{ steps.results.outputs.slang_lint_exit_code }}
       slang_total_tests: ${{ steps.results.outputs.slang_total_tests }}
       slang_passing_tests: ${{ steps.results.outputs.slang_passing_tests }}
       slang_exit_code: ${{ steps.results.outputs.slang_exit_code }}
@@ -581,7 +591,8 @@ jobs:
             --results-dir bazel-oss-aggregate \
             --expected python=1 \
             --expected stardoc=1 \
-            --expected slang=8 \
+            --expected slang_elab=4 \
+            --expected slang_lint=4 \
             --expected verilator=8 \
             --github-output "$GITHUB_OUTPUT" \
             --step-summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,22 +79,38 @@ jobs:
             suite: python-stardoc
             shard_index: 0
             shard_count: 1
-          - name: slang-1-of-4
+          - name: slang-1-of-8
             suite: slang
             shard_index: 0
-            shard_count: 4
-          - name: slang-2-of-4
+            shard_count: 8
+          - name: slang-2-of-8
             suite: slang
             shard_index: 1
-            shard_count: 4
-          - name: slang-3-of-4
+            shard_count: 8
+          - name: slang-3-of-8
             suite: slang
             shard_index: 2
-            shard_count: 4
-          - name: slang-4-of-4
+            shard_count: 8
+          - name: slang-4-of-8
             suite: slang
             shard_index: 3
-            shard_count: 4
+            shard_count: 8
+          - name: slang-5-of-8
+            suite: slang
+            shard_index: 4
+            shard_count: 8
+          - name: slang-6-of-8
+            suite: slang
+            shard_index: 5
+            shard_count: 8
+          - name: slang-7-of-8
+            suite: slang
+            shard_index: 6
+            shard_count: 8
+          - name: slang-8-of-8
+            suite: slang
+            shard_index: 7
+            shard_count: 8
           - name: verilator-1-of-8
             suite: verilator
             shard_index: 0
@@ -565,7 +581,7 @@ jobs:
             --results-dir bazel-oss-aggregate \
             --expected python=1 \
             --expected stardoc=1 \
-            --expected slang=4 \
+            --expected slang=8 \
             --expected verilator=8 \
             --github-output "$GITHUB_OUTPUT" \
             --step-summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,22 +79,38 @@ jobs:
             suite: python-stardoc
             shard_index: 0
             shard_count: 1
-          - name: slang-1-of-4
+          - name: slang-1-of-8
             suite: slang
             shard_index: 0
-            shard_count: 4
-          - name: slang-2-of-4
+            shard_count: 8
+          - name: slang-2-of-8
             suite: slang
             shard_index: 1
-            shard_count: 4
-          - name: slang-3-of-4
+            shard_count: 8
+          - name: slang-3-of-8
             suite: slang
             shard_index: 2
-            shard_count: 4
-          - name: slang-4-of-4
+            shard_count: 8
+          - name: slang-4-of-8
             suite: slang
             shard_index: 3
-            shard_count: 4
+            shard_count: 8
+          - name: slang-5-of-8
+            suite: slang
+            shard_index: 4
+            shard_count: 8
+          - name: slang-6-of-8
+            suite: slang
+            shard_index: 5
+            shard_count: 8
+          - name: slang-7-of-8
+            suite: slang
+            shard_index: 6
+            shard_count: 8
+          - name: slang-8-of-8
+            suite: slang
+            shard_index: 7
+            shard_count: 8
           - name: verilator-1-of-8
             suite: verilator
             shard_index: 0
@@ -518,7 +534,7 @@ jobs:
             --results-dir bazel-oss-aggregate \
             --expected python=1 \
             --expected stardoc=1 \
-            --expected slang=4 \
+            --expected slang=8 \
             --expected verilator=8 \
             --expected coverage=4 \
             --github-output "$GITHUB_OUTPUT" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,38 +79,38 @@ jobs:
             suite: python-stardoc
             shard_index: 0
             shard_count: 1
-          - name: slang-1-of-8
-            suite: slang
+          - name: slang-elab-1-of-4
+            suite: slang_elab
             shard_index: 0
-            shard_count: 8
-          - name: slang-2-of-8
-            suite: slang
+            shard_count: 4
+          - name: slang-elab-2-of-4
+            suite: slang_elab
             shard_index: 1
-            shard_count: 8
-          - name: slang-3-of-8
-            suite: slang
+            shard_count: 4
+          - name: slang-elab-3-of-4
+            suite: slang_elab
             shard_index: 2
-            shard_count: 8
-          - name: slang-4-of-8
-            suite: slang
+            shard_count: 4
+          - name: slang-elab-4-of-4
+            suite: slang_elab
             shard_index: 3
-            shard_count: 8
-          - name: slang-5-of-8
-            suite: slang
-            shard_index: 4
-            shard_count: 8
-          - name: slang-6-of-8
-            suite: slang
-            shard_index: 5
-            shard_count: 8
-          - name: slang-7-of-8
-            suite: slang
-            shard_index: 6
-            shard_count: 8
-          - name: slang-8-of-8
-            suite: slang
-            shard_index: 7
-            shard_count: 8
+            shard_count: 4
+          - name: slang-lint-1-of-4
+            suite: slang_lint
+            shard_index: 0
+            shard_count: 4
+          - name: slang-lint-2-of-4
+            suite: slang_lint
+            shard_index: 1
+            shard_count: 4
+          - name: slang-lint-3-of-4
+            suite: slang_lint
+            shard_index: 2
+            shard_count: 4
+          - name: slang-lint-4-of-4
+            suite: slang_lint
+            shard_index: 3
+            shard_count: 4
           - name: verilator-1-of-8
             suite: verilator
             shard_index: 0
@@ -311,9 +311,13 @@ jobs:
                 > /tmp/discovered-stardoc.txt
               run_discovered_suite stardoc 0 1 /tmp/discovered-stardoc.txt
               ;;
-            slang)
-              query_and_run_suite slang "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
-                '(tests(//...) intersect attr(tags, "slang", //...)) except attr(tags, "manual", //...)'
+            slang_elab)
+              query_and_run_suite slang_elab "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
+                '(tests(//...) intersect attr(tags, "slang", //...) intersect attr(tags, "elab", //...)) except attr(tags, "manual", //...)'
+              ;;
+            slang_lint)
+              query_and_run_suite slang_lint "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
+                '(tests(//...) intersect attr(tags, "slang", //...) intersect attr(tags, "lint", //...)) except attr(tags, "manual", //...)'
               ;;
             verilator)
               query_and_run_suite verilator "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
@@ -500,6 +504,12 @@ jobs:
       stardoc_total_tests: ${{ steps.results.outputs.stardoc_total_tests }}
       stardoc_passing_tests: ${{ steps.results.outputs.stardoc_passing_tests }}
       stardoc_exit_code: ${{ steps.results.outputs.stardoc_exit_code }}
+      slang_elab_total_tests: ${{ steps.results.outputs.slang_elab_total_tests }}
+      slang_elab_passing_tests: ${{ steps.results.outputs.slang_elab_passing_tests }}
+      slang_elab_exit_code: ${{ steps.results.outputs.slang_elab_exit_code }}
+      slang_lint_total_tests: ${{ steps.results.outputs.slang_lint_total_tests }}
+      slang_lint_passing_tests: ${{ steps.results.outputs.slang_lint_passing_tests }}
+      slang_lint_exit_code: ${{ steps.results.outputs.slang_lint_exit_code }}
       slang_total_tests: ${{ steps.results.outputs.slang_total_tests }}
       slang_passing_tests: ${{ steps.results.outputs.slang_passing_tests }}
       slang_exit_code: ${{ steps.results.outputs.slang_exit_code }}
@@ -534,7 +544,8 @@ jobs:
             --results-dir bazel-oss-aggregate \
             --expected python=1 \
             --expected stardoc=1 \
-            --expected slang=8 \
+            --expected slang_elab=4 \
+            --expected slang_lint=4 \
             --expected verilator=8 \
             --expected coverage=4 \
             --github-output "$GITHUB_OUTPUT" \

--- a/bazel/verilog.bzl
+++ b/bazel/verilog.bzl
@@ -1779,15 +1779,12 @@ def verilog_elab_and_lint_test_suite(
 
     for tool in lint_tools:
         test_name = name + "_" + tool + "_lint_test"
-        lint_kwargs = dict(kwargs)
-        if tool == "slang":
-            lint_kwargs["tags"] = kwargs.get("tags", []) + ["manual"]
         verilog_lint_test(
             name = test_name,
             tool = tool,
             deps = [":" + name + "_wrapper"],
             defines = defines,
-            **lint_kwargs
+            **kwargs
         )
 
 def is_param_combination_legal(params, illegal_param_combinations):

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -75,7 +75,6 @@ verilog_lint_test(
 
 verilog_lint_test(
     name = "br_unused_tb_slang_lint_test",
-    tags = ["manual"],
     tool = "slang",
     visibility = ["//visibility:public"],
     deps = [":br_unused_tb"],
@@ -111,7 +110,6 @@ verilog_lint_test(
 
 verilog_lint_test(
     name = "br_tieoff_tb_slang_lint_test",
-    tags = ["manual"],
     tool = "slang",
     deps = [":br_tieoff_tb"],
 )
@@ -295,7 +293,6 @@ verilog_lint_test(
 
 verilog_lint_test(
     name = "br_assign_slang_lint_test",
-    tags = ["manual"],
     tool = "slang",
     visibility = ["//visibility:public"],
     deps = [":br_assign_test"],

--- a/python/ci/bazel_oss_sharding.py
+++ b/python/ci/bazel_oss_sharding.py
@@ -13,7 +13,7 @@ from typing import Iterable
 
 SCHEMA_VERSION = 1
 PASSING_TESTS_RE = re.compile(r"(\d+) tests? pass(?:es)?")
-SUITES = ("python", "stardoc", "slang", "verilator", "coverage")
+SUITES = ("python", "stardoc", "slang_elab", "slang_lint", "verilator", "coverage")
 BUILD_SUITES = frozenset({"coverage"})
 
 
@@ -290,6 +290,14 @@ def aggregate_results(
     )
     if unknown_suites:
         errors.append(f"unexpected suites: {unknown_suites}")
+
+    if "slang_elab" in outputs and "slang_lint" in outputs:
+        slang_suites = (outputs["slang_elab"], outputs["slang_lint"])
+        outputs["slang"] = {
+            "total_tests": sum(suite["total_tests"] for suite in slang_suites),
+            "passing_tests": sum(suite["passing_tests"] for suite in slang_suites),
+            "exit_code": max(suite["exit_code"] for suite in slang_suites),
+        }
     return outputs, errors, summary_rows
 
 
@@ -397,7 +405,7 @@ def command_aggregate(args: argparse.Namespace) -> int:
     expected = parse_expected_shards(args.expected)
     outputs, errors, rows = aggregate_results(args.results_dir, expected)
     with args.github_output.open("a", encoding="utf-8") as output:
-        for suite in SUITES:
+        for suite in SUITES + ("slang",):
             for field in ("total_tests", "passing_tests", "exit_code"):
                 output.write(f"{suite}_{field}={outputs[suite][field]}\n")
     with args.step_summary.open("a", encoding="utf-8") as summary:

--- a/python/ci/bazel_oss_sharding.py
+++ b/python/ci/bazel_oss_sharding.py
@@ -13,7 +13,7 @@ from typing import Iterable
 
 SCHEMA_VERSION = 1
 PASSING_TESTS_RE = re.compile(r"(\d+) tests? pass(?:es)?")
-SUITES = ("python", "stardoc", "slang", "verilator", "coverage")
+SUITES = ("python", "stardoc", "slang_elab", "slang_lint", "verilator", "coverage")
 BUILD_SUITES = frozenset({"coverage"})
 
 
@@ -290,6 +290,14 @@ def aggregate_results(
     )
     if unknown_suites:
         errors.append(f"unexpected suites: {unknown_suites}")
+
+    if "slang_elab" in outputs and "slang_lint" in outputs:
+        slang_suites = (outputs["slang_elab"], outputs["slang_lint"])
+        outputs["slang"] = {
+            "total_tests": sum(suite["total_tests"] for suite in slang_suites),
+            "passing_tests": sum(suite["passing_tests"] for suite in slang_suites),
+            "exit_code": max(suite["exit_code"] for suite in slang_suites),
+        }
     return outputs, errors, summary_rows
 
 
@@ -395,7 +403,10 @@ def command_aggregate(args: argparse.Namespace) -> int:
     expected = parse_expected_shards(args.expected)
     outputs, errors, rows = aggregate_results(args.results_dir, expected)
     with args.github_output.open("a", encoding="utf-8") as output:
-        for suite in expected:
+        suites = list(expected)
+        if "slang" in outputs:
+            suites.append("slang")
+        for suite in suites:
             for field in ("total_tests", "passing_tests", "exit_code"):
                 output.write(f"{suite}_{field}={outputs[suite][field]}\n")
     with args.step_summary.open("a", encoding="utf-8") as summary:

--- a/python/ci/bazel_oss_sharding_test.py
+++ b/python/ci/bazel_oss_sharding_test.py
@@ -11,6 +11,7 @@ import unittest
 from python.ci.bazel_oss_sharding import (
     aggregate_results,
     canonicalize_labels,
+    command_aggregate,
     command_check,
     finalize_result,
     labels_digest,
@@ -53,7 +54,7 @@ class BazelOssShardingTest(unittest.TestCase):
     def test_prepare_rejects_empty_discovery_and_empty_shard(self):
         with tempfile.TemporaryDirectory() as temporary:
             output_dir = Path(temporary)
-            empty, _, _ = prepare_partition("slang", 0, 1, [], output_dir)
+            empty, _, _ = prepare_partition("slang_elab", 0, 1, [], output_dir)
             self.assertNotEqual(empty["exit_code"], 0)
             self.assertIn("test discovery selected no targets", empty["errors"])
 
@@ -61,7 +62,7 @@ class BazelOssShardingTest(unittest.TestCase):
             selected_index = shard_for_label(label, 2)
             empty_index = 1 - selected_index
             record, _, _ = prepare_partition(
-                "slang", empty_index, 2, [label], output_dir
+                "slang_elab", empty_index, 2, [label], output_dir
             )
             self.assertIn("shard selected no targets", record["errors"])
 
@@ -102,9 +103,15 @@ class BazelOssShardingTest(unittest.TestCase):
             self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
             self._write_suite(
                 results_dir,
-                "slang",
+                "slang_elab",
                 2,
-                [f"//rtl:slang_{index}" for index in range(20)],
+                [f"//rtl:slang_elab_{index}" for index in range(20)],
+            )
+            self._write_suite(
+                results_dir,
+                "slang_lint",
+                2,
+                [f"//rtl:slang_lint_{index}" for index in range(18)],
             )
             self._write_suite(
                 results_dir,
@@ -115,19 +122,79 @@ class BazelOssShardingTest(unittest.TestCase):
 
             outputs, errors, _ = aggregate_results(
                 results_dir,
-                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 3},
+                {
+                    "python": 1,
+                    "stardoc": 1,
+                    "slang_elab": 2,
+                    "slang_lint": 2,
+                    "verilator": 3,
+                },
             )
 
             self.assertEqual(errors, [])
-            self.assertEqual(outputs["slang"]["total_tests"], 20)
+            self.assertEqual(outputs["slang_elab"]["total_tests"], 20)
+            self.assertEqual(outputs["slang_lint"]["total_tests"], 18)
+            self.assertEqual(outputs["slang"]["total_tests"], 38)
+            self.assertEqual(outputs["slang"]["passing_tests"], 38)
+            self.assertEqual(outputs["slang"]["exit_code"], 0)
             self.assertEqual(outputs["verilator"]["passing_tests"], 30)
+
+    def test_aggregate_combines_slang_failures_for_existing_badge(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            self._write_suite(results_dir, "slang_elab", 1, ["//rtl:elab"])
+            paths = self._write_suite(results_dir, "slang_lint", 1, ["//rtl:lint"])
+            record = json.loads(paths[0].read_text(encoding="utf-8"))
+            record["passing_tests"] = 0
+            record["exit_code"] = 1
+            paths[0].write_text(json.dumps(record), encoding="utf-8")
+
+            outputs, errors, _ = aggregate_results(
+                results_dir, {"slang_elab": 1, "slang_lint": 1}
+            )
+
+            self.assertTrue(errors)
+            self.assertEqual(outputs["slang"]["total_tests"], 2)
+            self.assertEqual(outputs["slang"]["passing_tests"], 1)
+            self.assertEqual(outputs["slang"]["exit_code"], 1)
+
+    def test_aggregate_writes_separate_and_combined_slang_outputs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            suites = (
+                "python",
+                "stardoc",
+                "slang_elab",
+                "slang_lint",
+                "verilator",
+                "coverage",
+            )
+            for suite in suites:
+                self._write_suite(results_dir, suite, 1, [f"//pkg:{suite}"])
+            github_output = results_dir / "github-output.txt"
+            step_summary = results_dir / "step-summary.md"
+            args = argparse.Namespace(
+                expected=[f"{suite}=1" for suite in suites],
+                results_dir=results_dir,
+                github_output=github_output,
+                step_summary=step_summary,
+            )
+
+            self.assertEqual(command_aggregate(args), 0)
+
+            output = github_output.read_text(encoding="utf-8")
+            self.assertIn("slang_elab_total_tests=1\n", output)
+            self.assertIn("slang_lint_total_tests=1\n", output)
+            self.assertIn("slang_total_tests=2\n", output)
+            self.assertIn("| slang_elab |", step_summary.read_text(encoding="utf-8"))
+            self.assertIn("| slang_lint |", step_summary.read_text(encoding="utf-8"))
 
     def test_aggregate_rejects_missing_duplicate_and_inconsistent_shards(self):
         with tempfile.TemporaryDirectory() as temporary:
             results_dir = Path(temporary)
             paths = self._write_suite(
                 results_dir,
-                "slang",
+                "slang_elab",
                 2,
                 [f"//rtl:test_{index}" for index in range(20)],
             )
@@ -138,7 +205,7 @@ class BazelOssShardingTest(unittest.TestCase):
 
             _, errors, _ = aggregate_results(
                 results_dir,
-                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 1},
+                {"python": 1, "stardoc": 1, "slang_elab": 2, "verilator": 1},
             )
             self.assertTrue(any("missing shard indexes" in error for error in errors))
 
@@ -152,7 +219,7 @@ class BazelOssShardingTest(unittest.TestCase):
             )
             _, errors, _ = aggregate_results(
                 results_dir,
-                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 1},
+                {"python": 1, "stardoc": 1, "slang_elab": 2, "verilator": 1},
             )
             self.assertTrue(any("duplicate shard index" in error for error in errors))
 
@@ -161,14 +228,16 @@ class BazelOssShardingTest(unittest.TestCase):
             results_dir = Path(temporary)
             self._write_suite(results_dir, "python", 1, ["//python:test"])
             self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
-            paths = self._write_suite(results_dir, "slang", 1, ["//rtl:a", "//rtl:b"])
+            paths = self._write_suite(
+                results_dir, "slang_lint", 1, ["//rtl:a", "//rtl:b"]
+            )
             self._write_suite(results_dir, "verilator", 1, ["//sim:test"])
             record = json.loads(paths[0].read_text(encoding="utf-8"))
             (results_dir / record["target_file"]).write_text("//rtl:a\n")
 
             _, errors, _ = aggregate_results(
                 results_dir,
-                {"python": 1, "stardoc": 1, "slang": 1, "verilator": 1},
+                {"python": 1, "stardoc": 1, "slang_lint": 1, "verilator": 1},
             )
             self.assertTrue(any("does not match manifest" in error for error in errors))
             self.assertTrue(any("union digest" in error for error in errors))
@@ -180,7 +249,7 @@ class BazelOssShardingTest(unittest.TestCase):
             self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
             paths = self._write_suite(
                 results_dir,
-                "slang",
+                "slang_lint",
                 2,
                 [f"//rtl:test_{index}" for index in range(20)],
             )
@@ -191,7 +260,7 @@ class BazelOssShardingTest(unittest.TestCase):
 
             _, errors, _ = aggregate_results(
                 results_dir,
-                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 1},
+                {"python": 1, "stardoc": 1, "slang_lint": 2, "verilator": 1},
             )
             self.assertTrue(
                 any("discovered target digest" in error for error in errors)

--- a/python/ci/bazel_oss_sharding_test.py
+++ b/python/ci/bazel_oss_sharding_test.py
@@ -11,6 +11,7 @@ import unittest
 from python.ci.bazel_oss_sharding import (
     aggregate_results,
     canonicalize_labels,
+    command_aggregate,
     command_check,
     finalize_result,
     labels_digest,
@@ -54,7 +55,7 @@ class BazelOssShardingTest(unittest.TestCase):
     def test_prepare_rejects_empty_discovery_and_empty_shard(self):
         with tempfile.TemporaryDirectory() as temporary:
             output_dir = Path(temporary)
-            empty, _, _ = prepare_partition("slang", 0, 1, [], output_dir)
+            empty, _, _ = prepare_partition("slang_elab", 0, 1, [], output_dir)
             self.assertNotEqual(empty["exit_code"], 0)
             self.assertIn("test discovery selected no targets", empty["errors"])
 
@@ -62,7 +63,7 @@ class BazelOssShardingTest(unittest.TestCase):
             selected_index = shard_for_label(label, 2)
             empty_index = 1 - selected_index
             record, _, _ = prepare_partition(
-                "slang", empty_index, 2, [label], output_dir
+                "slang_elab", empty_index, 2, [label], output_dir
             )
             self.assertIn("shard selected no targets", record["errors"])
 
@@ -103,9 +104,15 @@ class BazelOssShardingTest(unittest.TestCase):
             self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
             self._write_suite(
                 results_dir,
-                "slang",
+                "slang_elab",
                 2,
-                [f"//rtl:slang_{index}" for index in range(20)],
+                [f"//rtl:slang_elab_{index}" for index in range(20)],
+            )
+            self._write_suite(
+                results_dir,
+                "slang_lint",
+                2,
+                [f"//rtl:slang_lint_{index}" for index in range(18)],
             )
             self._write_suite(
                 results_dir,
@@ -114,21 +121,81 @@ class BazelOssShardingTest(unittest.TestCase):
                 [f"//sim:verilator_{index}" for index in range(30)],
             )
 
-            expected = parse_expected_shards(
-                ["python=1", "stardoc=1", "slang=2", "verilator=3"]
+            outputs, errors, _ = aggregate_results(
+                results_dir,
+                {
+                    "python": 1,
+                    "stardoc": 1,
+                    "slang_elab": 2,
+                    "slang_lint": 2,
+                    "verilator": 3,
+                },
             )
-            outputs, errors, _ = aggregate_results(results_dir, expected)
 
             self.assertEqual(errors, [])
-            self.assertEqual(outputs["slang"]["total_tests"], 20)
+            self.assertEqual(outputs["slang_elab"]["total_tests"], 20)
+            self.assertEqual(outputs["slang_lint"]["total_tests"], 18)
+            self.assertEqual(outputs["slang"]["total_tests"], 38)
+            self.assertEqual(outputs["slang"]["passing_tests"], 38)
+            self.assertEqual(outputs["slang"]["exit_code"], 0)
             self.assertEqual(outputs["verilator"]["passing_tests"], 30)
+
+    def test_aggregate_combines_slang_failures_for_existing_badge(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            self._write_suite(results_dir, "slang_elab", 1, ["//rtl:elab"])
+            paths = self._write_suite(results_dir, "slang_lint", 1, ["//rtl:lint"])
+            record = json.loads(paths[0].read_text(encoding="utf-8"))
+            record["passing_tests"] = 0
+            record["exit_code"] = 1
+            paths[0].write_text(json.dumps(record), encoding="utf-8")
+
+            outputs, errors, _ = aggregate_results(
+                results_dir, {"slang_elab": 1, "slang_lint": 1}
+            )
+
+            self.assertTrue(errors)
+            self.assertEqual(outputs["slang"]["total_tests"], 2)
+            self.assertEqual(outputs["slang"]["passing_tests"], 1)
+            self.assertEqual(outputs["slang"]["exit_code"], 1)
+
+    def test_aggregate_writes_separate_and_combined_slang_outputs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            suites = (
+                "python",
+                "stardoc",
+                "slang_elab",
+                "slang_lint",
+                "verilator",
+                "coverage",
+            )
+            for suite in suites:
+                self._write_suite(results_dir, suite, 1, [f"//pkg:{suite}"])
+            github_output = results_dir / "github-output.txt"
+            step_summary = results_dir / "step-summary.md"
+            args = argparse.Namespace(
+                expected=[f"{suite}=1" for suite in suites],
+                results_dir=results_dir,
+                github_output=github_output,
+                step_summary=step_summary,
+            )
+
+            self.assertEqual(command_aggregate(args), 0)
+
+            output = github_output.read_text(encoding="utf-8")
+            self.assertIn("slang_elab_total_tests=1\n", output)
+            self.assertIn("slang_lint_total_tests=1\n", output)
+            self.assertIn("slang_total_tests=2\n", output)
+            self.assertIn("| slang_elab |", step_summary.read_text(encoding="utf-8"))
+            self.assertIn("| slang_lint |", step_summary.read_text(encoding="utf-8"))
 
     def test_aggregate_rejects_missing_duplicate_and_inconsistent_shards(self):
         with tempfile.TemporaryDirectory() as temporary:
             results_dir = Path(temporary)
             paths = self._write_suite(
                 results_dir,
-                "slang",
+                "slang_elab",
                 2,
                 [f"//rtl:test_{index}" for index in range(20)],
             )
@@ -139,7 +206,7 @@ class BazelOssShardingTest(unittest.TestCase):
 
             _, errors, _ = aggregate_results(
                 results_dir,
-                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 1},
+                {"python": 1, "stardoc": 1, "slang_elab": 2, "verilator": 1},
             )
             self.assertTrue(any("missing shard indexes" in error for error in errors))
 
@@ -153,7 +220,7 @@ class BazelOssShardingTest(unittest.TestCase):
             )
             _, errors, _ = aggregate_results(
                 results_dir,
-                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 1},
+                {"python": 1, "stardoc": 1, "slang_elab": 2, "verilator": 1},
             )
             self.assertTrue(any("duplicate shard index" in error for error in errors))
 
@@ -162,14 +229,16 @@ class BazelOssShardingTest(unittest.TestCase):
             results_dir = Path(temporary)
             self._write_suite(results_dir, "python", 1, ["//python:test"])
             self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
-            paths = self._write_suite(results_dir, "slang", 1, ["//rtl:a", "//rtl:b"])
+            paths = self._write_suite(
+                results_dir, "slang_lint", 1, ["//rtl:a", "//rtl:b"]
+            )
             self._write_suite(results_dir, "verilator", 1, ["//sim:test"])
             record = json.loads(paths[0].read_text(encoding="utf-8"))
             (results_dir / record["target_file"]).write_text("//rtl:a\n")
 
             _, errors, _ = aggregate_results(
                 results_dir,
-                {"python": 1, "stardoc": 1, "slang": 1, "verilator": 1},
+                {"python": 1, "stardoc": 1, "slang_lint": 1, "verilator": 1},
             )
             self.assertTrue(any("does not match manifest" in error for error in errors))
             self.assertTrue(any("union digest" in error for error in errors))
@@ -181,7 +250,7 @@ class BazelOssShardingTest(unittest.TestCase):
             self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
             paths = self._write_suite(
                 results_dir,
-                "slang",
+                "slang_lint",
                 2,
                 [f"//rtl:test_{index}" for index in range(20)],
             )
@@ -192,7 +261,7 @@ class BazelOssShardingTest(unittest.TestCase):
 
             _, errors, _ = aggregate_results(
                 results_dir,
-                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 1},
+                {"python": 1, "stardoc": 1, "slang_lint": 2, "verilator": 1},
             )
             self.assertTrue(
                 any("discovered target digest" in error for error in errors)


### PR DESCRIPTION
# Problem

The new Slang lint targets remain intentionally excluded from public CI until the complete rollout and every inline waiver have been reviewed. Elaborating and linting should have separate visible CI shard groups and independent result accounting.

# Solution

- Remove rollout-only `manual` tags from both suite-generated and standalone Slang lint tests.
- Run four dedicated Slang elaboration shards and four dedicated Slang lint shards, with separate Bazel tag queries and independently validated result manifests.
- Expose independent elaboration/lint totals while preserving the existing combined Slang badge, public aggregate check, image-publication contract, and dashboard behavior.
- Add aggregation tests covering complete shard coverage, independent totals, combined counts, and propagation of either suite's failure.
- Verified **2,183/2,183** public non-manual targets: 1,205 Slang elaboration tests, 954 production Slang lint tests, two Slang policy infrastructure tests, and the remaining Bazel/Python infrastructure tests.
- Production lint coverage remains exactly **954 AscentLint and 954 Slang targets**. Five representative RAM, shift, and assertion-macro Verilator simulations and the full pre-commit suite also pass.
- Keep this PR in draft until its upstream TopStitch, rollout, policy exceptions, and inline waivers receive human review.
