### PR TITLE
Flow declaration and connection macros

### DIFF
--- a/LIBRARIES.md
+++ b/LIBRARIES.md
@@ -157,6 +157,7 @@ The verification-artifact column reports repository evidence, not a promise that
 | `br_fifo_ctrl_1r1w_push_credit` | Controls a 1R1W external RAM FIFO with credit/valid push and ready/valid pop flow control. | Elab/lint, FPV. |
 | `br_fifo_flops` | Implements a FIFO using internal flop storage and ready/valid flow control. | Elab/lint, Sim, FPV. |
 | `br_fifo_flops_push_credit` | Implements a FIFO using internal flop storage with credit/valid push flow control. | Elab/lint, Sim, FPV. |
+| `br_fifo_flops_unstable` | Implements a flop FIFO that accepts unstable push valid/data and presents a stable ready/valid pop flow. | Elab/lint, Sim. |
 | `br_fifo_shared_dynamic_ctrl` | Dynamically shares FIFO storage across multiple logical FIFOs. | Elab/lint, FPV. |
 | `br_fifo_shared_dynamic_ctrl_ext_arbiter` | Dynamically shares FIFO storage using an externally supplied arbiter. | Elab/lint, FPV. |
 | `br_fifo_shared_dynamic_ctrl_push_credit` | Dynamically shares FIFO storage with credit/valid push flow control. | Elab/lint, FPV. |
@@ -196,9 +197,11 @@ The verification-artifact column reports repository evidence, not a promise that
 | `br_flow_deserializer` | Converts multiple narrow ready/valid flits into fewer wider flits. | Elab/lint, FPV. |
 | `br_flow_fork` | Forks one ready/valid flow to multiple downstream consumers. | Elab/lint, FPV. |
 | `br_flow_fork_select_multihot` | Forks one ready/valid flow to a multihot-selected subset of consumers. | Elab/lint, FPV. |
+| `br_flow_fork_unstable` | Combinationally forks an unstable ready/valid control flow to multiple unstable outputs. | Elab/lint, Sim. |
 | `br_flow_join` | Joins multiple ready/valid control flows into one output flow. | Elab/lint. |
 | `br_flow_mux_fixed` | Multiplexes ready/valid flows with fixed-priority arbitration. | Elab/lint, FPV. |
 | `br_flow_mux_fixed_stable` | Multiplexes stable-data ready/valid flows with fixed-priority arbitration. | Elab/lint, FPV. |
+| `br_flow_mux_fixed_unstable` | Combinationally multiplexes unstable ready/valid flows with fixed-priority arbitration. | Elab/lint, Sim. |
 | `br_flow_mux_lru` | Multiplexes ready/valid flows with least-recently-used arbitration. | Elab/lint, FPV. |
 | `br_flow_mux_lru_stable` | Multiplexes stable-data ready/valid flows with least-recently-used arbitration. | Elab/lint, FPV. |
 | `br_flow_mux_rr` | Multiplexes ready/valid flows with round-robin arbitration. | Elab/lint, FPV. |
@@ -207,6 +210,7 @@ The verification-artifact column reports repository evidence, not a promise that
 | `br_flow_mux_select_unstable` | Multiplexes ready/valid flows using a combinational external select. | Elab/lint, FPV. |
 | `br_flow_reg_both` | Registers both forward and reverse sides of a ready/valid flow. | Elab/lint, FPV. |
 | `br_flow_reg_fwd` | Registers the forward valid/data side of a ready/valid flow. | Elab/lint, FPV. |
+| `br_flow_reg_fwd_unstable` | Captures an unstable push flow and presents stable registered valid/data outputs. | Elab/lint, Sim. |
 | `br_flow_reg_none` | Passes a ready/valid flow through without registering it. | Elab/lint, FPV. |
 | `br_flow_reg_rev` | Registers the reverse ready side of a ready/valid flow. | Elab/lint, FPV. |
 | `br_flow_serializer` | Converts fewer wide ready/valid flits into multiple narrower flits. | Elab/lint, FPV. |

--- a/MACROS.md
+++ b/MACROS.md
@@ -251,6 +251,123 @@ These macros provide size-aware assignment helpers for common bit slicing and ex
 | `BR_INSERT_TO_LSB`, `BR_INSERT_TO_MSB` | Insert a narrower expression into the least-significant or most-significant bits of a wider destination. |
 
 
+## `br_flow.svh`: Ready/Valid Flow Helpers
+
+
+These macros reduce repetitive wiring for canonical ready/valid flows while keeping module ports
+explicit. Declaration macros create signal groups inside a module; bind macros connect those groups
+to a module instance's port prefix; connect macros join differently named groups with continuous
+assignments. They do not declare module ports, add storage, or change the flow-control contract.
+
+| Contract | Signals |
+| --- | --- |
+| Stable data | `<base>_ready`, `<base>_valid`, `<base>_data` |
+| Unstable data | `<base>_ready`, `<base>_valid_unstable`, `<base>_data_unstable` |
+| Stable control | `<base>_ready`, `<base>_valid` |
+| Unstable control | `<base>_ready`, `<base>_valid_unstable` |
+
+On a stable flow, valid and, for data flows, data remain stable while valid is asserted and ready is
+low. On an `_UNSTABLE` flow, valid may be withdrawn while stalled; data may also change on data
+flows. Control flows omit data.
+
+### Declare, bind, and observe
+
+
+| Need | Stable data | Unstable data | Stable control | Unstable control |
+| --- | --- | --- | --- | --- |
+| Declare scalar | `BR_FLOW_DECLARE` | `BR_FLOW_DECLARE_UNSTABLE` | `BR_FLOW_CONTROL_DECLARE` | `BR_FLOW_CONTROL_DECLARE_UNSTABLE` |
+| Declare packed array | `BR_FLOW_DECLARE_ARRAY` | `BR_FLOW_DECLARE_UNSTABLE_ARRAY` | `BR_FLOW_CONTROL_DECLARE_ARRAY` | `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY` |
+| Bind whole flow | `BR_FLOW_BIND` | `BR_FLOW_BIND_UNSTABLE` | `BR_FLOW_CONTROL_BIND` | `BR_FLOW_CONTROL_BIND_UNSTABLE` |
+| Bind one array lane | `BR_FLOW_BIND_INDEX` | `BR_FLOW_BIND_UNSTABLE_INDEX` | `BR_FLOW_CONTROL_BIND_INDEX` | `BR_FLOW_CONTROL_BIND_UNSTABLE_INDEX` |
+
+Use `BR_FLOW_FIRE(flow)` or `BR_FLOW_FIRE_UNSTABLE(flow)` to obtain the scalar handshake or packed
+vector of per-lane handshakes. The corresponding `BR_FLOW_FIRE_INDEX(flow, index)` and
+`BR_FLOW_FIRE_UNSTABLE_INDEX(flow, index)` forms return one lane's handshake. These macros work for
+both data and control flows.
+
+For example:
+
+```systemverilog
+typedef logic [31:0] payload_t;
+
+`BR_FLOW_DECLARE(input_flow, payload_t)
+`BR_FLOW_DECLARE(output_flow, payload_t)
+
+logic input_fire;
+
+br_flow_reg_fwd #(
+    .Width($bits(payload_t))
+) u_flow_reg (
+    // verilog_lint: waive module-port
+    .clk,
+    .rst,
+    `BR_FLOW_BIND(push, input_flow),
+    `BR_FLOW_BIND(pop, output_flow)
+);
+
+assign input_fire = `BR_FLOW_FIRE(input_flow);
+```
+
+### Connect differently named flows
+
+For connections, choose a contract root and append the topology suffix:
+
+| Contract | Root |
+| --- | --- |
+| Stable data | `BR_FLOW_CONNECT` |
+| Unstable data | `BR_FLOW_CONNECT_UNSTABLE` |
+| Stable control | `BR_FLOW_CONTROL_CONNECT` |
+| Unstable control | `BR_FLOW_CONTROL_CONNECT_UNSTABLE` |
+
+The first flow is the source and the second is the sink. Ready travels toward the source; valid and,
+for data flows, data travel toward the sink.
+
+| Topology | Suffix and arguments |
+| --- | --- |
+| Scalar-to-scalar or whole array-to-array | none: `(source, sink)` |
+| Source array lane to scalar sink | `_FROM_INDEX(source, source_index, sink)` |
+| Scalar source to sink array lane | `_TO_INDEX(source, sink, sink_index)` |
+| Source array lane to sink array lane | `_INDEX(source, source_index, sink, sink_index)` |
+
+For example, an unstable control connection from one array lane to a scalar sink uses
+`BR_FLOW_CONTROL_CONNECT_UNSTABLE_FROM_INDEX`.
+
+Prefer one shared flow name bound at both endpoints. When existing endpoints need different base
+names, connect them directly:
+
+```systemverilog
+`BR_FLOW_CONNECT_INDEX(upstream, UpstreamLane, downstream, DownstreamLane)
+```
+
+### Rules and limitations
+
+
+- Flow names and port prefixes must be bare identifiers because the macros form signal and port
+  names by token pasting.
+- Array counts must be positive constant expressions such as `1 << LogNumFlows`. Arrays add a
+  packed `[count-1:0]` lane dimension with lane 0 as the least-significant lane. Payloads may be
+  packed vectors, packed structs, or inline packed types such as `logic [31:0]`;
+  `<flow>_data[index]` or `<flow>_data_unstable[index]` selects one complete payload.
+- `_INDEX` helpers support elaboration-time constant expressions, including genvar arithmetic such
+  as `NumFlows - 1 - i`; runtime routing remains explicit RTL.
+- Use whole-flow binds for scalars or complete arrays. Use `_INDEX` to bind one lane; expressions
+  such as `flow[index]` cannot replace the flow-name argument.
+- Declaration and connect macros include their semicolons, fire macros are expressions, and bind
+  macros omit the trailing comma. Add a comma after any bind that is not last in a port list, and
+  invoke declaration and connect macros without another semicolon.
+- Verible may report `module-port` before a bind macro expands. If that rule is enabled, place one
+  local `// verilog_lint: waive module-port` immediately before the first port connection in the
+  affected instantiation.
+- Whole-array connects require equal lane counts; connected data payloads must be
+  assignment-compatible. Connect macros are direct assignments, so they do not prevent ready loops
+  or multiple drivers. Wrap a connect used as a generate body in a named `begin`/`end` block because
+  it expands to multiple assignments.
+- Cross-contract boundaries remain explicit. For data flows, `br_flow_reg_fwd_unstable` adapts an
+  unstable source to a stable sink.
+- Sidebands, multidimensional flow arrays, part-selects, concatenations, and differing lane mappings
+  for ready, valid, and data remain explicit.
+
+
 ## `br_fv.svh`: Formal Verification Helpers
 
 

--- a/MACROS.md
+++ b/MACROS.md
@@ -339,35 +339,6 @@ names, connect them directly:
 `BR_FLOW_CONNECT_INDEX(upstream, UpstreamLane, downstream, DownstreamLane)
 ```
 
-### Rules and limitations
-
-
-- Flow names and port prefixes must be bare identifiers because the macros form signal and port
-  names by token pasting.
-- Array counts must be positive constant expressions such as `1 << LogNumFlows`. Arrays add a
-  packed `[count-1:0]` lane dimension with lane 0 as the least-significant lane. Payloads may be
-  packed vectors, packed structs, or inline packed types such as `logic [31:0]`;
-  `<flow>_data[index]` or `<flow>_data_unstable[index]` selects one complete payload.
-- `_INDEX` helpers support elaboration-time constant expressions, including genvar arithmetic such
-  as `NumFlows - 1 - i`; runtime routing remains explicit RTL.
-- Use whole-flow binds for scalars or complete arrays. Use `_INDEX` to bind one lane; expressions
-  such as `flow[index]` cannot replace the flow-name argument.
-- Declaration and connect macros include their semicolons, fire macros are expressions, and bind
-  macros omit the trailing comma. Add a comma after any bind that is not last in a port list, and
-  invoke declaration and connect macros without another semicolon.
-- Verible may report `module-port` before a bind macro expands. If that rule is enabled, place one
-  local `// verilog_lint: waive module-port` immediately before the first port connection in the
-  affected instantiation.
-- Whole-array connects require equal lane counts; connected data payloads must be
-  assignment-compatible. Connect macros are direct assignments, so they do not prevent ready loops
-  or multiple drivers. Wrap a connect used as a generate body in a named `begin`/`end` block because
-  it expands to multiple assignments.
-- Cross-contract boundaries remain explicit. For data flows, `br_flow_reg_fwd_unstable` adapts an
-  unstable source to a stable sink.
-- Sidebands, multidimensional flow arrays, part-selects, concatenations, and differing lane mappings
-  for ready, valid, and data remain explicit.
-
-
 ## `br_fv.svh`: Formal Verification Helpers
 
 

