### PR TITLE
[fv] Add FPV for stable data CDC blocks

### DIFF
--- a/cdc/fpv/BUILD.bazel
+++ b/cdc/fpv/BUILD.bazel
@@ -735,6 +735,7 @@ br_verilog_fpv_test_tools_suite(
         "//gate/rtl:br_gate_mock",
     ],
 )
+
 # Bedrock-RTL Stable Data CDC
 verilog_library(
     name = "br_cdc_stable_data_fpv_monitor",

--- a/cdc/fpv/BUILD.bazel
+++ b/cdc/fpv/BUILD.bazel
@@ -735,3 +735,109 @@ br_verilog_fpv_test_tools_suite(
         "//gate/rtl:br_gate_mock",
     ],
 )
+# Bedrock-RTL Stable Data CDC
+verilog_library(
+    name = "br_cdc_stable_data_fpv_monitor",
+    srcs = ["br_cdc_stable_data_fpv_monitor.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cdc/rtl:br_cdc_stable_data",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_stable_data_fpv_monitor_elab_test",
+    opts = ["--ignore-unknown-modules"],
+    tool = "slang",
+    top = "br_cdc_stable_data_fpv_monitor",
+    deps = [
+        ":br_cdc_stable_data_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_stable_data_test_suite",
+    params = {
+        "InitValue": [
+            "0",
+            "1",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RegisterResetActive": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "5",
+        ],
+    },
+    tools = {
+        "jg": "br_cdc_stable_data_fpv.jg.tcl",
+    },
+    top = "br_cdc_stable_data_fpv_monitor",
+    deps = [
+        ":br_cdc_stable_data_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+####################################################################################
+# Bedrock-RTL Stable Data CDC with Automatic Update
+verilog_library(
+    name = "br_cdc_stable_data_autoupdate_fpv_monitor",
+    srcs = ["br_cdc_stable_data_autoupdate_fpv_monitor.sv"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cdc/rtl:br_cdc_stable_data_autoupdate",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_cdc_stable_data_autoupdate_fpv_monitor_elab_test",
+    opts = ["--ignore-unknown-modules"],
+    tool = "slang",
+    top = "br_cdc_stable_data_autoupdate_fpv_monitor",
+    deps = [
+        ":br_cdc_stable_data_autoupdate_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+    ],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_cdc_stable_data_autoupdate_test_suite",
+    params = {
+        "InitValue": [
+            "0",
+            "1",
+        ],
+        "NumSyncStages": [
+            "2",
+            "3",
+            "4",
+        ],
+        "RegisterResetActive": [
+            "0",
+            "1",
+        ],
+        "Width": [
+            "1",
+            "5",
+        ],
+    },
+    tools = {
+        "jg": "br_cdc_stable_data_autoupdate_fpv.jg.tcl",
+    },
+    top = "br_cdc_stable_data_autoupdate_fpv_monitor",
+    deps = [
+        ":br_cdc_stable_data_autoupdate_fpv_monitor",
+        "//gate/rtl:br_gate_mock",
+    ],
+)

--- a/cdc/fpv/br_cdc_stable_data_autoupdate_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_stable_data_autoupdate_fpv.jg.tcl
@@ -1,0 +1,30 @@
+# clock/reset set up
+clock clk
+clock src_clk -from 1 -to 10 -both_edges
+clock dst_clk -from 1 -to 10 -both_edges
+
+# Source and destination resets may deassert independently after system reset releases.
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+assume -env {rst |-> src_rst}
+assume -env {rst |-> dst_rst}
+assume -env {!src_rst |=> !src_rst}
+assume -env {!dst_rst |=> !dst_rst}
+assume -env {s_eventually !src_rst}
+assume -env {s_eventually !dst_rst}
+# Primary inputs only change with their local clock.
+clock -rate {src_data src_rst} src_clk
+clock -rate {dst_rst} dst_clk
+
+get_design_info
+
+# Destination update indication must remain low while the destination is in reset.
+assert -name no_dst_updated_during_reset {@(posedge dst_clk) \
+dst_rst |-> !dst_updated}
+
+# limit run time to 10 minutes
+set_prove_time_limit 600s
+
+prove -all

--- a/cdc/fpv/br_cdc_stable_data_autoupdate_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_stable_data_autoupdate_fpv.jg.tcl
@@ -24,6 +24,10 @@ get_design_info
 assert -name no_dst_updated_during_reset {@(posedge dst_clk) \
 dst_rst |-> !dst_updated}
 
+# Destination data must be initialized while the destination interface is in reset.
+assert -name dst_data_is_init_during_reset {@(posedge dst_clk) \
+dst_rst |-> dst_data == InitValue}
+
 # limit run time to 10 minutes
 set_prove_time_limit 600s
 

--- a/cdc/fpv/br_cdc_stable_data_autoupdate_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_stable_data_autoupdate_fpv_monitor.sv
@@ -61,8 +61,7 @@ module br_cdc_stable_data_autoupdate_fpv_monitor #(
   `BR_ASSERT_CR(src_to_dst_liveness_a, src_vr |-> s_eventually dst_updated, clk, rst)
 
   // Destination data must hold its last transferred value between updates.
-  `BR_ASSERT_CR(dst_data_stability_a, !dst_updated && !$fell(dst_updated) |-> $stable(dst_data),
-                dst_clk, dst_rst)
+  `BR_ASSERT_CR(dst_data_stability_a, !dst_updated |-> $stable(dst_data), dst_clk, dst_rst)
 
   // Preserve ordering and payload integrity for externally observed source updates.
   jasper_scoreboard_3 #(

--- a/cdc/fpv/br_cdc_stable_data_autoupdate_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_stable_data_autoupdate_fpv_monitor.sv
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL Stable Data CDC with Automatic Update
+//
+// Testplan:
+// - Exercise independent src_clk and dst_clk domains with independently deasserting resets.
+// - Model source updates only from externally visible src_data changes.
+// - Check every modeled source update reaches the destination exactly once with matching data.
+// - Check destination data changes only with dst_updated.
+// - Check accepted updates make forward progress without assuming reset release ordering.
+// - Cover source changes, nonzero transfer, and both reset-release orderings.
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_cdc_stable_data_autoupdate_fpv_monitor #(
+    parameter int Width = 1,
+    parameter logic [Width-1:0] InitValue = '0,
+    parameter bit RegisterResetActive = 1,
+    parameter int NumSyncStages = 3
+) (
+    // FV system clock and reset.
+    input logic clk,
+    input logic rst,
+
+    input logic src_clk,
+    input logic src_rst,
+    input logic [Width-1:0] src_data,
+
+    input logic dst_clk,
+    input logic dst_rst
+);
+  logic dst_updated;
+  logic [Width-1:0] dst_data;
+  logic [Width-1:0] fv_src_data_reg;
+  logic src_vr;
+
+  br_cdc_stable_data_autoupdate #(
+      .Width(Width),
+      .InitValue(InitValue),
+      .RegisterResetActive(RegisterResetActive),
+      .NumSyncStages(NumSyncStages)
+  ) dut (
+      .src_clk,
+      .src_rst,
+      .src_data,
+      .dst_clk,
+      .dst_rst,
+      .dst_updated,
+      .dst_data
+  );
+
+  // The interface does not expose the internal ready signal, so an exact external assumption for
+  // "infrequent" source changes would depend on the clock ratio. Check integrity only for a
+  // changed source value that the RTL actually accepts; users must ensure src_data changes slowly
+  // enough for their application.
+  assign src_vr = !src_rst && (src_data != fv_src_data_reg) && dut.src_ready;
+  `BR_REGLIX(fv_src_data_reg, src_data, src_vr, InitValue, src_clk, src_rst)
+
+  // Every externally observed source update must eventually become visible at the destination.
+  `BR_ASSERT_CR(src_to_dst_liveness_a, src_vr |-> s_eventually dst_updated, clk, rst)
+
+  // Destination data must hold its last transferred value between updates.
+  `BR_ASSERT_CR(dst_data_stability_a, !dst_updated && !$fell(dst_updated) |-> $stable(dst_data),
+                dst_clk, dst_rst)
+
+  // Preserve ordering and payload integrity for externally observed source updates.
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(Width),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(0),
+      .MAX_PENDING(2)
+  ) scoreboard (
+      .incoming_clk(src_clk),
+      .outgoing_clk(dst_clk),
+      .rstN(!rst),
+      .incoming_vld(src_vr),
+      .incoming_data(src_data),
+      .outgoing_vld(dst_updated),
+      .outgoing_data(dst_data)
+  );
+
+  // Exercise automatic update generation from a changed source value.
+  `BR_COVER_CR(source_change_c, src_data != InitValue, src_clk, src_rst)
+
+  // Exercise transfer of a non-reset payload.
+  `BR_COVER_CR(nonzero_update_c, src_vr && src_data != InitValue, src_clk, src_rst)
+
+  // Exercise both legal independent reset-release orderings.
+  `BR_COVER(src_reset_releases_later_c, src_rst && !dst_rst)
+  `BR_COVER(dst_reset_releases_later_c, !src_rst && dst_rst)
+
+endmodule : br_cdc_stable_data_autoupdate_fpv_monitor

--- a/cdc/fpv/br_cdc_stable_data_autoupdate_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_stable_data_autoupdate_fpv_monitor.sv
@@ -34,6 +34,7 @@ module br_cdc_stable_data_autoupdate_fpv_monitor #(
   logic [Width-1:0] dst_data;
   logic [Width-1:0] fv_src_data_reg;
   logic src_vr;
+  logic seen_dst_update;
 
   br_cdc_stable_data_autoupdate #(
       .Width(Width),
@@ -62,6 +63,12 @@ module br_cdc_stable_data_autoupdate_fpv_monitor #(
 
   // Destination data must hold its last transferred value between updates.
   `BR_ASSERT_CR(dst_data_stability_a, !dst_updated |-> $stable(dst_data), dst_clk, dst_rst)
+
+  `BR_REGX(seen_dst_update, seen_dst_update || dst_updated, dst_clk, dst_rst)
+
+  // Destination data must retain its reset value until the first update arrives.
+  `BR_ASSERT_CR(dst_data_init_until_update_a,
+                !seen_dst_update && !dst_updated |-> dst_data == InitValue, dst_clk, dst_rst)
 
   // Preserve ordering and payload integrity for externally observed source updates.
   jasper_scoreboard_3 #(

--- a/cdc/fpv/br_cdc_stable_data_autoupdate_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_stable_data_autoupdate_fpv_monitor.sv
@@ -61,6 +61,10 @@ module br_cdc_stable_data_autoupdate_fpv_monitor #(
   // Every externally observed source update must eventually become visible at the destination.
   `BR_ASSERT_CR(src_to_dst_liveness_a, src_vr |-> s_eventually dst_updated, clk, rst)
 
+  // The internal source-side CDC handshake must not remain backpressured forever.
+  `BR_ASSERT_CR(src_ready_liveness_a, !dut.src_ready |-> s_eventually dut.src_ready, src_clk,
+                src_rst)
+
   // Destination data must hold its last transferred value between updates.
   `BR_ASSERT_CR(dst_data_stability_a, !dst_updated |-> $stable(dst_data), dst_clk, dst_rst)
 

--- a/cdc/fpv/br_cdc_stable_data_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_stable_data_fpv.jg.tcl
@@ -28,6 +28,10 @@ src_rst |-> !src_valid}
 assert -name no_dst_updated_during_reset {@(posedge dst_clk) \
 dst_rst |-> !dst_updated}
 
+# Destination data must be initialized while the destination interface is in reset.
+assert -name dst_data_is_init_during_reset {@(posedge dst_clk) \
+dst_rst |-> dst_data == InitValue}
+
 # The wrapper has no external ready port; its integration assertion defines legal source spacing.
 assume -from_assert br_cdc_stable_data_fpv_monitor.dut.no_reg_overflow_A
 

--- a/cdc/fpv/br_cdc_stable_data_fpv.jg.tcl
+++ b/cdc/fpv/br_cdc_stable_data_fpv.jg.tcl
@@ -1,0 +1,37 @@
+# clock/reset set up
+clock clk
+clock src_clk -from 1 -to 10 -both_edges
+clock dst_clk -from 1 -to 10 -both_edges
+
+# Source and destination resets may deassert independently after system reset releases.
+reset -none
+assume -reset -name set_rst_during_reset {rst}
+assume -bound 1 -name delay_rst {rst}
+assume -name deassert_rst {##1 !rst}
+assume -env {rst |-> src_rst}
+assume -env {rst |-> dst_rst}
+assume -env {!src_rst |=> !src_rst}
+assume -env {!dst_rst |=> !dst_rst}
+assume -env {s_eventually !src_rst}
+assume -env {s_eventually !dst_rst}
+# Primary inputs only change with their local clock.
+clock -rate {src_valid src_data src_rst} src_clk
+clock -rate {dst_rst} dst_clk
+
+get_design_info
+
+# Source valid is illegal while the source interface is held in reset.
+assume -name no_src_valid_during_reset {@(posedge src_clk) \
+src_rst |-> !src_valid}
+
+# Destination update indication must remain low while the destination is in reset.
+assert -name no_dst_updated_during_reset {@(posedge dst_clk) \
+dst_rst |-> !dst_updated}
+
+# The wrapper has no external ready port; its integration assertion defines legal source spacing.
+assume -from_assert br_cdc_stable_data_fpv_monitor.dut.no_reg_overflow_A
+
+# limit run time to 10 minutes
+set_prove_time_limit 600s
+
+prove -all

--- a/cdc/fpv/br_cdc_stable_data_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_stable_data_fpv_monitor.sv
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Bedrock-RTL Stable Data CDC
+//
+// Testplan:
+// - Exercise independent src_clk and dst_clk domains with independently deasserting resets.
+// - Require legal source valid behavior only while src_rst is asserted.
+// - Check every source update reaches the destination exactly once with matching data.
+// - Check destination data changes only with dst_updated.
+// - Check accepted updates make forward progress without assuming reset release ordering.
+// - Cover nonzero transfer and both reset-release orderings.
+
+`include "br_asserts.svh"
+
+module br_cdc_stable_data_fpv_monitor #(
+    parameter int Width = 1,
+    parameter logic [Width-1:0] InitValue = '0,
+    parameter bit RegisterResetActive = 1,
+    parameter int NumSyncStages = 3
+) (
+    // FV system clock and reset.
+    input logic clk,
+    input logic rst,
+
+    input logic src_clk,
+    input logic src_rst,
+    input logic src_valid,
+    input logic [Width-1:0] src_data,
+
+    input logic dst_clk,
+    input logic dst_rst
+);
+  logic dst_updated;
+  logic [Width-1:0] dst_data;
+
+  br_cdc_stable_data #(
+      .Width(Width),
+      .InitValue(InitValue),
+      .RegisterResetActive(RegisterResetActive),
+      .NumSyncStages(NumSyncStages)
+  ) dut (
+      .src_clk,
+      .src_rst,
+      .src_valid,
+      .src_data,
+      .dst_clk,
+      .dst_rst,
+      .dst_updated,
+      .dst_data
+  );
+
+  // Every legal source update must eventually become visible at the destination.
+  `BR_ASSERT_CR(src_to_dst_liveness_a, src_valid |-> s_eventually dst_updated, clk, rst)
+
+  // Destination data must hold its last transferred value between updates.
+  `BR_ASSERT_CR(dst_data_stability_a, !dst_updated && !$fell(dst_updated) |-> $stable(dst_data),
+                dst_clk, dst_rst)
+
+  // Preserve ordering and payload integrity from source updates to destination updates.
+  jasper_scoreboard_3 #(
+      .CHUNK_WIDTH(Width),
+      .IN_CHUNKS(1),
+      .OUT_CHUNKS(1),
+      .SINGLE_CLOCK(0),
+      .MAX_PENDING(2)
+  ) scoreboard (
+      .incoming_clk(src_clk),
+      .outgoing_clk(dst_clk),
+      .rstN(!rst),
+      .incoming_vld(src_valid),
+      .incoming_data(src_data),
+      .outgoing_vld(dst_updated),
+      .outgoing_data(dst_data)
+  );
+
+  // Exercise transfer of a non-reset payload.
+  `BR_COVER_CR(nonzero_update_c, src_valid && src_data != InitValue, src_clk, src_rst)
+
+  // Exercise both legal independent reset-release orderings.
+  `BR_COVER(src_reset_releases_later_c, src_rst && !dst_rst)
+  `BR_COVER(dst_reset_releases_later_c, !src_rst && dst_rst)
+
+endmodule : br_cdc_stable_data_fpv_monitor

--- a/cdc/fpv/br_cdc_stable_data_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_stable_data_fpv_monitor.sv
@@ -53,8 +53,7 @@ module br_cdc_stable_data_fpv_monitor #(
   `BR_ASSERT_CR(src_to_dst_liveness_a, src_valid |-> s_eventually dst_updated, clk, rst)
 
   // Destination data must hold its last transferred value between updates.
-  `BR_ASSERT_CR(dst_data_stability_a, !dst_updated && !$fell(dst_updated) |-> $stable(dst_data),
-                dst_clk, dst_rst)
+  `BR_ASSERT_CR(dst_data_stability_a, !dst_updated |-> $stable(dst_data), dst_clk, dst_rst)
 
   // Preserve ordering and payload integrity from source updates to destination updates.
   jasper_scoreboard_3 #(

--- a/cdc/fpv/br_cdc_stable_data_fpv_monitor.sv
+++ b/cdc/fpv/br_cdc_stable_data_fpv_monitor.sv
@@ -11,6 +11,7 @@
 // - Cover nonzero transfer and both reset-release orderings.
 
 `include "br_asserts.svh"
+`include "br_registers.svh"
 
 module br_cdc_stable_data_fpv_monitor #(
     parameter int Width = 1,
@@ -32,6 +33,7 @@ module br_cdc_stable_data_fpv_monitor #(
 );
   logic dst_updated;
   logic [Width-1:0] dst_data;
+  logic seen_dst_update;
 
   br_cdc_stable_data #(
       .Width(Width),
@@ -54,6 +56,12 @@ module br_cdc_stable_data_fpv_monitor #(
 
   // Destination data must hold its last transferred value between updates.
   `BR_ASSERT_CR(dst_data_stability_a, !dst_updated |-> $stable(dst_data), dst_clk, dst_rst)
+
+  `BR_REGX(seen_dst_update, seen_dst_update || dst_updated, dst_clk, dst_rst)
+
+  // Destination data must retain its reset value until the first update arrives.
+  `BR_ASSERT_CR(dst_data_init_until_update_a,
+                !seen_dst_update && !dst_updated |-> dst_data == InitValue, dst_clk, dst_rst)
 
   // Preserve ordering and payload integrity from source updates to destination updates.
   jasper_scoreboard_3 #(


### PR DESCRIPTION
## Summary

- Add FPV environments for `br_cdc_stable_data` and `br_cdc_stable_data_autoupdate`.
- Add full parameter sweeps for `InitValue`, `NumSyncStages`, `RegisterResetActive`, and `Width`.
- Add independent source/destination clock and reset modeling consistent with other CDC FPV environments.
- Add end-to-end scoreboard, destination stability checks, reset checks, liveness checks, and reset-order covers.
- For autoupdate, qualify modeled source transactions with internal `src_ready` because the external interface does not expose backpressure; users remain responsible for changing `src_data` infrequently enough.

## Validation

- Ran `pre-commit` on all changed files.
- With a temporary RTL fix and reset-order diagnostic constraint, all 24 autoupdate parameter combinations had:
  - 0 CEX
  - 0 timeout
  - 0 undetermined
- Removed the temporary RTL fix and confirmed the FPV checker reproduces the existing autoupdate reset bug:
  - `src_to_dst_liveness_a`
  - scoreboard `data_integrity`
  - scoreboard `no_overflow`