### PR TITLE
[ci] Cancel superseded Pages deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -757,7 +757,7 @@ jobs:
       id-token: write
     concurrency:
       group: pages
-      cancel-in-progress: false
+      cancel-in-progress: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
# Problem

The Pages deployment job uses `cancel-in-progress: false`, allowing a stranded job to block subsequent deployments in the shared `pages` concurrency group. Run [#3158](https://github.com/xlsynth/bedrock-rtl/actions/runs/31431430083) remained queued for more than ten days while later Pages jobs waited or were canceled.

# Solution

Set `cancel-in-progress: true` on `deploy-test-results-pages` so a newly ready deployment cancels the previous job in the group. Keep the change scoped to Pages; CI tests and nightly concurrency are unchanged.

Validation: `pre-commit run --all-files` and `git diff --check`.
