### PR TITLE
[deps] Update GitPython to 3.1.58

### DIFF
--- a/requirements_lock_3_12.txt
+++ b/requirements_lock_3_12.txt
@@ -24,9 +24,9 @@ gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
     # via gitpython
-gitpython==3.1.57 \
-    --hash=sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf \
-    --hash=sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488
+gitpython==3.1.58 \
+    --hash=sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22 \
+    --hash=sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f
     # via testplanner
 hjson==3.1.0 \
     --hash=sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75 \


### PR DESCRIPTION
# Problem

The Python lockfile pins GitPython 3.1.57, which is affected by Dependabot alerts [16](https://github.com/xlsynth/bedrock-rtl/security/dependabot/16), [17](https://github.com/xlsynth/bedrock-rtl/security/dependabot/17), [18](https://github.com/xlsynth/bedrock-rtl/security/dependabot/18), [19](https://github.com/xlsynth/bedrock-rtl/security/dependabot/19), [20](https://github.com/xlsynth/bedrock-rtl/security/dependabot/20), and [21](https://github.com/xlsynth/bedrock-rtl/security/dependabot/21). GitPython is pulled in by testplanner.

# Solution

Update GitPython to 3.1.58, the first patched version for all six alerts, and regenerate its package hashes. No other Python dependencies change.

`MODULE.bazel.lock` does not need an update: regeneration left it unchanged, and the requirements test and testplanner smoke test both passed with `--lockfile_mode=error`.

Validation:

- `bazel test --lockfile_mode=error --test_output=errors --test_env=PIP_NO_EMIT_INDEX_URL=1 //:requirements_3_12.test`
- `bazel run --lockfile_mode=error //testplanner -- --help`
- `pre-commit run --all-files`
