### PR TITLE
Add fixed-priority APB mux

### DIFF
--- a/amba/rtl/BUILD.bazel
+++ b/amba/rtl/BUILD.bazel
@@ -171,6 +171,7 @@ verilog_library(
         "//arb/rtl:br_arb_fixed",
         "//macros:br_asserts_internal",
         "//macros:br_registers",
+        "//macros:br_unused",
         "//mux/rtl:br_mux_onehot",
     ],
 )

--- a/amba/rtl/BUILD.bazel
+++ b/amba/rtl/BUILD.bazel
@@ -163,6 +163,18 @@ verilog_library(
     ],
 )
 
+verilog_library(
+    name = "br_apb_mux",
+    srcs = ["br_apb_mux.sv"],
+    deps = [
+        ":br_amba_pkg",
+        "//arb/rtl:br_arb_fixed",
+        "//macros:br_asserts_internal",
+        "//macros:br_registers",
+        "//mux/rtl:br_mux_onehot",
+    ],
+)
+
 br_verilog_elab_and_lint_test_suite(
     name = "br_amba_axil2apb_test_suite",
     params = {
@@ -496,6 +508,23 @@ br_verilog_elab_and_lint_test_suite(
         "NumDownstreams": ["1"],
     },
     deps = [":br_apb_demux"],
+)
+
+br_verilog_elab_and_lint_test_suite(
+    name = "br_apb_mux_test_suite",
+    params = {
+        "AddrWidth": [
+            "1",
+            "12",
+            "32",
+        ],
+        "NumUpstreams": [
+            "1",
+            "2",
+            "4",
+        ],
+    },
+    deps = [":br_apb_mux"],
 )
 
 br_verilog_synth_suite(

--- a/amba/rtl/br_apb_mux.sv
+++ b/amba/rtl/br_apb_mux.sv
@@ -3,7 +3,7 @@
 // Bedrock-RTL Fixed-Priority APB Mux
 //
 // Routes one of several upstream APB interfaces to a shared downstream
-// interface. While idle, the lowest-index pending upstream is selected
+// interface. In Setup, the lowest-index pending upstream is selected
 // combinationally to drive the downstream setup phase. The winner is saved at
 // the setup-to-access transition and held until the downstream access completes.
 // This adds no arbitration cycle, but puts priority selection on the downstream
@@ -69,7 +69,7 @@ module br_apb_mux #(
   // Implementation
 
   typedef enum logic {
-    Idle   = 1'b0,
+    Setup  = 1'b0,
     Access = 1'b1
   } apb_state_t;
 
@@ -103,20 +103,20 @@ module br_apb_mux #(
 
   assign any_grant = |upstream_psel;
 
-  `BR_REGI(apb_state, apb_state_next, Idle)
+  `BR_REGI(apb_state, apb_state_next, Setup)
   `BR_REGL(grant_winner, grant, grant_winner_load)
 
   always_comb begin
     apb_state_next = apb_state;
     grant_winner_load = 1'b0;
-    request_select = grant_winner;
+    request_select = '0;
     downstream_psel = 1'b0;
     downstream_penable = 1'b0;
     upstream_pready = '0;
     upstream_pslverr = '0;
 
     unique case (apb_state)
-      Idle: begin
+      Setup: begin
         // An asserted request turns this cycle into downstream setup.
         request_select  = grant;
         downstream_psel = any_grant;
@@ -126,18 +126,19 @@ module br_apb_mux #(
         end
       end
       Access: begin
+        request_select = grant_winner;
         downstream_psel = 1'b1;
         downstream_penable = 1'b1;
         upstream_pready = grant_winner & upstream_penable & {NumUpstreams{downstream_pready}};
         upstream_pslverr = grant_winner & upstream_penable & {NumUpstreams{downstream_pslverr}};
 
         if (downstream_pready) begin
-          apb_state_next = Idle;
+          apb_state_next = Setup;
         end
       end
       default: begin
         // Both binary encodings are covered; recover from unknowns in simulation.
-        apb_state_next = Idle;  // ri lint_check_waive UNREACHABLE
+        apb_state_next = Setup;  // ri lint_check_waive UNREACHABLE
       end
     endcase
   end
@@ -175,9 +176,9 @@ module br_apb_mux #(
   `BR_ASSERT_IMPL(downstream_enable_requires_select_a, downstream_penable |-> downstream_psel)
   `BR_ASSERT_IMPL(setup_advances_to_access_a,
                   (downstream_psel && !downstream_penable) |=> downstream_penable)
-  `BR_ASSERT_IMPL(grant_stable_while_active_a, (apb_state != Idle) |=> $stable(grant_winner))
+  `BR_ASSERT_IMPL(grant_stable_while_active_a, (apb_state == Access) |=> $stable(grant_winner))
   `BR_ASSERT_IMPL(
-      downstream_completion_returns_idle_a,
-      (downstream_psel && downstream_penable && downstream_pready) |=> apb_state == Idle)
+      downstream_completion_returns_setup_a,
+      (downstream_psel && downstream_penable && downstream_pready) |=> apb_state == Setup)
 
 endmodule : br_apb_mux

--- a/amba/rtl/br_apb_mux.sv
+++ b/amba/rtl/br_apb_mux.sv
@@ -3,8 +3,11 @@
 // Bedrock-RTL Fixed-Priority APB Mux
 //
 // Routes one of several upstream APB interfaces to a shared downstream
-// interface. The lowest-index pending upstream wins arbitration when the APB
-// state machine leaves idle, and that winner is held until its access completes.
+// interface. While idle, the lowest-index pending upstream is selected
+// combinationally to drive the downstream setup phase. The winner is saved at
+// the setup-to-access transition and held until the downstream access completes.
+// This adds no arbitration cycle, but puts priority selection on the downstream
+// request timing path. Only the access state and the winner are stored.
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
@@ -65,10 +68,9 @@ module br_apb_mux #(
 
   // Implementation
 
-  typedef enum logic [1:0] {
-    Idle   = 2'b00,
-    Setup  = 2'b01,
-    Access = 2'b10
+  typedef enum logic {
+    Idle   = 1'b0,
+    Access = 1'b1
   } apb_state_t;
 
   typedef struct packed {
@@ -79,12 +81,14 @@ module br_apb_mux #(
     logic [31:0] wdata;
   } req_t;
 
-  apb_state_t apb_state;
+  // Two states intentionally use a single flop.
+  apb_state_t apb_state;  // ri lint_check_waive ONE_BIT_STATE_REG
   apb_state_t apb_state_next;
   logic any_grant;
   logic grant_winner_load;
   logic [NumUpstreams-1:0] grant;
   logic [NumUpstreams-1:0] grant_winner;
+  logic [NumUpstreams-1:0] request_select;
   req_t [NumUpstreams-1:0] upstream_req;
   req_t downstream_req;
 
@@ -105,6 +109,7 @@ module br_apb_mux #(
   always_comb begin
     apb_state_next = apb_state;
     grant_winner_load = 1'b0;
+    request_select = grant_winner;
     downstream_psel = 1'b0;
     downstream_penable = 1'b0;
     upstream_pready = '0;
@@ -112,14 +117,13 @@ module br_apb_mux #(
 
     unique case (apb_state)
       Idle: begin
+        // An asserted request turns this cycle into downstream setup.
+        request_select  = grant;
+        downstream_psel = any_grant;
         if (any_grant) begin
-          apb_state_next = Setup;
+          apb_state_next = Access;
           grant_winner_load = 1'b1;
         end
-      end
-      Setup: begin
-        downstream_psel = 1'b1;
-        apb_state_next  = Access;
       end
       Access: begin
         downstream_psel = 1'b1;
@@ -132,7 +136,8 @@ module br_apb_mux #(
         end
       end
       default: begin
-        apb_state_next = Idle;
+        // Both binary encodings are covered; recover from unknowns in simulation.
+        apb_state_next = Idle;  // ri lint_check_waive UNREACHABLE
       end
     endcase
   end
@@ -151,7 +156,7 @@ module br_apb_mux #(
       .NumSymbolsIn(NumUpstreams),
       .SymbolWidth ($bits(req_t))
   ) br_mux_onehot_req (
-      .select(grant_winner),
+      .select(request_select),
       .in(upstream_req),
       .out(downstream_req)
   );
@@ -166,8 +171,10 @@ module br_apb_mux #(
   // Implementation Checks
 
   `BR_ASSERT_IMPL(grant_winner_onehot0_a, $onehot0(grant_winner))
-  `BR_ASSERT_IMPL(active_grant_onehot_a, downstream_psel |-> $onehot(grant_winner))
+  `BR_ASSERT_IMPL(active_grant_onehot_a, downstream_psel |-> $onehot(request_select))
   `BR_ASSERT_IMPL(downstream_enable_requires_select_a, downstream_penable |-> downstream_psel)
+  `BR_ASSERT_IMPL(setup_advances_to_access_a,
+                  (downstream_psel && !downstream_penable) |=> downstream_penable)
   `BR_ASSERT_IMPL(grant_stable_while_active_a, (apb_state != Idle) |=> $stable(grant_winner))
   `BR_ASSERT_IMPL(
       downstream_completion_returns_idle_a,

--- a/amba/rtl/br_apb_mux.sv
+++ b/amba/rtl/br_apb_mux.sv
@@ -11,6 +11,7 @@
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
+`include "br_unused.svh"
 
 module br_apb_mux #(
     parameter int AddrWidth = 12,  // Must be at least 1
@@ -47,7 +48,6 @@ module br_apb_mux #(
   `BR_ASSERT_STATIC(legal_num_upstreams_a, NumUpstreams >= 1)
 
   for (genvar i = 0; i < NumUpstreams; i++) begin : gen_upstream_checks
-    `BR_ASSERT_INTG(enable_requires_select_a, upstream_penable[i] |-> upstream_psel[i])
     `BR_ASSERT_INTG(access_stable_while_waiting_a,
                     (upstream_psel[i] && upstream_penable[i] && !upstream_pready[i]) |=>
                     upstream_psel[i] && upstream_penable[i])
@@ -61,10 +61,17 @@ module br_apb_mux #(
                         upstream_pstrb[i]
                     ) && $stable(
                         upstream_pwrite[i]
-                    ) && $stable(
-                        upstream_pwdata[i]
                     ))
+    for (genvar byte_idx = 0; byte_idx < 4; byte_idx++) begin : gen_wdata_checks
+      `BR_ASSERT_INTG(wdata_stable_while_pending_a,
+                      (upstream_psel[i] && (!upstream_penable[i] || !upstream_pready[i]) &&
+                       upstream_pwrite[i] && upstream_pstrb[i][byte_idx]) |=>
+                      $stable(
+                          upstream_pwdata[i][8*byte_idx+:8]
+                      ))
+    end
   end
+  `BR_UNUSED(upstream_penable)
 
   // Implementation
 
@@ -85,9 +92,9 @@ module br_apb_mux #(
   apb_state_t apb_state;  // ri lint_check_waive ONE_BIT_STATE_REG
   apb_state_t apb_state_next;
   logic any_grant;
-  logic grant_winner_load;
+  logic grant_saved_load;
   logic [NumUpstreams-1:0] grant;
-  logic [NumUpstreams-1:0] grant_winner;
+  logic [NumUpstreams-1:0] grant_saved;
   logic [NumUpstreams-1:0] request_select;
   req_t [NumUpstreams-1:0] upstream_req;
   req_t downstream_req;
@@ -104,11 +111,11 @@ module br_apb_mux #(
   assign any_grant = |upstream_psel;
 
   `BR_REGI(apb_state, apb_state_next, Setup)
-  `BR_REGL(grant_winner, grant, grant_winner_load)
+  `BR_REGL(grant_saved, grant, grant_saved_load)
 
   always_comb begin
     apb_state_next = apb_state;
-    grant_winner_load = 1'b0;
+    grant_saved_load = 1'b0;
     request_select = '0;
     downstream_psel = 1'b0;
     downstream_penable = 1'b0;
@@ -121,16 +128,16 @@ module br_apb_mux #(
         request_select  = grant;
         downstream_psel = any_grant;
         if (any_grant) begin
-          apb_state_next = Access;
-          grant_winner_load = 1'b1;
+          apb_state_next   = Access;
+          grant_saved_load = 1'b1;
         end
       end
       Access: begin
-        request_select = grant_winner;
+        request_select = grant_saved;
         downstream_psel = 1'b1;
         downstream_penable = 1'b1;
-        upstream_pready = grant_winner & upstream_penable & {NumUpstreams{downstream_pready}};
-        upstream_pslverr = grant_winner & upstream_penable & {NumUpstreams{downstream_pslverr}};
+        upstream_pready = grant_saved & {NumUpstreams{downstream_pready}};
+        upstream_pslverr = grant_saved & {NumUpstreams{downstream_pslverr}};
 
         if (downstream_pready) begin
           apb_state_next = Setup;
@@ -171,12 +178,12 @@ module br_apb_mux #(
 
   // Implementation Checks
 
-  `BR_ASSERT_IMPL(grant_winner_onehot0_a, $onehot0(grant_winner))
+  `BR_ASSERT_IMPL(grant_saved_onehot0_a, $onehot0(grant_saved))
   `BR_ASSERT_IMPL(active_grant_onehot_a, downstream_psel |-> $onehot(request_select))
   `BR_ASSERT_IMPL(downstream_enable_requires_select_a, downstream_penable |-> downstream_psel)
   `BR_ASSERT_IMPL(setup_advances_to_access_a,
                   (downstream_psel && !downstream_penable) |=> downstream_penable)
-  `BR_ASSERT_IMPL(grant_stable_while_active_a, (apb_state == Access) |=> $stable(grant_winner))
+  `BR_ASSERT_IMPL(grant_saved_stable_while_active_a, (apb_state == Access) |=> $stable(grant_saved))
   `BR_ASSERT_IMPL(
       downstream_completion_returns_setup_a,
       (downstream_psel && downstream_penable && downstream_pready) |=> apb_state == Setup)

--- a/amba/rtl/br_apb_mux.sv
+++ b/amba/rtl/br_apb_mux.sv
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bedrock-RTL Fixed-Priority APB Mux
+//
+// Routes one of several upstream APB interfaces to a shared downstream
+// interface. The lowest-index pending upstream wins arbitration when the APB
+// state machine leaves idle, and that winner is held until its access completes.
+
+`include "br_asserts_internal.svh"
+`include "br_registers.svh"
+
+module br_apb_mux #(
+    parameter int AddrWidth = 12,  // Must be at least 1
+    parameter int NumUpstreams = 1  // Must be at least 1
+) (
+    input logic clk,
+    input logic rst,
+
+    input logic [NumUpstreams-1:0][AddrWidth-1:0] upstream_paddr,
+    input logic [NumUpstreams-1:0] upstream_psel,
+    input logic [NumUpstreams-1:0] upstream_penable,
+    input logic [NumUpstreams-1:0][br_amba::ApbProtWidth-1:0] upstream_pprot,
+    input logic [NumUpstreams-1:0][3:0] upstream_pstrb,
+    input logic [NumUpstreams-1:0] upstream_pwrite,
+    input logic [NumUpstreams-1:0][31:0] upstream_pwdata,
+    output logic [NumUpstreams-1:0][31:0] upstream_prdata,
+    output logic [NumUpstreams-1:0] upstream_pready,
+    output logic [NumUpstreams-1:0] upstream_pslverr,
+
+    output logic [AddrWidth-1:0] downstream_paddr,
+    output logic downstream_psel,
+    output logic downstream_penable,
+    output logic [br_amba::ApbProtWidth-1:0] downstream_pprot,
+    output logic [3:0] downstream_pstrb,
+    output logic downstream_pwrite,
+    output logic [31:0] downstream_pwdata,
+    input logic [31:0] downstream_prdata,
+    input logic downstream_pready,
+    input logic downstream_pslverr
+);
+  // Integration Checks
+
+  `BR_ASSERT_STATIC(legal_addr_width_a, AddrWidth >= 1)
+  `BR_ASSERT_STATIC(legal_num_upstreams_a, NumUpstreams >= 1)
+
+  for (genvar i = 0; i < NumUpstreams; i++) begin : gen_upstream_checks
+    `BR_ASSERT_INTG(enable_requires_select_a, upstream_penable[i] |-> upstream_psel[i])
+    `BR_ASSERT_INTG(access_stable_while_waiting_a,
+                    (upstream_psel[i] && upstream_penable[i] && !upstream_pready[i]) |=>
+                    upstream_psel[i] && upstream_penable[i])
+    `BR_ASSERT_INTG(request_stable_while_pending_a,
+                    (upstream_psel[i] && (!upstream_penable[i] || !upstream_pready[i])) |=>
+                    upstream_psel[i] && $stable(
+                        upstream_paddr[i]
+                    ) && $stable(
+                        upstream_pprot[i]
+                    ) && $stable(
+                        upstream_pstrb[i]
+                    ) && $stable(
+                        upstream_pwrite[i]
+                    ) && $stable(
+                        upstream_pwdata[i]
+                    ))
+  end
+
+  // Implementation
+
+  typedef enum logic [1:0] {
+    Idle   = 2'b00,
+    Setup  = 2'b01,
+    Access = 2'b10
+  } apb_state_t;
+
+  typedef struct packed {
+    logic [AddrWidth-1:0] addr;
+    logic [br_amba::ApbProtWidth-1:0] prot;
+    logic [3:0] strb;
+    logic write;
+    logic [31:0] wdata;
+  } req_t;
+
+  apb_state_t apb_state;
+  apb_state_t apb_state_next;
+  logic any_grant;
+  logic grant_winner_load;
+  logic [NumUpstreams-1:0] grant;
+  logic [NumUpstreams-1:0] grant_winner;
+  req_t [NumUpstreams-1:0] upstream_req;
+  req_t downstream_req;
+
+  br_arb_fixed #(
+      .NumRequesters(NumUpstreams)
+  ) br_arb_fixed (
+      .clk,
+      .rst,
+      .request(upstream_psel),
+      .grant
+  );
+
+  assign any_grant = |upstream_psel;
+
+  `BR_REGI(apb_state, apb_state_next, Idle)
+  `BR_REGL(grant_winner, grant, grant_winner_load)
+
+  always_comb begin
+    apb_state_next = apb_state;
+    grant_winner_load = 1'b0;
+    downstream_psel = 1'b0;
+    downstream_penable = 1'b0;
+    upstream_pready = '0;
+    upstream_pslverr = '0;
+
+    unique case (apb_state)
+      Idle: begin
+        if (any_grant) begin
+          apb_state_next = Setup;
+          grant_winner_load = 1'b1;
+        end
+      end
+      Setup: begin
+        downstream_psel = 1'b1;
+        apb_state_next  = Access;
+      end
+      Access: begin
+        downstream_psel = 1'b1;
+        downstream_penable = 1'b1;
+        upstream_pready = grant_winner & upstream_penable & {NumUpstreams{downstream_pready}};
+        upstream_pslverr = grant_winner & upstream_penable & {NumUpstreams{downstream_pslverr}};
+
+        if (downstream_pready) begin
+          apb_state_next = Idle;
+        end
+      end
+      default: begin
+        apb_state_next = Idle;
+      end
+    endcase
+  end
+
+  for (genvar i = 0; i < NumUpstreams; i++) begin : gen_upstream
+    assign upstream_req[i] = '{
+            addr: upstream_paddr[i],
+            prot: upstream_pprot[i],
+            strb: upstream_pstrb[i],
+            write: upstream_pwrite[i],
+            wdata: upstream_pwdata[i]
+        };
+  end
+
+  br_mux_onehot #(
+      .NumSymbolsIn(NumUpstreams),
+      .SymbolWidth ($bits(req_t))
+  ) br_mux_onehot_req (
+      .select(grant_winner),
+      .in(upstream_req),
+      .out(downstream_req)
+  );
+
+  assign upstream_prdata   = {NumUpstreams{downstream_prdata}};
+  assign downstream_paddr  = downstream_req.addr;
+  assign downstream_pprot  = downstream_req.prot;
+  assign downstream_pstrb  = downstream_req.strb;
+  assign downstream_pwrite = downstream_req.write;
+  assign downstream_pwdata = downstream_req.wdata;
+
+  // Implementation Checks
+
+  `BR_ASSERT_IMPL(grant_winner_onehot0_a, $onehot0(grant_winner))
+  `BR_ASSERT_IMPL(active_grant_onehot_a, downstream_psel |-> $onehot(grant_winner))
+  `BR_ASSERT_IMPL(downstream_enable_requires_select_a, downstream_penable |-> downstream_psel)
+  `BR_ASSERT_IMPL(grant_stable_while_active_a, (apb_state != Idle) |=> $stable(grant_winner))
+  `BR_ASSERT_IMPL(
+      downstream_completion_returns_idle_a,
+      (downstream_psel && downstream_penable && downstream_pready) |=> apb_state == Idle)
+
+endmodule : br_apb_mux

