### PR TITLE
Add ready/valid flow declaration and connection macros

### DIFF
--- a/MACROS.md
+++ b/MACROS.md
@@ -251,6 +251,78 @@ These macros provide size-aware assignment helpers for common bit slicing and ex
 | `BR_INSERT_TO_LSB`, `BR_INSERT_TO_MSB` | Insert a narrower expression into the least-significant or most-significant bits of a wider destination. |
 
 
+## `br_flow.svh`: Ready/Valid Flow Helpers
+
+
+These macros declare local signal groups for canonical ready/valid flows and connect differently
+named groups with continuous assignments. They do not declare module ports, add storage, or change
+the flow-control contract.
+
+| Contract | Signals |
+| --- | --- |
+| Stable data | `<base>_ready`, `<base>_valid`, `<base>_data` |
+| Unstable data | `<base>_ready`, `<base>_valid_unstable`, `<base>_data_unstable` |
+| Stable control | `<base>_ready`, `<base>_valid` |
+| Unstable control | `<base>_ready`, `<base>_valid_unstable` |
+
+On a stable flow, valid and, for data flows, data remain stable while valid is asserted and ready is
+low. On an unstable flow, valid may be withdrawn while stalled; data may also change on data flows.
+Control flows omit data.
+
+### Declare flows
+
+
+| Flow | Scalar | Packed array |
+| --- | --- | --- |
+| Stable data | `BR_FLOW_DECLARE` | `BR_FLOW_DECLARE_ARRAY` |
+| Unstable data | `BR_FLOW_DECLARE_UNSTABLE` | `BR_FLOW_DECLARE_UNSTABLE_ARRAY` |
+| Stable control | `BR_FLOW_CONTROL_DECLARE` | `BR_FLOW_CONTROL_DECLARE_ARRAY` |
+| Unstable control | `BR_FLOW_CONTROL_DECLARE_UNSTABLE` | `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY` |
+
+Data declarations take a packed payload type. Array declarations also take a positive constant flow
+count and add a packed, little-endian lane dimension outside the payload.
+
+### Connect flows
+
+
+For connections, choose the root matching the source and sink contract:
+
+| Contract | Root |
+| --- | --- |
+| Stable data | `BR_FLOW_CONNECT` |
+| Unstable data | `BR_FLOW_CONNECT_UNSTABLE` |
+| Stable control | `BR_FLOW_CONTROL_CONNECT` |
+| Unstable control | `BR_FLOW_CONTROL_CONNECT_UNSTABLE` |
+
+The first flow is the source and the second is the sink. Ready travels toward the source; valid and,
+for data flows, data travel toward the sink.
+
+| Topology | Suffix and arguments |
+| --- | --- |
+| Scalar-to-scalar or whole array-to-array | none: `(source, sink)` |
+| Source array lane to scalar sink | `_FROM_INDEX(source, source_index, sink)` |
+| Scalar source to sink array lane | `_TO_INDEX(source, sink, sink_index)` |
+| Source array lane to sink array lane | `_INDEX(source, source_index, sink, sink_index)` |
+
+For example:
+
+```systemverilog
+typedef logic [31:0] payload_t;
+
+`BR_FLOW_DECLARE(upstream, payload_t)
+`BR_FLOW_DECLARE(downstream, payload_t)
+`BR_FLOW_CONNECT(upstream, downstream)
+```
+
+Flow names must be bare identifiers because the macros form signal names by token pasting. Indexed
+forms are intended for elaboration-time constant expressions, including genvar arithmetic. Whole-
+array connections require equal lane counts, and data payloads must be assignment-compatible.
+
+Declaration and connection macros include their semicolons. Connections are raw continuous
+assignments: they do not prevent multiple drivers or ready loops, route at runtime, or adapt between
+stable and unstable contracts.
+
+
 ## `br_fv.svh`: Formal Verification Helpers
 
 

--- a/macros/BUILD.bazel
+++ b/macros/BUILD.bazel
@@ -278,6 +278,50 @@ verilog_lint_test(
     deps = [":br_assign_test"],
 )
 
+verilog_library(
+    name = "br_flow",
+    hdrs = ["br_flow.svh"],
+    visibility = ["//visibility:public"],
+)
+
+verilog_library(
+    name = "br_flow_test",
+    srcs = ["br_flow_test.sv"],
+    deps = [
+        ":br_asserts",
+        ":br_flow",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_elab_test",
+    tool = "slang",
+    deps = [":br_flow_test"],
+)
+
+verilog_elab_test(
+    name = "br_flow_verific_elab_test",
+    tool = "verific",
+    deps = [":br_flow_test"],
+)
+
+verilog_lint_test(
+    name = "br_flow_lint_test",
+    tool = "ascentlint",
+    visibility = ["//visibility:public"],
+    deps = [":br_flow_test"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_flow_sim_test_tools_suite",
+    elab_only = True,
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_flow_test"],
+)
+
 verilog_sim_coverage_aggregate(
     name = "br_macros_verilator_coverage",
     coverage_reports = [

--- a/macros/br_flow.svh
+++ b/macros/br_flow.svh
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+`ifndef BR_FLOW_SVH
+`define BR_FLOW_SVH
+
+// Declares one canonical data-carrying ready-valid flow.
+`define BR_FLOW_DECLARE(__flow__, __data_t__) \
+  logic __flow__``_ready; \
+  logic __flow__``_valid; \
+  __data_t__ __flow__``_data;
+
+// Declares a packed, little-endian array of canonical data-carrying ready-valid flows.
+// The element typedef keeps each data index aligned with one ready-valid lane.
+`define BR_FLOW_DECLARE_ARRAY(__flow__, __data_t__, __num_flows__) \
+  typedef __data_t__ __flow__``_data_element_t; \
+  logic [(__num_flows__)-1:0] __flow__``_ready; \
+  logic [(__num_flows__)-1:0] __flow__``_valid; \
+  __flow__``_data_element_t [(__num_flows__)-1:0] __flow__``_data;
+
+// Declares one data-carrying ready/unstable-valid flow.
+// Valid and data may change while ready is low.
+`define BR_FLOW_DECLARE_UNSTABLE(__flow__, __data_t__) \
+  logic __flow__``_ready; \
+  logic __flow__``_valid_unstable; \
+  __data_t__ __flow__``_data_unstable;
+
+// Declares a packed, little-endian array of data-carrying ready/unstable-valid flows.
+// The element typedef keeps each data index aligned with one ready-valid lane.
+`define BR_FLOW_DECLARE_UNSTABLE_ARRAY(__flow__, __data_t__, __num_flows__) \
+  typedef __data_t__ __flow__``_data_element_t; \
+  logic [(__num_flows__)-1:0] __flow__``_ready; \
+  logic [(__num_flows__)-1:0] __flow__``_valid_unstable; \
+  __flow__``_data_element_t [(__num_flows__)-1:0] __flow__``_data_unstable;
+
+// Declares one control-only ready-valid flow.
+`define BR_FLOW_CONTROL_DECLARE(__flow__) \
+  logic __flow__``_ready; \
+  logic __flow__``_valid;
+
+// Declares a packed, little-endian array of control-only ready-valid flows.
+`define BR_FLOW_CONTROL_DECLARE_ARRAY(__flow__, __num_flows__) \
+  logic [(__num_flows__)-1:0] __flow__``_ready; \
+  logic [(__num_flows__)-1:0] __flow__``_valid;
+
+// Declares one control-only ready/unstable-valid flow.
+`define BR_FLOW_CONTROL_DECLARE_UNSTABLE(__flow__) \
+  logic __flow__``_ready; \
+  logic __flow__``_valid_unstable;
+
+// Declares a packed, little-endian array of control-only ready/unstable-valid flows.
+`define BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(__flow__, __num_flows__) \
+  logic [(__num_flows__)-1:0] __flow__``_ready; \
+  logic [(__num_flows__)-1:0] __flow__``_valid_unstable;
+
+// Continuously connects one canonical source flow or aligned packed flow array to one sink.
+// Ready travels toward the source; valid and data travel toward the sink.
+`define BR_FLOW_CONNECT(__source__, __sink__) \
+  assign __source__``_ready = __sink__``_ready; \
+  assign __sink__``_valid = __source__``_valid; \
+  assign __sink__``_data = __source__``_data;
+
+// Continuously connects one canonical source flow-array lane to one scalar sink flow.
+// Ready travels toward the source; valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_FROM_INDEX(__source__, __source_index__, __sink__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready; \
+  assign __sink__``_valid = __source__``_valid[__source_index__]; \
+  assign __sink__``_data = __source__``_data[__source_index__];
+
+// Continuously connects one canonical scalar source flow to one sink flow-array lane.
+// Ready travels toward the source; valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_TO_INDEX(__source__, __sink__, __sink_index__) \
+  assign __source__``_ready = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid[__sink_index__] = __source__``_valid; \
+  assign __sink__``_data[__sink_index__] = __source__``_data;
+
+// Continuously connects one canonical source flow-array lane to one sink lane.
+// Ready travels toward the source; valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_INDEX(__source__, __source_index__, __sink__, __sink_index__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid[__sink_index__] = __source__``_valid[__source_index__]; \
+  assign __sink__``_data[__sink_index__] = __source__``_data[__source_index__];
+
+// Continuously connects one explicitly unstable source flow or aligned packed flow array to
+// one sink. Ready travels toward the source; unstable valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_UNSTABLE(__source__, __sink__) \
+  assign __source__``_ready = __sink__``_ready; \
+  assign __sink__``_valid_unstable = __source__``_valid_unstable; \
+  assign __sink__``_data_unstable = __source__``_data_unstable;
+
+// Continuously connects one explicitly unstable source flow-array lane to one scalar sink flow.
+// Ready travels toward the source; unstable valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_UNSTABLE_FROM_INDEX(__source__, __source_index__, __sink__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready; \
+  assign __sink__``_valid_unstable = __source__``_valid_unstable[__source_index__]; \
+  assign __sink__``_data_unstable = __source__``_data_unstable[__source_index__];
+
+// Continuously connects one explicitly unstable scalar source flow to one sink flow-array lane.
+// Ready travels toward the source; unstable valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_UNSTABLE_TO_INDEX(__source__, __sink__, __sink_index__) \
+  assign __source__``_ready = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid_unstable[__sink_index__] = __source__``_valid_unstable; \
+  assign __sink__``_data_unstable[__sink_index__] = __source__``_data_unstable;
+
+// Continuously connects one explicitly unstable source flow-array lane to one sink lane.
+// Ready travels toward the source; unstable valid and data travel toward the sink.
+`define BR_FLOW_CONNECT_UNSTABLE_INDEX(__source__, __source_index__, __sink__, __sink_index__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid_unstable[__sink_index__] = \
+      __source__``_valid_unstable[__source_index__]; \
+  assign __sink__``_data_unstable[__sink_index__] = \
+      __source__``_data_unstable[__source_index__];
+
+// Continuously connects one canonical control source or aligned packed source array to one sink.
+// Ready travels toward the source; valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT(__source__, __sink__) \
+  assign __source__``_ready = __sink__``_ready; \
+  assign __sink__``_valid = __source__``_valid;
+
+// Continuously connects one canonical control source-array lane to one scalar sink flow.
+// Ready travels toward the source; valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_FROM_INDEX(__source__, __source_index__, __sink__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready; \
+  assign __sink__``_valid = __source__``_valid[__source_index__];
+
+// Continuously connects one canonical scalar control source to one sink-array lane.
+// Ready travels toward the source; valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_TO_INDEX(__source__, __sink__, __sink_index__) \
+  assign __source__``_ready = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid[__sink_index__] = __source__``_valid;
+
+// Continuously connects one canonical control source-array lane to one sink-array lane.
+// Ready travels toward the source; valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_INDEX(__source__, __source_index__, __sink__, __sink_index__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid[__sink_index__] = __source__``_valid[__source_index__];
+
+// Continuously connects one explicitly unstable control source or aligned packed source array to
+// one sink. Ready travels toward the source; unstable valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_UNSTABLE(__source__, __sink__) \
+  assign __source__``_ready = __sink__``_ready; \
+  assign __sink__``_valid_unstable = __source__``_valid_unstable;
+
+// Continuously connects one explicitly unstable control source-array lane to one scalar sink flow.
+// Ready travels toward the source; unstable valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_UNSTABLE_FROM_INDEX(__source__, __source_index__, __sink__) \
+  assign __source__``_ready[__source_index__] = __sink__``_ready; \
+  assign __sink__``_valid_unstable = __source__``_valid_unstable[__source_index__];
+
+// Continuously connects one explicitly unstable scalar control source to one sink-array lane.
+// Ready travels toward the source; unstable valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_UNSTABLE_TO_INDEX(__source__, __sink__, __sink_index__) \
+  assign __source__``_ready = __sink__``_ready[__sink_index__]; \
+  assign __sink__``_valid_unstable[__sink_index__] = __source__``_valid_unstable;
+
+// Continuously connects one explicitly unstable control source-array lane to one sink-array lane.
+// Ready travels toward the source; unstable valid travels toward the sink.
+`define BR_FLOW_CONTROL_CONNECT_UNSTABLE_INDEX(__source__, __source_i__, __sink__, __sink_i__) \
+  assign __source__``_ready[__source_i__] = __sink__``_ready[__sink_i__]; \
+  assign __sink__``_valid_unstable[__sink_i__] = __source__``_valid_unstable[__source_i__];
+
+`endif  // BR_FLOW_SVH

--- a/macros/br_flow_test.sv
+++ b/macros/br_flow_test.sv
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+// Elaboration coverage for ready-valid flow declaration and direct-connection macros.
+
+`include "br_flow.svh"
+`include "br_asserts.svh"
+
+module br_flow_test #(
+    parameter int LogNumFlows = 2,
+    localparam int NumFlows = 1 << LogNumFlows,
+    localparam type payload_t = logic [31:0]
+) (
+    input  logic        stimulus,
+    input  logic [31:0] payload_in,
+    output logic        observed
+);
+
+  // Packed payload verifies that one array index selects one complete payload.
+  typedef struct packed {
+    logic [7:0]  tag;
+    logic [23:0] value;
+  } struct_payload_t;
+
+  localparam int PayloadWidth = $bits(payload_t);
+  localparam int StructPayloadWidth = $bits(struct_payload_t);
+
+  `BR_ASSERT_STATIC(log_num_flows_must_be_nonnegative_a, LogNumFlows >= 0)
+
+  //------------------------------------------
+  // Stable data flows
+  //------------------------------------------
+  `BR_FLOW_DECLARE(stable_scalar_source, payload_t)
+  `BR_FLOW_DECLARE(stable_scalar_sink, payload_t)
+
+  // The shift expression verifies that declaration macros group the flow count before `-1`.
+  `BR_FLOW_DECLARE_ARRAY(stable_array_source, logic [31:0], 1 << LogNumFlows)
+  `BR_FLOW_DECLARE_ARRAY(stable_array_sink, payload_t, NumFlows)
+
+  `BR_FLOW_DECLARE_ARRAY(stable_from_source, struct_payload_t, 1)
+  `BR_FLOW_DECLARE(stable_from_sink, struct_payload_t)
+
+  `BR_FLOW_DECLARE(stable_to_source, struct_payload_t)
+  `BR_FLOW_DECLARE_ARRAY(stable_to_sink, struct_payload_t, 1)
+
+  `BR_FLOW_DECLARE_ARRAY(stable_index_source, struct_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_ARRAY(stable_index_sink, struct_payload_t, NumFlows)
+
+  assign stable_scalar_source_valid = stimulus;
+  assign stable_scalar_source_data  = payload_in;
+  assign stable_scalar_sink_ready   = stimulus;
+  `BR_FLOW_CONNECT(stable_scalar_source, stable_scalar_sink)
+
+  assign stable_array_source_valid = {NumFlows{stimulus}};
+  assign stable_array_source_data  = {NumFlows{payload_in}};
+  assign stable_array_sink_ready   = {NumFlows{stimulus}};
+  `BR_FLOW_CONNECT(stable_array_source, stable_array_sink)
+
+  assign stable_from_source_valid = stimulus;
+  assign stable_from_source_data  = payload_in;
+  assign stable_from_sink_ready   = stimulus;
+  `BR_FLOW_CONNECT_FROM_INDEX(stable_from_source, 0, stable_from_sink)
+
+  assign stable_to_source_valid = stimulus;
+  assign stable_to_source_data  = payload_in;
+  assign stable_to_sink_ready   = stimulus;
+  `BR_FLOW_CONNECT_TO_INDEX(stable_to_source, stable_to_sink, 0)
+
+  assign stable_index_source_valid = {NumFlows{stimulus}};
+  assign stable_index_source_data  = {NumFlows{payload_in}};
+  assign stable_index_sink_ready   = {NumFlows{stimulus}};
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_stable_data_index
+    `BR_FLOW_CONNECT_INDEX(stable_index_source, i, stable_index_sink, NumFlows - 1 - i)
+  end
+
+  `BR_ASSERT_STATIC(stable_array_ready_width_a, $bits(stable_array_source_ready) == NumFlows)
+  `BR_ASSERT_STATIC(stable_array_data_width_a, $bits(stable_array_source_data)
+                    == (NumFlows * PayloadWidth))
+  `BR_ASSERT_STATIC(stable_array_element_width_a, $bits(stable_array_source_data[0])
+                    == PayloadWidth)
+  `BR_ASSERT_STATIC(stable_struct_element_width_a, $bits(stable_index_source_data[0])
+                    == StructPayloadWidth)
+
+  //------------------------------------------
+  // Unstable data flows
+  //------------------------------------------
+  `BR_FLOW_DECLARE_UNSTABLE(unstable_scalar_source, payload_t)
+  `BR_FLOW_DECLARE_UNSTABLE(unstable_scalar_sink, payload_t)
+
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_array_source, logic [31:0], 1 << LogNumFlows)
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_array_sink, payload_t, NumFlows)
+
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_from_source, struct_payload_t, 1)
+  `BR_FLOW_DECLARE_UNSTABLE(unstable_from_sink, struct_payload_t)
+
+  `BR_FLOW_DECLARE_UNSTABLE(unstable_to_source, struct_payload_t)
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_to_sink, struct_payload_t, 1)
+
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_index_source, struct_payload_t, NumFlows)
+  `BR_FLOW_DECLARE_UNSTABLE_ARRAY(unstable_index_sink, struct_payload_t, NumFlows)
+
+  assign unstable_scalar_source_valid_unstable = stimulus;
+  assign unstable_scalar_source_data_unstable = payload_in;
+  assign unstable_scalar_sink_ready = stimulus;
+  `BR_FLOW_CONNECT_UNSTABLE(unstable_scalar_source, unstable_scalar_sink)
+
+  assign unstable_array_source_valid_unstable = {NumFlows{stimulus}};
+  assign unstable_array_source_data_unstable = {NumFlows{payload_in}};
+  assign unstable_array_sink_ready = {NumFlows{stimulus}};
+  `BR_FLOW_CONNECT_UNSTABLE(unstable_array_source, unstable_array_sink)
+
+  assign unstable_from_source_valid_unstable = stimulus;
+  assign unstable_from_source_data_unstable = payload_in;
+  assign unstable_from_sink_ready = stimulus;
+  `BR_FLOW_CONNECT_UNSTABLE_FROM_INDEX(unstable_from_source, 0, unstable_from_sink)
+
+  assign unstable_to_source_valid_unstable = stimulus;
+  assign unstable_to_source_data_unstable = payload_in;
+  assign unstable_to_sink_ready = stimulus;
+  `BR_FLOW_CONNECT_UNSTABLE_TO_INDEX(unstable_to_source, unstable_to_sink, 0)
+
+  assign unstable_index_source_valid_unstable = {NumFlows{stimulus}};
+  assign unstable_index_source_data_unstable = {NumFlows{payload_in}};
+  assign unstable_index_sink_ready = {NumFlows{stimulus}};
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_unstable_data_index
+    `BR_FLOW_CONNECT_UNSTABLE_INDEX(unstable_index_source, i, unstable_index_sink, NumFlows - 1 - i)
+  end
+
+  `BR_ASSERT_STATIC(unstable_array_ready_width_a, $bits(unstable_array_source_ready) == NumFlows)
+  `BR_ASSERT_STATIC(unstable_array_data_width_a, $bits(unstable_array_source_data_unstable)
+                    == (NumFlows * PayloadWidth))
+  `BR_ASSERT_STATIC(unstable_array_element_width_a, $bits(unstable_array_source_data_unstable[0])
+                    == PayloadWidth)
+  `BR_ASSERT_STATIC(unstable_struct_element_width_a, $bits(unstable_index_source_data_unstable[0])
+                    == StructPayloadWidth)
+
+  //------------------------------------------
+  // Stable control flows
+  //------------------------------------------
+  `BR_FLOW_CONTROL_DECLARE(control_scalar_source)
+  `BR_FLOW_CONTROL_DECLARE(control_scalar_sink)
+
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_array_source, 1 << LogNumFlows)
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_array_sink, NumFlows)
+
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_from_source, 1)
+  `BR_FLOW_CONTROL_DECLARE(control_from_sink)
+
+  `BR_FLOW_CONTROL_DECLARE(control_to_source)
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_to_sink, 1)
+
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_index_source, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_ARRAY(control_index_sink, NumFlows)
+
+  assign control_scalar_source_valid = stimulus;
+  assign control_scalar_sink_ready   = stimulus;
+  `BR_FLOW_CONTROL_CONNECT(control_scalar_source, control_scalar_sink)
+
+  assign control_array_source_valid = {NumFlows{stimulus}};
+  assign control_array_sink_ready   = {NumFlows{stimulus}};
+  `BR_FLOW_CONTROL_CONNECT(control_array_source, control_array_sink)
+
+  assign control_from_source_valid = stimulus;
+  assign control_from_sink_ready   = stimulus;
+  `BR_FLOW_CONTROL_CONNECT_FROM_INDEX(control_from_source, 0, control_from_sink)
+
+  assign control_to_source_valid = stimulus;
+  assign control_to_sink_ready   = stimulus;
+  `BR_FLOW_CONTROL_CONNECT_TO_INDEX(control_to_source, control_to_sink, 0)
+
+  assign control_index_source_valid = {NumFlows{stimulus}};
+  assign control_index_sink_ready   = {NumFlows{stimulus}};
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_stable_control_index
+    `BR_FLOW_CONTROL_CONNECT_INDEX(control_index_source, i, control_index_sink, NumFlows - 1 - i)
+  end
+
+  `BR_ASSERT_STATIC(control_array_width_a, $bits(control_array_source_ready) == NumFlows)
+
+  //------------------------------------------
+  // Unstable control flows
+  //------------------------------------------
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE(unstable_control_scalar_source)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE(unstable_control_scalar_sink)
+
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_array_source, 1 << LogNumFlows)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_array_sink, NumFlows)
+
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_from_source, 1)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE(unstable_control_from_sink)
+
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE(unstable_control_to_source)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_to_sink, 1)
+
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_index_source, NumFlows)
+  `BR_FLOW_CONTROL_DECLARE_UNSTABLE_ARRAY(unstable_control_index_sink, NumFlows)
+
+  assign unstable_control_scalar_source_valid_unstable = stimulus;
+  assign unstable_control_scalar_sink_ready = stimulus;
+  `BR_FLOW_CONTROL_CONNECT_UNSTABLE(unstable_control_scalar_source, unstable_control_scalar_sink)
+
+  assign unstable_control_array_source_valid_unstable = {NumFlows{stimulus}};
+  assign unstable_control_array_sink_ready = {NumFlows{stimulus}};
+  `BR_FLOW_CONTROL_CONNECT_UNSTABLE(unstable_control_array_source, unstable_control_array_sink)
+
+  assign unstable_control_from_source_valid_unstable = stimulus;
+  assign unstable_control_from_sink_ready = stimulus;
+  `BR_FLOW_CONTROL_CONNECT_UNSTABLE_FROM_INDEX(unstable_control_from_source, 0,
+                                               unstable_control_from_sink)
+
+  assign unstable_control_to_source_valid_unstable = stimulus;
+  assign unstable_control_to_sink_ready = stimulus;
+  `BR_FLOW_CONTROL_CONNECT_UNSTABLE_TO_INDEX(unstable_control_to_source, unstable_control_to_sink,
+                                             0)
+
+  assign unstable_control_index_source_valid_unstable = {NumFlows{stimulus}};
+  assign unstable_control_index_sink_ready = {NumFlows{stimulus}};
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_unstable_control_index
+    `BR_FLOW_CONTROL_CONNECT_UNSTABLE_INDEX(unstable_control_index_source, i,
+                                            unstable_control_index_sink, NumFlows - 1 - i)
+  end
+
+  `BR_ASSERT_STATIC(unstable_control_array_width_a, $bits(unstable_control_array_source_ready)
+                    == NumFlows)
+
+  // Consume every result so lint also checks that each connection produces the expected signals.
+  assign observed = |{
+    stable_scalar_source_ready,
+    stable_scalar_sink_valid,
+    stable_scalar_sink_data,
+    stable_array_source_ready,
+    stable_array_sink_valid,
+    stable_array_sink_data,
+    stable_from_source_ready,
+    stable_from_sink_valid,
+    stable_from_sink_data,
+    stable_to_source_ready,
+    stable_to_sink_valid,
+    stable_to_sink_data,
+    stable_index_source_ready,
+    stable_index_sink_valid,
+    stable_index_sink_data,
+    unstable_scalar_source_ready,
+    unstable_scalar_sink_valid_unstable,
+    unstable_scalar_sink_data_unstable,
+    unstable_array_source_ready,
+    unstable_array_sink_valid_unstable,
+    unstable_array_sink_data_unstable,
+    unstable_from_source_ready,
+    unstable_from_sink_valid_unstable,
+    unstable_from_sink_data_unstable,
+    unstable_to_source_ready,
+    unstable_to_sink_valid_unstable,
+    unstable_to_sink_data_unstable,
+    unstable_index_source_ready,
+    unstable_index_sink_valid_unstable,
+    unstable_index_sink_data_unstable,
+    control_scalar_source_ready,
+    control_scalar_sink_valid,
+    control_array_source_ready,
+    control_array_sink_valid,
+    control_from_source_ready,
+    control_from_sink_valid,
+    control_to_source_ready,
+    control_to_sink_valid,
+    control_index_source_ready,
+    control_index_sink_valid,
+    unstable_control_scalar_source_ready,
+    unstable_control_scalar_sink_valid_unstable,
+    unstable_control_array_source_ready,
+    unstable_control_array_sink_valid_unstable,
+    unstable_control_from_source_ready,
+    unstable_control_from_sink_valid_unstable,
+    unstable_control_to_source_ready,
+    unstable_control_to_sink_valid_unstable,
+    unstable_control_index_source_ready,
+    unstable_control_index_sink_valid_unstable
+  };
+
+endmodule : br_flow_test


### PR DESCRIPTION
  ## Problem

Bedrock represents ready/valid interfaces as prefix-grouped flat signals. Declaring these signal groups and connecting ready in the opposite direction from valid and data is repetitive and error-prone, particularly for packed arrays and stable versus unstable contracts.

Add `br_flow.svh` with helpers for:

 - Stable and unstable flows
 - Data-carrying and control-only flows
 - Scalar and packed-array declarations
 - Whole-flow and indexed source/sink connections

Array declarations preserve each payload as a complete lane and correctly parenthesize expression-valued flow counts. Connection macros emit continuous assignments: ready travels toward the source, while valid and data travel toward the sink.

These helpers operate on local signal groups. They do not declare module ports, add storage, convert stability contracts, route dynamically, or prevent multiple drivers and ready loops.

Document the API in `MACROS.md` and add self-contained coverage for every declaration and connection form.