### PR TITLE
[ci] Update Coverview version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -720,7 +720,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: antmicro/coverview
-          ref: 1d9f9cacd3d8395e5ee23fcbe1ab43af73afeb03
+          ref: 6e5e15f986df1e8071b1b1f6a284fecca95c34a2
           path: coverview
           persist-credentials: false
       - name: Set up Node.js


### PR DESCRIPTION
This PR updates the Coverview version to include recent features:
* option for displaying total number of hits per coverage:
<img width="1552" height="982" alt="image" src="https://github.com/user-attachments/assets/dbc87299-9013-4bc2-8671-f3dbf75cd0ba" />

* changing coverage details to vertical layout: 
<img width="1090" height="318" alt="image" src="https://github.com/user-attachments/assets/c95a89f6-6e8b-43b9-b942-5fa2fe7e0c35" />