### PR TITLE
Account for clock phase when sizing asynchronous FIFOs

### DIFF
--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_fpv_monitor.sv
@@ -83,6 +83,7 @@ module br_cdc_fifo_ctrl_1r1w_fpv_monitor #(
   // ----------Instantiate DUT----------
   br_cdc_fifo_ctrl_1r1w #(
       .Depth(Depth),
+      .ValidateDepthSupportsFullBandwidth(0),
       .Width(Width),
       .RegisterPopOutputs(RegisterPopOutputs),
       .RamWriteLatency(RamWriteLatency),

--- a/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor.sv
@@ -88,6 +88,7 @@ module br_cdc_fifo_ctrl_1r1w_push_credit_fpv_monitor #(
   // ----------Instantiate DUT----------
   br_cdc_fifo_ctrl_1r1w_push_credit #(
       .Depth(Depth),
+      .ValidateDepthSupportsFullBandwidth(0),
       .Width(Width),
       .RegisterPopOutputs(RegisterPopOutputs),
       .RamWriteLatency(RamWriteLatency),

--- a/cdc/fpv/br_cdc_fifo_flops_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_flops_fpv_monitor.sv
@@ -61,6 +61,7 @@ module br_cdc_fifo_flops_fpv_monitor #(
   // ----------Instantiate DUT----------
   br_cdc_fifo_flops #(
       .Depth(Depth),
+      .ValidateDepthSupportsFullBandwidth(0),
       .Width(Width),
       .RegisterPopOutputs(RegisterPopOutputs),
       .NumSyncStages(NumSyncStages),

--- a/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_fifo_flops_push_credit_fpv_monitor.sv
@@ -70,6 +70,7 @@ module br_cdc_fifo_flops_push_credit_fpv_monitor #(
   // ----------Instantiate DUT----------
   br_cdc_fifo_flops_push_credit #(
       .Depth(Depth),
+      .ValidateDepthSupportsFullBandwidth(0),
       .Width(Width),
       .MaxCredit(MaxCredit),
       .RegisterPushOutputs(RegisterPushOutputs),

