### PR TITLE
[ci] Run uncached Verilator coverage on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,32 +127,11 @@ jobs:
             suite: verilator
             shard_index: 7
             shard_count: 8
-          - name: coverage-1-of-4
-            suite: coverage
-            shard_index: 0
-            shard_count: 4
-          - name: coverage-2-of-4
-            suite: coverage
-            shard_index: 1
-            shard_count: 4
-          - name: coverage-3-of-4
-            suite: coverage
-            shard_index: 2
-            shard_count: 4
-          - name: coverage-4-of-4
-            suite: coverage
-            shard_index: 3
-            shard_count: 4
     steps:
-      - name: Skip exhaustive Verilator coverage on pull requests
-        if: ${{ matrix.suite == 'coverage' && github.event_name == 'pull_request' }}
-        run: echo "Exhaustive Verilator coverage runs after merge."
       # actions/checkout v7.0.0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
       # bazel-contrib/setup-bazel v0.19.0
       - name: Set up Bazel caches
-        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
         with:
           bazelisk-cache: true
@@ -165,7 +144,6 @@ jobs:
           cache-save: ${{ github.event_name != 'pull_request' }}
           output-base: ${{ runner.temp }}/bazel-output
       - name: Configure public Bazel environment
-        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         run: |
           # setup-bazel restores these paths on a cache hit. Create them on a
           # miss so Docker can bind-mount the same host paths below.
@@ -179,19 +157,16 @@ jobs:
           # up `slang` on PATH. The public Docker image installs it here.
           echo 'common --action_env=SLANG_PATH=/usr/local/bin/slang' > ci.bazelrc
       - name: Download public Docker image
-        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         # actions/download-artifact v8.0.1
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: bedrock-rtl-dev-image-${{ github.sha }}
           path: /tmp
       - name: Load public Docker image
-        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         run: docker load --input /tmp/bedrock-rtl-dev.tar
       # Do not use `bazel test //...` with a tag filter here. Bazel would still
       # analyze targets that need proprietary verilog_runner plugins.
       - name: Run public Bazel test shard
-        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         continue-on-error: true
         run: |
           # Keep stdin attached so `bash -s` receives the heredoc below. The
@@ -252,13 +227,8 @@ jobs:
             echo $(date -d "today" +"%Y-%m-%d-%H-%M-%S") > $RESULTS_DIR/timestamp-${suite}-${shard_index}-of-${shard_count}.txt
             # A target-pattern file guarantees one Bazel invocation even when
             # thousands of labels would exceed the shell argument limit.
-            if [[ "$suite" == "coverage" ]]; then
-              bazel build "${BAZEL_FLAGS[@]}" \
-                --target_pattern_file="$targets" 2>&1 | tee "$log"
-            else
-              bazel test "${BAZEL_FLAGS[@]}" \
-                --target_pattern_file="$targets" 2>&1 | tee "$log"
-            fi
+            bazel test "${BAZEL_FLAGS[@]}" \
+              --target_pattern_file="$targets" 2>&1 | tee "$log"
             local bazel_exit_code=${PIPESTATUS[0]}
             python3.12 "$HELPER" finalize \
               --result "$result" \
@@ -312,10 +282,6 @@ jobs:
               query_and_run_suite verilator "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
                 'tests(//...) intersect attr(tags, "verilator", //...) intersect attr(tags, "sim", //...)'
               ;;
-            coverage)
-              query_and_run_suite coverage "$CI_SHARD_INDEX" "$CI_SHARD_COUNT" \
-                'kind(".*_coverage_data", //...)'
-              ;;
             *)
               echo "Unknown public suite: $CI_SUITE" >&2
               exit 4
@@ -331,7 +297,7 @@ jobs:
           python3.12 "$HELPER" check "${check_args[@]}"
           EOF
       - name: Upload public shard result
