### PR TITLE
[fv] Enable AXI 4KB boundary checks in FPV

### DIFF
--- a/amba/fpv/BUILD.bazel
+++ b/amba/fpv/BUILD.bazel
@@ -101,6 +101,7 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi2axil_test_suite",
     elab_opts = [
+        "-parameter AddrWidth 16",
         "-parameter MaxOutstandingReqs 4",
     ],
     tools = {
@@ -162,6 +163,9 @@ verilog_elab_test(
 
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_timing_slice_test_suite",
+    elab_opts = [
+        "-parameter AddrWidth 16",
+    ],
     tools = {
         "jg": "br_amba_axi_timing_slice_fpv.jg.tcl",
     },
@@ -320,6 +324,7 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_isolate_mgr_test_suite",
     elab_opts = [
+        "-parameter AddrWidth 16",
         "-parameter MaxOutstanding 4",
     ],
     params = {
@@ -356,6 +361,7 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_isolate_sub_test_suite",
     elab_opts = [
+        "-parameter AddrWidth 16",
         "-parameter AwMaxOutstanding 4",
         "-parameter ArMaxOutstanding 4",
         "-parameter AwAxiIdCount 2",
@@ -414,6 +420,7 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_demux_test_suite",
     elab_opts = [
+        "-parameter AddrWidth 16",
         "-parameter AwAxiIdWidth 2",
         "-parameter ArAxiIdWidth 2",
     ],
@@ -455,6 +462,7 @@ verilog_elab_test(
 br_verilog_fpv_test_tools_suite(
     name = "br_amba_axi_shrinker_test_suite",
     elab_opts = [
+        "-parameter AddrWidth 16",
         "-parameter WideDataWidth 128",
         "-parameter MaxOutstandingReqs 4",
         "-parameter IdWidth 3",

--- a/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
+++ b/amba/fpv/br_amba_axi_shrinker_fpv_monitor.sv
@@ -226,7 +226,19 @@ module br_amba_axi_shrinker_fpv_monitor #(
     end
   endfunction
 
+  function automatic logic fv_addr_aligned(input logic [AddrWidth-1:0] addr,
+                                           input logic [br_amba::AxiBurstSizeWidth-1:0] size);
+    logic [AddrWidth-1:0] beat_bytes;
+    beat_bytes = AddrWidth'(1'b1) << size;
+    fv_addr_aligned = (addr % beat_bytes) == '0;
+  endfunction
+
   // ----------FV assumptions----------
+  // br_amba_axi_shrinker does not support requests whose start address is not aligned
+  // to AxSIZE.
+  `BR_ASSUME(wide_awaddr_aligned_a, wide_awvalid |-> fv_addr_aligned(wide_awaddr, wide_awsize))
+  `BR_ASSUME(wide_araddr_aligned_a, wide_arvalid |-> fv_addr_aligned(wide_araddr, wide_arsize))
+
   `BR_ASSUME(
       shrinking_awburst_incr_a,
       (wide_awvalid && wide_awsize > NarrowSizeLog2) |-> wide_awburst == br_amba::AxiBurstIncr)


### PR DESCRIPTION
## Summary

- Override `AddrWidth=16` in burst-capable AMBA FPV suites so Cadence AXI VIP 4KB-boundary assertions are generated.
- Add FPV assumptions that `br_amba_axi_shrinker` wide AW/AR request addresses are aligned to `AxSIZE`, matching the module's supported input contract.

## Verification

- Ran all 43 generated Jasper targets.
- 43/43 targets passed.
- No AXI 4KB-boundary CEX was observed.