--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -92,7 +92,6 @@ verilog_library(
 
 br_verilog_elab_and_lint_test_suite(
     name = "br_cdc_fifo_ctrl_1r1w_test_suite",
-    include_default_params = False,
     params = {
         "Depth": [
             "5",
@@ -132,7 +131,6 @@ verilog_library(
 
 br_verilog_elab_and_lint_test_suite(
     name = "br_cdc_fifo_ctrl_1r1w_push_credit_test_suite",
-    include_default_params = False,
     params = {
         "Depth": [
             "5",
@@ -172,7 +170,6 @@ verilog_library(
 
 br_verilog_elab_and_lint_test_suite(
     name = "br_cdc_fifo_flops_test_suite",
-    include_default_params = False,
     params = {
         "Depth": [
             "5",
@@ -212,7 +209,6 @@ verilog_library(
 
 br_verilog_elab_and_lint_test_suite(
     name = "br_cdc_fifo_flops_push_credit_test_suite",
-    include_default_params = False,
     params = {
         "Depth": [
             "5",

--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -92,6 +92,7 @@ verilog_library(
 
 br_verilog_elab_and_lint_test_suite(
     name = "br_cdc_fifo_ctrl_1r1w_test_suite",
+    include_default_params = False,
     params = {
         "Depth": [
             "5",
@@ -111,6 +112,7 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
+        "ValidateDepthSupportsFullBandwidth": ["0"],
     },
     top = "br_cdc_fifo_ctrl_1r1w",
     deps = [
@@ -130,6 +132,7 @@ verilog_library(
 
 br_verilog_elab_and_lint_test_suite(
     name = "br_cdc_fifo_ctrl_1r1w_push_credit_test_suite",
+    include_default_params = False,
     params = {
         "Depth": [
             "5",
@@ -149,6 +152,7 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
+        "ValidateDepthSupportsFullBandwidth": ["0"],
     },
     top = "br_cdc_fifo_ctrl_1r1w_push_credit",
     deps = [
@@ -168,6 +172,7 @@ verilog_library(
 
 br_verilog_elab_and_lint_test_suite(
     name = "br_cdc_fifo_flops_test_suite",
+    include_default_params = False,
     params = {
         "Depth": [
             "5",
@@ -186,6 +191,7 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
+        "ValidateDepthSupportsFullBandwidth": ["0"],
     },
     top = "br_cdc_fifo_flops",
     deps = [
@@ -206,6 +212,7 @@ verilog_library(
 
 br_verilog_elab_and_lint_test_suite(
     name = "br_cdc_fifo_flops_push_credit_test_suite",
+    include_default_params = False,
     params = {
         "Depth": [
             "5",
@@ -224,6 +231,7 @@ br_verilog_elab_and_lint_test_suite(
             "0",
             "1",
         ],
+        "ValidateDepthSupportsFullBandwidth": ["0"],
     },
     top = "br_cdc_fifo_flops_push_credit",
     deps = [
@@ -418,6 +426,7 @@ br_verilog_synth_suite(
         "RamReadLatency": ["0"],
         "RamWriteLatency": ["1"],
         "RegisterPopOutputs": ["0"],
+        "ValidateDepthSupportsFullBandwidth": ["0"],
         "Width": ["32"],
     },
     deps = [":br_cdc_fifo_ctrl_1r1w"],
@@ -515,6 +524,7 @@ br_verilog_synth_suite(
         "RamWriteLatency": ["1"],
         "RegisterPopOutputs": ["0"],
         "RegisterPushOutputs": ["0"],
+        "ValidateDepthSupportsFullBandwidth": ["0"],
         "Width": ["32"],
     },
     deps = [":br_cdc_fifo_ctrl_1r1w_push_credit"],
@@ -540,6 +550,7 @@ br_verilog_synth_suite(
         "Depth": ["8"],
         "NumSyncStages": ["2"],
         "RegisterPopOutputs": ["0"],
+        "ValidateDepthSupportsFullBandwidth": ["0"],
         "Width": ["32"],
     },
     deps = [":br_cdc_fifo_flops"],
@@ -568,6 +579,7 @@ br_verilog_synth_suite(
         "NumSyncStages": ["2"],
         "RegisterPopOutputs": ["0"],
         "RegisterPushOutputs": ["0"],
+        "ValidateDepthSupportsFullBandwidth": ["0"],
         "Width": ["32"],
     },
     deps = [":br_cdc_fifo_flops_push_credit"],

--- a/cdc/rtl/BUILD.bazel
+++ b/cdc/rtl/BUILD.bazel
@@ -54,6 +54,7 @@ verilog_library(
     deps = [
         ":br_cdc_fifo_ctrl_pop_1r1w",
         ":br_cdc_fifo_ctrl_push_1r1w",
+        "//pkg:br_math_pkg",
     ],
 )
 
@@ -126,6 +127,7 @@ verilog_library(
     deps = [
         ":br_cdc_fifo_ctrl_pop_1r1w",
         ":br_cdc_fifo_ctrl_push_1r1w_push_credit",
+        "//pkg:br_math_pkg",
     ],
 )
 

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
@@ -137,10 +137,12 @@ module br_cdc_fifo_ctrl_1r1w #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  // Maximum CDC depth is required when the push/pop clock frequencies are the same, so assume
+  // that for these calculations.
   localparam int ResetActiveCycles = RegisterResetActive + 1;
-  localparam int ForwardLatencyCycles =
-      ((ResetActiveCycles > RamWriteLatency) ? ResetActiveCycles : RamWriteLatency) +
-      NumSyncStages + RamReadLatency + RegisterPopOutputs;
+  localparam int ForwardLatencyCycles = br_math::max2(
+      ResetActiveCycles, RamWriteLatency
+  ) + NumSyncStages + RamReadLatency + RegisterPopOutputs;
   localparam int ReturnLatencyCycles = ResetActiveCycles + NumSyncStages;
   localparam int MinFullBandwidthDepth = ForwardLatencyCycles + ReturnLatencyCycles + 1;
 

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
@@ -22,22 +22,22 @@
 //
 // The RegisterPopOutputs parameter can be set to 1 to add an additional br_flow_reg_fwd
 // before the pop interface of the FIFO. This may improve timing of paths dependent on
-// the pop interface at the expense of an additional pop cycle of cut-through latency.
+// the pop interface at the expense of an additional pop cycle of forward latency.
 
-// The cut-through latency (push_valid to pop_valid latency) and backpressure
-// latency (pop_ready to push_ready) can be calculated as follows:
+// The forward latency (push_valid to pop_valid) and return latency
+// (pop_ready to push_ready) can be calculated as follows:
 //
 // Let PushT and PopT be the push period and pop period, respectively.
 //
-// The cut-through latency is max(RegisterResetActive + 1, RamWriteLatency)
+// The forward latency is max(RegisterResetActive + 1, RamWriteLatency)
 // * PushT + (NumSyncStages + RamReadLatency + RegisterPopOutputs) * PopT.
 //
-// The backpressure latency is (RegisterResetActive + 1) * PopT +
+// The return latency is (RegisterResetActive + 1) * PopT +
 // NumSyncStages * PushT.
 //
 // To sustain full bandwidth with arbitrary push/pop clock phase, use a FIFO
 // depth of at least
-// ceil((CutThroughLatency + BackpressureLatency) / max(PushT, PopT)) + 1.
+// ceil((ForwardLatency + ReturnLatency) / max(PushT, PopT)) + 1.
 //
 // The additional entry accounts for clock skew and propagation delay into the
 // first Gray-count synchronizer stage in each direction. These asynchronous
@@ -53,14 +53,14 @@ module br_cdc_fifo_ctrl_1r1w #(
     parameter int Depth = 16,  // Number of entries in the FIFO. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then ensure pop_valid/pop_data always come directly from a register
-    // at the cost of an additional pop cycle of cut-through latency.
+    // at the cost of an additional pop cycle of forward latency.
     // If 0, pop_valid/pop_data can come directly from the push interface
     // (if bypass is enabled), the RAM read interface, and/or an internal staging
     // buffer (if RAM read latency is >0).
     parameter bit RegisterPopOutputs = 0,
     // If 1 (the default), register push_rst on push_clk and pop_rst on pop_clk
-    // before sending to the CDC synchronizers. This adds one cycle to the cut-through
-    // latency and one cycle to the backpressure latency.
+    // before sending to the CDC synchronizers. This adds one forward cycle and one
+    // return cycle.
     // Do not set this to 0 unless push_rst and pop_rst are driven directly by
     // registers.
     parameter bit RegisterResetActive = 1,

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
@@ -50,7 +50,7 @@
 `include "br_gates.svh"
 
 module br_cdc_fifo_ctrl_1r1w #(
-    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Depth = 16,  // Number of entries in the FIFO. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then ensure pop_valid/pop_data always come directly from a register
     // at the cost of an additional pop cycle of cut-through latency.

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w.sv
@@ -32,11 +32,19 @@
 // The cut-through latency is max(RegisterResetActive + 1, RamWriteLatency)
 // * PushT + (NumSyncStages + RamReadLatency + RegisterPopOutputs) * PopT.
 //
-// The backpressure latency is (RegisterResetActive + 1) * PopT + (NumSyncStages
-// + RegisterPushOutputs) * PushT.
+// The backpressure latency is (RegisterResetActive + 1) * PopT +
+// NumSyncStages * PushT.
 //
-// To achieve full bandwidth, the depth of the FIFO must be at least
-// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+// To sustain full bandwidth with arbitrary push/pop clock phase, use a FIFO
+// depth of at least
+// ceil((CutThroughLatency + BackpressureLatency) / max(PushT, PopT)) + 1.
+//
+// The additional entry accounts for clock skew and propagation delay into the
+// first Gray-count synchronizer stage in each direction. These asynchronous
+// paths are not covered by ordinary setup timing; constrain both directions
+// with a max delay tighter than min(PushT, PopT), including setup and
+// clock-skew margin. Smaller FIFO depths remain functionally correct when full
+// bandwidth is not required.
 
 `include "br_asserts_internal.svh"
 `include "br_gates.svh"
@@ -80,6 +88,9 @@ module br_cdc_fifo_ctrl_1r1w #(
     // If 1, assert that push-side backpressure is impossible.
     // Can only be enabled if EnableCoverPushBackpressure is disabled.
     parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, require enough depth for full bandwidth at equal clock frequencies.
+    // Set to 0 when full bandwidth is unnecessary or the clock ratio permits less depth.
+    parameter bit ValidateDepthSupportsFullBandwidth = 1,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1)
 ) (
@@ -126,7 +137,15 @@ module br_cdc_fifo_ctrl_1r1w #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  // Rely on submodule integration checks
+  localparam int ResetActiveCycles = RegisterResetActive + 1;
+  localparam int ForwardLatencyCycles =
+      ((ResetActiveCycles > RamWriteLatency) ? ResetActiveCycles : RamWriteLatency) +
+      NumSyncStages + RamReadLatency + RegisterPopOutputs;
+  localparam int ReturnLatencyCycles = ResetActiveCycles + NumSyncStages;
+  localparam int MinFullBandwidthDepth = ForwardLatencyCycles + ReturnLatencyCycles + 1;
+
+  `BR_ASSERT_STATIC(depth_supports_full_bandwidth_a,
+                    !ValidateDepthSupportsFullBandwidth || Depth >= MinFullBandwidthDepth)
 
   //------------------------------------------
   // Implementation

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
@@ -22,22 +22,22 @@
 //
 // The RegisterPopOutputs parameter can be set to 1 to add an additional br_flow_reg_fwd
 // before the pop interface of the FIFO. This may improve timing of paths dependent on
-// the pop interface at the expense of an additional pop cycle of cut-through latency.
+// the pop interface at the expense of an additional pop cycle of forward latency.
 
-// The cut-through latency (push_valid to pop_valid latency) and backpressure
-// latency (pop_ready to push_ready) can be calculated as follows:
+// The forward latency (push_valid to pop_valid) and return latency
+// (pop_ready to push_credit) can be calculated as follows:
 //
 // Let PushT and PopT be the push period and pop period, respectively.
 //
-// The cut-through latency is max(RegisterResetActive + 1, RamWriteLatency)
+// The forward latency is max(RegisterResetActive + 1, RamWriteLatency)
 // * PushT + (NumSyncStages + RamReadLatency + RegisterPopOutputs) * PopT.
 //
-// The backpressure latency is (RegisterResetActive + 1) * PopT + (NumSyncStages
+// The return latency is (RegisterResetActive + 1) * PopT + (NumSyncStages
 // + RegisterPushOutputs) * PushT.
 //
 // To sustain full bandwidth with arbitrary push/pop clock phase, use a FIFO
 // depth of at least
-// ceil((CutThroughLatency + BackpressureLatency) / max(PushT, PopT)) + 1.
+// ceil((ForwardLatency + ReturnLatency) / max(PushT, PopT)) + 1.
 //
 // The additional entry accounts for clock skew and propagation delay into the
 // first Gray-count synchronizer stage in each direction. These asynchronous
@@ -53,7 +53,7 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
     parameter int Depth = 16,  // Number of entries in the FIFO. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then ensure pop_valid/pop_data always come directly from a register
-    // at the cost of an additional pop cycle of cut-through latency.
+    // at the cost of an additional pop cycle of forward latency.
     // If 0, pop_valid/pop_data can come directly from the push interface
     // (if bypass is enabled), the RAM read interface, and/or an internal staging
     // buffer (if RAM read latency is >0).
@@ -73,11 +73,11 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
     parameter int MaxCredit = Depth,
     // If 1, add a retiming stage to the push_credit signal so that it is
     // driven directly from a flop. This comes at the expense of one additional
-    // push cycle of credit loop latency.
+    // push cycle of return latency.
     parameter bit RegisterPushOutputs = 0,
     // If 1 (the default), register push_rst on push_clk and pop_rst on pop_clk
-    // before sending to the CDC synchronizers. This adds one cycle to the cut-through
-    // latency and one cycle to the backpressure latency.
+    // before sending to the CDC synchronizers. This adds one forward cycle and one
+    // return cycle.
     // Do not set this to 0 unless push_rst and pop_rst are driven directly by
     // registers. If set to 0, push_sender_in_reset must be tied to 0.
     parameter bit RegisterResetActive = 1,

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
@@ -154,10 +154,12 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
+  // Maximum CDC depth is required when the push/pop clock frequencies are the same, so assume
+  // that for these calculations.
   localparam int ResetActiveCycles = RegisterResetActive + 1;
-  localparam int ForwardLatencyCycles =
-      ((ResetActiveCycles > RamWriteLatency) ? ResetActiveCycles : RamWriteLatency) +
-      NumSyncStages + RamReadLatency + RegisterPopOutputs;
+  localparam int ForwardLatencyCycles = br_math::max2(
+      ResetActiveCycles, RamWriteLatency
+  ) + NumSyncStages + RamReadLatency + RegisterPopOutputs;
   localparam int ReturnLatencyCycles = ResetActiveCycles + NumSyncStages + RegisterPushOutputs;
   localparam int MinFullBandwidthDepth = ForwardLatencyCycles + ReturnLatencyCycles + 1;
 

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
@@ -50,7 +50,7 @@
 `include "br_gates.svh"
 
 module br_cdc_fifo_ctrl_1r1w_push_credit #(
-    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Depth = 16,  // Number of entries in the FIFO. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then ensure pop_valid/pop_data always come directly from a register
     // at the cost of an additional pop cycle of cut-through latency.

--- a/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_ctrl_1r1w_push_credit.sv
@@ -35,8 +35,16 @@
 // The backpressure latency is (RegisterResetActive + 1) * PopT + (NumSyncStages
 // + RegisterPushOutputs) * PushT.
 //
-// To achieve full bandwidth, the depth of the FIFO must be at least
-// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+// To sustain full bandwidth with arbitrary push/pop clock phase, use a FIFO
+// depth of at least
+// ceil((CutThroughLatency + BackpressureLatency) / max(PushT, PopT)) + 1.
+//
+// The additional entry accounts for clock skew and propagation delay into the
+// first Gray-count synchronizer stage in each direction. These asynchronous
+// paths are not covered by ordinary setup timing; constrain both directions
+// with a max delay tighter than min(PushT, PopT), including setup and
+// clock-skew margin. Smaller FIFO depths remain functionally correct when full
+// bandwidth is not required.
 
 `include "br_asserts_internal.svh"
 `include "br_gates.svh"
@@ -87,6 +95,9 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, require enough depth for full bandwidth at equal clock frequencies.
+    // Set to 0 when full bandwidth is unnecessary or the clock ratio permits less depth.
+    parameter bit ValidateDepthSupportsFullBandwidth = 1,
     localparam int AddrWidth = $clog2(Depth),
     localparam int CountWidth = $clog2(Depth + 1),
     localparam int CreditWidth = $clog2(MaxCredit + 1)
@@ -143,7 +154,15 @@ module br_cdc_fifo_ctrl_1r1w_push_credit #(
   //------------------------------------------
   // Integration checks
   //------------------------------------------
-  // Rely on submodule integration checks
+  localparam int ResetActiveCycles = RegisterResetActive + 1;
+  localparam int ForwardLatencyCycles =
+      ((ResetActiveCycles > RamWriteLatency) ? ResetActiveCycles : RamWriteLatency) +
+      NumSyncStages + RamReadLatency + RegisterPopOutputs;
+  localparam int ReturnLatencyCycles = ResetActiveCycles + NumSyncStages + RegisterPushOutputs;
+  localparam int MinFullBandwidthDepth = ForwardLatencyCycles + ReturnLatencyCycles + 1;
+
+  `BR_ASSERT_STATIC(depth_supports_full_bandwidth_a,
+                    !ValidateDepthSupportsFullBandwidth || Depth >= MinFullBandwidthDepth)
 
   //------------------------------------------
   // Implementation

--- a/cdc/rtl/br_cdc_fifo_flops.sv
+++ b/cdc/rtl/br_cdc_fifo_flops.sv
@@ -15,23 +15,23 @@
 //
 // The RegisterPopOutputs parameter can be set to 1 to add an additional br_flow_reg_fwd
 // before the pop interface of the FIFO. This may improve timing of paths dependent on
-// the pop interface at the expense of an additional pop cycle of cut-through latency.
+// the pop interface at the expense of an additional pop cycle of forward latency.
 
-// The cut-through latency (push_valid to pop_valid latency) and backpressure
-// latency (pop_ready to push_ready) can be calculated as follows:
+// The forward latency (push_valid to pop_valid) and return latency
+// (pop_ready to push_ready) can be calculated as follows:
 //
 // Let PushT and PopT be the push period and pop period, respectively.
 //
-// The cut-through latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 1) * PushT +
+// The forward latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 1) * PushT +
 // (NumSyncStages + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
 // FlopRamReadDataWidthStages + RegisterPopOutputs) * PopT.
 //
-// The backpressure latency is (RegisterResetActive + 1) * PopT +
+// The return latency is (RegisterResetActive + 1) * PopT +
 // NumSyncStages * PushT.
 //
 // To sustain full bandwidth with arbitrary push/pop clock phase, use a FIFO
 // depth of at least
-// ceil((CutThroughLatency + BackpressureLatency) / max(PushT, PopT)) + 1.
+// ceil((ForwardLatency + ReturnLatency) / max(PushT, PopT)) + 1.
 //
 // The additional entry accounts for clock skew and propagation delay into the
 // first Gray-count synchronizer stage in each direction. These asynchronous
@@ -44,13 +44,13 @@ module br_cdc_fifo_flops #(
     parameter int Depth = 16,  // Number of entries in the FIFO. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then ensure pop_valid/pop_data always come directly from a register
-    // at the cost of an additional pop cycle of cut-through latency.
+    // at the cost of an additional pop cycle of forward latency.
     // If 0, pop_valid/pop_data comes directly from push_valid (if bypass is enabled)
     // and/or ram_wr_data.
     parameter bit RegisterPopOutputs = 0,
     // If 1 (the default), register push_rst on push_clk and pop_rst on pop_clk
-    // before sending to the CDC synchronizers. This adds one cycle to the cut-through
-    // latency and one cycle to the backpressure latency.
+    // before sending to the CDC synchronizers. This adds one forward cycle and one
+    // return cycle.
     // Do not set this to 0 unless push_rst and pop_rst are driven directly by
     // registers.
     parameter bit RegisterResetActive = 1,

--- a/cdc/rtl/br_cdc_fifo_flops.sv
+++ b/cdc/rtl/br_cdc_fifo_flops.sv
@@ -41,7 +41,7 @@
 // bandwidth is not required.
 
 module br_cdc_fifo_flops #(
-    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Depth = 16,  // Number of entries in the FIFO. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // If 1, then ensure pop_valid/pop_data always come directly from a register
     // at the cost of an additional pop cycle of cut-through latency.

--- a/cdc/rtl/br_cdc_fifo_flops.sv
+++ b/cdc/rtl/br_cdc_fifo_flops.sv
@@ -27,10 +27,18 @@
 // FlopRamReadDataWidthStages + RegisterPopOutputs) * PopT.
 //
 // The backpressure latency is (RegisterResetActive + 1) * PopT +
-// (NumSyncStages + RegisterPushOutputs) * PushT.
+// NumSyncStages * PushT.
 //
-// To achieve full bandwidth, the depth of the FIFO must be at least
-// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+// To sustain full bandwidth with arbitrary push/pop clock phase, use a FIFO
+// depth of at least
+// ceil((CutThroughLatency + BackpressureLatency) / max(PushT, PopT)) + 1.
+//
+// The additional entry accounts for clock skew and propagation delay into the
+// first Gray-count synchronizer stage in each direction. These asynchronous
+// paths are not covered by ordinary setup timing; constrain both directions
+// with a max delay tighter than min(PushT, PopT), including setup and
+// clock-skew margin. Smaller FIFO depths remain functionally correct when full
+// bandwidth is not required.
 
 module br_cdc_fifo_flops #(
     parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
@@ -81,6 +89,9 @@ module br_cdc_fifo_flops #(
     // If 1, assert that push-side backpressure is impossible.
     // Can only be enabled if EnableCoverPushBackpressure is disabled.
     parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    // If 1, require enough depth for full bandwidth at equal clock frequencies.
+    // Set to 0 when full bandwidth is unnecessary or the clock ratio permits less depth.
+    parameter bit ValidateDepthSupportsFullBandwidth = 1,
 
     // Internal computed parameters
     localparam int AddrWidth  = $clog2(Depth),
@@ -147,7 +158,8 @@ module br_cdc_fifo_flops #(
       .EnableAssertPushValidStability(EnableAssertPushValidStability),
       .EnableAssertPushDataStability(EnableAssertPushDataStability),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .ValidateDepthSupportsFullBandwidth(ValidateDepthSupportsFullBandwidth)
   ) br_cdc_fifo_ctrl_1r1w (
       .push_clk,
       .push_rst,

--- a/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
@@ -26,8 +26,16 @@
 // The backpressure latency is (RegisterResetActive + 1) * PopT +
 // (NumSyncStages + RegisterPushOutputs) * PushT.
 //
-// To achieve full bandwidth, the depth of the FIFO must be at least
-// (CutThroughLatency + BackpressureLatency) / max(PushT, PopT).
+// To sustain full bandwidth with arbitrary push/pop clock phase, use a FIFO
+// depth of at least
+// ceil((CutThroughLatency + BackpressureLatency) / max(PushT, PopT)) + 1.
+//
+// The additional entry accounts for clock skew and propagation delay into the
+// first Gray-count synchronizer stage in each direction. These asynchronous
+// paths are not covered by ordinary setup timing; constrain both directions
+// with a max delay tighter than min(PushT, PopT), including setup and
+// clock-skew margin. Smaller FIFO depths remain functionally correct when full
+// bandwidth is not required.
 
 
 module br_cdc_fifo_flops_push_credit #(
@@ -86,6 +94,9 @@ module br_cdc_fifo_flops_push_credit #(
     // If 1, then assert there are no valid bits asserted and that the FIFO is
     // empty at the end of the test.
     parameter bit EnableAssertFinalNotValid = 1,
+    // If 1, require enough depth for full bandwidth at equal clock frequencies.
+    // Set to 0 when full bandwidth is unnecessary or the clock ratio permits less depth.
+    parameter bit ValidateDepthSupportsFullBandwidth = 1,
 
     // Internal computed parameters
     localparam int AddrWidth   = $clog2(Depth),
@@ -163,7 +174,8 @@ module br_cdc_fifo_flops_push_credit #(
       .EnableCoverPushSenderInReset(EnableCoverPushSenderInReset),
       .EnableCoverPushCreditStall(EnableCoverPushCreditStall),
       .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
-      .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .ValidateDepthSupportsFullBandwidth(ValidateDepthSupportsFullBandwidth)
   ) br_cdc_fifo_ctrl_1r1w_push_credit (
       .push_clk,
       // Not using push_either_rst here so that there is no path from

--- a/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
@@ -39,7 +39,7 @@
 
 
 module br_cdc_fifo_flops_push_credit #(
-    parameter int Depth = 2,  // Number of entries in the FIFO. Must be at least 2.
+    parameter int Depth = 16,  // Number of entries in the FIFO. Must be at least 2.
     parameter int Width = 1,  // Width of each entry in the FIFO. Must be at least 1.
     // Maximum credit for the internal credit counter. Must be at least Depth.
     // Recommended to not override the default because it is the smallest viable size.

--- a/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
+++ b/cdc/rtl/br_cdc_fifo_flops_push_credit.sv
@@ -12,23 +12,23 @@
 //
 // The RegisterPopOutputs parameter can be set to 1 to add an additional br_flow_reg_fwd
 // before the pop interface of the FIFO. This may improve timing of paths dependent on
-// the pop interface at the expense of an additional pop cycle of cut-through latency.
+// the pop interface at the expense of an additional pop cycle of forward latency.
 
-// The cut-through latency (push_valid to pop_valid latency) and backpressure
-// latency (pop_ready to push_ready) can be calculated as follows:
+// The forward latency (push_valid to pop_valid) and return latency
+// (pop_ready to push_credit) can be calculated as follows:
 //
 // Let PushT and PopT be the push period and pop period, respectively.
 //
-// The cut-through latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 1) * PushT +
+// The forward latency is max(RegisterResetActive + 1, FlopRamAddressDepthStages + 1) * PushT +
 // (NumSyncStages + FlopRamAddressDepthStages + FlopRamReadDataDepthStages +
 // FlopRamReadDataWidthStages + RegisterPopOutputs) * PopT.
 //
-// The backpressure latency is (RegisterResetActive + 1) * PopT +
+// The return latency is (RegisterResetActive + 1) * PopT +
 // (NumSyncStages + RegisterPushOutputs) * PushT.
 //
 // To sustain full bandwidth with arbitrary push/pop clock phase, use a FIFO
 // depth of at least
-// ceil((CutThroughLatency + BackpressureLatency) / max(PushT, PopT)) + 1.
+// ceil((ForwardLatency + ReturnLatency) / max(PushT, PopT)) + 1.
 //
 // The additional entry accounts for clock skew and propagation delay into the
 // first Gray-count synchronizer stage in each direction. These asynchronous
@@ -48,16 +48,16 @@ module br_cdc_fifo_flops_push_credit #(
     parameter int MaxCredit = Depth,
     // If 1, add a retiming stage to the push_credit signal so that it is
     // driven directly from a flop. This comes at the expense of one additional
-    // push cycle of credit loop latency.
+    // push cycle of return latency.
     parameter bit RegisterPushOutputs = 0,
     // If 1, then ensure pop_valid/pop_data always come directly from a register
-    // at the cost of an additional pop cycle of cut-through latency.
+    // at the cost of an additional pop cycle of forward latency.
     // If 0, pop_valid/pop_data comes directly from push_valid (if bypass is enabled)
     // and/or ram_wr_data.
     parameter bit RegisterPopOutputs = 1,
     // If 1 (the default), register push_rst on push_clk and pop_rst on pop_clk
-    // before sending to the CDC synchronizers. This adds one cycle to the cut-through
-    // latency and one cycle to the backpressure latency.
+    // before sending to the CDC synchronizers. This adds one forward cycle and one
+    // return cycle.
     // Do not set this to 0 unless push_rst and pop_rst are driven directly by
     // registers. If set to 0, push_sender_in_reset must be tied to 0.
     parameter bit RegisterResetActive = 1,

--- a/cdc/sim/br_cdc_fifo_ctrl_1r1w_push_credit_tb.sv
+++ b/cdc/sim/br_cdc_fifo_ctrl_1r1w_push_credit_tb.sv
@@ -44,6 +44,9 @@ module br_cdc_fifo_ctrl_1r1w_push_credit_tb;
   localparam int PushCountSettleCycles = (RegisterResetActive + 1 > RamWriteLatency) ?
       RegisterResetActive + 1 : RamWriteLatency;
   localparam int PopCountSettleCycles = RegisterResetActive + 1;
+  localparam int MinFullBandwidthDepth = PushCountSettleCycles + NumSyncStages +
+      RamReadLatency + RegisterPopOutputs + PopCountSettleCycles + NumSyncStages +
+      RegisterPushOutputs + 1;
   localparam int ResetAssertPushCycles = PushCountSettleCycles + NumSyncStages + PropDelay + 4;
   localparam int ResetAssertPopCycles = PopCountSettleCycles + NumSyncStages + 4;
   localparam int ResetSettlePushCycles = NumSyncStages + RegisterResetActive + PropDelay + 4;
@@ -167,7 +170,9 @@ module br_cdc_fifo_ctrl_1r1w_push_credit_tb;
       .EnableCoverPushSenderInReset(1),
       .EnableCoverPushCreditStall(1),
       .EnableAssertPushDataKnown(1),
-      .EnableAssertFinalNotValid(1)
+      .EnableAssertFinalNotValid(1),
+      // Functional tests also exercise shallow FIFOs that cannot sustain full bandwidth.
+      .ValidateDepthSupportsFullBandwidth(Depth >= MinFullBandwidthDepth)
   ) dut (
       .push_clk,
       .push_rst,

--- a/cdc/sim/br_cdc_fifo_ctrl_1r1w_tb.sv
+++ b/cdc/sim/br_cdc_fifo_ctrl_1r1w_tb.sv
@@ -50,6 +50,8 @@ module br_cdc_fifo_ctrl_1r1w_tb;
   localparam int PushCountSettleCycles = (RegisterResetActive + 1 > RamWriteLatency) ?
       RegisterResetActive + 1 : RamWriteLatency;
   localparam int PopCountSettleCycles = RegisterResetActive + 1;
+  localparam int MinFullBandwidthDepth = PushCountSettleCycles + NumSyncStages +
+      RamReadLatency + RegisterPopOutputs + PopCountSettleCycles + NumSyncStages + 1;
   localparam int ResetAssertPushCycles = PushCountSettleCycles + NumSyncStages + 4;
   localparam int ResetAssertPopCycles = PopCountSettleCycles + NumSyncStages + 4;
   localparam int ResetSettlePushCycles = NumSyncStages + RegisterResetActive + 4;
@@ -145,7 +147,9 @@ module br_cdc_fifo_ctrl_1r1w_tb;
       .EnableAssertPushDataStability(1),
       .EnableAssertPushDataKnown(1),
       .EnableAssertFinalNotValid(1),
-      .EnableAssertNoPushBackpressure(0)
+      .EnableAssertNoPushBackpressure(0),
+      // Functional tests also exercise shallow FIFOs that cannot sustain full bandwidth.
+      .ValidateDepthSupportsFullBandwidth(Depth >= MinFullBandwidthDepth)
   ) dut (
       .push_clk,
       .push_rst,


### PR DESCRIPTION
## Summary

- Account for arbitrary clock phase and synchronizer-input propagation when computing the FIFO depth needed to sustain full bandwidth.
- Add default-on depth checks to ready/valid and push-credit CDC FIFO controllers and expose `ValidateDepthSupportsFullBandwidth` through both FIFO wrappers.
- Default complete FIFO controllers and wrappers to 16 entries so their default configurations support full bandwidth.
- Correct the ready/valid return-latency formula and document the asynchronous-path timing constraints behind the additional entry.
- Keep existing shallow functional, formal, elaboration, and synthesis configurations by explicitly opting them out where full bandwidth is not required.

Existing integrations that intentionally use shallow CDC FIFOs must set `ValidateDepthSupportsFullBandwidth=0` before updating to this revision. Integrations that omit `Depth` receive the new 16-entry default.

## Verification

- Repository pre-commit checks, including Buildifier, Verible formatting/lint, and secret scanning.
- Eight Slang elaboration tests covering all four production FIFO variants and all four formal-verification monitors.
- Four Synopsys VCS simulations covering shallow ready/valid and push-credit opt-outs plus both full-bandwidth FIFO variants.