-        if: ${{ always() && (matrix.suite != 'coverage' || github.event_name != 'pull_request') }}
+        if: ${{ always() }}
         # actions/upload-artifact v7.0.1
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -344,7 +310,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       - name: Check public shard result
-        if: ${{ always() && (matrix.suite != 'coverage' || github.event_name != 'pull_request') }}
+        if: ${{ always() }}
         run: |
           check_args=(
             --results-dir "bazel-oss-results/${{ matrix.suite }}-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}"
@@ -356,25 +322,174 @@ jobs:
           fi
           python3.12 python/ci/bazel_oss_sharding.py check "${check_args[@]}"
 
+  bazel-oss-verilator-coverage-shard:
+    name: bazel-oss-verilator-coverage-shard (${{ matrix.name }})
+    runs-on: ubuntu-24.04
+    needs: bazel-oss-docker-image
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: coverage-1-of-4
+            shard_index: 0
+            shard_count: 4
+          - name: coverage-2-of-4
+            shard_index: 1
+            shard_count: 4
+          - name: coverage-3-of-4
+            shard_index: 2
+            shard_count: 4
+          - name: coverage-4-of-4
+            shard_index: 3
+            shard_count: 4
+    steps:
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      # bazel-contrib/setup-bazel v0.19.0
+      - name: Restore Bazel dependency caches
+        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+          # Coverage action outputs are intentionally never saved to the
+          # repository's persistent Actions cache allocation.
+          cache-save: false
+          output-base: ${{ runner.temp }}/bazel-output
+      - name: Configure public Bazel environment
+        run: |
+          mkdir -p \
+            "${HOME}/.cache/bazel" \
+            "${HOME}/.cache/bazelisk" \
+            "${HOME}/.cache/bazel-repo" \
+            "${RUNNER_TEMP}/bazel-output" \
+            "${RUNNER_TEMP}/coverage-disk-cache"
+          echo 'common --action_env=SLANG_PATH=/usr/local/bin/slang' > ci.bazelrc
+      - name: Download public Docker image
+        # actions/download-artifact v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: bedrock-rtl-dev-image-${{ github.sha }}
+          path: /tmp
+      - name: Load public Docker image
+        run: docker load --input /tmp/bedrock-rtl-dev.tar
+      - name: Run public Verilator coverage shard
+        continue-on-error: true
+        run: |
+          docker run --rm -i \
+            --user "$(id -u):$(id -g)" \
+            --env USER=user \
+            --env HOME="${HOME}" \
+            --env COVERAGE_DISK_CACHE="${RUNNER_TEMP}/coverage-disk-cache" \
+            --env CI_SHARD_INDEX="${{ matrix.shard_index }}" \
+            --env CI_SHARD_COUNT="${{ matrix.shard_count }}" \
+            --workdir "${GITHUB_WORKSPACE}" \
+            --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+            --volume "${HOME}/.bazelrc:${HOME}/.bazelrc:ro" \
+            --volume "${HOME}/.cache/bazel:${HOME}/.cache/bazel" \
+            --volume "${HOME}/.cache/bazelisk:${HOME}/.cache/bazelisk" \
+            --volume "${HOME}/.cache/bazel-repo:${HOME}/.cache/bazel-repo" \
+            --volume "${RUNNER_TEMP}/bazel-output:${RUNNER_TEMP}/bazel-output" \
+            --volume "${RUNNER_TEMP}/coverage-disk-cache:${RUNNER_TEMP}/coverage-disk-cache" \
+            bedrock-rtl-dev:${{ github.sha }} \
+            bash -s <<'EOF'
+          set +e
+          BAZEL_FLAGS=(
+            --action_env=PATH
+            --noshow_loading_progress
+            --disk_cache="${COVERAGE_DISK_CACHE}"
+            --repository_cache="${HOME}/.cache/bazel-repo"
+          )
+          HELPER=python/ci/bazel_oss_sharding.py
+          RESULTS_DIR="bazel-oss-results/coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}"
+          DISCOVERED="/tmp/discovered-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.txt"
+          RESULT="${RESULTS_DIR}/result-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.json"
+          TARGETS="${RESULTS_DIR}/targets-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.txt"
+          LOG="/tmp/bazel-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.log"
+          mkdir -p "${RESULTS_DIR}"
+          : > "${LOG}"
+
+          bazel query --noshow_progress 'kind(".*_coverage_data", //...)' > "${DISCOVERED}"
+          query_exit_code=$?
+          python3.12 "${HELPER}" partition \
+            --suite coverage \
+            --shard-index "${CI_SHARD_INDEX}" \
+            --shard-count "${CI_SHARD_COUNT}" \
+            --input "${DISCOVERED}" \
+            --output-dir "${RESULTS_DIR}"
+          partition_exit_code=$?
+
+          if [ "${query_exit_code}" -ne 0 ]; then
+            python3.12 "${HELPER}" discovery-failure \
+              --result "${RESULT}" \
+              --exit-code "${query_exit_code}" \
+              --message "Bazel query failed"
+          elif [ "${partition_exit_code}" -ne 0 ]; then
+            python3.12 "${HELPER}" discovery-failure \
+              --result "${RESULT}" \
+              --exit-code "${partition_exit_code}" \
+              --message "Coverage partitioning failed"
+          else
+            echo $(date -d "today" +"%Y-%m-%d-%H-%M-%S") > \
+              "${RESULTS_DIR}/timestamp-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.txt"
+            bazel build "${BAZEL_FLAGS[@]}" \
+              --target_pattern_file="${TARGETS}" 2>&1 | tee "${LOG}"
+            bazel_exit_code=${PIPESTATUS[0]}
+            python3.12 "${HELPER}" finalize \
+              --result "${RESULT}" \
+              --log "${LOG}" \
+              --exit-code "${bazel_exit_code}"
+          fi
+
+          cp "${LOG}" "${RESULTS_DIR}/"
+          EOF
+      - name: Upload public coverage shard result
+        if: ${{ always() }}
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: bazel-oss-result-${{ matrix.name }}
+          path: bazel-oss-results/coverage-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload ephemeral coverage action outputs
+        if: ${{ always() }}
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: bazel-oss-coverage-disk-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}
+          path: ${{ runner.temp }}/coverage-disk-cache
+          compression-level: 0
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 1
+      - name: Check public coverage shard result
+        if: ${{ always() }}
+        run: |
+          python3.12 python/ci/bazel_oss_sharding.py check \
+            --results-dir "bazel-oss-results/coverage-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}" \
+            --expected-suite coverage
+
   bazel-oss-verilator-coverage:
     runs-on: ubuntu-24.04
