### PR TITLE
Optimized br_mux_bin_structured_gates so that fewer gates are used

### DIFF
--- a/mux/rtl/br_mux_bin_structured_gates.sv
+++ b/mux/rtl/br_mux_bin_structured_gates.sv
@@ -46,54 +46,77 @@ module br_mux_bin_structured_gates #(
 
   end else begin : gen_n
 
-    // Round up number of input symbols to a power of 2, padding with 0s.
-    // When select is out of range, the output will be 0, which matches the behavior of br_mux_bin.
-    localparam int PaddedNumSymbolsIn = 2 ** $clog2(NumSymbolsIn);
-    localparam int NumLevels = $clog2(PaddedNumSymbolsIn);
+    localparam int NumLevels = $clog2(NumSymbolsIn);
 
     // The final output is computed through a tree of mux2 gates.
     // The number of stages is clog2(NumSymbolsIn).
     // This signal contains the intermediate results of each stage.
     // Stage 0 is the input and stage NumLevels is the output.
-    logic [NumLevels:0][PaddedNumSymbolsIn-1:0][SymbolWidth-1:0] in_stages;
+    logic [NumLevels:0][NumSymbolsIn-1:0][SymbolWidth-1:0] in_stages;
 
-    always_comb begin
-      in_stages[0] = '0;  // ri lint_check_waive OVERWRITTEN
-      in_stages[0][NumSymbolsIn-1:0] = in;
-    end
+    assign in_stages[0] = in;
 
+    // Build a tree of muxes with select taking successive bits
+    // starting from the LSB. Each time, the distance between
+    // inputs of the mux2s double. So stage 0 (the input), pairs
+    // 0&1, 2&3, 4&5, etc. Stage 1 pairs 0&2, 4&6, 8&10, etc. and so on.
+    // For non power-of-2 NumSymbolsIn, any pairing that goes outside the range
+    // will have the missing input replaced with zero to match the behavior
+    // of the non-structured br_mux_bin.
     for (genvar i = 0; i < NumLevels; i++) begin : gen_level
-      // At each stage, each mux2 will cover 2x the number of input
-      // symbols as the previous stage.
-      localparam int LastStageNumSymbolsInPerMux = 2 ** i;
-      localparam int LastStageNumSymbols = br_math::ceil_div(
-          PaddedNumSymbolsIn, LastStageNumSymbolsInPerMux
-      );
-      localparam int NumSymbolsInPerMux = 2 ** (i + 1);
-      localparam int NumMuxes = br_math::ceil_div(PaddedNumSymbolsIn, NumSymbolsInPerMux);
+      localparam int InputStride = 2 ** i;
+      localparam int OutputStride = 2 * InputStride;
+      localparam int NumMuxes = br_math::ceil_div(NumSymbolsIn, OutputStride);
 
       for (genvar j = 0; j < NumMuxes; j++) begin : gen_mux
+        localparam int In0Index = j * OutputStride;
+        localparam int In1Index = j * OutputStride + InputStride;
+        localparam int OutIndex = In0Index;
+        localparam int OutZeroLsb = OutIndex + 1;
+        localparam int OutZeroMsb = br_math::min2(OutIndex + OutputStride - 1, NumSymbolsIn - 1);
+        localparam int In0UnusedLsb = In0Index + 1;
+        localparam int In0UnusedMsb = br_math::min2(In0Index + InputStride - 1, NumSymbolsIn - 1);
+        localparam int In1UnusedLsb = In1Index + 1;
+        localparam int In1UnusedMsb = br_math::min2(In1Index + InputStride - 1, NumSymbolsIn - 1);
+
+        logic [SymbolWidth-1:0] stage_in0, stage_in1, stage_out;
+
+        assign stage_in0 = in_stages[i][In0Index];
+
+        if (In1Index < NumSymbolsIn) begin : gen_in1
+          assign stage_in1 = in_stages[i][In1Index];
+        end else begin : gen_in1_tieoff
+          assign stage_in1 = '0;
+        end
+
         // Each output of the stage depends on two inputs from the previous stage.
         for (genvar k = 0; k < SymbolWidth; k++) begin : gen_mux2_gate
           br_gate_mux2 br_gate_mux2_inst (
               .sel(select[i]),
-              .in0(in_stages[i][(j*2)+0][k]),
-              .in1(in_stages[i][(j*2)+1][k]),
-              .out(in_stages[i+1][j][k])
+              .in0(stage_in0[k]),
+              .in1(stage_in1[k]),
+              .out(stage_out[k])
           );
         end
