### PR TITLE
Fix shrinker alignment mask width

### DIFF
--- a/amba/rtl/br_amba_axi_shrinker.sv
+++ b/amba/rtl/br_amba_axi_shrinker.sv
@@ -152,7 +152,7 @@ module br_amba_axi_shrinker #(
                                               logic [br_amba::AxiBurstSizeWidth-1:0] size);
     logic [AddrWidth-1:0] addr_mask;
     // ri lint_check_waive VAR_SHIFT
-    addr_mask = (1'b1 << size) - 1'b1;
+    addr_mask = (AddrWidth'(1'b1) << size) - AddrWidth'(1'b1);
     return (addr & addr_mask) == '0;
   endfunction
 `endif


### PR DESCRIPTION
## Summary

- Fix `br_amba_axi_shrinker` alignment mask calculation by casting `1'b1` to `AddrWidth` before shifting.
- The previous expression kept the shifted value one bit wide, causing nonzero `AxSIZE` values to produce an all-ones mask and incorrectly require `AxADDR == 0`.
- This restores the intended integration assertion behavior: require `AxADDR` to be aligned to `AxSIZE`.

## Verification

- Ran `pre-commit run --all-files`.
- Ran all generated `br_amba_axi_shrinker` Jasper FPV targets:
  - `ndw8`
  - `ndw16`
  - `ndw32`
- 3/3 targets passed.
- `awaddr_aligned_awsize_a` and `araddr_aligned_arsize_a` proved in all configurations with covered preconditions.
- No CEX observed.