-    needs: bazel-oss-tool-test-shard
-    if: ${{ always() && github.event_name != 'pull_request' }}
+    needs: bazel-oss-verilator-coverage-shard
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
     steps:
       # actions/checkout v7.0.0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       # bazel-contrib/setup-bazel v0.19.0
-      - name: Set up Bazel caches
+      - name: Restore Bazel dependency caches
         uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
         with:
           bazelisk-cache: true
-          # PRs may restore default-branch caches without creating PR-ref cache
-          # entries; main pushes and manual runs save the merged coverage cache.
-          disk-cache: ${{ github.workflow }}-oss-coverage-aggregate
           repository-cache: true
-          cache-save: ${{ github.event_name != 'pull_request' }}
+          # Coverage aggregation consumes same-run artifacts and never writes a
+          # persistent Actions cache entry.
+          cache-save: false
           output-base: ${{ runner.temp }}/bazel-output
       - name: Configure public Bazel environment
         run: |
@@ -383,48 +498,19 @@ jobs:
           mkdir -p \
             "${HOME}/.cache/bazel" \
             "${HOME}/.cache/bazelisk" \
-            "${HOME}/.cache/bazel-disk" \
             "${HOME}/.cache/bazel-repo" \
-            "${RUNNER_TEMP}/bazel-output"
+            "${RUNNER_TEMP}/bazel-output" \
+            "${RUNNER_TEMP}/coverage-disk-cache"
           # The Slang plugin executes $SLANG_PATH directly rather than looking
           # up `slang` on PATH. The public Docker image installs it here.
           echo 'common --action_env=SLANG_PATH=/usr/local/bin/slang' > ci.bazelrc
-      # bazel-contrib/setup-bazel v0.19.0
-      - name: Restore public coverage shard 1 Bazel disk cache
-        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
+      - name: Download ephemeral coverage action outputs
+        # actions/download-artifact v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          disk-cache: ${{ github.workflow }}-oss-coverage-0-of-4
-          repository-cache: true
-          # Just restores the cache, do not save it.
-          cache-save: false
-          output-base: ${{ runner.temp }}/bazel-output
-      # bazel-contrib/setup-bazel v0.19.0
-      - name: Restore public coverage shard 2 Bazel disk cache
-        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
-        with:
-          disk-cache: ${{ github.workflow }}-oss-coverage-1-of-4
-          repository-cache: true
-          # Just restores the cache, do not save it.
-          cache-save: false
-          output-base: ${{ runner.temp }}/bazel-output
-      # bazel-contrib/setup-bazel v0.19.0
-      - name: Restore public coverage shard 3 Bazel disk cache
-        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
-        with:
-          disk-cache: ${{ github.workflow }}-oss-coverage-2-of-4
-          repository-cache: true
-          # Just restores the cache, do not save it.
-          cache-save: false
-          output-base: ${{ runner.temp }}/bazel-output
-      # bazel-contrib/setup-bazel v0.19.0
-      - name: Restore public coverage shard 4 Bazel disk cache
-        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
-        with:
-          disk-cache: ${{ github.workflow }}-oss-coverage-3-of-4
-          repository-cache: true
-          # Just restores the cache, do not save it.
-          cache-save: false
-          output-base: ${{ runner.temp }}/bazel-output
+          pattern: bazel-oss-coverage-disk-*
+          path: ${{ runner.temp }}/coverage-disk-cache
+          merge-multiple: true
       - name: Download public Docker image
         # actions/download-artifact v8.0.1
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -443,24 +529,23 @@ jobs:
             --env USER=user \
             --env HOME="${HOME}" \
             --env TESTPLAN_LINK=".." \