--- a/fifo/rtl/BUILD.bazel
+++ b/fifo/rtl/BUILD.bazel
@@ -44,6 +44,15 @@ verilog_library(
     ],
 )
 
+verilog_library(
+    name = "br_fifo_flops_unstable",
+    srcs = ["br_fifo_flops_unstable.sv"],
+    deps = [
+        ":br_fifo_flops",
+        "//macros:br_asserts",
+    ],
+)
+
 br_verilog_synth_suite(
     name = "br_fifo_flops_baseline_ppa",
     params = {
@@ -404,6 +413,42 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_fifo_flops"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_flops_unstable_test_suite",
+    params = {
+        "Depth": [
+            "2",
+            "4",
+        ],
+        "Width": [
+            "1",
+            "8",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+    },
+    deps = [":br_fifo_flops_unstable"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_fifo_flops_unstable_pipelined_test_suite",
+    params = {
+        "Depth": ["4"],
+        "Width": ["8"],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "FlopRamAddressDepthStages": [
+            "1",
+            "2",
+        ],
+    },
+    deps = [":br_fifo_flops_unstable"],
 )
 
 br_verilog_elab_and_lint_test_suite(

--- a/fifo/rtl/br_fifo_flops_unstable.sv
+++ b/fifo/rtl/br_fifo_flops_unstable.sv
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+// Bedrock-RTL Flop FIFO With Unstable Push Interface
+//
+// Accepts valid and data that may change or be revoked while push_ready is low, then presents a
+// stable ready-valid pop interface. Combinational push-to-pop bypass is disabled so unstable input
+// signals cannot propagate to the pop interface.
+
+`include "br_asserts.svh"
+
+module br_fifo_flops_unstable #(
+    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
+    // If 1, ensure pop_valid/pop_data always come directly from a register.
+    parameter bit RegisterPopOutputs = 0,
+    // Number of tiles in the depth dimension. Must be at least 1.
+    parameter int FlopRamDepthTiles = 1,
+    // Number of tiles in the width dimension. Must be at least 1 and evenly divide Width.
+    parameter int FlopRamWidthTiles = 1,
+    // Number of pipeline stages along the RAM write-address and read-address paths.
+    parameter int FlopRamAddressDepthStages = 0,
+    // Number of pipeline stages along the RAM read-data path in the depth dimension.
+    parameter int FlopRamReadDataDepthStages = 0,
+    // Number of pipeline stages along the RAM read-data path in the width dimension.
+    parameter int FlopRamReadDataWidthStages = 0,
+    // If 1, cover push-side backpressure.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_data_unstable is known whenever push_valid_unstable is asserted.
+    parameter bit EnableAssertPushDataKnown = 1,
+    // If 1, assert that the FIFO is empty at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+
+    localparam int CountWidth = $clog2(Depth + 1)
+) (
+    input logic clk,
+    input logic rst,
+
+    output logic             push_ready,
+    input  logic             push_valid_unstable,
+    input  logic [Width-1:0] push_data_unstable,
+
+    input  logic             pop_ready,
+    output logic             pop_valid,
+    output logic [Width-1:0] pop_data,
+
+    output logic                  full,
+    output logic                  full_next,
+    output logic [CountWidth-1:0] slots,
+    output logic [CountWidth-1:0] slots_next,
+
+    output logic                  empty,
+    output logic                  empty_next,
+    output logic [CountWidth-1:0] items,
+    output logic [CountWidth-1:0] items_next
+);
+
+  localparam int RamReadLatency =
+      FlopRamAddressDepthStages + FlopRamReadDataDepthStages + FlopRamReadDataWidthStages;
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+  `BR_ASSERT_STATIC(depth_must_be_at_least_two_a, Depth >= 2)
+  `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
+  `BR_ASSERT_STATIC(flop_ram_depth_tiles_must_be_at_least_one_a, FlopRamDepthTiles >= 1)
+  `BR_ASSERT_STATIC(flop_ram_width_tiles_must_be_at_least_one_a, FlopRamWidthTiles >= 1)
+  if (FlopRamWidthTiles >= 1) begin : gen_flop_ram_width_tiles_divisibility_check
+    `BR_ASSERT_STATIC(flop_ram_width_tiles_must_evenly_divide_width_a,
+                      (Width % FlopRamWidthTiles) == 0)
+  end
+  `BR_ASSERT_STATIC(flop_ram_address_depth_stages_must_be_nonnegative_a,
+                    FlopRamAddressDepthStages >= 0)
+  `BR_ASSERT_STATIC(flop_ram_read_data_depth_stages_must_be_nonnegative_a,
+                    FlopRamReadDataDepthStages >= 0)
+  `BR_ASSERT_STATIC(flop_ram_read_data_width_stages_must_be_nonnegative_a,
+                    FlopRamReadDataWidthStages >= 0)
+  `BR_ASSERT_STATIC(depth_must_exceed_ram_read_latency_a, Depth > (RamReadLatency + 1))
+
+  // Rely on submodule integration checks.
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  br_fifo_flops #(
+      .Depth(Depth),
+      .Width(Width),
+      .EnableBypass(1'b0),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .FlopRamDepthTiles(FlopRamDepthTiles),
+      .FlopRamWidthTiles(FlopRamWidthTiles),
+      .FlopRamAddressDepthStages(FlopRamAddressDepthStages),
+      .FlopRamReadDataDepthStages(FlopRamReadDataDepthStages),
+      .FlopRamReadDataWidthStages(FlopRamReadDataWidthStages),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(1'b0),
+      .EnableAssertPushDataStability(1'b0),
+      .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure)
+  ) br_fifo_flops (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid(push_valid_unstable),
+      .push_data (push_data_unstable),
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .full,
+      .full_next,
+      .slots,
+      .slots_next,
+      .empty,
+      .empty_next,
+      .items,
+      .items_next
+  );
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  // Rely on submodule implementation checks.
+
+endmodule : br_fifo_flops_unstable

--- a/fifo/sim/BUILD.bazel
+++ b/fifo/sim/BUILD.bazel
@@ -256,6 +256,42 @@ br_verilog_sim_test_tools_suite(
 )
 
 verilog_library(
+    name = "br_fifo_flops_unstable_tb",
+    srcs = ["br_fifo_flops_unstable_tb.sv"],
+    deps = [
+        "//fifo/rtl:br_fifo_flops_unstable",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_fifo_flops_unstable_tb_elab_test",
+    tool = "slang",
+    deps = [":br_fifo_flops_unstable_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_fifo_flops_unstable_sim_test_tools_suite",
+    params = {
+        "Depth": [
+            "3",
+            "13",
+        ],
+        "Width": ["8"],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "FlopRamAddressDepthStages": [
+            "0",
+            "1",
+        ],
+    },
+    tools = ["vcs"],
+    deps = [":br_fifo_flops_unstable_tb"],
+)
+
+verilog_library(
     name = "br_fifo_flops_push_credit_tb",
     srcs = ["br_fifo_flops_push_credit_tb.sv"],
     deps = [

--- a/fifo/sim/br_fifo_flops_unstable_tb.sv
+++ b/fifo/sim/br_fifo_flops_unstable_tb.sv
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+`timescale 1ns / 1ps
+
+// Fills the FIFO, changes and revokes a blocked push, then verifies that only accepted data drains
+// in order. The test covers the unstable push contract independently of the wrapped FIFO logic.
+module br_fifo_flops_unstable_tb #(
+    parameter int Depth = 13,
+    parameter int Width = 8,
+    parameter int RegisterPopOutputs = 0,
+    parameter int FlopRamAddressDepthStages = 0
+);
+  localparam int TimeoutCycles = Depth + FlopRamAddressDepthStages + RegisterPopOutputs + 10;
+
+  logic clk;
+  logic rst;
+
+  logic push_ready;
+  logic push_valid_unstable;
+  logic [Width-1:0] push_data_unstable;
+
+  logic pop_ready;
+  logic pop_valid;
+  logic [Width-1:0] pop_data;
+
+  logic empty;
+  logic full;
+  logic [$clog2(Depth+1)-1:0] items;
+  logic [$clog2(Depth+1)-1:0] slots;
+
+  br_fifo_flops_unstable #(
+      .Depth(Depth),
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .FlopRamAddressDepthStages(FlopRamAddressDepthStages)
+  ) dut (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid_unstable,
+      .push_data_unstable,
+      .pop_ready,
+      .pop_valid,
+      .pop_data,
+      .empty,
+      .empty_next(),
+      .slots,
+      .slots_next(),
+      .full,
+      .full_next (),
+      .items,
+      .items_next()
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  initial begin
+    int timeout;
+
+    push_valid_unstable = 1'b0;
+    push_data_unstable = '0;
+    pop_ready = 1'b0;
+
+    td.reset_dut();
+    #1;
+    td.check(push_ready, "empty FIFO should accept a push");
+    td.check(empty, "FIFO should be empty after reset");
+
+    // Fill the FIFO with known accepted data while the pop side is blocked.
+    for (int item = 0; item < Depth; item++) begin
+      @(negedge clk);
+      push_valid_unstable = 1'b1;
+      push_data_unstable  = Width'(item + 1);
+      #1;
+      td.check(push_ready, "FIFO should accept each fill item");
+      @(posedge clk);
+    end
+
+    @(negedge clk);
+    #1;
+    td.check(!push_ready, "full FIFO should backpressure the push side");
+    td.check(full, "FIFO should report full after the fill");
+
+    timeout = TimeoutCycles;
+    while (!pop_valid && (timeout > 0)) begin
+      @(negedge clk);
+      timeout = timeout - 1;
+    end
+    td.check(timeout > 0, "first accepted item did not reach the pop interface");
+    td.check(pop_data === Width'(1), "first accepted item should remain at the pop interface");
+
+    // Change data while valid remains asserted and push_ready remains low.
+    push_data_unstable = '1;
+    #1;
+    td.check(!push_ready, "changed blocked push should remain unaccepted");
+    td.check(pop_data === Width'(1), "blocked data change must not disturb the pop item");
+    @(posedge clk);
+
+    @(negedge clk);
+    push_data_unstable = '0;
+    #1;
+    td.check(!push_ready, "second changed blocked push should remain unaccepted");
+    td.check(pop_data === Width'(1), "second blocked data change must not disturb the pop item");
+    @(posedge clk);
+
+    // Revoke the blocked push. None of the blocked values may enter the FIFO.
+    @(negedge clk);
+    push_valid_unstable = 1'b0;
+    push_data_unstable  = '1;
+    #1;
+    td.check(!push_ready, "revoked blocked push should remain unaccepted");
+    td.check(pop_data === Width'(1), "blocked valid revocation must not disturb the pop item");
+
+    pop_ready = 1'b1;
+    for (int item = 0; item < Depth; item++) begin
+      timeout = TimeoutCycles;
+      while (!pop_valid && (timeout > 0)) begin
+        @(negedge clk);
+        timeout = timeout - 1;
+      end
+      td.check(timeout > 0, "accepted item did not reach the pop interface");
+      td.check(pop_data === Width'(item + 1), "accepted FIFO data drained out of order");
+      @(posedge clk);
+      if (item != (Depth - 1)) begin
+        @(negedge clk);
+      end
+    end
+
+    @(negedge clk);
+    pop_ready = 1'b0;
+    #1;
+    td.check(empty, "FIFO should be empty after draining accepted data");
+    td.check(!pop_valid, "blocked push values must not appear at the pop interface");
+    td.check(items == '0, "FIFO item count should return to zero");
+    td.check(slots == Depth, "FIFO slot count should return to its capacity");
+
+    td.finish();
+  end
+
+endmodule : br_fifo_flops_unstable_tb

--- a/flow/rtl/BUILD.bazel
+++ b/flow/rtl/BUILD.bazel
@@ -72,6 +72,15 @@ verilog_library(
 )
 
 verilog_library(
+    name = "br_flow_fork_unstable",
+    srcs = ["br_flow_fork_unstable.sv"],
+    deps = [
+        ":br_flow_fork",
+        "//macros:br_asserts",
+    ],
+)
+
+verilog_library(
     name = "br_flow_fork_select_multihot",
     srcs = ["br_flow_fork_select_multihot.sv"],
     deps = [
@@ -170,6 +179,15 @@ verilog_library(
         "//flow/rtl/internal:br_flow_mux_core",
         "//macros:br_asserts_internal",
         "//macros:br_unused",
+    ],
+)
+
+verilog_library(
+    name = "br_flow_mux_fixed_unstable",
+    srcs = ["br_flow_mux_fixed_unstable.sv"],
+    deps = [
+        ":br_flow_mux_fixed",
+        "//macros:br_asserts",
     ],
 )
 
@@ -343,6 +361,15 @@ verilog_library(
         "//flow/rtl/internal:br_flow_checks_valid_data_intg",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
+    ],
+)
+
+verilog_library(
+    name = "br_flow_reg_fwd_unstable",
+    srcs = ["br_flow_reg_fwd_unstable.sv"],
+    deps = [
+        ":br_flow_reg_fwd",
+        "//macros:br_asserts",
     ],
 )
 
@@ -897,6 +924,18 @@ br_verilog_elab_and_lint_test_suite(
 )
 
 br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_fork_unstable_test_suite",
+    params = {
+        "NumFlows": [
+            "1",
+            "2",
+            "3",
+        ],
+    },
+    deps = [":br_flow_fork_unstable"],
+)
+
+br_verilog_elab_and_lint_test_suite(
     name = "br_flow_fork_select_multihot_test_suite",
     params = {
         "NumFlows": [
@@ -1023,6 +1062,22 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_flow_mux_fixed"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_mux_fixed_unstable_test_suite",
+    params = {
+        "NumFlows": [
+            "1",
+            "2",
+            "3",
+        ],
+        "Width": [
+            "1",
+            "2",
+        ],
+    },
+    deps = [":br_flow_mux_fixed_unstable"],
 )
 
 br_verilog_elab_and_lint_test_suite(
@@ -1326,6 +1381,17 @@ br_verilog_elab_and_lint_test_suite(
         ],
     },
     deps = [":br_flow_reg_fwd"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_flow_reg_fwd_unstable_test_suite",
+    params = {
+        "Width": [
+            "1",
+            "2",
+        ],
+    },
+    deps = [":br_flow_reg_fwd_unstable"],
 )
 
 br_verilog_elab_and_lint_test_suite(

--- a/flow/rtl/br_flow_fork_unstable.sv
+++ b/flow/rtl/br_flow_fork_unstable.sv
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+// Bedrock-RTL Flow Fork With Unstable Push
+//
+// A flow fork that accepts valid which may change or be revoked while
+// push_ready is low. The fork remains purely combinational, so each pop valid
+// is also explicitly unstable while any other pop flow is backpressured.
+
+`include "br_asserts.svh"
+
+module br_flow_fork_unstable #(
+    // Must be at least 1
+    parameter int NumFlows = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, then assert there are no valid bits asserted at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
+) (
+    input  logic                clk,
+    input  logic                rst,
+    output logic                push_ready,
+    input  logic                push_valid_unstable,
+    input  logic [NumFlows-1:0] pop_ready,
+    output logic [NumFlows-1:0] pop_valid_unstable
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+  `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
+
+  // Rely on submodule integration checks.
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  // The fork accepts only ready/valid transfers. Disable its push-side valid
+  // stability check because instability is this wrapper's contract.
+  br_flow_fork #(
+      .NumFlows(NumFlows),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(1'b0),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure)
+  ) br_flow_fork (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid(push_valid_unstable),
+      .pop_ready,
+      .pop_valid_unstable
+  );
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  // Rely on submodule implementation checks.
+
+endmodule : br_flow_fork_unstable

--- a/flow/rtl/br_flow_mux_fixed_unstable.sv
+++ b/flow/rtl/br_flow_mux_fixed_unstable.sv
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+// Bedrock-RTL Flow-Controlled Multiplexer (Fixed-Priority, Unstable Push)
+//
+// A fixed-priority flow mux that accepts valid and data which may change or be
+// revoked while push_ready is low. The mux is purely combinational, so the pop
+// valid and data are also explicitly unstable while pop_ready is low.
+
+`include "br_asserts.svh"
+
+module br_flow_mux_fixed_unstable #(
+    // Must be at least 1
+    parameter int NumFlows = 1,
+    // Must be at least 1
+    parameter int Width = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_data_unstable is always known (not X) when
+    // push_valid_unstable is asserted.
+    parameter bit EnableAssertPushDataKnown = 1,
+    // If 1, then assert there are no valid bits asserted at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
+) (
+    input  logic                           clk,
+    input  logic                           rst,
+    output logic [NumFlows-1:0]            push_ready,
+    input  logic [NumFlows-1:0]            push_valid_unstable,
+    input  logic [NumFlows-1:0][Width-1:0] push_data_unstable,
+    input  logic                           pop_ready,
+    output logic                           pop_valid_unstable,
+    output logic [   Width-1:0]            pop_data_unstable
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+  `BR_ASSERT_STATIC(num_flows_gte_1_a, NumFlows >= 1)
+  `BR_ASSERT_STATIC(datawidth_gte_1_a, Width >= 1)
+
+  // Rely on submodule integration checks.
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  // The fixed mux accepts only ready/valid transfers. Disable its push-side
+  // stability checks because instability is this wrapper's contract.
+  br_flow_mux_fixed #(
+      .NumFlows(NumFlows),
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(1'b0),
+      .EnableAssertPushDataStability(1'b0),
+      .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure)
+  ) br_flow_mux_fixed (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid(push_valid_unstable),
+      .push_data (push_data_unstable),
+      .pop_ready,
+      .pop_valid_unstable,
+      .pop_data_unstable
+  );
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  // Rely on submodule implementation checks.
+
+endmodule : br_flow_mux_fixed_unstable

--- a/flow/rtl/br_flow_reg_fwd_unstable.sv
+++ b/flow/rtl/br_flow_reg_fwd_unstable.sv
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+// Bedrock-RTL Flow Register (Forward Variant, Unstable Push Interface)
+//
+// A forward flow register that accepts valid and data that may change or be
+// revoked while push_ready is low, then presents a stable ready-valid pop
+// interface. Only a transfer observed while push_ready is high is captured.
+//
+// The cut-through latency (minimum delay from push_valid_unstable to pop_valid)
+// is 1 cycle. The backpressure latency (minimum delay from pop_ready to
+// push_ready) is 0 cycles. The steady-state throughput is 1 transaction per
+// cycle.
+
+`include "br_asserts.svh"
+
+module br_flow_reg_fwd_unstable #(
+    // Must be at least 1
+    parameter int Width = 1,
+    // If 1, cover that the push side experiences backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
+    parameter bit EnableCoverPushBackpressure = 1,
+    // If 1, assert that push_data_unstable is always known (not X) when
+    // push_valid_unstable is asserted.
+    parameter bit EnableAssertPushDataKnown = 1,
+    // If 1, cover that the pop side experiences backpressure.
+    // If 0, disable backpressure coverage. By default, this also
+    // asserts that backpressure is impossible.
+    parameter bit EnableCoverPopBackpressure = 1,
+    // If 1, then assert there are no valid bits asserted at the end of the test.
+    parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, assert that push-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPushBackpressure is disabled.
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, assert that pop-side backpressure is impossible.
+    // Can only be enabled if EnableCoverPopBackpressure is disabled.
+    parameter bit EnableAssertNoPopBackpressure = !EnableCoverPopBackpressure
+) (
+    input logic clk,
+    input logic rst,  // Synchronous active-high
+
+    output logic             push_ready,
+    input  logic             push_valid_unstable,
+    input  logic [Width-1:0] push_data_unstable,
+
+    input  logic             pop_ready,
+    output logic             pop_valid,
+    output logic [Width-1:0] pop_data
+);
+
+  //------------------------------------------
+  // Integration checks
+  //------------------------------------------
+  `BR_ASSERT_STATIC(legal_assert_no_push_backpressure_a,
+                    !(EnableAssertNoPushBackpressure && EnableCoverPushBackpressure))
+  `BR_ASSERT_STATIC(legal_assert_no_pop_backpressure_a,
+                    !(EnableAssertNoPopBackpressure && EnableCoverPopBackpressure))
+  `BR_ASSERT_STATIC(bit_width_must_be_at_least_one_a, Width >= 1)
+
+  // Rely on submodule integration checks.
+
+  //------------------------------------------
+  // Implementation
+  //------------------------------------------
+  // The forward register captures only ready/valid transfers and holds its
+  // registered pop outputs during downstream backpressure. Disable its
+  // push-side stability checks because instability is this wrapper's contract.
+  br_flow_reg_fwd #(
+      .Width(Width),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableAssertPushValidStability(1'b0),
+      .EnableAssertPushDataStability(1'b0),
+      .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
+      .EnableCoverPopBackpressure(EnableCoverPopBackpressure),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPopBackpressure)
+  ) br_flow_reg_fwd (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid(push_valid_unstable),
+      .push_data (push_data_unstable),
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
+
+  //------------------------------------------
+  // Implementation checks
+  //------------------------------------------
+  // Rely on submodule implementation checks.
+
+endmodule : br_flow_reg_fwd_unstable

--- a/flow/sim/BUILD.bazel
+++ b/flow/sim/BUILD.bazel
@@ -81,6 +81,34 @@ br_verilog_sim_test_tools_suite(
     deps = [":br_flow_reg_tb"],
 )
 
+verilog_library(
+    name = "br_flow_reg_fwd_unstable_tb",
+    srcs = ["br_flow_reg_fwd_unstable_tb.sv"],
+    deps = [
+        "//flow/rtl:br_flow_reg_fwd_unstable",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_reg_fwd_unstable_tb_elab_test",
+    tool = "slang",
+    deps = [":br_flow_reg_fwd_unstable_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_flow_reg_fwd_unstable_sim_test_tools_suite",
+    params = {
+        "Width": [
+            "1",
+            "8",
+            "17",
+        ],
+    },
+    tools = _FLOW_REG_SIM_TOOLS,
+    deps = [":br_flow_reg_fwd_unstable_tb"],
+)
+
 verilog_elab_test(
     name = "br_flow_reg_rev_tb_elab_test",
     tool = "slang",
@@ -167,6 +195,30 @@ br_verilog_sim_test_tools_suite(
     },
     tools = _FLOW_PRIMITIVE_SIM_TOOLS,
     deps = [":br_flow_fork_select_tb"],
+)
+
+verilog_library(
+    name = "br_flow_fork_unstable_tb",
+    srcs = ["br_flow_fork_unstable_tb.sv"],
+    deps = [
+        "//flow/rtl:br_flow_fork_unstable",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_fork_unstable_tb_elab_test",
+    tool = "slang",
+    deps = [":br_flow_fork_unstable_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_flow_fork_unstable_sim_test_tools_suite",
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_flow_fork_unstable_tb"],
 )
 
 verilog_library(
@@ -477,6 +529,30 @@ br_verilog_sim_test_tools_suite(
         "verilator",
     ],
     deps = [":br_flow_mux_fixed_tb"],
+)
+
+verilog_library(
+    name = "br_flow_mux_fixed_unstable_tb",
+    srcs = ["br_flow_mux_fixed_unstable_tb.sv"],
+    deps = [
+        "//flow/rtl:br_flow_mux_fixed_unstable",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_mux_fixed_unstable_tb_elab_test",
+    tool = "slang",
+    deps = [":br_flow_mux_fixed_unstable_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_flow_mux_fixed_unstable_sim_test_tools_suite",
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_flow_mux_fixed_unstable_tb"],
 )
 
 verilog_library(
@@ -967,10 +1043,12 @@ verilog_sim_coverage_aggregate(
     name = "br_flow_verilator_coverage",
     coverage_reports = [
         ":br_flow_reg_fwd_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_reg_fwd_unstable_sim_test_tools_suite_verilator_coverage",
         ":br_flow_reg_rev_sim_test_tools_suite_verilator_coverage",
         ":br_flow_reg_none_sim_test_tools_suite_verilator_coverage",
         ":br_flow_reg_both_sim_test_tools_suite_verilator_coverage",
         ":br_flow_fork_select_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_fork_unstable_sim_test_tools_suite_verilator_coverage",
         ":br_flow_join_sim_test_tools_suite_verilator_coverage",
         ":br_flow_valve_sim_test_tools_suite_verilator_coverage",
         ":br_flow_mux_select_sim_test_tools_suite_verilator_coverage",
@@ -984,6 +1062,7 @@ verilog_sim_coverage_aggregate(
         ":br_flow_arb_rr_sim_test_tools_suite_verilator_coverage",
         ":br_flow_arb_lru_sim_test_tools_suite_verilator_verilator_coverage",
         ":br_flow_mux_fixed_sim_test_tools_suite_verilator_coverage",
+        ":br_flow_mux_fixed_unstable_sim_test_tools_suite_verilator_coverage",
         ":br_flow_mux_rr_sim_test_tools_suite_verilator_coverage",
         ":br_flow_mux_lru_sim_test_tools_suite_verilator_verilator_coverage",
         ":br_flow_mux_weighted_rr_sim_test_tools_suite_verilator_coverage",

--- a/flow/sim/br_flow_fork_unstable_tb.sv
+++ b/flow/sim/br_flow_fork_unstable_tb.sv
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL Flow Fork With Unstable Push Testbench
+//
+// Test plan: backpressure one fork lane, revoke and reassert the blocked push
+// valid, then release backpressure and verify all lanes transfer together.
+
+module br_flow_fork_unstable_tb;
+  localparam int NumFlows = 3;
+
+  logic                clk;
+  logic                rst;
+  logic                push_ready;
+  logic                push_valid_unstable;
+  logic [NumFlows-1:0] pop_ready;
+  logic [NumFlows-1:0] pop_valid_unstable;
+
+  br_flow_fork_unstable #(
+      .NumFlows(NumFlows)
+  ) dut (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid_unstable,
+      .pop_ready,
+      .pop_valid_unstable
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  // Check a blocked fork cycle, including the lane that still observes valid.
+  task automatic check_blocked_output(input logic [NumFlows-1:0] expected_pop_valid,
+                                      input string message);
+    td.check(!push_ready, {message, ": push_ready should remain low"});
+    td.check(pop_valid_unstable == expected_pop_valid, {message, ": pop_valid mismatch"});
+  endtask
+
+  initial begin
+    push_valid_unstable = 1'b0;
+    pop_ready = '0;
+
+    td.reset_dut();
+
+    // Lane 0 backpressures the fork; only that lane observes the blocked valid.
+    @(negedge clk);
+    pop_ready = 3'b110;
+    push_valid_unstable = 1'b1;
+    #1;
+    check_blocked_output(3'b001, "initial blocked push");
+
+    // Valid may be revoked while push_ready is low.
+    @(posedge clk);
+    @(negedge clk);
+    push_valid_unstable = 1'b0;
+    #1;
+    check_blocked_output(3'b000, "blocked valid revocation");
+
+    // The same blocked source may reassert valid before any transfer occurs.
+    @(posedge clk);
+    @(negedge clk);
+    push_valid_unstable = 1'b1;
+    #1;
+    check_blocked_output(3'b001, "blocked valid reassertion");
+
+    // All lanes transfer together once the last downstream lane is ready.
+    @(posedge clk);
+    @(negedge clk);
+    pop_ready = '1;
+    #1;
+    td.check(push_ready, "fork should accept when every pop lane is ready");
+    td.check(pop_valid_unstable == '1, "every pop lane should transfer");
+
+    @(posedge clk);
+    @(negedge clk);
+    push_valid_unstable = 1'b0;
+    #1;
+    td.check(pop_valid_unstable == '0, "fork should drain");
+
+    td.finish();
+  end
+
+endmodule : br_flow_fork_unstable_tb

--- a/flow/sim/br_flow_mux_fixed_unstable_tb.sv
+++ b/flow/sim/br_flow_mux_fixed_unstable_tb.sv
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL Fixed-Priority Flow Mux With Unstable Push Testbench
+//
+// Test plan: hold the mux under pop backpressure, change data on a blocked
+// valid flow, revoke that valid, and reassert another blocked flow. Then release
+// backpressure and verify fixed-priority transfers still work.
+
+module br_flow_mux_fixed_unstable_tb;
+  localparam int NumFlows = 3;
+  localparam int Width = 8;
+  localparam logic [Width-1:0] InitialData = 8'h21;
+  localparam logic [Width-1:0] ChangedData = 8'h22;
+  localparam logic [Width-1:0] ReplacementData = 8'h32;
+  localparam logic [Width-1:0] PreemptingData = 8'h10;
+
+  logic                           clk;
+  logic                           rst;
+  logic [NumFlows-1:0]            push_ready;
+  logic [NumFlows-1:0]            push_valid_unstable;
+  logic [NumFlows-1:0][Width-1:0] push_data_unstable;
+  logic                           pop_ready;
+  logic                           pop_valid_unstable;
+  logic [   Width-1:0]            pop_data_unstable;
+
+  br_flow_mux_fixed_unstable #(
+      .NumFlows(NumFlows),
+      .Width(Width)
+  ) dut (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid_unstable,
+      .push_data_unstable,
+      .pop_ready,
+      .pop_valid_unstable,
+      .pop_data_unstable
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  // Check the combinational mux output while all push flows are backpressured.
+  task automatic check_blocked_output(input logic expected_valid,
+                                      input logic [Width-1:0] expected_data, input string message);
+    td.check(push_ready == '0, {message, ": push_ready should remain low"});
+    td.check(pop_valid_unstable == expected_valid, {message, ": pop_valid mismatch"});
+    if (expected_valid) begin
+      td.check(pop_data_unstable === expected_data, {message, ": pop_data mismatch"});
+    end
+  endtask
+
+  // Check which push flow transfers when downstream backpressure is released.
+  task automatic check_transfer(input logic [NumFlows-1:0] expected_ready,
+                                input logic [Width-1:0] expected_data, input string message);
+    td.check((push_ready & push_valid_unstable) == expected_ready, {
+             message, ": accepted flow mismatch"});
+    td.check(pop_valid_unstable, {message, ": pop_valid should be asserted"});
+    td.check(pop_data_unstable === expected_data, {message, ": pop_data mismatch"});
+  endtask
+
+  initial begin
+    push_valid_unstable = '0;
+    push_data_unstable = '0;
+    pop_ready = 1'b0;
+
+    td.reset_dut();
+
+    // Present a lower-priority request while the pop side is stalled.
+    @(negedge clk);
+    push_valid_unstable[1] = 1'b1;
+    push_data_unstable[1]  = InitialData;
+    #1;
+    check_blocked_output(1'b1, InitialData, "initial blocked request");
+
+    // Data may change while the same valid request remains blocked.
+    @(posedge clk);
+    @(negedge clk);
+    push_data_unstable[1] = ChangedData;
+    #1;
+    check_blocked_output(1'b1, ChangedData, "blocked data change");
+
+    // Valid may be revoked while blocked; the combinational pop follows it.
+    @(posedge clk);
+    @(negedge clk);
+    push_valid_unstable[1] = 1'b0;
+    push_data_unstable[1]  = '0;
+    #1;
+    check_blocked_output(1'b0, '0, "blocked valid revocation");
+
+    // A different flow may assert while blocked.
+    @(posedge clk);
+    @(negedge clk);
+    push_valid_unstable[2] = 1'b1;
+    push_data_unstable[2]  = ReplacementData;
+    #1;
+    check_blocked_output(1'b1, ReplacementData, "blocked replacement request");
+
+    // A higher-priority request may preempt the visible blocked pop.
+    @(posedge clk);
+    @(negedge clk);
+    push_valid_unstable[0] = 1'b1;
+    push_data_unstable[0]  = PreemptingData;
+    #1;
+    check_blocked_output(1'b1, PreemptingData, "blocked priority preemption");
+
+    // Release backpressure and drain the requests in fixed-priority order.
+    @(posedge clk);
+    @(negedge clk);
+    pop_ready = 1'b1;
+    #1;
+    check_transfer(3'b001, PreemptingData, "higher-priority transfer");
+
+    @(posedge clk);
+    @(negedge clk);
+    push_valid_unstable[0] = 1'b0;
+    #1;
+    check_transfer(3'b100, ReplacementData, "lower-priority transfer");
+
+    @(posedge clk);
+    @(negedge clk);
+    push_valid_unstable[2] = 1'b0;
+    #1;
+    td.check(!pop_valid_unstable, "mux should drain");
+
+    td.finish();
+  end
+
+endmodule : br_flow_mux_fixed_unstable_tb

--- a/flow/sim/br_flow_reg_fwd_unstable_tb.sv
+++ b/flow/sim/br_flow_reg_fwd_unstable_tb.sv
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL Forward Flow Register With Unstable Push Testbench
+//
+// Test plan: fill the register, change and revoke the blocked push interface,
+// verify that the registered pop interface stays stable, then replace the held
+// item with a simultaneous pop and push.
+
+module br_flow_reg_fwd_unstable_tb #(
+    parameter int Width = 8
+);
+  localparam logic [Width-1:0] HeldData = '1;
+  localparam logic [Width-1:0] ChangedData = '0;
+  localparam logic [Width-1:0] RevokedData = Width'('ha5);
+  localparam logic [Width-1:0] ReplacementData = Width'('h96);
+
+  logic             clk;
+  logic             rst;
+
+  logic             push_ready;
+  logic             push_valid_unstable;
+  logic [Width-1:0] push_data_unstable;
+  logic             pop_ready;
+  logic             pop_valid;
+  logic [Width-1:0] pop_data;
+
+  br_flow_reg_fwd_unstable #(
+      .Width(Width)
+  ) dut (
+      .clk,
+      .rst,
+      .push_ready,
+      .push_valid_unstable,
+      .push_data_unstable,
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  // Check the valid registered pop item and detect both data mismatches and X values.
+  task automatic check_pop(input logic [Width-1:0] expected_data, input string message);
+    td.check(pop_valid, {message, ": pop_valid should be asserted"});
+    td.check(pop_data === expected_data, {message, ": pop_data mismatch"});
+  endtask
+
+  initial begin
+    if (Width < 1) begin
+      $fatal(1, "Width must be at least 1");
+    end
+
+    push_valid_unstable = 1'b0;
+    push_data_unstable = '0;
+    pop_ready = 1'b0;
+
+    td.reset_dut();
+    #1;
+    td.check(push_ready, "empty register should be ready after reset");
+    td.check(!pop_valid, "empty register should not assert pop_valid after reset");
+
+    // Capture one item while the downstream side is stalled.
+    @(negedge clk);
+    push_valid_unstable = 1'b1;
+    push_data_unstable  = HeldData;
+    #1;
+    td.check(push_ready, "empty register should accept the first push");
+    td.check(!pop_valid, "forward register should add one cycle of latency");
+
+    @(posedge clk);
+    #1;
+    td.check(!push_ready, "full register should backpressure the push side");
+    check_pop(HeldData, "captured item");
+
+    // Valid and data may change while push_ready is low. Neither change may
+    // disturb the held registered pop item.
+    @(negedge clk);
+    push_valid_unstable = 1'b1;
+    push_data_unstable  = ChangedData;
+    #1;
+    td.check(!push_ready, "blocked changed push should remain unaccepted");
+    check_pop(HeldData, "held item after blocked data change");
+
+    @(posedge clk);
+    #1;
+    check_pop(HeldData, "held item after blocked data-change cycle");
+
+    // Revoking valid and changing data again while blocked must also be ignored.
+    @(negedge clk);
+    push_valid_unstable = 1'b0;
+    push_data_unstable  = RevokedData;
+    #1;
+    td.check(!push_ready, "blocked revoked push should remain unaccepted");
+    check_pop(HeldData, "held item after blocked valid revocation");
+
+    @(posedge clk);
+    #1;
+    check_pop(HeldData, "held item after blocked valid-revocation cycle");
+
+    // Pop the held item and accept its replacement on the same edge.
+    @(negedge clk);
+    pop_ready = 1'b1;
+    push_valid_unstable = 1'b1;
+    push_data_unstable = ReplacementData;
+    #1;
+    td.check(push_ready, "simultaneous pop/push should make push_ready high");
+    check_pop(HeldData, "item presented before simultaneous pop/push");
+
+    @(posedge clk);
+    #1;
+    check_pop(ReplacementData, "replacement after simultaneous pop/push");
+
+    // Backpressure the replacement to demonstrate that the stable pop contract
+    // continues after a simultaneous transfer.
+    @(negedge clk);
+    pop_ready = 1'b0;
+    push_valid_unstable = 1'b0;
+    push_data_unstable = ChangedData;
+    #1;
+    td.check(!push_ready, "replacement should backpressure the push side");
+    check_pop(ReplacementData, "backpressured replacement");
+
+    @(posedge clk);
+    #1;
+    check_pop(ReplacementData, "held backpressured replacement");
+
+    // Drain the final item so final-not-valid assertions can check a clean end state.
+    @(negedge clk);
+    pop_ready = 1'b1;
+    #1;
+    td.check(push_ready, "draining replacement should make push_ready high");
+    check_pop(ReplacementData, "replacement before drain");
+
+    @(posedge clk);
+    #1;
+    td.check(!pop_valid, "register should be empty after the final drain");
+
+    @(negedge clk);
+    pop_ready = 1'b0;
+    push_data_unstable = '0;
+
+    td.finish();
+  end
+
+endmodule : br_flow_reg_fwd_unstable_tb

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -278,6 +278,59 @@ verilog_lint_test(
     deps = [":br_assign_test"],
 )
 
+verilog_library(
+    name = "br_flow",
+    hdrs = ["br_flow.svh"],
+    visibility = ["//visibility:public"],
+)
+
+verilog_library(
+    name = "br_flow_test",
+    srcs = ["br_flow_test.sv"],
+    deps = [
+        ":br_asserts",
+        ":br_flow",
+        ":br_unused",
+        "//fifo/rtl:br_fifo_shared_pop_ctrl",
+        "//flow/rtl:br_flow_arb_fixed",
+        "//flow/rtl:br_flow_fork",
+        "//flow/rtl:br_flow_join",
+        "//flow/rtl:br_flow_mux_select_unstable",
+        "//flow/rtl:br_flow_reg_none",
+        "//flow/rtl:br_flow_valve",
+        "//flow/rtl:br_flow_xbar_fixed",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_elab_test",
+    tool = "slang",
+    deps = [":br_flow_test"],
+)
+
+verilog_elab_test(
+    name = "br_flow_verific_elab_test",
+    tool = "verific",
+    deps = [":br_flow_test"],
+)
+
+verilog_lint_test(
+    name = "br_flow_lint_test",
+    tool = "ascentlint",
+    visibility = ["//visibility:public"],
+    deps = [":br_flow_test"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_flow_sim_test_tools_suite",
+    elab_only = True,
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_flow_test"],
+)
+
 verilog_sim_coverage_aggregate(
     name = "br_macros_verilator_coverage",
     coverage_reports = [

--- a/macros/br_flow.svh
+++ b/macros/br_flow.svh
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+`ifndef BR_FLOW_SVH
+`define BR_FLOW_SVH
+
+// Declares one canonical data-carrying ready-valid flow.
+`define BR_FLOW_DECLARE(__flow__, __data_t__) \
+  logic __flow__``_ready; \
+  logic __flow__``_valid; \
+  __data_t__ __flow__``_data;
+
+// Declares a packed, little-endian array of canonical data-carrying ready-valid flows.
+// The element typedef keeps each data index aligned with one ready-valid lane.
+`define BR_FLOW_DECLARE_ARRAY(__flow__, __data_t__, __num_flows__) \
+  typedef __data_t__ __flow__``_data_element_t; \
+  logic [(__num_flows__)-1:0] __flow__``_ready; \
+  logic [(__num_flows__)-1:0] __flow__``_valid; \
+  __flow__``_data_element_t [(__num_flows__)-1:0] __flow__``_data;
+
+// Declares one data-carrying ready/unstable-valid flow.
+// Valid and data may change while ready is low.
+`define BR_FLOW_DECLARE_UNSTABLE(__flow__, __data_t__) \
+  logic __flow__``_ready; \
+  logic __flow__``_valid_unstable; \
+  __data_t__ __flow__``_data_unstable;
+
+// Declares a packed, little-endian array of data-carrying ready/unstable-valid flows.
+// The element typedef keeps each data index aligned with one ready-valid lane.
+`define BR_FLOW_DECLARE_UNSTABLE_ARRAY(__flow__, __data_t__, __num_flows__) \
+  typedef __data_t__ __flow__``_data_element_t; \
+  logic [(__num_flows__)-1:0] __flow__``_ready; \
+  logic [(__num_flows__)-1:0] __flow__``_valid_unstable; \
+  __flow__``_data_element_t [(__num_flows__)-1:0] __flow__``_data_unstable;
+
+// Declares one control-only ready-valid flow.
+`define BR_FLOW_CONTROL_DECLARE(__flow__) \
+  logic __flow__``_ready; \
+  logic __flow__``_valid;
+
+// Declares a packed, little-endian array of control-only ready-valid flows.
+`define BR_FLOW_CONTROL_DECLARE_ARRAY(__flow__, __num_flows__) \
+  logic [(__num_flows__)-1:0] __flow__``_ready; \
+  logic [(__num_flows__)-1:0] __flow__``_valid;
+
+// Declares one control-only ready/unstable-valid flow.
+`define BR_FLOW_CONTROL_DECLARE_UNSTABLE(__flow__) \
+  logic __flow__``_ready; \
+  logic __flow__``_valid_unstable;
+
+// Declares a packed, little-endian array of control-only ready/unstable-valid flows.
+`define BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(__flow__, __num_flows__) \
+  logic [(__num_flows__)-1:0] __flow__``_ready; \
+  logic [(__num_flows__)-1:0] __flow__``_valid_unstable;
+
+// Returns the scalar handshake or per-lane packed handshake for a canonical flow.
+// Bitwise AND preserves the shape of the ready and valid signals.
+`define BR_FLOW_FIRE(__flow__) ((__flow__``_valid) & (__flow__``_ready))
+
+// Selects one canonical packed-flow lane and returns its scalar handshake.
+`define BR_FLOW_FIRE_INDEX(__flow__, __index__) \
+  ((__flow__``_valid[(__index__)]) && (__flow__``_ready[(__index__)]))
+
+// Returns the scalar handshake or per-lane packed handshake for an unstable-valid flow.
+// Bitwise AND preserves the shape of the ready and unstable-valid signals.
+`define BR_FLOW_FIRE_UNSTABLE(__flow__) \
+  ((__flow__``_valid_unstable) & (__flow__``_ready))
+
+// Selects one unstable-valid packed-flow lane and returns its scalar handshake.
+`define BR_FLOW_FIRE_UNSTABLE_INDEX(__flow__, __index__) \
+  ((__flow__``_valid_unstable[(__index__)]) && (__flow__``_ready[(__index__)]))
+
+// Binds a scalar flow or a complete packed flow array to canonical module ports.
+// The caller owns any comma that follows this port group.
+`define BR_FLOW_BIND(__port__, __flow__) \
+  .__port__``_ready(__flow__``_ready), \
+  .__port__``_valid(__flow__``_valid), \
+  .__port__``_data (__flow__``_data)
+
+// Binds one element of a packed flow array to canonical scalar module ports.
+// The caller owns any comma that follows this port group.
+`define BR_FLOW_BIND_INDEX(__port__, __flow__, __index__) \
+  .__port__``_ready(__flow__``_ready[__index__]), \
+  .__port__``_valid(__flow__``_valid[__index__]), \
+  .__port__``_data (__flow__``_data[__index__])
+
+// Binds a scalar flow or a complete packed flow array to unstable-valid/data module ports.
+// The local flow uses the same instability contract. The caller owns any following comma.
+`define BR_FLOW_BIND_UNSTABLE(__port__, __flow__) \
+  .__port__``_ready(__flow__``_ready), \
+  .__port__``_valid_unstable(__flow__``_valid_unstable), \
+  .__port__``_data_unstable (__flow__``_data_unstable)
+
+// Binds one packed-array element to scalar unstable-valid/data module ports.
+// The local flow uses the same instability contract. The caller owns any following comma.
+`define BR_FLOW_BIND_UNSTABLE_INDEX(__port__, __flow__, __index__) \
+  .__port__``_ready(__flow__``_ready[__index__]), \
+  .__port__``_valid_unstable(__flow__``_valid_unstable[__index__]), \
+  .__port__``_data_unstable (__flow__``_data_unstable[__index__])
+
+// Continuously connects one canonical source flow or aligned packed flow array to one sink.
+// Ready travels toward the source; valid and data travel toward the sink.
+`define BR_FLOW_CONNECT(__source__, __sink__) \
+  assign __source__``_ready = __sink__``_ready; \
+  assign __sink__``_valid = __source__``_valid; \
+  assign __sink__``_data = __source__``_data;
+
+// Continuously connects one canonical source flow-array lane to one scalar sink flow.
+// Ready travels toward the source; valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_FROM_INDEX(__source__, __source_index__, __sink__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready; \
+  assign __sink__``_valid = __source__``_valid[__source_index__]; \
+  assign __sink__``_data = __source__``_data[__source_index__];
+
+// Continuously connects one canonical scalar source flow to one sink flow-array lane.
+// Ready travels toward the source; valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_TO_INDEX(__source__, __sink__, __sink_index__) \
+  assign __source__``_ready = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid[__sink_index__] = __source__``_valid; \
+  assign __sink__``_data[__sink_index__] = __source__``_data;
+
+// Continuously connects one canonical source flow-array lane to one sink lane.
+// Ready travels toward the source; valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_INDEX(__source__, __source_index__, __sink__, __sink_index__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid[__sink_index__] = __source__``_valid[__source_index__]; \
+  assign __sink__``_data[__sink_index__] = __source__``_data[__source_index__];
+
+// Continuously connects one explicitly unstable source flow or aligned packed flow array to
+// one sink. Ready travels toward the source; unstable valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_UNSTABLE(__source__, __sink__) \
+  assign __source__``_ready = __sink__``_ready; \
+  assign __sink__``_valid_unstable = __source__``_valid_unstable; \
+  assign __sink__``_data_unstable = __source__``_data_unstable;
+
+// Continuously connects one explicitly unstable source flow-array lane to one scalar sink flow.
+// Ready travels toward the source; unstable valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_UNSTABLE_FROM_INDEX(__source__, __source_index__, __sink__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready; \
+  assign __sink__``_valid_unstable = __source__``_valid_unstable[__source_index__]; \
+  assign __sink__``_data_unstable = __source__``_data_unstable[__source_index__];
+
+// Continuously connects one explicitly unstable scalar source flow to one sink flow-array lane.
+// Ready travels toward the source; unstable valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_UNSTABLE_TO_INDEX(__source__, __sink__, __sink_index__) \
+  assign __source__``_ready = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid_unstable[__sink_index__] = __source__``_valid_unstable; \
+  assign __sink__``_data_unstable[__sink_index__] = __source__``_data_unstable;
+
+// Continuously connects one explicitly unstable source flow-array lane to one sink lane.
+// Ready travels toward the source; unstable valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_UNSTABLE_INDEX(__source__, __source_index__, __sink__, __sink_index__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid_unstable[__sink_index__] = \
+      __source__``_valid_unstable[__source_index__]; \
+  assign __sink__``_data_unstable[__sink_index__] = \
+      __source__``_data_unstable[__source_index__];
+
+// Binds a scalar control flow or a complete packed control-flow array to canonical module ports.
+// The caller owns any comma that follows this port group.
+`define BR_FLOW_CONTROL_BIND(__port__, __flow__) \
+  .__port__``_ready(__flow__``_ready), \
+  .__port__``_valid(__flow__``_valid)
+
+// Binds one packed control-flow-array element to canonical scalar module ports.
+// The caller owns any comma that follows this port group.
+`define BR_FLOW_CONTROL_BIND_INDEX(__port__, __flow__, __index__) \
+  .__port__``_ready(__flow__``_ready[__index__]), \
+  .__port__``_valid(__flow__``_valid[__index__])
+
+// Binds a scalar control flow or a complete packed control-flow array to an unstable-valid port.
+// The local flow's valid signal uses the same instability contract.
+// The caller owns any comma that follows this port group.
+`define BR_FLOW_CONTROL_BIND_UNSTABLE(__port__, __flow__) \
+  .__port__``_ready(__flow__``_ready), \
+  .__port__``_valid_unstable(__flow__``_valid_unstable)
+
+// Binds one packed control-flow-array element to scalar unstable-valid module ports.
+// The local flow uses the same instability contract. The caller owns any following comma.
+`define BR_FLOW_CONTROL_BIND_UNSTABLE_INDEX(__port__, __flow__, __index__) \
+  .__port__``_ready(__flow__``_ready[__index__]), \
+  .__port__``_valid_unstable(__flow__``_valid_unstable[__index__])
+
+// Continuously connects one canonical control source or aligned packed source array to one sink.
+// Ready travels toward the source; valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT(__source__, __sink__) \
+  assign __source__``_ready = __sink__``_ready; \
+  assign __sink__``_valid = __source__``_valid;
+
+// Continuously connects one canonical control source-array lane to one scalar sink flow.
+// Ready travels toward the source; valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_FROM_INDEX(__source__, __source_index__, __sink__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready; \
+  assign __sink__``_valid = __source__``_valid[__source_index__];
+
+// Continuously connects one canonical scalar control source to one sink-array lane.
+// Ready travels toward the source; valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_TO_INDEX(__source__, __sink__, __sink_index__) \
+  assign __source__``_ready = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid[__sink_index__] = __source__``_valid;
+
+// Continuously connects one canonical control source-array lane to one sink-array lane.
+// Ready travels toward the source; valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_INDEX(__source__, __source_index__, __sink__, __sink_index__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid[__sink_index__] = __source__``_valid[__source_index__];
+
+// Continuously connects one explicitly unstable control source or aligned packed source array to
+// one sink. Ready travels toward the source; unstable valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_UNSTABLE(__source__, __sink__) \
+  assign __source__``_ready = __sink__``_ready; \
+  assign __sink__``_valid_unstable = __source__``_valid_unstable;
+
+// Continuously connects one explicitly unstable control source-array lane to one scalar sink flow.
+// Ready travels toward the source; unstable valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_UNSTABLE_FROM_INDEX(__source__, __source_index__, __sink__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready; \
+  assign __sink__``_valid_unstable = __source__``_valid_unstable[__source_index__];
+
+// Continuously connects one explicitly unstable scalar control source to one sink-array lane.
+// Ready travels toward the source; unstable valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_UNSTABLE_TO_INDEX(__source__, __sink__, __sink_index__) \
+  assign __source__``_ready = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid_unstable[__sink_index__] = __source__``_valid_unstable;
+
+// Continuously connects one explicitly unstable control source-array lane to one sink-array lane.
+// Ready travels toward the source; unstable valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_UNSTABLE_INDEX(__source__, __source_i__, __sink__, __sink_i__) \
+  assign __source__``_ready[__source_i__] = __sink__``_ready[__sink_i__]; \
+  assign __sink__``_valid_unstable[__sink_i__] = __source__``_valid_unstable[__source_i__];
+
+`endif  // BR_FLOW_SVH

--- a/macros/br_flow_test.sv
+++ b/macros/br_flow_test.sv
@@ -1,0 +1,581 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+// Elaboration coverage for canonical ready-valid flow declaration, binding, connect, and fire
+// macros.
+// Verible checks bind macros before expansion, so each affected instantiation needs one local
+// module-port waiver immediately before its first port connection.
+
+`include "br_flow.svh"
+`include "br_asserts.svh"
+`include "br_unused.svh"
+
+module br_flow_test #(
+    parameter int LogNumFlows = 2,
+    parameter int NumFlows = 1 << LogNumFlows,
+    localparam type br_flow_test_payload_t = logic [31:0]
+) (
+    input logic clk,
+    input logic rst,
+
+    input  logic                  scalar_push_valid_in,
+    input  br_flow_test_payload_t scalar_push_data_in,
+    output logic                  scalar_push_ready_out,
+    input  logic                  scalar_pop_ready_in,
+    output logic                  scalar_pop_valid_out,
+    output br_flow_test_payload_t scalar_pop_data_out,
+    output logic                  scalar_push_fire_out,
+
+    input  logic [NumFlows-1:0]       vector_push_valid_in,
+    input  logic [NumFlows-1:0][31:0] vector_push_data_in,
+    output logic [NumFlows-1:0]       vector_push_ready_out,
+    input  logic [NumFlows-1:0]       vector_pop_ready_in,
+    output logic [NumFlows-1:0]       vector_pop_valid_out,
+    output logic [NumFlows-1:0][31:0] vector_pop_data_out,
+    output logic [NumFlows-1:0]       vector_push_fire_out,
+    output logic                      vector_push_fire_index_out,
+
+    input  logic [NumFlows-1:0]       struct_push_valid_in,
+    input  logic [NumFlows-1:0][31:0] struct_push_data_in,
+    output logic [NumFlows-1:0]       struct_push_ready_out,
+    input  logic [NumFlows-1:0]       struct_pop_ready_in,
+    output logic [NumFlows-1:0]       struct_pop_valid_out,
+    output logic [NumFlows-1:0][31:0] struct_pop_data_out,
+
+    input  logic                  unstable_scalar_push_valid_unstable_in,
+    input  br_flow_test_payload_t unstable_scalar_push_data_unstable_in,
+    output logic                  unstable_scalar_push_ready_out,
+    input  logic                  unstable_scalar_pop_ready_in,
+    output logic                  unstable_scalar_pop_valid_unstable_out,
+    output br_flow_test_payload_t unstable_scalar_pop_data_unstable_out,
+    output logic                  unstable_scalar_push_fire_out,
+
+    input  logic [NumFlows-1:0]       unstable_vector_push_valid_unstable_in,
+    input  logic [NumFlows-1:0][31:0] unstable_vector_push_data_unstable_in,
+    output logic [NumFlows-1:0]       unstable_vector_push_ready_out,
+    input  logic [NumFlows-1:0]       unstable_vector_pop_ready_in,
+    output logic [NumFlows-1:0]       unstable_vector_pop_valid_unstable_out,
+    output logic [NumFlows-1:0][31:0] unstable_vector_pop_data_unstable_out,
+    output logic [NumFlows-1:0]       unstable_vector_push_fire_out,
+    output logic                      unstable_vector_push_fire_index_out,
+
+    input  logic [NumFlows-1:0]       unstable_struct_push_valid_unstable_in,
+    input  logic [NumFlows-1:0][31:0] unstable_struct_push_data_unstable_in,
+    output logic [NumFlows-1:0]       unstable_struct_push_ready_out,
+    input  logic [NumFlows-1:0]       unstable_struct_pop_ready_in,
+    output logic [NumFlows-1:0]       unstable_struct_pop_valid_unstable_out,
+    output logic [NumFlows-1:0][31:0] unstable_struct_pop_data_unstable_out,
+
+    input  logic control_scalar_push_valid_in,
+    output logic control_scalar_push_ready_out,
+    input  logic control_scalar_pop_ready_in,
+    output logic control_scalar_pop_valid_unstable_out,
+
+    input  logic [NumFlows-1:0] control_array_push_valid_in,
+    output logic [NumFlows-1:0] control_array_push_ready_out,
+    input  logic [NumFlows-1:0] control_array_pop_ready_in,
+    output logic [NumFlows-1:0] control_array_pop_valid_unstable_out,
+
+    input  logic control_connect_scalar_push_valid_in,
+    output logic control_connect_scalar_push_ready_out,
+    input  logic control_connect_scalar_pop_ready_in,
+    output logic control_connect_scalar_pop_valid_out,
+
+    input  logic [NumFlows-1:0] control_connect_array_push_valid_in,
+    output logic [NumFlows-1:0] control_connect_array_push_ready_out,
+    input  logic [NumFlows-1:0] control_connect_array_pop_ready_in,
+    output logic [NumFlows-1:0] control_connect_array_pop_valid_out,
+
+    input  logic unstable_control_connect_scalar_push_valid_unstable_in,
+    output logic unstable_control_connect_scalar_push_ready_out,
+    input  logic unstable_control_connect_scalar_pop_ready_in,
+    output logic unstable_control_connect_scalar_pop_valid_unstable_out,
+
+    input  logic [NumFlows-1:0] unstable_control_connect_array_push_valid_unstable_in,
+    output logic [NumFlows-1:0] unstable_control_connect_array_push_ready_out,
+    input  logic [NumFlows-1:0] unstable_control_connect_array_pop_ready_in,
+    output logic [NumFlows-1:0] unstable_control_connect_array_pop_valid_unstable_out
+);
+
+  // Packed payload used to verify that one array index selects one complete payload.
+  typedef struct packed {
+    logic [7:0]  tag;
+    logic [23:0] value;
+  } br_flow_test_struct_payload_t;
+
+  `BR_FLOW_DECLARE(scalar_push, br_flow_test_payload_t)
+  `BR_FLOW_DECLARE(scalar_pop, br_flow_test_payload_t)
+  `BR_FLOW_DECLARE(scalar_connect_sink, br_flow_test_payload_t)
+
+  // The shift expression verifies that declaration macros group the flow count before `-1`.
+  `BR_FLOW_DECLARE_ARRAY(vector_push, logic [31:0], 1 << LogNumFlows)
+  `BR_FLOW_DECLARE_ARRAY(vector_pop, br_flow_test_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_ARRAY(vector_connect_sink, br_flow_test_payload_t, NumFlows)
+
+  `BR_FLOW_DECLARE_ARRAY(struct_push, br_flow_test_struct_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_ARRAY(struct_pop, br_flow_test_struct_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_ARRAY(struct_index_sink, br_flow_test_struct_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_ARRAY(struct_connect_sink, br_flow_test_struct_payload_t, NumFlows)
+
+  `BR_FLOW_DECLARE_UNSTABLE(unstable_scalar_push, br_flow_test_payload_t)
+  `BR_FLOW_DECLARE_UNSTABLE(unstable_scalar_pop, br_flow_test_payload_t)
+  `BR_FLOW_DECLARE_UNSTABLE(unstable_scalar_connect_sink, br_flow_test_payload_t)
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_scalar_fifo_push, br_flow_test_payload_t, 2)
+  `BR_FLOW_DECLARE_ARRAY(unstable_scalar_fifo_pop, br_flow_test_payload_t, 2)
+  `BR_FLOW_DECLARE_ARRAY(unstable_scalar_mux_push, br_flow_test_payload_t, 1)
+
+  // This shift expression covers the unstable array declaration separately.
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_vector_push, logic [31:0], 1 << LogNumFlows)
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_vector_pop, br_flow_test_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_vector_connect_sink, br_flow_test_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_ARRAY(unstable_vector_fifo_pop, br_flow_test_payload_t, NumFlows)
+
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_struct_push, br_flow_test_struct_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_struct_pop, br_flow_test_struct_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_struct_index_sink, br_flow_test_struct_payload_t,
+                                  NumFlows)
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_struct_connect_sink, br_flow_test_struct_payload_t,
+                                  NumFlows)
+  `BR_FLOW_DECLARE_ARRAY(unstable_struct_fifo_pop, br_flow_test_struct_payload_t, NumFlows)
+
+  `BR_FLOW_CONTROL_DECLARE(control_scalar_push)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE(control_scalar_pop)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(control_scalar_fork_pop, 1)
+
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_array_push, 1 << LogNumFlows)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(control_array_pop, 1 << LogNumFlows)
+
+  `BR_FLOW_CONTROL_DECLARE(control_connect_scalar_push)
+  `BR_FLOW_CONTROL_DECLARE(control_connect_scalar_pop)
+
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_connect_array_bind_push, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_connect_array_source, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_connect_array_direct_sink, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_connect_array_index_sink, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_connect_array_sink, NumFlows)
+
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE(unstable_control_connect_scalar_push)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE(unstable_control_connect_scalar_pop)
+
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_connect_array_bind_push, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_connect_array_source, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_connect_array_direct_sink, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_connect_array_index_sink, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_connect_array_sink, NumFlows)
+
+  `BR_ASSERT_STATIC(num_flows_supports_shared_fifo_a, NumFlows >= 2)
+  `BR_ASSERT_STATIC(vector_push_ready_width_a, $bits(vector_push_ready) == NumFlows)
+  `BR_ASSERT_STATIC(vector_push_valid_width_a, $bits(vector_push_valid) == NumFlows)
+  `BR_ASSERT_STATIC(vector_push_data_width_a, $bits(vector_push_data) == (NumFlows * 32))
+  `BR_ASSERT_STATIC(control_array_push_ready_width_a, $bits(control_array_push_ready) == NumFlows)
+  `BR_ASSERT_STATIC(control_array_push_valid_width_a, $bits(control_array_push_valid) == NumFlows)
+  `BR_ASSERT_STATIC(control_array_pop_ready_width_a, $bits(control_array_pop_ready) == NumFlows)
+  `BR_ASSERT_STATIC(control_array_pop_valid_width_a, $bits(control_array_pop_valid_unstable)
+                    == NumFlows)
+  `BR_ASSERT_STATIC(unstable_scalar_ready_width_a, $bits(unstable_scalar_push_ready) == 1)
+  `BR_ASSERT_STATIC(unstable_scalar_valid_width_a, $bits(unstable_scalar_push_valid_unstable) == 1)
+  `BR_ASSERT_STATIC(unstable_scalar_data_width_a, $bits(unstable_scalar_push_data_unstable)
+                    == $bits(br_flow_test_payload_t))
+  `BR_ASSERT_STATIC(unstable_vector_ready_width_a, $bits(unstable_vector_push_ready) == NumFlows)
+  `BR_ASSERT_STATIC(unstable_vector_valid_width_a, $bits(unstable_vector_push_valid_unstable)
+                    == NumFlows)
+  `BR_ASSERT_STATIC(unstable_vector_data_width_a, $bits(unstable_vector_push_data_unstable)
+                    == (NumFlows * 32))
+  `BR_ASSERT_STATIC(unstable_vector_data_lane_width_a, $bits(unstable_vector_push_data_unstable[0])
+                    == 32)
+  `BR_ASSERT_STATIC(unstable_struct_ready_width_a, $bits(unstable_struct_push_ready) == NumFlows)
+  `BR_ASSERT_STATIC(unstable_struct_valid_width_a, $bits(unstable_struct_push_valid_unstable)
+                    == NumFlows)
+  `BR_ASSERT_STATIC(unstable_struct_data_width_a, $bits(unstable_struct_push_data_unstable)
+                    == (NumFlows * $bits(br_flow_test_struct_payload_t)))
+  `BR_ASSERT_STATIC(unstable_struct_data_lane_width_a, $bits(unstable_struct_push_data_unstable[0])
+                    == $bits(br_flow_test_struct_payload_t))
+  `BR_ASSERT_STATIC(scalar_fire_width_a, $bits(`BR_FLOW_FIRE(scalar_push)) == 1)
+  `BR_ASSERT_STATIC(vector_fire_width_a, $bits(`BR_FLOW_FIRE(vector_push)) == NumFlows)
+  `BR_ASSERT_STATIC(vector_fire_index_width_a, $bits
+                    (`BR_FLOW_FIRE_INDEX(vector_push, NumFlows - 1)) == 1)
+  `BR_ASSERT_STATIC(unstable_scalar_fire_width_a, $bits
+                    (`BR_FLOW_FIRE_UNSTABLE(unstable_scalar_push)) == 1)
+  `BR_ASSERT_STATIC(unstable_vector_fire_width_a, $bits
+                    (`BR_FLOW_FIRE_UNSTABLE(unstable_vector_push)) == NumFlows)
+  `BR_ASSERT_STATIC(unstable_vector_fire_index_width_a, $bits
+                    (`BR_FLOW_FIRE_UNSTABLE_INDEX(unstable_vector_push, NumFlows - 1)) == 1)
+
+  assign scalar_push_valid = scalar_push_valid_in;
+  assign scalar_push_data = scalar_push_data_in;
+  assign scalar_push_ready_out = scalar_push_ready;
+  assign scalar_push_fire_out = `BR_FLOW_FIRE(scalar_push);
+  assign scalar_connect_sink_ready = scalar_pop_ready_in;
+  assign scalar_pop_valid_out = scalar_connect_sink_valid;
+  assign scalar_pop_data_out = scalar_connect_sink_data;
+  `BR_FLOW_CONNECT(scalar_pop, scalar_connect_sink)
+
+  assign vector_push_valid = vector_push_valid_in;
+  assign vector_push_data = vector_push_data_in;
+  assign vector_push_ready_out = vector_push_ready;
+  assign vector_push_fire_out = `BR_FLOW_FIRE(vector_push);
+  assign vector_push_fire_index_out = `BR_FLOW_FIRE_INDEX(vector_push, NumFlows - 1);
+  assign vector_connect_sink_ready = vector_pop_ready_in;
+  assign vector_pop_valid_out = vector_connect_sink_valid;
+  assign vector_pop_data_out = vector_connect_sink_data;
+  `BR_FLOW_CONNECT(vector_pop, vector_connect_sink)
+
+  assign struct_push_valid = struct_push_valid_in;
+  assign struct_push_data = struct_push_data_in;
+  assign struct_push_ready_out = struct_push_ready;
+  assign struct_connect_sink_ready = struct_pop_ready_in;
+  assign struct_pop_valid_out = struct_connect_sink_valid;
+  assign struct_pop_data_out = struct_connect_sink_data;
+
+  assign unstable_scalar_push_valid_unstable = unstable_scalar_push_valid_unstable_in;
+  assign unstable_scalar_push_data_unstable = unstable_scalar_push_data_unstable_in;
+  assign unstable_scalar_push_ready_out = unstable_scalar_push_ready;
+  assign unstable_scalar_push_fire_out = `BR_FLOW_FIRE_UNSTABLE(unstable_scalar_push);
+  assign unstable_scalar_connect_sink_ready = unstable_scalar_pop_ready_in;
+  assign unstable_scalar_pop_valid_unstable_out = unstable_scalar_connect_sink_valid_unstable;
+  assign unstable_scalar_pop_data_unstable_out = unstable_scalar_connect_sink_data_unstable;
+  `BR_FLOW_CONNECT_UNSTABLE(unstable_scalar_pop, unstable_scalar_connect_sink)
+
+  assign unstable_vector_push_valid_unstable = unstable_vector_push_valid_unstable_in;
+  assign unstable_vector_push_data_unstable = unstable_vector_push_data_unstable_in;
+  assign unstable_vector_push_ready_out = unstable_vector_push_ready;
+  assign unstable_vector_push_fire_out = `BR_FLOW_FIRE_UNSTABLE(unstable_vector_push);
+  assign unstable_vector_push_fire_index_out = `BR_FLOW_FIRE_UNSTABLE_INDEX(
+          unstable_vector_push, NumFlows - 1);
+  assign unstable_vector_connect_sink_ready = unstable_vector_pop_ready_in;
+  assign unstable_vector_pop_valid_unstable_out = unstable_vector_connect_sink_valid_unstable;
+  assign unstable_vector_pop_data_unstable_out = unstable_vector_connect_sink_data_unstable;
+  `BR_FLOW_CONNECT_UNSTABLE(unstable_vector_pop, unstable_vector_connect_sink)
+
+  assign unstable_struct_push_valid_unstable = unstable_struct_push_valid_unstable_in;
+  assign unstable_struct_push_data_unstable = unstable_struct_push_data_unstable_in;
+  assign unstable_struct_push_ready_out = unstable_struct_push_ready;
+  assign unstable_struct_connect_sink_ready = unstable_struct_pop_ready_in;
+  assign unstable_struct_pop_valid_unstable_out = unstable_struct_connect_sink_valid_unstable;
+  assign unstable_struct_pop_data_unstable_out = unstable_struct_connect_sink_data_unstable;
+
+  assign control_scalar_push_valid = control_scalar_push_valid_in;
+  assign control_scalar_push_ready_out = control_scalar_push_ready;
+  assign control_scalar_pop_ready = control_scalar_pop_ready_in;
+  assign control_scalar_pop_valid_unstable_out = control_scalar_pop_valid_unstable;
+
+  assign control_array_push_valid = control_array_push_valid_in;
+  assign control_array_push_ready_out = control_array_push_ready;
+  assign control_array_pop_ready = control_array_pop_ready_in;
+  assign control_array_pop_valid_unstable_out = control_array_pop_valid_unstable;
+
+  assign control_connect_scalar_push_valid = control_connect_scalar_push_valid_in;
+  assign control_connect_scalar_push_ready_out = control_connect_scalar_push_ready;
+  assign control_connect_scalar_pop_ready = control_connect_scalar_pop_ready_in;
+  assign control_connect_scalar_pop_valid_out = control_connect_scalar_pop_valid;
+  `BR_FLOW_CONTROL_CONNECT(control_connect_scalar_push, control_connect_scalar_pop)
+
+  assign control_connect_array_bind_push_valid = control_connect_array_push_valid_in;
+  assign control_connect_array_push_ready_out = control_connect_array_bind_push_ready;
+  assign control_connect_array_sink_ready = control_connect_array_pop_ready_in;
+  assign control_connect_array_pop_valid_out = control_connect_array_sink_valid;
+  `BR_FLOW_CONTROL_CONNECT(control_connect_array_source, control_connect_array_direct_sink)
+
+  assign unstable_control_connect_scalar_push_valid_unstable =
+      unstable_control_connect_scalar_push_valid_unstable_in;
+  assign unstable_control_connect_scalar_push_ready_out =
+      unstable_control_connect_scalar_push_ready;
+  assign unstable_control_connect_scalar_pop_ready = unstable_control_connect_scalar_pop_ready_in;
+  assign unstable_control_connect_scalar_pop_valid_unstable_out =
+      unstable_control_connect_scalar_pop_valid_unstable;
+  `BR_FLOW_CONTROL_CONNECT_UNSTABLE(unstable_control_connect_scalar_push,
+                                    unstable_control_connect_scalar_pop)
+
+  assign unstable_control_connect_array_bind_push_valid_unstable =
+      unstable_control_connect_array_push_valid_unstable_in;
+  assign unstable_control_connect_array_push_ready_out =
+      unstable_control_connect_array_bind_push_ready;
+  assign unstable_control_connect_array_sink_ready = unstable_control_connect_array_pop_ready_in;
+  assign unstable_control_connect_array_pop_valid_unstable_out =
+      unstable_control_connect_array_sink_valid_unstable;
+  `BR_FLOW_CONTROL_CONNECT_UNSTABLE(unstable_control_connect_array_source,
+                                    unstable_control_connect_array_direct_sink)
+
+  // The first bind needs a caller-supplied comma; the last bind must not emit one.
+  br_flow_reg_none #(
+      .Width($bits(br_flow_test_payload_t))
+  ) u_scalar_endpoint (
+      // verilog_lint: waive module-port
+      .clk,
+      .rst,
+      `BR_FLOW_BIND(push, scalar_push),
+      `BR_FLOW_BIND(pop, scalar_pop)
+  );
+
+  // Inline packed-vector payload syntax and complete packed-array binding elaborate together.
+  br_flow_xbar_fixed #(
+      .NumPushFlows(NumFlows),
+      .NumPopFlows(NumFlows),
+      .Width($bits(br_flow_test_payload_t)),
+      .RegisterPopOutputs(1'b1)
+  ) u_array_endpoint (
+      // verilog_lint: waive module-port
+      .clk,
+      .rst,
+      `BR_FLOW_BIND(push, vector_push),
+      .push_dest_id('0),
+      `BR_FLOW_BIND(pop, vector_pop)
+  );
+
+  // Reversed lanes exercise indexed binding and connection with an arithmetic expression.
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_struct_endpoints
+    `BR_FLOW_DECLARE(struct_scalar_bridge, br_flow_test_struct_payload_t)
+
+    br_flow_reg_none #(
+        .Width($bits(br_flow_test_struct_payload_t))
+    ) u_struct_endpoint (
+        // verilog_lint: waive module-port
+        .clk,
+        .rst,
+        `BR_FLOW_BIND_INDEX(push, struct_push, NumFlows - 1 - i),
+        `BR_FLOW_BIND_INDEX(pop, struct_pop, NumFlows - 1 - i)
+    );
+    `BR_FLOW_CONNECT_INDEX(struct_pop, NumFlows - 1 - i, struct_index_sink, i)
+    `BR_FLOW_CONNECT_FROM_INDEX(struct_index_sink, i, struct_scalar_bridge)
+    `BR_FLOW_CONNECT_TO_INDEX(struct_scalar_bridge, struct_connect_sink, NumFlows - 1 - i)
+  end
+
+  // A real FIFO bypass accepts the unstable scalar source in lane zero and stabilizes it.
+  `BR_FLOW_CONNECT_UNSTABLE_TO_INDEX(unstable_scalar_push, unstable_scalar_fifo_push, 0)
+  assign unstable_scalar_fifo_push_valid_unstable[1] = 1'b0;
+  assign unstable_scalar_fifo_push_data_unstable[1]  = '0;
+
+  br_fifo_shared_pop_ctrl #(
+      .NumReadPorts(1),
+      .NumFifos(2),
+      .Depth(5),
+      .Width($bits(br_flow_test_payload_t)),
+      .StagingBufferDepth(1),
+      .RegisterPopOutputs(1'b1),
+      .EnableBypass(1'b1),
+      .RamReadLatency(0)
+  ) u_unstable_scalar_stabilizer (
+      // verilog_lint: waive module-port
+      .clk,
+      .rst,
+      .head_valid('0),
+      .head_ready(),
+      .head('0),
+      .ram_empty('1),
+      .ram_items('0),
+      `BR_FLOW_BIND_UNSTABLE(bypass, unstable_scalar_fifo_push),
+      `BR_FLOW_BIND(pop, unstable_scalar_fifo_pop),
+      .pop_empty(),
+      .dealloc_valid(),
+      .dealloc_entry_id(),
+      .data_ram_rd_addr_valid(),
+      .data_ram_rd_addr(),
+      .data_ram_rd_data_valid('0),
+      .data_ram_rd_data('0)
+  );
+  assign unstable_scalar_fifo_pop_ready[1] = 1'b1;
+  `BR_UNUSED_NAMED(unstable_scalar_fifo_unused_lane, {unstable_scalar_fifo_push_ready[1],
+                                                      unstable_scalar_fifo_pop_valid[1],
+                                                      unstable_scalar_fifo_pop_data[1]})
+  `BR_FLOW_CONNECT_INDEX(unstable_scalar_fifo_pop, 0, unstable_scalar_mux_push, 0)
+
+  br_flow_mux_select_unstable #(
+      .NumFlows(1),
+      .Width($bits(br_flow_test_payload_t))
+  ) u_unstable_scalar_endpoint (
+      // verilog_lint: waive module-port
+      .clk,
+      .rst,
+      .select('0),
+      `BR_FLOW_BIND(push, unstable_scalar_mux_push),
+      `BR_FLOW_BIND_UNSTABLE(pop, unstable_scalar_pop)
+  );
+
+  // The shared FIFO's bypass ports are a real packed unstable-input interface.
+  br_fifo_shared_pop_ctrl #(
+      .NumReadPorts(1),
+      .NumFifos(NumFlows),
+      .Depth(5),
+      .Width($bits(br_flow_test_payload_t)),
+      .StagingBufferDepth(1),
+      .RegisterPopOutputs(1'b1),
+      .EnableBypass(1'b1),
+      .RamReadLatency(0)
+  ) u_unstable_vector_endpoint (
+      // verilog_lint: waive module-port
+      .clk,
+      .rst,
+      .head_valid('0),
+      .head_ready(),
+      .head('0),
+      .ram_empty('1),
+      .ram_items('0),
+      `BR_FLOW_BIND_UNSTABLE(bypass, unstable_vector_push),
+      `BR_FLOW_BIND(pop, unstable_vector_fifo_pop),
+      .pop_empty(),
+      .dealloc_valid(),
+      .dealloc_entry_id(),
+      .data_ram_rd_addr_valid(),
+      .data_ram_rd_addr(),
+      .data_ram_rd_data_valid('0),
+      .data_ram_rd_data('0)
+  );
+
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_unstable_vector_endpoints
+    // The declaration macro's element typedef intentionally follows the generated lane's scope.
+    // ri lint_check_waive GENERATE_TYPEDEF
+    `BR_FLOW_DECLARE_ARRAY(unstable_vector_mux_push, br_flow_test_payload_t, 1)
+
+    `BR_FLOW_CONNECT_INDEX(unstable_vector_fifo_pop, i, unstable_vector_mux_push, 0)
+    br_flow_mux_select_unstable #(
+        .NumFlows(1),
+        .Width($bits(br_flow_test_payload_t))
+    ) u_unstable_vector_lane_endpoint (
+        // verilog_lint: waive module-port
+        .clk,
+        .rst,
+        .select('0),
+        `BR_FLOW_BIND(push, unstable_vector_mux_push),
+        `BR_FLOW_BIND_UNSTABLE_INDEX(pop, unstable_vector_pop, i)
+    );
+  end
+
+  // A second FIFO bypass verifies whole-array binding with a packed-struct payload.
+  br_fifo_shared_pop_ctrl #(
+      .NumReadPorts(1),
+      .NumFifos(NumFlows),
+      .Depth(5),
+      .Width($bits(br_flow_test_struct_payload_t)),
+      .StagingBufferDepth(1),
+      .RegisterPopOutputs(1'b1),
+      .EnableBypass(1'b1),
+      .RamReadLatency(0)
+  ) u_unstable_struct_stabilizer (
+      // verilog_lint: waive module-port
+      .clk,
+      .rst,
+      .head_valid('0),
+      .head_ready(),
+      .head('0),
+      .ram_empty('1),
+      .ram_items('0),
+      `BR_FLOW_BIND_UNSTABLE(bypass, unstable_struct_push),
+      `BR_FLOW_BIND(pop, unstable_struct_fifo_pop),
+      .pop_empty(),
+      .dealloc_valid(),
+      .dealloc_entry_id(),
+      .data_ram_rd_addr_valid(),
+      .data_ram_rd_addr(),
+      .data_ram_rd_data_valid('0),
+      .data_ram_rd_data('0)
+  );
+
+  // Reversed lanes verify indexed binding and connection of an unstable packed-struct payload.
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_unstable_struct_endpoints
+    // The declaration macro's element typedef intentionally follows the generated lane's scope.
+    // ri lint_check_waive GENERATE_TYPEDEF
+    `BR_FLOW_DECLARE_ARRAY(unstable_struct_mux_push, br_flow_test_struct_payload_t, 1)
+    `BR_FLOW_DECLARE_UNSTABLE(unstable_struct_scalar_bridge, br_flow_test_struct_payload_t)
+
+    `BR_FLOW_CONNECT_INDEX(unstable_struct_fifo_pop, NumFlows - 1 - i, unstable_struct_mux_push, 0)
+
+    br_flow_mux_select_unstable #(
+        .NumFlows(1),
+        .Width($bits(br_flow_test_struct_payload_t))
+    ) u_unstable_struct_endpoint (
+        // verilog_lint: waive module-port
+        .clk,
+        .rst,
+        .select('0),
+        `BR_FLOW_BIND(push, unstable_struct_mux_push),
+        `BR_FLOW_BIND_UNSTABLE_INDEX(pop, unstable_struct_pop, NumFlows - 1 - i)
+    );
+    `BR_FLOW_CONNECT_UNSTABLE_INDEX(unstable_struct_pop, NumFlows - 1 - i,
+                                    unstable_struct_index_sink, i)
+    `BR_FLOW_CONNECT_UNSTABLE_FROM_INDEX(unstable_struct_index_sink, i,
+                                         unstable_struct_scalar_bridge)
+    `BR_FLOW_CONNECT_UNSTABLE_TO_INDEX(unstable_struct_scalar_bridge, unstable_struct_connect_sink,
+                                       NumFlows - 1 - i)
+  end
+
+  // Stable control connections exercise whole-array, indexed, array-to-scalar, and
+  // scalar-to-array forms while indexed binding reverses lanes at the endpoint.
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_control_connect_endpoints
+    `BR_FLOW_CONTROL_DECLARE_ARRAY(control_connect_join_push, 1)
+    `BR_FLOW_CONTROL_DECLARE(control_connect_scalar_bridge)
+
+    `BR_FLOW_CONTROL_CONNECT_INDEX(control_connect_array_bind_push, NumFlows - 1 - i,
+                                   control_connect_join_push, 0)
+    br_flow_join #(
+        .NumFlows(1)
+    ) u_control_stable_endpoint (
+        // verilog_lint: waive module-port
+        .clk,
+        .rst,
+        `BR_FLOW_CONTROL_BIND(push, control_connect_join_push),
+        `BR_FLOW_CONTROL_BIND_INDEX(pop, control_connect_array_source, NumFlows - 1 - i)
+    );
+    `BR_FLOW_CONTROL_CONNECT_INDEX(control_connect_array_direct_sink, NumFlows - 1 - i,
+                                   control_connect_array_index_sink, i)
+    `BR_FLOW_CONTROL_CONNECT_FROM_INDEX(control_connect_array_index_sink, i,
+                                        control_connect_scalar_bridge)
+    `BR_FLOW_CONTROL_CONNECT_TO_INDEX(control_connect_scalar_bridge, control_connect_array_sink,
+                                      NumFlows - 1 - i)
+  end
+
+  // The arbiter permits unstable requests and preserves that contract at its pop interface.
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_unstable_control_connect_endpoints
+    `BR_FLOW_CONTROL_DECLARE_ARRAY(unstable_control_connect_arb_push, 1)
+    `BR_FLOW_CONTROL_DECLARE_UNSTABLE(unstable_control_connect_scalar_bridge)
+
+    assign unstable_control_connect_array_bind_push_ready[NumFlows-1-i] =
+        unstable_control_connect_arb_push_ready[0];
+    assign unstable_control_connect_arb_push_valid[0] =
+        unstable_control_connect_array_bind_push_valid_unstable[NumFlows-1-i];
+
+    br_flow_arb_fixed #(
+        .NumFlows(1),
+        .EnableAssertPushValidStability(1'b0)
+    ) u_control_unstable_endpoint (
+        // verilog_lint: waive module-port
+        .clk,
+        .rst,
+        `BR_FLOW_CONTROL_BIND(push, unstable_control_connect_arb_push),
+        `BR_FLOW_CONTROL_BIND_UNSTABLE_INDEX(pop, unstable_control_connect_array_source,
+                                             NumFlows - 1 - i)
+    );
+    `BR_FLOW_CONTROL_CONNECT_UNSTABLE_INDEX(unstable_control_connect_array_direct_sink,
+                                            NumFlows - 1 - i,
+                                            unstable_control_connect_array_index_sink, i)
+    `BR_FLOW_CONTROL_CONNECT_UNSTABLE_FROM_INDEX(unstable_control_connect_array_index_sink, i,
+                                                 unstable_control_connect_scalar_bridge)
+    `BR_FLOW_CONTROL_CONNECT_UNSTABLE_TO_INDEX(unstable_control_connect_scalar_bridge,
+                                               unstable_control_connect_array_sink,
+                                               NumFlows - 1 - i)
+  end
+
+  // A real fork provides the scalar stable-input and packed unstable-output control ports.
+  br_flow_fork #(
+      .NumFlows(1)
+  ) u_control_scalar_endpoint (
+      // verilog_lint: waive module-port
+      .clk,
+      .rst,
+      `BR_FLOW_CONTROL_BIND(push, control_scalar_push),
+      `BR_FLOW_CONTROL_BIND_UNSTABLE(pop, control_scalar_fork_pop)
+  );
+  `BR_FLOW_CONTROL_CONNECT_UNSTABLE_FROM_INDEX(control_scalar_fork_pop, 0, control_scalar_pop)
+
+  // A valve has complete packed stable-input and unstable-output control arrays.
+  br_flow_valve #(
+      .NumFlows(NumFlows)
+  ) u_control_array_endpoint (
+      // verilog_lint: waive module-port
+      .clk,
+      .rst,
+      .en('1),
+      `BR_FLOW_CONTROL_BIND(push, control_array_push),
+      `BR_FLOW_CONTROL_BIND_UNSTABLE(pop, control_array_pop)
+  );
+
+endmodule : br_flow_test


### PR DESCRIPTION
  # Problem

  Bedrock represents ready/valid interfaces as groups of flat signals. Declaring, binding, and connecting these signals becomes repetitive and error-prone when designs mix scalar flows, packed lane arrays, stable and unstable contracts, and data-carrying and control-only flows.

  Existing modules also need explicit adapters when an upstream interface may change or revoke valid and data while backpressured.

  # Solution

  Add `br_flow.svh`, which provides declaration, binding, transfer, and direct-connection macros for:

  - Stable and unstable ready/valid contracts
  - Data-carrying and control-only flows
  - Scalar flows, packed arrays, and individual array lanes
  - Packed vector and packed struct payloads
  - Array counts expressed as positive constant expressions

  The connection macros preserve Bedrock's flat-port convention. They wire ready from sink to source and valid/data from source to sink. They add no storage, protocol conversion, arbitration, or ready-loop protection.

  Add four modules for composing unstable interfaces:

  - `br_flow_reg_fwd_unstable` accepts unstable traffic and presents a stable registered output.
  - `br_fifo_flops_unstable` disables combinational bypass so unstable push signals cannot leak to its stable pop interface.
  - `br_flow_fork_unstable` exposes the fork's combinational outputs as explicitly unstable.
  - `br_flow_mux_fixed_unstable` exposes the fixed-priority mux output as explicitly unstable.

  Document the macro API in `MACROS.md`, add the new modules to `LIBRARIES.md`, and add elaboration, lint, and directed simulation collateral covering the macro families and new modules.