--- a/amba/sim/BUILD.bazel
+++ b/amba/sim/BUILD.bazel
@@ -275,6 +275,66 @@ br_verilog_sim_test_tools_suite(
 )
 
 verilog_library(
+    name = "br_apb_mux_tb",
+    srcs = ["br_apb_mux_tb.sv"],
+    deps = [
+        "//amba/rtl:br_amba_pkg",
+        "//amba/rtl:br_apb_mux",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_apb_mux_tb_elab_test",
+    tool = "slang",
+    deps = [":br_apb_mux_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_apb_mux_sim_test_tools_suite",
+    params = {
+        "AddrWidth": [
+            "1",
+            "12",
+            "16",
+        ],
+        "NumUpstreams": [
+            "1",
+            "2",
+            "4",
+        ],
+    },
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_apb_mux_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_apb_mux_protocol_violation_sim_test_tools_suite",
+    defines = [
+        "BR_ASSERT_ON",
+        "BR_ENABLE_IMPL_CHECKS",
+        "BR_DISABLE_INTG_CHECKS",
+        "SIMULATION",
+    ],
+    params = {
+        "AddrWidth": [
+            "1",
+            "12",
+        ],
+        "ExerciseProtocolViolations": ["1"],
+        "NumUpstreams": [
+            "1",
+            "2",
+        ],
+    },
+    tools = ["vcs"],
+    deps = [":br_apb_mux_tb"],
+)
+
+verilog_library(
     name = "br_amba_axi_timing_slice_tb",
     srcs = ["br_amba_axi_timing_slice_tb.sv"],
     deps = [
@@ -735,6 +795,7 @@ verilog_sim_coverage_aggregate(
         ":br_amba_apb_timing_slice_sim_test_tools_suite_verilator_coverage",
         # Re-enable after confirming that test suite with coverage gathering passes
         # ":br_apb_demux_sim_test_tools_suite_verilator_coverage",
+        ":br_apb_mux_sim_test_tools_suite_verilator_coverage",
         ":br_amba_axi_timing_slice_sim_test_tools_suite_verilator_coverage",
         ":br_amba_axi_timing_slice_multi_sim_test_tools_suite_verilator_coverage",
         ":br_amba_axi_default_target_sim_test_tools_suite_verilator_coverage",

--- a/amba/sim/br_apb_mux_tb.sv
+++ b/amba/sim/br_apb_mux_tb.sv
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+module br_apb_mux_tb;
+  parameter int AddrWidth = 12;
+  parameter int NumUpstreams = 2;
+  parameter bit ExerciseProtocolViolations = 0;
+
+  localparam int TimeoutCycles = 40;
+
+  logic clk;
+  logic rst;
+
+  logic [NumUpstreams-1:0][AddrWidth-1:0] upstream_paddr;
+  logic [NumUpstreams-1:0] upstream_psel;
+  logic [NumUpstreams-1:0] upstream_penable;
+  logic [NumUpstreams-1:0][br_amba::ApbProtWidth-1:0] upstream_pprot;
+  logic [NumUpstreams-1:0][3:0] upstream_pstrb;
+  logic [NumUpstreams-1:0] upstream_pwrite;
+  logic [NumUpstreams-1:0][31:0] upstream_pwdata;
+  logic [NumUpstreams-1:0][31:0] upstream_prdata;
+  logic [NumUpstreams-1:0] upstream_pready;
+  logic [NumUpstreams-1:0] upstream_pslverr;
+
+  logic [AddrWidth-1:0] downstream_paddr;
+  logic downstream_psel;
+  logic downstream_penable;
+  logic [br_amba::ApbProtWidth-1:0] downstream_pprot;
+  logic [3:0] downstream_pstrb;
+  logic downstream_pwrite;
+  logic [31:0] downstream_pwdata;
+  logic [31:0] downstream_prdata;
+  logic downstream_pready;
+  logic downstream_pslverr;
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  br_apb_mux #(
+      .AddrWidth(AddrWidth),
+      .NumUpstreams(NumUpstreams)
+  ) dut (
+      .clk,
+      .rst,
+      .upstream_paddr,
+      .upstream_psel,
+      .upstream_penable,
+      .upstream_pprot,
+      .upstream_pstrb,
+      .upstream_pwrite,
+      .upstream_pwdata,
+      .upstream_prdata,
+      .upstream_pready,
+      .upstream_pslverr,
+      .downstream_paddr,
+      .downstream_psel,
+      .downstream_penable,
+      .downstream_pprot,
+      .downstream_pstrb,
+      .downstream_pwrite,
+      .downstream_pwdata,
+      .downstream_prdata,
+      .downstream_pready,
+      .downstream_pslverr
+  );
+
+  task automatic check_downstream_request(input logic [AddrWidth-1:0] expected_addr,
+                                          input logic expected_write,
+                                          input logic [31:0] expected_wdata);
+    td.check_integer(32'(downstream_paddr), 32'(expected_addr), "downstream PADDR mismatch");
+    td.check_integer(32'(downstream_pprot), expected_write ? 3 : 5, "downstream PPROT mismatch");
+    td.check_integer(32'(downstream_pstrb), expected_write ? 13 : 0, "downstream PSTRB mismatch");
+    td.check(downstream_pwrite == expected_write, "downstream PWRITE mismatch");
+    td.check_integer(downstream_pwdata, expected_wdata, "downstream PWDATA mismatch");
+  endtask
+
+  task automatic wait_for_downstream_select();
+    bit saw_select;
+
+    saw_select = 1'b0;
+    for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
+      @(posedge clk);
+      if (downstream_psel) begin
+        saw_select = 1'b1;
+        break;
+      end
+    end
+    td.check(saw_select, "timeout waiting for downstream PSEL");
+  endtask
+
+  task automatic drive_upstream(input int source, input logic [AddrWidth-1:0] addr,
+                                input logic write, input logic [31:0] wdata,
+                                input logic [31:0] expected_rdata, input logic expected_slverr);
+    bit completed;
+
+    @(negedge clk);
+    upstream_paddr[source] = addr;
+    upstream_psel[source] = 1'b1;
+    upstream_penable[source] = 1'b0;
+    upstream_pprot[source] = write ? 3'b011 : 3'b101;
+    upstream_pstrb[source] = write ? 4'b1101 : 4'b0000;
+    upstream_pwrite[source] = write;
+    upstream_pwdata[source] = wdata;
+
+    @(posedge clk);
+    td.check(!upstream_pready[source], "upstream PREADY asserted during APB setup");
+
+    @(negedge clk);
+    upstream_penable[source] = 1'b1;
+    completed = 1'b0;
+    for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
+      @(posedge clk);
+      if (upstream_pready[source]) begin
+        td.check_integer(upstream_prdata[source], expected_rdata, "upstream PRDATA mismatch");
+        td.check(upstream_pslverr[source] == expected_slverr, "upstream PSLVERR mismatch");
+        completed = 1'b1;
+        break;
+      end
+    end
+    td.check(completed, "timeout waiting for upstream APB completion");
+
+    @(negedge clk);
+    upstream_psel[source] = 1'b0;
+    upstream_penable[source] = 1'b0;
+  endtask
+
+  task automatic expect_downstream(input int source, input logic [AddrWidth-1:0] expected_addr,
+                                   input logic expected_write, input logic [31:0] expected_wdata,
+                                   input int wait_cycles, input logic [31:0] rdata,
+                                   input logic slverr);
+    bit saw_setup;
+    bit saw_access;
+    logic [NumUpstreams-1:0] expected_grant;
+
+    expected_grant = '0;
+    expected_grant[source] = 1'b1;
+    saw_setup = 1'b0;
+    for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
+      @(posedge clk);
+      if (downstream_psel) begin
+        td.check(!downstream_penable, "downstream APB setup was not observed");
+        td.check(upstream_pready == '0, "upstream PREADY asserted during downstream setup");
+        check_downstream_request(expected_addr, expected_write, expected_wdata);
+        saw_setup = 1'b1;
+        break;
+      end
+    end
+    td.check(saw_setup, "timeout waiting for downstream APB setup");
+
+    saw_access = 1'b0;
+    for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
+      @(posedge clk);
+      if (downstream_penable) begin
+        td.check(downstream_psel, "downstream PENABLE asserted without PSEL");
+        check_downstream_request(expected_addr, expected_write, expected_wdata);
+        saw_access = 1'b1;
+        break;
+      end
+    end
+    td.check(saw_access, "timeout waiting for downstream APB access");
+
+    repeat (wait_cycles) begin
+      @(posedge clk);
+      td.check(downstream_psel && downstream_penable, "downstream access dropped while waiting");
+      td.check(upstream_pready == '0, "upstream PREADY asserted while downstream waited");
+      check_downstream_request(expected_addr, expected_write, expected_wdata);
+    end
+
+    @(negedge clk);
+    downstream_prdata  = rdata;
+    downstream_pready  = 1'b1;
+    downstream_pslverr = slverr;
+    @(posedge clk);
+    td.check(upstream_pready == expected_grant, "APB completion reached the wrong upstream");
+    for (int i = 0; i < NumUpstreams; i++) begin
+      td.check_integer(upstream_prdata[i], rdata, "upstream PRDATA was not broadcast");
+    end
+    td.check((upstream_pslverr & ~expected_grant) == '0,
+             "APB error reached an unselected upstream");
+
+    @(negedge clk);
+    downstream_prdata  = '0;
+    downstream_pready  = 1'b0;
+    downstream_pslverr = 1'b0;
+  endtask
+
+  task automatic check_malformed_transfer_recovers(input bit drop_select);
+    @(negedge clk);
+    upstream_paddr[0] = AddrWidth'(12'h620);
+    upstream_psel[0] = 1'b1;
+    upstream_penable[0] = 1'b0;
+    upstream_pprot[0] = 3'b101;
+    upstream_pstrb[0] = '0;
+    upstream_pwrite[0] = 1'b0;
+    upstream_pwdata[0] = 32'ha000_0620;
+
+    @(posedge clk);
+    @(negedge clk);
+    upstream_penable[0] = !drop_select;
+    if (drop_select) begin
+      upstream_psel[0] = 1'b0;
+    end
+
+    @(posedge clk);
+    td.check(downstream_psel && !downstream_penable,
+             "malformed upstream request skipped downstream setup");
+
+    @(negedge clk);
+    upstream_penable[0] = 1'b0;
+
+    repeat (2) begin
+      @(posedge clk);
+      td.check(downstream_psel && downstream_penable,
+               "malformed upstream request disrupted downstream access");
+      td.check(upstream_pready == '0, "malformed upstream request unexpectedly completed");
+    end
+
+    @(negedge clk);
+    downstream_pready = 1'b1;
+    @(posedge clk);
+    td.check(downstream_psel && downstream_penable,
+             "malformed upstream request prevented downstream completion");
+    td.check(upstream_pready == '0, "inactive upstream unexpectedly received completion");
+
+    @(negedge clk);
+    downstream_pready = 1'b0;
+    upstream_psel[0] = 1'b0;
+    upstream_penable[0] = 1'b0;
+    td.check(!downstream_psel && !downstream_penable,
+             "arbiter did not return to idle after malformed upstream request");
+
+    fork
+      drive_upstream(NumUpstreams - 1, AddrWidth'(12'h740), 1'b0, 32'ha000_0740, 32'hc000_0740,
+                     1'b0);
+      expect_downstream(NumUpstreams - 1, AddrWidth'(12'h740), 1'b0, 32'ha000_0740, 0,
+                        32'hc000_0740, 1'b0);
+    join
+  endtask
+
+  initial begin
+    upstream_paddr = '0;
+    upstream_psel = '0;
+    upstream_penable = '0;
+    upstream_pprot = '0;
+    upstream_pstrb = '0;
+    upstream_pwrite = '0;
+    upstream_pwdata = '0;
+    downstream_prdata = '0;
+    downstream_pready = 1'b0;
+    downstream_pslverr = 1'b0;
+
+    td.reset_dut();
+    td.wait_cycles(2);
+    td.check(!downstream_psel, "downstream PSEL asserted during reset/idle");
+    td.check(!downstream_penable, "downstream PENABLE asserted during reset/idle");
+    td.check(upstream_pready == '0, "upstream PREADY asserted during reset/idle");
+
+    fork
+      drive_upstream(NumUpstreams - 1, AddrWidth'(12'h120), 1'b0, 32'ha000_0120, 32'hc000_0120,
+                     1'b0);
+      expect_downstream(NumUpstreams - 1, AddrWidth'(12'h120), 1'b0, 32'ha000_0120, 0,
+                        32'hc000_0120, 1'b0);
+    join
+
+    if (NumUpstreams > 1) begin
+      fork
+        drive_upstream(0, AddrWidth'(12'h240), 1'b1, 32'ha000_0240, 32'hc000_0240, 1'b0);
+        drive_upstream(NumUpstreams - 1, AddrWidth'(12'h360), 1'b0, 32'ha000_0360, 32'hc000_0360,
+                       1'b0);
+        begin
+          expect_downstream(0, AddrWidth'(12'h240), 1'b1, 32'ha000_0240, 2, 32'hc000_0240, 1'b0);
+          expect_downstream(NumUpstreams - 1, AddrWidth'(12'h360), 1'b0, 32'ha000_0360, 0,
+                            32'hc000_0360, 1'b0);
+        end
+      join
+
+      fork
+        drive_upstream(NumUpstreams - 1, AddrWidth'(12'h480), 1'b1, 32'ha000_0480, 32'hc000_0480,
+                       1'b1);
+        begin
+          wait_for_downstream_select();
+          drive_upstream(0, AddrWidth'(12'h5a0), 1'b0, 32'ha000_05a0, 32'hc000_05a0, 1'b0);
+        end
+        begin
+          expect_downstream(NumUpstreams - 1, AddrWidth'(12'h480), 1'b1, 32'ha000_0480, 3,
+                            32'hc000_0480, 1'b1);
+          expect_downstream(0, AddrWidth'(12'h5a0), 1'b0, 32'ha000_05a0, 0, 32'hc000_05a0, 1'b0);
+        end
+      join
+    end
+
+    if (ExerciseProtocolViolations) begin
+      @(negedge clk);
+      upstream_penable[0] = 1'b1;
+      repeat (2) begin
+        @(posedge clk);
+        td.check(!downstream_psel, "PENABLE without PSEL started a downstream request");
+      end
+      @(negedge clk);
+      upstream_penable[0] = 1'b0;
+
+      check_malformed_transfer_recovers(1'b1);
+      check_malformed_transfer_recovers(1'b0);
+    end
+
+    td.finish(2);
+  end
+endmodule : br_apb_mux_tb

--- a/amba/sim/br_apb_mux_tb.sv
+++ b/amba/sim/br_apb_mux_tb.sv
@@ -67,12 +67,13 @@ module br_apb_mux_tb;
       .downstream_pslverr
   );
 
-  task automatic check_downstream_request(input logic [AddrWidth-1:0] expected_addr,
-                                          input logic expected_write,
-                                          input logic [31:0] expected_wdata);
+  task automatic check_downstream_request(
+      input logic [AddrWidth-1:0] expected_addr,
+      input logic [br_amba::ApbProtWidth-1:0] expected_prot, input logic [3:0] expected_strb,
+      input logic expected_write, input logic [31:0] expected_wdata);
     td.check_integer(32'(downstream_paddr), 32'(expected_addr), "downstream PADDR mismatch");
-    td.check_integer(32'(downstream_pprot), expected_write ? 3 : 5, "downstream PPROT mismatch");
-    td.check_integer(32'(downstream_pstrb), expected_write ? 13 : 0, "downstream PSTRB mismatch");
+    td.check_integer(32'(downstream_pprot), 32'(expected_prot), "downstream PPROT mismatch");
+    td.check_integer(32'(downstream_pstrb), 32'(expected_strb), "downstream PSTRB mismatch");
     td.check(downstream_pwrite == expected_write, "downstream PWRITE mismatch");
     td.check_integer(downstream_pwdata, expected_wdata, "downstream PWDATA mismatch");
   endtask
@@ -92,7 +93,8 @@ module br_apb_mux_tb;
   endtask
 
   task automatic drive_upstream(input int source, input logic [AddrWidth-1:0] addr,
-                                input logic write, input logic [31:0] wdata,
+                                input logic [br_amba::ApbProtWidth-1:0] prot,
+                                input logic [3:0] strb, input logic write, input logic [31:0] wdata,
                                 input logic [31:0] expected_rdata, input logic expected_slverr);
     bit completed;
 
@@ -100,8 +102,8 @@ module br_apb_mux_tb;
     upstream_paddr[source] = addr;
     upstream_psel[source] = 1'b1;
     upstream_penable[source] = 1'b0;
-    upstream_pprot[source] = write ? 3'b011 : 3'b101;
-    upstream_pstrb[source] = write ? 4'b1101 : 4'b0000;
+    upstream_pprot[source] = prot;
+    upstream_pstrb[source] = strb;
     upstream_pwrite[source] = write;
     upstream_pwdata[source] = wdata;
 
@@ -128,9 +130,10 @@ module br_apb_mux_tb;
   endtask
 
   task automatic expect_downstream(input int source, input logic [AddrWidth-1:0] expected_addr,
-                                   input logic expected_write, input logic [31:0] expected_wdata,
-                                   input int wait_cycles, input logic [31:0] rdata,
-                                   input logic slverr);
+                                   input logic [br_amba::ApbProtWidth-1:0] expected_prot,
+                                   input logic [3:0] expected_strb, input logic expected_write,
+                                   input logic [31:0] expected_wdata, input int wait_cycles,
+                                   input logic [31:0] rdata, input logic slverr);
     logic [NumUpstreams-1:0] expected_grant;
 
     expected_grant = '0;
@@ -138,13 +141,15 @@ module br_apb_mux_tb;
     wait_for_downstream_select();
     td.check(!downstream_penable, "downstream APB setup was not observed");
     td.check(upstream_pready == '0, "upstream PREADY asserted during downstream setup");
-    check_downstream_request(expected_addr, expected_write, expected_wdata);
+    check_downstream_request(expected_addr, expected_prot, expected_strb, expected_write,
+                             expected_wdata);
 
     repeat (wait_cycles) begin
       @(posedge clk);
       td.check(downstream_psel && downstream_penable, "downstream access dropped while waiting");
       td.check(upstream_pready == '0, "upstream PREADY asserted while downstream waited");
-      check_downstream_request(expected_addr, expected_write, expected_wdata);
+      check_downstream_request(expected_addr, expected_prot, expected_strb, expected_write,
+                               expected_wdata);
     end
 
     @(negedge clk);
@@ -153,7 +158,8 @@ module br_apb_mux_tb;
     downstream_pslverr = slverr;
     @(posedge clk);
     td.check(downstream_psel && downstream_penable, "downstream APB access was not observed");
-    check_downstream_request(expected_addr, expected_write, expected_wdata);
+    check_downstream_request(expected_addr, expected_prot, expected_strb, expected_write,
+                             expected_wdata);
     td.check(upstream_pready == expected_grant, "APB completion reached the wrong upstream");
     for (int i = 0; i < NumUpstreams; i++) begin
       td.check_integer(upstream_prdata[i], rdata, "upstream PRDATA was not broadcast");
@@ -196,7 +202,8 @@ module br_apb_mux_tb;
       @(posedge clk);
       td.check(downstream_psel && !downstream_penable, "extra cycle before downstream setup");
       td.check(upstream_pready == '0, "upstream completed during setup");
-      check_downstream_request(addr, write, wdata);
+      check_downstream_request(addr, write ? 3'b011 : 3'b101, write ? 4'b1101 : 4'b0000, write,
+                               wdata);
 
       @(negedge clk);
       upstream_penable[source] = 1'b1;
@@ -206,7 +213,8 @@ module br_apb_mux_tb;
                "zero-wait transfer did not finish in two cycles");
       td.check_integer(upstream_prdata[source], ~wdata, "zero-wait read data mismatch");
       td.check(upstream_pslverr[source] == write, "zero-wait error response mismatch");
-      check_downstream_request(addr, write, wdata);
+      check_downstream_request(addr, write ? 3'b011 : 3'b101, write ? 4'b1101 : 4'b0000, write,
+                               wdata);
       @(negedge clk);
     end
     upstream_psel[source] = 1'b0;
@@ -240,7 +248,7 @@ module br_apb_mux_tb;
       @(posedge clk);
       td.check(downstream_psel && !downstream_penable, "missing setup or bubble during handoff");
       td.check(upstream_pready == '0, "waiting upstream completed during downstream setup");
-      check_downstream_request(AddrWidth'(i), 1'b1, 32'habcd_0000 | 32'(i));
+      check_downstream_request(AddrWidth'(i), 3'b011, 4'b1101, 1'b1, 32'habcd_0000 | 32'(i));
 
       @(negedge clk);
       upstream_penable = upstream_psel;
@@ -249,12 +257,62 @@ module br_apb_mux_tb;
       td.check(upstream_pready == expected_grant, "handoff completed the wrong upstream");
       td.check_integer(upstream_prdata[i], 32'hcafe_1234, "handoff read data mismatch");
       td.check(upstream_pslverr == '0, "handoff error response mismatch");
-      check_downstream_request(AddrWidth'(i), 1'b1, 32'habcd_0000 | 32'(i));
+      check_downstream_request(AddrWidth'(i), 3'b011, 4'b1101, 1'b1, 32'habcd_0000 | 32'(i));
 
       @(negedge clk);
       upstream_psel[i] = 1'b0;
       upstream_penable[i] = 1'b0;
     end
+    downstream_pready = 1'b0;
+    downstream_prdata = '0;
+  endtask
+
+  // Reads may change all PWDATA bits; sparse writes may change unstrobed bytes.
+  // Exercise both from setup through stalled access with integration checks on.
+  task automatic check_inactive_wdata(input bit write);
+    logic [31:0] wdata;
+    logic [ 3:0] strb;
+
+    wdata = 32'ha123_4567;
+    strb  = write ? 4'b1101 : 4'b0000;
+    @(negedge clk);
+    upstream_paddr[0] = AddrWidth'(12'h580);
+    upstream_psel[0] = 1'b1;
+    upstream_penable[0] = 1'b0;
+    upstream_pprot[0] = 3'b101;
+    upstream_pstrb[0] = strb;
+    upstream_pwrite[0] = write;
+    upstream_pwdata[0] = wdata;
+
+    @(posedge clk);
+    td.check(downstream_psel && !downstream_penable, "inactive-data test skipped setup");
+    td.check(upstream_pready == '0, "inactive-data test completed during setup");
+    check_downstream_request(AddrWidth'(12'h580), 3'b101, strb, write, wdata);
+
+    repeat (3) begin
+      @(negedge clk);
+      upstream_penable[0] = 1'b1;
+      wdata ^= write ? 32'h0000_ff00 : 32'hffff_ffff;
+      upstream_pwdata[0] = wdata;
+      @(posedge clk);
+      td.check(downstream_psel && downstream_penable, "inactive-data test lost access");
+      td.check(upstream_pready == '0, "inactive-data test completed while waiting");
+      check_downstream_request(AddrWidth'(12'h580), 3'b101, strb, write, wdata);
+    end
+
+    @(negedge clk);
+    downstream_pready = 1'b1;
+    downstream_prdata = 32'hc123_4567;
+    @(posedge clk);
+    td.check(downstream_psel && downstream_penable, "inactive-data test lost completion");
+    td.check(upstream_pready == NumUpstreams'(1), "inactive-data test completion mismatch");
+    td.check_integer(upstream_prdata[0], 32'hc123_4567, "inactive-data test read mismatch");
+    td.check(upstream_pslverr == '0, "inactive-data test error mismatch");
+    check_downstream_request(AddrWidth'(12'h580), 3'b101, strb, write, wdata);
+
+    @(negedge clk);
+    upstream_psel[0] = 1'b0;
+    upstream_penable[0] = 1'b0;
     downstream_pready = 1'b0;
     downstream_prdata = '0;
   endtask
@@ -293,14 +351,19 @@ module br_apb_mux_tb;
     end
 
     @(negedge clk);
-    downstream_pready = 1'b1;
+    downstream_pready  = 1'b1;
+    downstream_pslverr = 1'b1;
     @(posedge clk);
     td.check(downstream_psel && downstream_penable,
              "malformed upstream request prevented downstream completion");
-    td.check(upstream_pready == '0, "inactive upstream unexpectedly received completion");
+    td.check(upstream_pready == NumUpstreams'(1), "saved grant did not route completion");
+    td.check(upstream_pslverr == NumUpstreams'(1), "saved grant did not route error");
+    td.check((upstream_psel & upstream_penable & upstream_pready) == '0,
+             "inactive upstream unexpectedly accepted a transfer");
 
     @(negedge clk);
     downstream_pready = 1'b0;
+    downstream_pslverr = 1'b0;
     upstream_psel[0] = 1'b0;
     upstream_penable[0] = 1'b0;
     td.check(!downstream_penable,
@@ -309,10 +372,10 @@ module br_apb_mux_tb;
     td.check(!downstream_psel, "arbiter did not become idle after all requesters withdrew");
 
     fork
-      drive_upstream(NumUpstreams - 1, AddrWidth'(12'h740), 1'b0, 32'ha000_0740, 32'hc000_0740,
-                     1'b0);
-      expect_downstream(NumUpstreams - 1, AddrWidth'(12'h740), 1'b0, 32'ha000_0740, 0,
-                        32'hc000_0740, 1'b0);
+      drive_upstream(NumUpstreams - 1, AddrWidth'(12'h740), 3'b101, 4'b0000, 1'b0, 32'ha000_0740,
+                     32'hc000_0740, 1'b0);
+      expect_downstream(NumUpstreams - 1, AddrWidth'(12'h740), 3'b101, 4'b0000, 1'b0, 32'ha000_0740,
+                        0, 32'hc000_0740, 1'b0);
     join
   endtask
 
@@ -334,55 +397,65 @@ module br_apb_mux_tb;
     td.check(!downstream_penable, "downstream PENABLE asserted during reset/idle");
     td.check(upstream_pready == '0, "upstream PREADY asserted during reset/idle");
 
+    // PENABLE can be broadcast for a transfer to a different peripheral.
+    @(negedge clk);
+    upstream_penable = '1;
+    repeat (2) begin
+      @(posedge clk);
+      td.check(!downstream_psel, "PENABLE without PSEL started a downstream request");
+      td.check(!downstream_penable, "PENABLE without PSEL started downstream access");
+      td.check(upstream_pready == '0, "unselected upstream received completion");
+    end
+    @(negedge clk);
+    upstream_penable = '0;
+
+    check_inactive_wdata(1'b0);
+    check_inactive_wdata(1'b1);
+
     for (int i = 0; i < NumUpstreams; i++) begin
       check_zero_wait_burst(i);
     end
     check_zero_wait_handoffs();
 
     fork
-      drive_upstream(NumUpstreams - 1, AddrWidth'(12'h120), 1'b0, 32'ha000_0120, 32'hc000_0120,
-                     1'b0);
-      expect_downstream(NumUpstreams - 1, AddrWidth'(12'h120), 1'b0, 32'ha000_0120, 0,
-                        32'hc000_0120, 1'b0);
+      drive_upstream(NumUpstreams - 1, AddrWidth'(12'h120), 3'b101, 4'b0000, 1'b0, 32'ha000_0120,
+                     32'hc000_0120, 1'b0);
+      expect_downstream(NumUpstreams - 1, AddrWidth'(12'h120), 3'b101, 4'b0000, 1'b0, 32'ha000_0120,
+                        0, 32'hc000_0120, 1'b0);
     join
 
     if (NumUpstreams > 1) begin
       fork
-        drive_upstream(0, AddrWidth'(12'h240), 1'b1, 32'ha000_0240, 32'hc000_0240, 1'b0);
-        drive_upstream(NumUpstreams - 1, AddrWidth'(12'h360), 1'b0, 32'ha000_0360, 32'hc000_0360,
+        drive_upstream(0, AddrWidth'(12'h240), 3'b011, 4'b1101, 1'b1, 32'ha000_0240, 32'hc000_0240,
                        1'b0);
+        drive_upstream(NumUpstreams - 1, AddrWidth'(12'h360), 3'b101, 4'b0000, 1'b0, 32'ha000_0360,
+                       32'hc000_0360, 1'b0);
         begin
-          expect_downstream(0, AddrWidth'(12'h240), 1'b1, 32'ha000_0240, 2, 32'hc000_0240, 1'b0);
-          expect_downstream(NumUpstreams - 1, AddrWidth'(12'h360), 1'b0, 32'ha000_0360, 0,
-                            32'hc000_0360, 1'b0);
+          expect_downstream(0, AddrWidth'(12'h240), 3'b011, 4'b1101, 1'b1, 32'ha000_0240, 2,
+                            32'hc000_0240, 1'b0);
+          expect_downstream(NumUpstreams - 1, AddrWidth'(12'h360), 3'b101, 4'b0000, 1'b0,
+                            32'ha000_0360, 0, 32'hc000_0360, 1'b0);
         end
       join
 
       fork
-        drive_upstream(NumUpstreams - 1, AddrWidth'(12'h480), 1'b1, 32'ha000_0480, 32'hc000_0480,
-                       1'b1);
+        drive_upstream(NumUpstreams - 1, AddrWidth'(12'h480), 3'b011, 4'b1101, 1'b1, 32'ha000_0480,
+                       32'hc000_0480, 1'b1);
         begin
           wait_for_downstream_select();
-          drive_upstream(0, AddrWidth'(12'h5a0), 1'b0, 32'ha000_05a0, 32'hc000_05a0, 1'b0);
+          drive_upstream(0, AddrWidth'(12'h5a0), 3'b101, 4'b0000, 1'b0, 32'ha000_05a0,
+                         32'hc000_05a0, 1'b0);
         end
         begin
-          expect_downstream(NumUpstreams - 1, AddrWidth'(12'h480), 1'b1, 32'ha000_0480, 3,
-                            32'hc000_0480, 1'b1);
-          expect_downstream(0, AddrWidth'(12'h5a0), 1'b0, 32'ha000_05a0, 0, 32'hc000_05a0, 1'b0);
+          expect_downstream(NumUpstreams - 1, AddrWidth'(12'h480), 3'b011, 4'b1101, 1'b1,
+                            32'ha000_0480, 3, 32'hc000_0480, 1'b1);
+          expect_downstream(0, AddrWidth'(12'h5a0), 3'b101, 4'b0000, 1'b0, 32'ha000_05a0, 0,
+                            32'hc000_05a0, 1'b0);
         end
       join
     end
 
     if (ExerciseProtocolViolations) begin
-      @(negedge clk);
-      upstream_penable[0] = 1'b1;
-      repeat (2) begin
-        @(posedge clk);
-        td.check(!downstream_psel, "PENABLE without PSEL started a downstream request");
-      end
-      @(negedge clk);
-      upstream_penable[0] = 1'b0;
-
       check_malformed_transfer_recovers(1'b1);
       check_malformed_transfer_recovers(1'b0);
     end

--- a/amba/sim/br_apb_mux_tb.sv
+++ b/amba/sim/br_apb_mux_tb.sv
@@ -131,36 +131,14 @@ module br_apb_mux_tb;
                                    input logic expected_write, input logic [31:0] expected_wdata,
                                    input int wait_cycles, input logic [31:0] rdata,
                                    input logic slverr);
-    bit saw_setup;
-    bit saw_access;
     logic [NumUpstreams-1:0] expected_grant;
 
     expected_grant = '0;
     expected_grant[source] = 1'b1;
-    saw_setup = 1'b0;
-    for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
-      @(posedge clk);
-      if (downstream_psel) begin
-        td.check(!downstream_penable, "downstream APB setup was not observed");
-        td.check(upstream_pready == '0, "upstream PREADY asserted during downstream setup");
-        check_downstream_request(expected_addr, expected_write, expected_wdata);
-        saw_setup = 1'b1;
-        break;
-      end
-    end
-    td.check(saw_setup, "timeout waiting for downstream APB setup");
-
-    saw_access = 1'b0;
-    for (int cycle = 0; cycle < TimeoutCycles; cycle++) begin
-      @(posedge clk);
-      if (downstream_penable) begin
-        td.check(downstream_psel, "downstream PENABLE asserted without PSEL");
-        check_downstream_request(expected_addr, expected_write, expected_wdata);
-        saw_access = 1'b1;
-        break;
-      end
-    end
-    td.check(saw_access, "timeout waiting for downstream APB access");
+    wait_for_downstream_select();
+    td.check(!downstream_penable, "downstream APB setup was not observed");
+    td.check(upstream_pready == '0, "upstream PREADY asserted during downstream setup");
+    check_downstream_request(expected_addr, expected_write, expected_wdata);
 
     repeat (wait_cycles) begin
       @(posedge clk);
@@ -174,6 +152,8 @@ module br_apb_mux_tb;
     downstream_pready  = 1'b1;
     downstream_pslverr = slverr;
     @(posedge clk);
+    td.check(downstream_psel && downstream_penable, "downstream APB access was not observed");
+    check_downstream_request(expected_addr, expected_write, expected_wdata);
     td.check(upstream_pready == expected_grant, "APB completion reached the wrong upstream");
     for (int i = 0; i < NumUpstreams; i++) begin
       td.check_integer(upstream_prdata[i], rdata, "upstream PRDATA was not broadcast");
@@ -187,6 +167,98 @@ module br_apb_mux_tb;
     downstream_pslverr = 1'b0;
   endtask
 
+  // PSEL stays asserted between transfers. A permanently ready subordinate
+  // must complete each transfer in exactly two cycles, including the first.
+  task automatic check_zero_wait_burst(input int source);
+    logic [NumUpstreams-1:0] expected_grant;
+    logic [AddrWidth-1:0] addr;
+    logic write;
+    logic [31:0] wdata;
+
+    expected_grant = '0;
+    expected_grant[source] = 1'b1;
+    @(negedge clk);
+    downstream_pready = 1'b1;
+    for (int transfer = 0; transfer < 4; transfer++) begin
+      addr = AddrWidth'(4 * source + transfer);
+      write = 1'(transfer);
+      wdata = 32'ha100_0000 | (32'(source) << 8) | 32'(transfer);
+      upstream_psel[source] = 1'b1;
+      upstream_penable[source] = 1'b0;
+      upstream_paddr[source] = addr;
+      upstream_pprot[source] = write ? 3'b011 : 3'b101;
+      upstream_pstrb[source] = write ? 4'b1101 : 4'b0000;
+      upstream_pwrite[source] = write;
+      upstream_pwdata[source] = wdata;
+      downstream_prdata = ~wdata;
+      downstream_pslverr = write;
+
+      @(posedge clk);
+      td.check(downstream_psel && !downstream_penable, "extra cycle before downstream setup");
+      td.check(upstream_pready == '0, "upstream completed during setup");
+      check_downstream_request(addr, write, wdata);
+
+      @(negedge clk);
+      upstream_penable[source] = 1'b1;
+      @(posedge clk);
+      td.check(downstream_psel && downstream_penable, "extra cycle before downstream access");
+      td.check(upstream_pready == expected_grant,
+               "zero-wait transfer did not finish in two cycles");
+      td.check_integer(upstream_prdata[source], ~wdata, "zero-wait read data mismatch");
+      td.check(upstream_pslverr[source] == write, "zero-wait error response mismatch");
+      check_downstream_request(addr, write, wdata);
+      @(negedge clk);
+    end
+    upstream_psel[source] = 1'b0;
+    upstream_penable[source] = 1'b0;
+    downstream_pready = 1'b0;
+    downstream_prdata = '0;
+    downstream_pslverr = 1'b0;
+  endtask
+
+  // All masters contend at once. Waiting masters are already in upstream
+  // access when selected, but must still receive a full downstream setup cycle.
+  task automatic check_zero_wait_handoffs();
+    logic [NumUpstreams-1:0] expected_grant;
+
+    @(negedge clk);
+    upstream_psel = '1;
+    upstream_penable = '0;
+    downstream_pready = 1'b1;
+    downstream_prdata = 32'hcafe_1234;
+    downstream_pslverr = 1'b0;
+    for (int i = 0; i < NumUpstreams; i++) begin
+      upstream_paddr[i]  = AddrWidth'(i);
+      upstream_pprot[i]  = 3'b011;
+      upstream_pstrb[i]  = 4'b1101;
+      upstream_pwrite[i] = 1'b1;
+      upstream_pwdata[i] = 32'habcd_0000 | 32'(i);
+    end
+    for (int i = 0; i < NumUpstreams; i++) begin
+      expected_grant = '0;
+      expected_grant[i] = 1'b1;
+      @(posedge clk);
+      td.check(downstream_psel && !downstream_penable, "missing setup or bubble during handoff");
+      td.check(upstream_pready == '0, "waiting upstream completed during downstream setup");
+      check_downstream_request(AddrWidth'(i), 1'b1, 32'habcd_0000 | 32'(i));
+
+      @(negedge clk);
+      upstream_penable = upstream_psel;
+      @(posedge clk);
+      td.check(downstream_psel && downstream_penable, "handoff skipped downstream access");
+      td.check(upstream_pready == expected_grant, "handoff completed the wrong upstream");
+      td.check_integer(upstream_prdata[i], 32'hcafe_1234, "handoff read data mismatch");
+      td.check(upstream_pslverr == '0, "handoff error response mismatch");
+      check_downstream_request(AddrWidth'(i), 1'b1, 32'habcd_0000 | 32'(i));
+
+      @(negedge clk);
+      upstream_psel[i] = 1'b0;
+      upstream_penable[i] = 1'b0;
+    end
+    downstream_pready = 1'b0;
+    downstream_prdata = '0;
+  endtask
+
   task automatic check_malformed_transfer_recovers(input bit drop_select);
     @(negedge clk);
     upstream_paddr[0] = AddrWidth'(12'h620);
@@ -198,6 +270,8 @@ module br_apb_mux_tb;
     upstream_pwdata[0] = 32'ha000_0620;
 
     @(posedge clk);
+    td.check(downstream_psel && !downstream_penable,
+             "malformed upstream request skipped downstream setup");
     @(negedge clk);
     upstream_penable[0] = !drop_select;
     if (drop_select) begin
@@ -205,8 +279,8 @@ module br_apb_mux_tb;
     end
 
     @(posedge clk);
-    td.check(downstream_psel && !downstream_penable,
-             "malformed upstream request skipped downstream setup");
+    td.check(downstream_psel && downstream_penable,
+             "malformed upstream request prevented downstream access");
 
     @(negedge clk);
     upstream_penable[0] = 1'b0;
@@ -229,8 +303,10 @@ module br_apb_mux_tb;
     downstream_pready = 1'b0;
     upstream_psel[0] = 1'b0;
     upstream_penable[0] = 1'b0;
-    td.check(!downstream_psel && !downstream_penable,
-             "arbiter did not return to idle after malformed upstream request");
+    td.check(!downstream_penable,
+             "arbiter did not release access after malformed upstream request");
+    @(posedge clk);
+    td.check(!downstream_psel, "arbiter did not become idle after all requesters withdrew");
 
     fork
       drive_upstream(NumUpstreams - 1, AddrWidth'(12'h740), 1'b0, 32'ha000_0740, 32'hc000_0740,
@@ -257,6 +333,11 @@ module br_apb_mux_tb;
     td.check(!downstream_psel, "downstream PSEL asserted during reset/idle");
     td.check(!downstream_penable, "downstream PENABLE asserted during reset/idle");
     td.check(upstream_pready == '0, "upstream PREADY asserted during reset/idle");
+
+    for (int i = 0; i < NumUpstreams; i++) begin
+      check_zero_wait_burst(i);
+    end
+    check_zero_wait_handoffs();
 
     fork
       drive_upstream(NumUpstreams - 1, AddrWidth'(12'h120), 1'b0, 32'ha000_0120, 32'hc000_0120,


### PR DESCRIPTION
- Add a fixed-priority N-to-1 APB mux using Bedrock arbitration/mux libraries, a two-state FSM, and a saved one-hot grant, with no buffering.
- Drive setup combinationally for two-cycle zero-wait transfers and back-to-back handoffs; priority selection is on the downstream request timing path.
- Release access on slave completion even if the requester drops PSEL/PENABLE; the next cycle can immediately start another setup.
- Validation: 23 focused Slang/Verific, AscentLint, and VCS checks passed, including legal inactive signals and malformed-requester recovery; full pre-commit passed.