+            --env COVERAGE_DISK_CACHE="${RUNNER_TEMP}/coverage-disk-cache" \
             --workdir "${GITHUB_WORKSPACE}" \
             --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
             --volume "${HOME}/.bazelrc:${HOME}/.bazelrc:ro" \
             --volume "${HOME}/.cache/bazel:${HOME}/.cache/bazel" \
             --volume "${HOME}/.cache/bazelisk:${HOME}/.cache/bazelisk" \
-            --volume "${HOME}/.cache/bazel-disk:${HOME}/.cache/bazel-disk" \
             --volume "${HOME}/.cache/bazel-repo:${HOME}/.cache/bazel-repo" \
             --volume "${RUNNER_TEMP}/bazel-output:${RUNNER_TEMP}/bazel-output" \
+            --volume "${RUNNER_TEMP}/coverage-disk-cache:${RUNNER_TEMP}/coverage-disk-cache" \
             bedrock-rtl-dev:${{ github.sha }} \
             bash -s <<'EOF'
           set -euo pipefail
           BAZEL_FLAGS=(
             --action_env=PATH
             --noshow_loading_progress
-            --disk_cache=/home/runner/.cache/bazel-disk
-            --repository_cache=/home/runner/.cache/bazel-repo
-            --experimental_disk_cache_gc_max_size=256M
-            --experimental_disk_cache_gc_max_age=7d
+            --disk_cache="${COVERAGE_DISK_CACHE}"
+            --repository_cache="${HOME}/.cache/bazel-repo"
           )
 
           bazel run "${BAZEL_FLAGS[@]}" //:br_verilator_coverage
@@ -481,7 +566,7 @@ jobs:
   # image-publication interface; individual shards remain visible underneath it.
   bazel-oss-tool-test:
     runs-on: ubuntu-24.04
-    needs: bazel-oss-tool-test-shard
+    needs: [bazel-oss-tool-test-shard, bazel-oss-verilator-coverage-shard]
     if: ${{ always() }}
     permissions:
       contents: read
@@ -529,7 +614,7 @@ jobs:
             --expected slang=4
             --expected verilator=8
           )
-          if [ "$GITHUB_EVENT_NAME" != pull_request ]; then
+          if [ "$GITHUB_REF" = refs/heads/main ]; then
             expected_args+=(--expected coverage=4)
           fi
           python3.12 python/ci/bazel_oss_sharding.py aggregate \
@@ -543,6 +628,11 @@ jobs:
             echo "::error title=Public Bazel shard failed::One or more matrix jobs failed"
             exit 1
           fi
+          if [ "$GITHUB_REF" = refs/heads/main ] && \
+             [ "${{ needs.bazel-oss-verilator-coverage-shard.result }}" != success ]; then
+            echo "::error title=Public coverage shard failed::One or more coverage jobs failed"
+            exit 1
+          fi
           if [ "${{ steps.results.outcome }}" != success ]; then
             echo "::error title=Public Bazel aggregation failed::Shard results were incomplete or failed validation"
             exit 1
@@ -551,7 +641,7 @@ jobs:
   generate-test-results-dashboard:
     runs-on: ubuntu-24.04
     needs: [bazel-oss-tool-test-shard, bazel-oss-verilator-coverage]
-    if: ${{ always() && github.event_name != 'pull_request' }}
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
     steps:
@@ -571,9 +661,8 @@ jobs:
         with:
           bazelisk-cache: true
           repository-cache: true
-          # PRs may restore default-branch caches without creating PR-ref cache
-          # entries; main pushes and manual runs refresh the repository cache.
-          cache-save: ${{ github.event_name != 'pull_request' }}
+          # Dashboard generation should not create a coverage-adjacent cache.
+          cache-save: false
       - name: Configure public Bazel environment
         run: |
           # setup-bazel restores these paths on a cache hit. Create them on a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,15 @@ jobs:
             shard_index: 3
             shard_count: 4
     steps:
+      - name: Skip exhaustive Verilator coverage on pull requests
+        if: ${{ matrix.suite == 'coverage' && github.event_name == 'pull_request' }}
+        run: echo "Exhaustive Verilator coverage runs after merge."
       # actions/checkout v7.0.0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
       # bazel-contrib/setup-bazel v0.19.0
       - name: Set up Bazel caches
+        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
         with:
           bazelisk-cache: true
@@ -161,6 +166,7 @@ jobs:
           cache-save: true
           output-base: ${{ runner.temp }}/bazel-output
       - name: Configure public Bazel environment
+        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         run: |
           # setup-bazel restores these paths on a cache hit. Create them on a
           # miss so Docker can bind-mount the same host paths below.
@@ -174,16 +180,19 @@ jobs:
           # up `slang` on PATH. The public Docker image installs it here.
           echo 'common --action_env=SLANG_PATH=/usr/local/bin/slang' > ci.bazelrc
       - name: Download public Docker image
