### PR TITLE
[fpv] Add br_cdc_reg fpv

### DIFF
--- a/cdc/fpv/BUILD.bazel
+++ b/cdc/fpv/BUILD.bazel
@@ -603,3 +603,135 @@ br_verilog_fpv_test_tools_suite(
         "//mux/rtl:br_mux_bin_structured_gates_mock",
     ],
 )
+
+####################################################################################
+# Bedrock-RTL CDC Register
+
+verilog_library(
+    name = "br_cdc_reg_fpv_monitor",
+    srcs = ["br_cdc_reg_fpv_monitor.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cdc/rtl:br_cdc_reg",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_reg_fpv_monitor_elab_test",
+    opts = ["--ignore-unknown-modules"],
+    tool = "slang",
+    top = "br_cdc_reg_fpv_monitor",
+    deps = [
+        ":br_cdc_reg_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+# Sweep all ready/valid and backpressure configuration parameters.
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_reg_test_backpressure",
+    illegal_param_combinations = {
+        (
+            "EnableCoverPushBackpressure",
+            "EnableAssertPushValidStability",
+            "EnableAssertPushDataStability",
+            "EnableAssertNoPushBackpressure",
+        ): [
+            ("0", "0", "1", "0"),
+            ("0", "0", "1", "1"),
+            ("0", "1", "0", "0"),
+            ("0", "1", "0", "1"),
+            ("0", "1", "1", "0"),
+            ("0", "1", "1", "1"),
+            ("1", "0", "0", "1"),
+            ("1", "0", "1", "0"),
+            ("1", "0", "1", "1"),
+            ("1", "1", "0", "1"),
+            ("1", "1", "1", "1"),
+        ],
+        (
+            "EnableCoverPopBackpressure",
+            "EnableAssertNoPopBackpressure",
+        ): [
+            ("1", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertNoPopBackpressure": [
+            "0",
+            "1",
+        ],
+        "EnableAssertNoPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushDataStability": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPopBackpressure": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+        ],
+    },
+    tools = {
+        "jg": "br_cdc_reg_fpv.jg.tcl",
+    },
+    top = "br_cdc_reg_fpv_monitor",
+    deps = [
+        ":br_cdc_reg_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+# Sweep all datapath, synchronization, reset, and remaining assertion parameters.
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_reg_test_suite",
+    params = {
+        "EnableAssertFinalNotValid": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushDataKnown": [
+            "0",
+            "1",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RegisterPopOutputs": [
+            "0",
+            "1",
+        ],
+        "RegisterResetActive": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "5",
+        ],
+    },
+    tools = {
+        "jg": "br_cdc_reg_fpv.jg.tcl",
+    },
+    top = "br_cdc_reg_fpv_monitor",
+    deps = [
+        ":br_cdc_reg_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+    ],
+)

--- a/cdc/fpv/br_cdc_reg_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_reg_fpv.jg.tcl
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# clock/reset set up
+clock clk
+clock push_clk -from 1 -to 10 -both_edges
+clock pop_clk -from 1 -to 10 -both_edges
+
+# declare always_in system clock
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+# push/pop resets are ready at different times
+assume -env {rst |-> push_rst}
+assume -env {rst |-> pop_rst}
+assume -env {!push_rst |=> !push_rst}
+assume -env {!pop_rst |=> !pop_rst}
+assume -env {s_eventually !push_rst}
+assume -env {s_eventually !pop_rst}
+
+# push/pop side primary input signals only toggle w.r.t. their own clock
+clock -rate {push_valid push_data push_rst} push_clk
+clock -rate {pop_ready pop_rst} pop_clk
+
+get_design_info
+
+# primary input control signal should be legal during reset
+assume -name no_push_valid_during_reset {@(posedge push_clk) push_rst |-> push_valid == 'd0}
+
+# limit run time to 10 minutes
+set_prove_time_limit 600s
+
+prove -all

--- a/cdc/fpv/br_cdc_reg_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_reg_fpv.jg.tcl
@@ -25,7 +25,7 @@ clock -rate {pop_ready pop_rst} pop_clk
 get_design_info
 
 # primary input control signal should be legal during reset
-assume -name no_push_valid_during_reset {@(posedge push_clk) push_rst |-> push_valid == 'd0}
+assume -name no_push_valid_during_reset {@(posedge push_clk) +push_rst |-> push_valid == 'd0}
 
 # limit run time to 10 minutes
 set_prove_time_limit 600s

--- a/cdc/fpv/br_cdc_reg_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_reg_fpv_monitor.sv
@@ -103,9 +103,6 @@ module br_cdc_reg_fpv_monitor #(
     `BR_ASSUME_CR(no_push_backpressure_a, push_valid |-> push_ready, push_clk, push_rst)
   end
 
-  // Keep traffic quiescent until both independent CDC reset domains are released.
-  `BR_ASSUME_CR(no_push_while_pop_reset_a, pop_rst |-> !push_valid, push_clk, push_rst)
-
   if (((EnableCoverPushBackpressure && EnableAssertPushValidStability) ||
        (!EnableCoverPushBackpressure && EnableAssertNoPushBackpressure)) &&
       (EnableCoverPopBackpressure ||
@@ -145,7 +142,7 @@ module br_cdc_reg_fpv_monitor #(
   ) scoreboard (
       .incoming_clk(push_clk),
       .outgoing_clk(pop_clk),
-      .rstN(!fv_rst),
+      .rstN(!rst),
       .incoming_vld(push_vr),
       .incoming_data(push_data),
       .outgoing_vld(pop_vr),

--- a/cdc/fpv/br_cdc_reg_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_reg_fpv_monitor.sv
@@ -103,13 +103,16 @@ module br_cdc_reg_fpv_monitor #(
     `BR_ASSUME_CR(no_push_backpressure_a, push_valid |-> push_ready, push_clk, push_rst)
   end
 
-  if (((EnableCoverPushBackpressure && EnableAssertPushValidStability) ||
-       (!EnableCoverPushBackpressure && EnableAssertNoPushBackpressure)) &&
-      (EnableCoverPopBackpressure ||
-       (!EnableCoverPopBackpressure &&
-        EnableAssertNoPopBackpressure))) begin : gen_push_to_pop_liveness
-    // Every persistent push offer eventually becomes visible at the destination.
-    `BR_ASSERT_CR(push_to_pop_liveness_a, push_valid |-> s_eventually pop_valid, clk, fv_rst)
+  if (EnableCoverPopBackpressure ||
+      (!EnableCoverPopBackpressure &&
+       EnableAssertNoPopBackpressure)) begin : gen_push_to_pop_liveness
+    if (EnableCoverPushBackpressure && EnableAssertPushValidStability) begin : gen_stable
+      // Every persistent push offer eventually becomes visible at the destination.
+      `BR_ASSERT_CR(push_to_pop_liveness_a, push_valid |-> s_eventually pop_valid, clk, fv_rst)
+    end else begin : gen_not_stable
+      // Without a persistent offer, only accepted pushes require forward progress.
+      `BR_ASSERT_CR(push_to_pop_liveness_a, push_vr |-> s_eventually pop_valid, clk, fv_rst)
+    end
   end
 
   if (!EnableCoverPopBackpressure && EnableAssertNoPopBackpressure) begin : gen_no_pop_backpressure

--- a/cdc/fpv/br_cdc_reg_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_reg_fpv_monitor.sv
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL CDC Register
+//
+// Testplan:
+// - Exercise independent push_clk and pop_clk domains with independently deasserting resets.
+// - Check ready/valid protocol assumptions at the push and pop interfaces.
+// - Check forward progress, deadlock freedom, and single-entry capacity behavior.
+// - Check end-to-end ordering and payload integrity from accepted push to accepted pop.
+// - Check that invalid pop_data is blocked at the br_cdc_reg boundary.
+// - Check pop_valid/pop_data stability while the pop side is backpressured.
+// - Cover nonzero payload transfer, push backpressure, pop backpressure, reset overlap,
+//   and both registered and unregistered pop output configurations.
+
+`include "br_asserts.svh"
+
+module br_cdc_reg_fpv_monitor #(
+    parameter int Width = 1,
+    parameter bit RegisterPopOutputs = 0,
+    parameter bit RegisterResetActive = 1,
+    parameter int NumSyncStages = 3,
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableCoverPopBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertPushDataStability = EnableAssertPushValidStability,
+    parameter bit EnableAssertPushDataKnown = 1,
+    parameter bit EnableAssertFinalNotValid = 1,
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure,
+    parameter bit EnableAssertNoPopBackpressure = !EnableCoverPopBackpressure
+) (
+    // FV system clock and reset.
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface.
+    input logic             push_clk,
+    input logic             push_rst,
+    input logic             push_valid,
+    input logic [Width-1:0] push_data,
+
+    // Pop-side interface.
+    input logic pop_clk,
+    input logic pop_rst,
+    input logic pop_ready
+);
+
+  logic             push_ready;
+  logic             pop_valid;
+  logic [Width-1:0] pop_data;
+
+  br_cdc_reg #(
+      .Width(Width),
+      .RegisterPopOutputs(RegisterPopOutputs),
+      .RegisterResetActive(RegisterResetActive),
+      .NumSyncStages(NumSyncStages),
+      .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+      .EnableCoverPopBackpressure(EnableCoverPopBackpressure),
+      .EnableAssertPushValidStability(EnableAssertPushValidStability),
+      .EnableAssertPushDataStability(EnableAssertPushDataStability),
+      .EnableAssertPushDataKnown(EnableAssertPushDataKnown),
+      .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+      .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure),
+      .EnableAssertNoPopBackpressure(EnableAssertNoPopBackpressure)
+  ) dut (
+      .push_clk,
+      .push_rst,
+      .push_ready,
+      .push_valid,
+      .push_data,
+      .pop_clk,
+      .pop_rst,
+      .pop_ready,
+      .pop_valid,
+      .pop_data
+  );
+
+  logic push_vr;
+  logic pop_vr;
+  logic fv_rst;
+
+  assign push_vr = push_valid && push_ready;
+  assign pop_vr  = pop_valid && pop_ready;
+  assign fv_rst  = push_rst || pop_rst;
+
+  if (EnableCoverPopBackpressure) begin : gen_pop_ready_liveness
+    // Prevent destination backpressure from remaining asserted indefinitely.
+    `BR_ASSUME_CR(pop_ready_liveness_a, !pop_ready |-> s_eventually pop_ready, pop_clk, pop_rst)
+  end
+
+  if (EnableCoverPushBackpressure) begin : gen_push_backpressure
+    if (EnableAssertPushValidStability) begin : gen_push_valid_stability
+      // Hold push_valid until the CDC register accepts the transfer.
+      `BR_ASSUME_CR(push_valid_stability_a, push_valid && !push_ready |=> push_valid, push_clk,
+                    push_rst)
+    end
+    if (EnableAssertPushDataStability) begin : gen_push_data_stability
+      // Hold push_data until the CDC register accepts the transfer.
+      `BR_ASSUME_CR(push_data_stability_a, push_valid && !push_ready |=> $stable(push_data),
+                    push_clk, push_rst)
+    end
+  end else if (EnableAssertNoPushBackpressure) begin : gen_no_push_backpressure
+    // Keep the source legal when this configuration forbids push-side backpressure.
+    `BR_ASSUME_CR(no_push_backpressure_a, push_valid |-> push_ready, push_clk, push_rst)
+  end
+
+  // Keep traffic quiescent until both independent CDC reset domains are released.
+  `BR_ASSUME_CR(no_push_while_pop_reset_a, pop_rst |-> !push_valid, push_clk, push_rst)
+
+  if (((EnableCoverPushBackpressure && EnableAssertPushValidStability) ||
+       (!EnableCoverPushBackpressure && EnableAssertNoPushBackpressure)) &&
+      (EnableCoverPopBackpressure ||
+       (!EnableCoverPopBackpressure &&
+        EnableAssertNoPopBackpressure))) begin : gen_push_to_pop_liveness
+    // Every persistent push offer eventually becomes visible at the destination.
+    `BR_ASSERT_CR(push_to_pop_liveness_a, push_valid |-> s_eventually pop_valid, clk, fv_rst)
+  end
+
+  if (!EnableCoverPopBackpressure && EnableAssertNoPopBackpressure) begin : gen_no_pop_backpressure
+    // Keep the destination legal when this configuration forbids pop-side backpressure.
+    `BR_ASSUME_CR(no_pop_backpressure_a, pop_ready, pop_clk, pop_rst)
+  end
+
+  if (!RegisterPopOutputs) begin : gen_unregistered_pop_output_checks
+    // Unregistered outputs are directly qualified by internal_pop_valid and must be zero when invalid.
+    `BR_ASSERT_CR(invalid_pop_data_blocked_a, !pop_valid |-> pop_data == '0, pop_clk, fv_rst)
+  end
+
+  // Prevent payload movement while the output remains invalid in either output mode.
+  `BR_ASSERT_CR(invalid_pop_data_stability_a,
+                !pop_valid && !$fell(pop_valid) |-> $stable(pop_data), pop_clk, fv_rst)
+
+  if (EnableCoverPopBackpressure) begin : gen_pop_backpressure_stability
+    // Hold valid and payload stable while the destination applies backpressure.
+    `BR_ASSERT_CR(pop_backpressure_stability_a,
+                  pop_valid && !pop_ready |=> pop_valid && $stable(pop_data), pop_clk, fv_rst)
+  end
+
+  // Preserve ordering and payload integrity across the asynchronous clock boundary.
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(Width),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(0),
+      .MAX_PENDING(RegisterPopOutputs ? 2 : 1)
+  ) scoreboard (
+      .incoming_clk(push_clk),
+      .outgoing_clk(pop_clk),
+      .rstN(!fv_rst),
+      .incoming_vld(push_vr),
+      .incoming_data(push_data),
+      .outgoing_vld(pop_vr),
+      .outgoing_data(pop_data)
+  );
+
+  // Exercise a nonzero payload so invalid-data blocking is non-vacuous.
+  `BR_COVER_CR(nonzero_push_c, push_vr && push_data != '0, push_clk, push_rst)
+
+  // Exercise push-side backpressure when enabled.
+  if (EnableCoverPushBackpressure) begin : gen_push_backpressure_cover
+    `BR_COVER_CR(push_backpressure_c, push_valid && !push_ready, push_clk, push_rst)
+  end
+
+  // Exercise pop-side backpressure when enabled.
+  if (EnableCoverPopBackpressure) begin : gen_pop_backpressure_cover
+    `BR_COVER_CR(pop_backpressure_c, pop_valid && !pop_ready, pop_clk, pop_rst)
+  end
+
+  // Exercise independent reset release across the two clock domains.
+  `BR_COVER(reset_overlap_c, push_rst != pop_rst)
+
+endmodule : br_cdc_reg_fpv_monitor


### PR DESCRIPTION
## Summary

- Add a new `br_cdc_reg` FPV environment:
  - `br_cdc_reg_fpv_monitor.sv`
  - `br_cdc_reg_fpv.jg.tcl`
  - BUILD targets and parameter sweeps in `cdc/fpv/BUILD.bazel`
- Ran the full 111-target FPV parameter sweep with:
  - `--test_timeout=600`
  - `--jobs=20`
  - `--local_resources=verilog_test_tool_licenses_jg=20`
- Result: `111/111` targets fail.
- The failures reproduce a real reset-ordering bug when `push_rst` deasserts before `pop_rst`.
- A push can be accepted while the pop side remains in reset, causing `pop_flag_int_next` to toggle during `pop_rst` and propagate a false pop acknowledgment back to the push side.
- The resulting counterexamples include lost pushes, scoreboard data-integrity failures, overflow failures, and liveness failures.
- Representative VCDs were inspected for stable-valid, unstable-valid, and registered-pop-output configurations; all failures point to the same reset-time phantom-pop behavior.

## Checks Added to catch bugs fixed by #1259

- Invalid pop data is zero for unregistered outputs:
  - `!pop_valid |-> pop_data == '0`
- Invalid pop data remains stable for both registered and unregistered outputs:
  - `!pop_valid && !$fell(pop_valid) |-> $stable(pop_data)`

## Bug Reproduction

- Reverted PR #1259 RTL changes in a temporary pre-fix worktree.
- Ran:
  - `br_cdc_reg_test_suite_jg_eafnv1_eapdk1_nss3_rpo0_rra1_w1_fpv_test`
- Jasper reproduced two depth-4 CEXs:
  - `invalid_pop_data_blocked_a`
  - `invalid_pop_data_stability_a`
- VCD showed `push_reg_data` changing from `0` to `1` while `internal_pop_valid=0` and `pop_valid=0`; pre-fix RTL directly exposed `push_reg_data` on `pop_data`.
- Fixed RTL qualifies pop data with `internal_pop_valid`, preventing invalid data movement.