-      end
 
-      // Tie-off unused upper part of this stage's output.
-      assign in_stages[i+1][PaddedNumSymbolsIn-1:NumMuxes] = '0;
-      // Mark as unread the unused upper part of this stage's input.
-      if (i != 0) begin : gen_last_stage_unused
-        `BR_UNUSED_NAMED(last_stage_unused, in_stages[i][PaddedNumSymbolsIn-1:LastStageNumSymbols])
+
+        assign in_stages[i+1][OutIndex] = stage_out;
+        if (OutZeroLsb <= OutZeroMsb) begin : gen_out_zero
+          assign in_stages[i+1][OutZeroMsb:OutZeroLsb] = '0;
+        end
+
+        // Mark as unread the previous stage values in between the input strides
+        if (In0UnusedLsb <= In0UnusedMsb) begin : gen_in0_unused
+          `BR_UNUSED_NAMED(last_stage_unused0, in_stages[i][In0UnusedMsb:In0UnusedLsb])
+        end
+        if (In1UnusedLsb <= In1UnusedMsb) begin : gen_in1_unused
+          `BR_UNUSED_NAMED(last_stage_unused1, in_stages[i][In1UnusedMsb:In1UnusedLsb])
+        end
       end
     end
 
     assign out = in_stages[NumLevels][0];
-    `BR_UNUSED_NAMED(final_stage_unused, in_stages[NumLevels][PaddedNumSymbolsIn-1:1])
+    `BR_UNUSED_NAMED(final_stage_unused, in_stages[NumLevels][NumSymbolsIn-1:1])
 
     assign out_valid = select < NumSymbolsIn;  // ri lint_check_waive INVALID_COMPARE
   end

--- a/mux/sim/br_mux_bin_structured_gates_tb.sv
+++ b/mux/sim/br_mux_bin_structured_gates_tb.sv
@@ -4,12 +4,14 @@ module br_mux_bin_structured_gates_tb;
 
   parameter int NumSymbolsIn = 2;
   parameter int SymbolWidth = 8;
+  localparam int SelectRange = 2 ** $clog2(NumSymbolsIn);
 
   logic clk;
   logic rst;
 
   logic [NumSymbolsIn-1:0][SymbolWidth-1:0] in;
   logic [SymbolWidth-1:0] out;
+  logic out_valid;
   logic [$clog2(NumSymbolsIn)-1:0] select;
 
   br_mux_bin_structured_gates #(
@@ -19,7 +21,7 @@ module br_mux_bin_structured_gates_tb;
       .select,
       .in,
       .out,
-      .out_valid()
+      .out_valid
   );
 
   br_test_driver td (
@@ -35,11 +37,22 @@ module br_mux_bin_structured_gates_tb;
     select = 0;
     td.reset_dut();
 
-    // Check that the correct input is selected for each possible select value
+    // Check that the correct input is selected for each valid select value
     for (int i = 0; i < NumSymbolsIn; i++) begin
       select = i;
       td.wait_cycles();
       td.check_integer(out, in[i], $sformatf("Output does not match expected for select = %0d", i));
+      td.check(out_valid, $sformatf("Output valid should be high for select = %0d", i));
+    end
+
+    // Check that out and out_valid are zero for out-of-range select values
+    for (int i = NumSymbolsIn; i < SelectRange; i++) begin
+      select = i;
+      td.wait_cycles();
+      td.check_integer(out, '0, $sformatf("Output should be zero for out-of-range select = %0d", i
+                       ));
+      td.check(!out_valid, $sformatf("Output valid should be low for out-of-range select = %0d", i
+               ));
     end
 
     td.wait_cycles();


### PR DESCRIPTION
Previously, we just padded the input to the closest power of two and
created a full-size mux2 tree. However, we can get the same behavior
with fewer gates if we remove the mux2 gates that only have zeros as
inputs.

<!-- spr-stack:start -->
**Stack**:
-   #1289
-   #1290
-   #1288
- ➡ #1287

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->