+        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         # actions/download-artifact v8.0.1
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: bedrock-rtl-dev-image-${{ github.sha }}
           path: /tmp
       - name: Load public Docker image
+        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         run: docker load --input /tmp/bedrock-rtl-dev.tar
       # Do not use `bazel test //...` with a tag filter here. Bazel would still
       # analyze targets that need proprietary verilog_runner plugins.
       - name: Run public Bazel test shard
+        if: ${{ matrix.suite != 'coverage' || github.event_name != 'pull_request' }}
         continue-on-error: true
         run: |
           # Keep stdin attached so `bash -s` receives the heredoc below. The
@@ -323,7 +332,7 @@ jobs:
           python3.12 "$HELPER" check "${check_args[@]}"
           EOF
       - name: Upload public shard result
-        if: ${{ always() }}
+        if: ${{ always() && (matrix.suite != 'coverage' || github.event_name != 'pull_request') }}
         # actions/upload-artifact v7.0.1
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -336,7 +345,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       - name: Check public shard result
-        if: ${{ always() }}
+        if: ${{ always() && (matrix.suite != 'coverage' || github.event_name != 'pull_request') }}
         run: |
           check_args=(
             --results-dir "bazel-oss-results/${{ matrix.suite }}-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}"
@@ -351,7 +360,7 @@ jobs:
   bazel-oss-verilator-coverage:
     runs-on: ubuntu-24.04
     needs: bazel-oss-tool-test-shard
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name != 'pull_request' }}
     permissions:
       contents: read
     steps:
@@ -514,13 +523,18 @@ jobs:
         id: results
         continue-on-error: true
         run: |
+          expected_args=(
+            --expected python=1
+            --expected stardoc=1
+            --expected slang=4
+            --expected verilator=8
+          )
+          if [ "$GITHUB_EVENT_NAME" != pull_request ]; then
+            expected_args+=(--expected coverage=4)
+          fi
           python3.12 python/ci/bazel_oss_sharding.py aggregate \
             --results-dir bazel-oss-aggregate \
-            --expected python=1 \
-            --expected stardoc=1 \
-            --expected slang=4 \
-            --expected verilator=8 \
-            --expected coverage=4 \
+            "${expected_args[@]}" \
             --github-output "$GITHUB_OUTPUT" \
             --step-summary "$GITHUB_STEP_SUMMARY"
       - name: Check public Bazel test suite results
@@ -537,7 +551,7 @@ jobs:
   generate-test-results-dashboard:
     runs-on: ubuntu-24.04
     needs: [bazel-oss-tool-test-shard, bazel-oss-verilator-coverage]
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name != 'pull_request' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,6 @@ jobs:
       - name: Load public Docker image
         run: docker load --input /tmp/bedrock-rtl-dev.tar
       - name: Run public Verilator coverage shard
-        continue-on-error: true
         run: |
           docker run --rm -i \
             --user "$(id -u):$(id -g)" \
@@ -395,7 +394,7 @@ jobs:
             --volume "${RUNNER_TEMP}/coverage-disk-cache:${RUNNER_TEMP}/coverage-disk-cache" \
             bedrock-rtl-dev:${{ github.sha }} \
             bash -s <<'EOF'
-          set +e
+          set -euo pipefail
           BAZEL_FLAGS=(
             --action_env=PATH
             --noshow_loading_progress
@@ -403,79 +402,36 @@ jobs:
             --repository_cache="${HOME}/.cache/bazel-repo"
           )
           HELPER=python/ci/bazel_oss_sharding.py
-          RESULTS_DIR="bazel-oss-results/coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}"
+          PARTITION_DIR="/tmp/coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}"
           DISCOVERED="/tmp/discovered-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.txt"
-          RESULT="${RESULTS_DIR}/result-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.json"
-          TARGETS="${RESULTS_DIR}/targets-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.txt"
-          LOG="/tmp/bazel-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.log"
-          mkdir -p "${RESULTS_DIR}"
-          : > "${LOG}"
+          TARGETS="${PARTITION_DIR}/targets-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.txt"
+          mkdir -p "${PARTITION_DIR}"
 
           bazel query --noshow_progress 'kind(".*_coverage_data", //...)' > "${DISCOVERED}"
-          query_exit_code=$?
           python3.12 "${HELPER}" partition \
             --suite coverage \
             --shard-index "${CI_SHARD_INDEX}" \
             --shard-count "${CI_SHARD_COUNT}" \
             --input "${DISCOVERED}" \
