### PR TITLE
Add unit test for br_gate modules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -72,6 +72,7 @@ verilog_sim_coverage_aggregate(
         "//enc/sim:br_enc_verilator_coverage",
         "//flow/sim:br_flow_verilator_coverage",
         "//fifo/sim:br_fifo_verilator_coverage",
+        "//gate/sim:br_gate_verilator_coverage",
         "//lfsr/sim:br_lfsr_verilator_coverage",
         "//macros:br_macros_verilator_coverage",
         "//misc/sim:br_misc_verilator_coverage",

--- a/gate/rtl/BUILD.bazel
+++ b/gate/rtl/BUILD.bazel
@@ -124,6 +124,14 @@ br_verilog_elab_and_lint_test_suite(
 )
 
 br_verilog_elab_and_lint_test_suite(
+    name = "br_gate_mux4_test_suite",
+    top = "br_gate_mux4",
+    deps = [
+        ":br_gate_mock",
+    ],
+)
+
+br_verilog_elab_and_lint_test_suite(
     name = "br_gate_clk_mux2_test_suite",
     top = "br_gate_clk_mux2",
     deps = [

--- a/gate/rtl/br_gate_mock.sv
+++ b/gate/rtl/br_gate_mock.sv
@@ -105,6 +105,26 @@ module br_gate_mux2 (
 
 endmodule : br_gate_mux2
 
+// 4-input MUX gate
+module br_gate_mux4 (
+    input logic in0,
+    input logic in1,
+    input logic in2,
+    input logic in3,
+    input logic [1:0] sel,
+    output logic out
+);
+  always_comb begin
+    unique case (sel)
+      2'b00:   out = in0;
+      2'b01:   out = in1;
+      2'b10:   out = in2;
+      2'b11:   out = in3;
+      default: out = 'x;
+    endcase
+  end
+endmodule : br_gate_mux4
+
 // 2-input Clock MUX gate
 // This is *not* meant to be a glitchless clock mux. This is simply a stdcell
 // mux that can be used to select between two clock sources. Some vendors may

--- a/gate/sim/BUILD.bazel
+++ b/gate/sim/BUILD.bazel
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_sim_test_tools_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test", "verilog_sim_coverage_aggregate")
+
+package(default_visibility = ["//visibility:private"])
+
+verilog_library(
+    name = "br_gate_tb",
+    srcs = ["br_gate_tb.sv"],
+    deps = [
+        "//gate/rtl:br_gate_mock",
+        "//misc/sim:br_test_driver",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_gate_tb_elab_test",
+    tool = "slang",
+    deps = [":br_gate_tb"],
+)
+
+br_verilog_sim_test_tools_suite(
+    name = "br_gate_sim_test_tools_suite",
+    tools = [
+        "vcs",
+        "verilator",
+    ],
+    deps = [":br_gate_tb"],
+)
+
+verilog_sim_coverage_aggregate(
+    name = "br_gate_verilator_coverage",
+    coverage_reports = [
+        ":br_gate_sim_test_tools_suite_verilator_coverage",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/gate/sim/br_gate_tb.sv
+++ b/gate/sim/br_gate_tb.sv
@@ -1,0 +1,125 @@
+// Testbench for various br_gate behavioral modules.
+// Modules involving CDC or clock buffer/invert are not included.
+// TODO(zhemao): Determine how to get test coverage for CDC and clock converter.
+
+module br_gate_tb;
+  logic in0;
+  logic in1;
+  logic in2;
+  logic in3;
+  logic [1:0] sel;
+
+  logic out_buf;
+  logic out_inv;
+  logic out_and;
+  logic out_or;
+  logic out_xor;
+  logic out_mux2;
+  logic out_mux4;
+
+  br_gate_buf br_gate_buf_inst (
+      .in (in0),
+      .out(out_buf)
+  );
+
+  br_gate_inv br_gate_inv_inst (
+      .in (in0),
+      .out(out_inv)
+  );
+
+  br_gate_and2 br_gate_and2_inst (
+      .in0(in0),
+      .in1(in1),
+      .out(out_and)
+  );
+
+  br_gate_or2 br_gate_or2_inst (
+      .in0(in0),
+      .in1(in1),
+      .out(out_or)
+  );
+
+  br_gate_xor2 br_gate_xor2_inst (
+      .in0(in0),
+      .in1(in1),
+      .out(out_xor)
+  );
+
+  br_gate_mux2 br_gate_mux2_inst (
+      .in0(in0),
+      .in1(in1),
+      .sel(sel[0]),
+      .out(out_mux2)
+  );
+
+  br_gate_mux4 br_gate_mux4_inst (
+      .in0(in0),
+      .in1(in1),
+      .in2(in2),
+      .in3(in3),
+      .sel(sel),
+      .out(out_mux4)
+  );
+
+  // Every combination of inputs
+  localparam int NumTests = 64;
+
+  logic expected_out_buf;
+  logic expected_out_inv;
+  logic expected_out_and;
+  logic expected_out_or;
+  logic expected_out_xor;
+  logic expected_out_mux2;
+  logic expected_out_mux4;
+
+  logic clk;
+  logic rst;
+
+  br_test_driver td (
+      .clk,
+      .rst
+  );
+
+  initial begin
+    in0 = 1'b0;
+    in1 = 1'b0;
+    in2 = 1'b0;
+    in3 = 1'b0;
+    sel = 2'b00;
+    td.reset_dut();
+    td.wait_cycles();
+
+    for (int i = 0; i < NumTests; i++) begin
+      {in0, in1, in2, in3, sel} = i[5:0];
+      expected_out_buf = in0;
+      expected_out_inv = ~in0;
+      expected_out_and = in0 && in1;
+      expected_out_or = in0 || in1;
+      expected_out_xor = in0 ^ in1;
+      expected_out_mux2 = sel[0] ? in1 : in0;
+      expected_out_mux4 = (sel == 2'b00) ? in0 :
+                          (sel == 2'b01) ? in1 :
+                          (sel == 2'b10) ? in2 :
+                          (sel == 2'b11) ? in3 : 1'b0;
+      @(posedge clk);
+      td.check_integer(out_buf, expected_out_buf, $sformatf(
+                       "Test failed for out_buf at index %0d", i));
+      td.check_integer(out_inv, expected_out_inv, $sformatf(
+                       "Test failed for out_inv at index %0d", i));
+      td.check_integer(out_and, expected_out_and, $sformatf(
+                       "Test failed for out_and at index %0d", i));
+      td.check_integer(out_or, expected_out_or, $sformatf("Test failed for out_or at index %0d", i
+                       ));
+      td.check_integer(out_xor, expected_out_xor, $sformatf(
+                       "Test failed for out_xor at index %0d", i));
+      td.check_integer(out_mux2, expected_out_mux2, $sformatf(
+                       "Test failed for out_mux2 at index %0d", i));
+      td.check_integer(out_mux4, expected_out_mux4, $sformatf(
+                       "Test failed for out_mux4 at index %0d", i));
+      @(negedge clk);
+    end
+
+    td.finish();
+  end
+
+endmodule


### PR DESCRIPTION
These are kind of trivial, but it's best of have some kind of test
coverage. For the br_gate modules not related to clock
crossing/transformation, sweep the whole range of inputs and check that
the output is as expected.

<!-- spr-stack:start -->
**Stack**:
-   #1289
- ➡ #1290
-   #1288

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->