-            --output-dir "${RESULTS_DIR}"
-          partition_exit_code=$?
-
-          if [ "${query_exit_code}" -ne 0 ]; then
-            python3.12 "${HELPER}" discovery-failure \
-              --result "${RESULT}" \
-              --exit-code "${query_exit_code}" \
-              --message "Bazel query failed"
-          elif [ "${partition_exit_code}" -ne 0 ]; then
-            python3.12 "${HELPER}" discovery-failure \
-              --result "${RESULT}" \
-              --exit-code "${partition_exit_code}" \
-              --message "Coverage partitioning failed"
-          else
-            echo $(date -d "today" +"%Y-%m-%d-%H-%M-%S") > \
-              "${RESULTS_DIR}/timestamp-coverage-${CI_SHARD_INDEX}-of-${CI_SHARD_COUNT}.txt"
-            bazel build "${BAZEL_FLAGS[@]}" \
-              --target_pattern_file="${TARGETS}" 2>&1 | tee "${LOG}"
-            bazel_exit_code=${PIPESTATUS[0]}
-            python3.12 "${HELPER}" finalize \
-              --result "${RESULT}" \
-              --log "${LOG}" \
-              --exit-code "${bazel_exit_code}"
-          fi
-
-          cp "${LOG}" "${RESULTS_DIR}/"
+            --output-dir "${PARTITION_DIR}"
+          bazel build "${BAZEL_FLAGS[@]}" \
+            --target_pattern_file="${TARGETS}"
           EOF
-      - name: Upload public coverage shard result
-        if: ${{ always() }}
-        # actions/upload-artifact v7.0.1
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: bazel-oss-result-${{ matrix.name }}
-          path: bazel-oss-results/coverage-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}
-          if-no-files-found: error
-          retention-days: 1
       - name: Upload ephemeral coverage action outputs
-        if: ${{ always() }}
         # actions/upload-artifact v7.0.1
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: bazel-oss-coverage-disk-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}
           path: ${{ runner.temp }}/coverage-disk-cache
           compression-level: 0
-          if-no-files-found: warn
+          if-no-files-found: error
           include-hidden-files: true
           retention-days: 1
-      - name: Check public coverage shard result
-        if: ${{ always() }}
-        run: |
-          python3.12 python/ci/bazel_oss_sharding.py check \
-            --results-dir "bazel-oss-results/coverage-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}" \
-            --expected-suite coverage
 
   bazel-oss-verilator-coverage:
     runs-on: ubuntu-24.04
     needs: bazel-oss-verilator-coverage-shard
-    if: ${{ always() && github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
     steps:
@@ -566,7 +522,7 @@ jobs:
   # image-publication interface; individual shards remain visible underneath it.
   bazel-oss-tool-test:
     runs-on: ubuntu-24.04
-    needs: [bazel-oss-tool-test-shard, bazel-oss-verilator-coverage-shard]
+    needs: bazel-oss-tool-test-shard
     if: ${{ always() }}
     permissions:
       contents: read
@@ -584,9 +540,6 @@ jobs:
       verilator_total_tests: ${{ steps.results.outputs.verilator_total_tests }}
       verilator_passing_tests: ${{ steps.results.outputs.verilator_passing_tests }}
       verilator_exit_code: ${{ steps.results.outputs.verilator_exit_code }}
-      coverage_total_tests: ${{ steps.results.outputs.coverage_total_tests }}
-      coverage_passing_tests: ${{ steps.results.outputs.coverage_passing_tests }}
-      coverage_exit_code: ${{ steps.results.outputs.coverage_exit_code }}
     steps:
       # actions/checkout v7.0.0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -608,29 +561,18 @@ jobs:
         id: results
         continue-on-error: true
         run: |
-          expected_args=(
-            --expected python=1
-            --expected stardoc=1
-            --expected slang=4
-            --expected verilator=8
-          )
-          if [ "$GITHUB_REF" = refs/heads/main ]; then
-            expected_args+=(--expected coverage=4)
-          fi
           python3.12 python/ci/bazel_oss_sharding.py aggregate \
             --results-dir bazel-oss-aggregate \
-            "${expected_args[@]}" \
+            --expected python=1 \
+            --expected stardoc=1 \
+            --expected slang=4 \
+            --expected verilator=8 \
             --github-output "$GITHUB_OUTPUT" \
             --step-summary "$GITHUB_STEP_SUMMARY"
       - name: Check public Bazel test suite results
         run: |
           if [ "${{ needs.bazel-oss-tool-test-shard.result }}" != success ]; then
             echo "::error title=Public Bazel shard failed::One or more matrix jobs failed"
-            exit 1
-          fi
-          if [ "$GITHUB_REF" = refs/heads/main ] && \
-             [ "${{ needs.bazel-oss-verilator-coverage-shard.result }}" != success ]; then
-            echo "::error title=Public coverage shard failed::One or more coverage jobs failed"
             exit 1
           fi
           if [ "${{ steps.results.outcome }}" != success ]; then
@@ -641,7 +583,7 @@ jobs:
   generate-test-results-dashboard:
     runs-on: ubuntu-24.04
     needs: [bazel-oss-tool-test-shard, bazel-oss-verilator-coverage]
-    if: ${{ always() && github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
     steps:
@@ -661,8 +603,9 @@ jobs:
         with:
           bazelisk-cache: true
           repository-cache: true
-          # Dashboard generation should not create a coverage-adjacent cache.
-          cache-save: false
+          # PRs may restore default-branch caches without creating PR-ref cache
+          # entries; main pushes and manual runs refresh the repository cache.
+          cache-save: ${{ github.event_name != 'pull_request' }}
       - name: Configure public Bazel environment
         run: |
           # setup-bazel restores these paths on a cache hit. Create them on a

--- a/python/ci/bazel_oss_sharding.py
+++ b/python/ci/bazel_oss_sharding.py
@@ -360,12 +360,12 @@ def parse_expected_shards(values: list[str]) -> dict[str, int]:
         suite, separator, count_text = value.partition("=")
         if not separator or suite not in SUITES:
             raise ValueError(f"invalid expected shard specification: {value}")
+        if suite in expected:
+            raise ValueError(f"duplicate expected shard specification: {suite}")
         count = int(count_text)
         if count <= 0:
             raise ValueError(f"invalid expected shard count: {value}")
         expected[suite] = count
-    if set(expected) != set(SUITES):
-        raise ValueError(f"expected shard specifications for {SUITES}")
     return expected
 
 
@@ -399,7 +399,9 @@ def command_aggregate(args: argparse.Namespace) -> int:
     with args.github_output.open("a", encoding="utf-8") as output:
         for suite in SUITES:
             for field in ("total_tests", "passing_tests", "exit_code"):
-                output.write(f"{suite}_{field}={outputs[suite][field]}\n")
+                output.write(
+                    f"{suite}_{field}={outputs.get(suite, {}).get(field, '')}\n"
+                )
     with args.step_summary.open("a", encoding="utf-8") as summary:
         summary.write("## Public Bazel test suites\n\n")
         summary.write("| Suite | Shards | Passing | Status |\n")

--- a/python/ci/bazel_oss_sharding.py
+++ b/python/ci/bazel_oss_sharding.py
@@ -360,8 +360,6 @@ def parse_expected_shards(values: list[str]) -> dict[str, int]:
         suite, separator, count_text = value.partition("=")
         if not separator or suite not in SUITES:
             raise ValueError(f"invalid expected shard specification: {value}")
-        if suite in expected:
-            raise ValueError(f"duplicate expected shard specification: {suite}")
         count = int(count_text)
         if count <= 0:
             raise ValueError(f"invalid expected shard count: {value}")
@@ -397,11 +395,9 @@ def command_aggregate(args: argparse.Namespace) -> int:
     expected = parse_expected_shards(args.expected)
     outputs, errors, rows = aggregate_results(args.results_dir, expected)
     with args.github_output.open("a", encoding="utf-8") as output:
-        for suite in SUITES:
+        for suite in expected:
             for field in ("total_tests", "passing_tests", "exit_code"):
-                output.write(
-                    f"{suite}_{field}={outputs.get(suite, {}).get(field, '')}\n"
-                )
+                output.write(f"{suite}_{field}={outputs[suite][field]}\n")
     with args.step_summary.open("a", encoding="utf-8") as summary:
         summary.write("## Public Bazel test suites\n\n")
         summary.write("| Suite | Shards | Passing | Status |\n")

--- a/python/ci/bazel_oss_sharding_test.py
+++ b/python/ci/bazel_oss_sharding_test.py
@@ -12,7 +12,6 @@ from python.ci.bazel_oss_sharding import (
     aggregate_results,
     canonicalize_labels,
     command_check,
-    command_aggregate,
     finalize_result,
     labels_digest,
     parse_expected_shards,
@@ -115,46 +114,14 @@ class BazelOssShardingTest(unittest.TestCase):
                 [f"//sim:verilator_{index}" for index in range(30)],
             )
 
-            outputs, errors, _ = aggregate_results(
-                results_dir,
-                {"python": 1, "stardoc": 1, "slang": 2, "verilator": 3},
+            expected = parse_expected_shards(
+                ["python=1", "stardoc=1", "slang=2", "verilator=3"]
             )
+            outputs, errors, _ = aggregate_results(results_dir, expected)
 
             self.assertEqual(errors, [])
             self.assertEqual(outputs["slang"]["total_tests"], 20)
             self.assertEqual(outputs["verilator"]["passing_tests"], 30)
-
-    def test_command_aggregate_accepts_population_without_coverage(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            results_dir = Path(temporary)
-            self._write_suite(results_dir, "python", 1, ["//python:test"])
-            self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
-            self._write_suite(results_dir, "slang", 1, ["//rtl:test"])
-            self._write_suite(results_dir, "verilator", 1, ["//sim:test"])
-            github_output = results_dir / "github-output.txt"
-            step_summary = results_dir / "step-summary.md"
-            args = argparse.Namespace(
-                results_dir=results_dir,
-                expected=[
-                    "python=1",
-                    "stardoc=1",
-                    "slang=1",
-                    "verilator=1",
-                ],
-                github_output=github_output,
-                step_summary=step_summary,
-            )
-
-            self.assertEqual(command_aggregate(args), 0)
-            output_lines = github_output.read_text(encoding="utf-8").splitlines()
-            self.assertIn("verilator_total_tests=1", output_lines)
-            self.assertIn("coverage_total_tests=", output_lines)
-            self.assertIn("coverage_passing_tests=", output_lines)
-            self.assertIn("coverage_exit_code=", output_lines)
-
-    def test_parse_expected_shards_rejects_duplicate_suite(self):
-        with self.assertRaisesRegex(ValueError, "duplicate"):
-            parse_expected_shards(["python=1", "python=2"])
 
     def test_aggregate_rejects_missing_duplicate_and_inconsistent_shards(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/python/ci/bazel_oss_sharding_test.py
+++ b/python/ci/bazel_oss_sharding_test.py
@@ -12,8 +12,10 @@ from python.ci.bazel_oss_sharding import (
     aggregate_results,
     canonicalize_labels,
     command_check,
+    command_aggregate,
     finalize_result,
     labels_digest,
+    parse_expected_shards,
     partition_labels,
     prepare_partition,
     shard_for_label,
@@ -121,6 +123,38 @@ class BazelOssShardingTest(unittest.TestCase):
             self.assertEqual(errors, [])
             self.assertEqual(outputs["slang"]["total_tests"], 20)
             self.assertEqual(outputs["verilator"]["passing_tests"], 30)
+
+    def test_command_aggregate_accepts_population_without_coverage(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            results_dir = Path(temporary)
+            self._write_suite(results_dir, "python", 1, ["//python:test"])
+            self._write_suite(results_dir, "stardoc", 1, ["//bazel:test"])
+            self._write_suite(results_dir, "slang", 1, ["//rtl:test"])
+            self._write_suite(results_dir, "verilator", 1, ["//sim:test"])
+            github_output = results_dir / "github-output.txt"
+            step_summary = results_dir / "step-summary.md"
+            args = argparse.Namespace(
+                results_dir=results_dir,
+                expected=[
+                    "python=1",
+                    "stardoc=1",
+                    "slang=1",
+                    "verilator=1",
+                ],
+                github_output=github_output,
+                step_summary=step_summary,
+            )
+
+            self.assertEqual(command_aggregate(args), 0)
+            output_lines = github_output.read_text(encoding="utf-8").splitlines()
+            self.assertIn("verilator_total_tests=1", output_lines)
+            self.assertIn("coverage_total_tests=", output_lines)
+            self.assertIn("coverage_passing_tests=", output_lines)
+            self.assertIn("coverage_exit_code=", output_lines)
+
+    def test_parse_expected_shards_rejects_duplicate_suite(self):
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            parse_expected_shards(["python=1", "python=2"])
 
     def test_aggregate_rejects_missing_duplicate_and_inconsistent_shards(self):
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
# Problem

Pull requests and main both need the same ordinary eight-shard Verilator test flow so main can refresh the exact Bazel action cache entries that pull requests restore. Exhaustive coverage is published only from main, but the previous shared matrix mixed four coverage rows into every workflow and persisted their large, coverage-specific action outputs. Those entries consumed several GiB of the repository's 10 GiB Actions cache allocation and displaced the ordinary Verilator caches.

# Solution

Keep the ordinary Python, Slang, and eight-shard Verilator matrix identical on pull requests and main. Run four exhaustive coverage shards in a dedicated main-only job, with failures reported directly by those matrix jobs rather than routed through the ordinary test-result aggregate.

Coverage jobs may restore Bazelisk and repository download caches, but every coverage-related `setup-bazel` invocation uses `cache-save: false` and has no persistent disk-cache key. Each shard uses a fresh local Bazel disk cache only within that workflow run and uploads it as a one-day workflow artifact. The aggregation job merges those same-run artifacts before producing `br_verilator_coverage.zip`, avoiding a second cold compilation without consuming the repository's Actions cache allocation.

The ordinary aggregate remains coverage-agnostic on both pull requests and main. Its helper now emits results only for the explicitly expected suites, allowing coverage to remain an independent main-only flow.