### PR TITLE
br_credit_receiver Assert Fix

### DIFF
--- a/credit/fpv/BUILD.bazel
+++ b/credit/fpv/BUILD.bazel
@@ -229,6 +229,30 @@ br_verilog_fpv_test_tools_suite(
     deps = [":br_credit_receiver_fpv_monitor"],
 )
 
+br_verilog_fpv_test_tools_suite(
+    name = "br_credit_receiver_gated_assert_test_suite",
+    params = {
+        "EnableAssertPushValidInReset": ["0"],
+        "MaxCredit": ["5"],
+        "NumFlows": [
+            "1",
+            "3",
+        ],
+        "PopCreditMaxChange": ["3"],
+        "PushCreditMaxChange": ["3"],
+        "RegisterPushOutputs": [
+            "0",
+            "1",
+        ],
+        "Width": ["8"],
+    },
+    tools = {
+        "jg": "br_credit_receiver_fpv.jg.tcl",
+    },
+    top = "br_credit_receiver",
+    deps = [":br_credit_receiver_fpv_monitor"],
+)
+
 ##################################################################
 # Bedrock-RTL Credit Sender
 verilog_library(

--- a/credit/fpv/br_credit_receiver_fpv.jg.tcl
+++ b/credit/fpv/br_credit_receiver_fpv.jg.tcl
@@ -11,17 +11,19 @@ assume -bound 1 -name delay_rst {rst}
 assume -name deassert_rst {##1 !rst}
 
 get_design_info
+array set param_list [get_design_info -list parameter]
+# Jasper reports bit parameters as sized SystemVerilog literals.
 
 # primary input control signal should be legal during reset
 assume -name initial_value_during_reset {rst | push_sender_in_reset |-> \
 (credit_initial <= MaxCredit) && $stable(credit_initial)}
-# Do not constrain push_valid/data during either reset: the receiver drops these
-# transfers. The monitor uses independently qualified valids for credit accounting
-# and data checks. Four-state simulation additionally checks unknown inputs.
+# Strict checking requires idle raw valids during reset. In gated mode, leave
+# them unconstrained; the monitor qualifies valids for credit accounting and data checks.
+if {$param_list(EnableAssertPushValidInReset) eq "1'b1"} {
+  assume -name no_push_during_reset {rst | push_sender_in_reset |-> push_valid == 'd0}
+}
 
 # primary output control signal should be legal during reset
-array set param_list [get_design_info -list parameter]
-# Jasper reports bit parameters as sized SystemVerilog literals.
 if {$param_list(RegisterPushOutputs) eq "1'b1"} {
   assert -name fv_rst_check_push_credit {rst | push_sender_in_reset |=> push_credit == 'd0}
 } else {

--- a/credit/fpv/br_credit_receiver_fpv.jg.tcl
+++ b/credit/fpv/br_credit_receiver_fpv.jg.tcl
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+# Model startup with arbitrary sender reset release skew. Coordinated resets
+# after traffic are outside the scope of this startup proof.
 # clock/reset set up
 clock clk
 reset -none
@@ -13,10 +15,18 @@ get_design_info
 # primary input control signal should be legal during reset
 assume -name initial_value_during_reset {rst | push_sender_in_reset |-> \
 (credit_initial <= MaxCredit) && $stable(credit_initial)}
-assume -name no_push_during_reset {rst | push_sender_in_reset |-> push_valid == 'd0}
+# Do not constrain push_valid/data during either reset: the receiver drops these
+# transfers. The monitor uses independently qualified valids for credit accounting
+# and data checks. Four-state simulation additionally checks unknown inputs.
 
 # primary output control signal should be legal during reset
-assert -name fv_rst_check_push_credit {rst | push_sender_in_reset |-> push_credit == 'd0}
+array set param_list [get_design_info -list parameter]
+# Jasper reports bit parameters as sized SystemVerilog literals.
+if {$param_list(RegisterPushOutputs) eq "1'b1"} {
+  assert -name fv_rst_check_push_credit {rst | push_sender_in_reset |=> push_credit == 'd0}
+} else {
+  assert -name fv_rst_check_push_credit {rst | push_sender_in_reset |-> push_credit == 'd0}
+}
 assert -name fv_rst_check_pop_valid {rst | push_sender_in_reset |-> pop_valid == 'd0}
 
 # prove command

--- a/credit/fpv/br_credit_receiver_fpv_monitor.sv
+++ b/credit/fpv/br_credit_receiver_fpv_monitor.sv
@@ -98,7 +98,7 @@ module br_credit_receiver_fpv_monitor #(
       .MAX_PENDING(MaxCredit)
   ) scoreboard (
       .clk(clk),
-      .rstN(!fv_rst),
+      .rstN(!rst),
       .incoming_vld(fv_push_valid[fv_flow]),
       .incoming_data(push_data[fv_flow]),
       .outgoing_vld(pop_valid[fv_flow]),

--- a/credit/fpv/br_credit_receiver_fpv_monitor.sv
+++ b/credit/fpv/br_credit_receiver_fpv_monitor.sv
@@ -15,6 +15,7 @@ module br_credit_receiver_fpv_monitor #(
     parameter int PushCreditMaxChange = 1,
     parameter int PopCreditMaxChange = 1,
     parameter bit EnableAssertFinalNotValid = 1,
+    parameter bit EnableAssertPushValidInReset = 1,
     localparam int CounterWidth = $clog2(MaxCredit + 1),
     localparam int PushCreditWidth = $clog2(PushCreditMaxChange + 1),
     localparam int PopCreditChangeWidth = $clog2(PopCreditMaxChange + 1)
@@ -57,7 +58,7 @@ module br_credit_receiver_fpv_monitor #(
   logic [CounterWidth-1:0] fv_max_credit;
 
   assign fv_rst = rst | push_sender_in_reset;
-  // Reset-held raw valids are unconstrained and are not accepted transfers.
+  // Only reset-gated valids represent accepted transfers in either checking mode.
   assign fv_push_valid = push_valid & {NumFlows{!fv_rst}};
   `BR_REGX(fv_push_credit_cnt, fv_push_credit_cnt + push_credit - $countones(fv_push_valid), clk,
            fv_rst)
@@ -86,9 +87,11 @@ module br_credit_receiver_fpv_monitor #(
              |fv_push_valid && (push_credit == 'd0) |-> s_eventually (fv_push_credit_cnt != 'd0))
   `BR_ASSERT(pop_valid_passthru_a, pop_valid == fv_push_valid)
   `BR_ASSERT(no_spurious_pop_valid_a, (fv_pop_credit_cnt + pop_credit) == 'd0 |-> pop_valid == 'd0)
-  `BR_COVER(sender_reset_with_push_c, push_sender_in_reset && |push_valid)
-  `BR_COVER(sender_reset_release_traffic_c,
-            push_sender_in_reset && |push_valid ##1 !push_sender_in_reset ##[1:3] |fv_push_valid)
+  if (!EnableAssertPushValidInReset) begin : gen_gated_push_valid_covers
+    `BR_COVER(sender_reset_with_push_c, push_sender_in_reset && |push_valid)
+    `BR_COVER(sender_reset_release_traffic_c,
+              push_sender_in_reset && |push_valid ##1 !push_sender_in_reset ##[1:3] |fv_push_valid)
+  end
   // ----------Data integrity Check----------
   jasper_scoreboard_3 #(
       .CHUNK_WIDTH(Width),
@@ -114,5 +117,6 @@ bind br_credit_receiver br_credit_receiver_fpv_monitor #(
     .RegisterPushOutputs(RegisterPushOutputs),
     .PushCreditMaxChange(PushCreditMaxChange),
     .PopCreditMaxChange(PopCreditMaxChange),
-    .EnableAssertFinalNotValid(EnableAssertFinalNotValid)
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+    .EnableAssertPushValidInReset(EnableAssertPushValidInReset)
 ) monitor (.*);

--- a/credit/fpv/br_credit_receiver_fpv_monitor.sv
+++ b/credit/fpv/br_credit_receiver_fpv_monitor.sv
@@ -51,21 +51,30 @@ module br_credit_receiver_fpv_monitor #(
   `BR_ASSUME(fv_flow_legal_a, $stable(fv_flow) && fv_flow < NumFlows)
 
   logic fv_rst;
+  logic [NumFlows-1:0] fv_push_valid;
   logic [CounterWidth-1:0] fv_push_credit_cnt;
   logic [CounterWidth-1:0] fv_pop_credit_cnt;
   logic [CounterWidth-1:0] fv_max_credit;
 
   assign fv_rst = rst | push_sender_in_reset;
-  `BR_REG(fv_push_credit_cnt, fv_push_credit_cnt + push_credit - $countones(push_valid))
-  `BR_REGIX(fv_pop_credit_cnt, fv_pop_credit_cnt + pop_credit - $countones(pop_valid),
-            credit_initial, clk, fv_rst)
-  `BR_REGIX(fv_max_credit, fv_max_credit, credit_initial, clk, fv_rst)
+  // Reset-held raw valids are unconstrained and are not accepted transfers.
+  assign fv_push_valid = push_valid & {NumFlows{!fv_rst}};
+  `BR_REGX(fv_push_credit_cnt, fv_push_credit_cnt + push_credit - $countones(fv_push_valid), clk,
+           fv_rst)
+  // The attached buffer shares only local rst. Its credits can still return
+  // while the sender is in reset, until the buffer itself is reset.
+  `BR_REGI(fv_pop_credit_cnt, fv_pop_credit_cnt + pop_credit - $countones(pop_valid),
+           credit_initial)
+  `BR_REGI(fv_max_credit, fv_max_credit, credit_initial)
 
   // ----------FV assumptions----------
+  // This monitor proves startup release skew. Coordinated resets after traffic
+  // are outside the scope of this startup proof.
   `BR_ASSUME(push_sender_in_reset_a, !push_sender_in_reset |=> !push_sender_in_reset)
   `BR_ASSUME(credit_withhold_a, credit_withhold <= MaxCredit)
   `BR_ASSUME(credit_withhold_liveness_a, s_eventually (credit_withhold < fv_max_credit))
-  `BR_ASSUME(no_spurious_push_valid_a, fv_push_credit_cnt + push_credit >= $countones(push_valid))
+  `BR_ASSUME(no_spurious_push_valid_a, fv_push_credit_cnt + push_credit >= $countones(fv_push_valid
+                                                                                         ))
   `BR_ASSUME(no_spurious_pop_credit_a, (fv_max_credit - fv_pop_credit_cnt + $countones(pop_valid)
              ) >= pop_credit)
   `BR_ASSUME(legal_pop_credit_a, pop_credit <= PopCreditMaxChange)
@@ -74,8 +83,12 @@ module br_credit_receiver_fpv_monitor #(
   `BR_ASSERT(legal_push_credit_a, push_credit <= PushCreditMaxChange)
   `BR_ASSERT(fv_credit_sanity_a, fv_push_credit_cnt <= fv_max_credit)
   `BR_ASSERT(push_credit_deadlock_a,
-             |push_valid && (push_credit == 'd0) |-> s_eventually (fv_push_credit_cnt != 'd0))
+             |fv_push_valid && (push_credit == 'd0) |-> s_eventually (fv_push_credit_cnt != 'd0))
+  `BR_ASSERT(pop_valid_passthru_a, pop_valid == fv_push_valid)
   `BR_ASSERT(no_spurious_pop_valid_a, (fv_pop_credit_cnt + pop_credit) == 'd0 |-> pop_valid == 'd0)
+  `BR_COVER(sender_reset_with_push_c, push_sender_in_reset && |push_valid)
+  `BR_COVER(sender_reset_release_traffic_c,
+            push_sender_in_reset && |push_valid ##1 !push_sender_in_reset ##[1:3] |fv_push_valid)
   // ----------Data integrity Check----------
   jasper_scoreboard_3 #(
       .CHUNK_WIDTH(Width),
@@ -85,8 +98,8 @@ module br_credit_receiver_fpv_monitor #(
       .MAX_PENDING(MaxCredit)
   ) scoreboard (
       .clk(clk),
-      .rstN(!rst),
-      .incoming_vld(push_valid[fv_flow]),
+      .rstN(!fv_rst),
+      .incoming_vld(fv_push_valid[fv_flow]),
       .incoming_data(push_data[fv_flow]),
       .outgoing_vld(pop_valid[fv_flow]),
       .outgoing_data(pop_data[fv_flow])

--- a/credit/rtl/BUILD.bazel
+++ b/credit/rtl/BUILD.bazel
@@ -236,6 +236,10 @@ br_verilog_synth_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_credit_receiver_test_suite_basic",
     params = {
+        "EnableAssertPushValidInReset": [
+            "0",
+            "1",
+        ],
         "MaxCredit": [
             "3",
             "8",
@@ -259,6 +263,10 @@ br_verilog_elab_and_lint_test_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_credit_receiver_test_suite_multi_push",
     params = {
+        "EnableAssertPushValidInReset": [
+            "0",
+            "1",
+        ],
         "NumFlows": [
             "2",
             "3",

--- a/credit/rtl/br_credit_receiver.sv
+++ b/credit/rtl/br_credit_receiver.sv
@@ -27,7 +27,7 @@
 //   - Users will likely want to register the push-side interface (e.g., with br_delay_valid).
 //
 // Reset:
-//   - If either this sender or the receiver resets, then the other side must also reset
+//   - If either the sender or this receiver resets, then the other side must also reset
 //     to ensure they collectively have a coherent view of the total credits and an empty receiver
 //     buffer.
 //     - If there is no reset skew between sender and receiver, the push_sender_in_reset and
@@ -36,15 +36,21 @@
 //       then the push_sender_in_reset and push_receiver_in_reset signals should be connected accordingly
 //       between sender and receiver.
 //     - Note that this is *NOT* a general-purpose substitute for a higher-level reset protocol and
-//       architectural reset domain crossing (RDC). All it does is make sure the sender and receiver
-//       can be reset with skew or completely independently without causing a permanent loss of credits and
-//       broken flow control.
-//   - When in reset (the rst port and/or the push_receiver_in_reset port is high), this module:
-//     - Ignores (drops) any incoming push valids.
-//     - Does not send output credits on the push interface.
-//     - Ignores (drops) any incoming pop credits.
-//     - Does not send output valids on the pop interface.
-//     - Loads the initial value for the credit counter from the credit_initial port.
+//       architectural reset domain crossing (RDC). Both endpoints and the receiver buffer must
+//       complete the coordinated reset, with stale in-flight traffic discarded, before traffic resumes.
+//   - When rst or push_sender_in_reset is high, this module:
+//     - Ignores (drops) incoming push valids, which may be unknown during this reset hold.
+//     - Deasserts pop_valid. The unqualified push_data-to-pop_data wire may still carry unknown data.
+//     - Stops issuing push credits. RegisterPushOutputs delays this by one cycle, so a previously
+//       registered credit may remain visible during the first reset cycle.
+//     - Loads credit_initial into the functional credit counter on each clock edge, discarding
+//       incoming pop credits from that pool.
+//   - The attached receiver buffer resets only with rst, not push_sender_in_reset. While rst is low,
+//     pop_credit must remain known and report actual buffer releases, including during sender reset
+//     skew. The occupancy checker retains buffered entries and subtracts those releases until rst.
+//     When rst is high, pop_credit is ignored by both the credit pool and occupancy checker.
+//   - Outside a known reset hold, push_valid must be known and obey the credit protocol; data must
+//     be valid for each accepted flow. Unknown valids are not treated as zero by the checker.
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
@@ -75,7 +81,8 @@ module br_credit_receiver #(
     parameter bit EnableCoverPushCreditStall = 1,
     // The maximum credit count value that will be checked by covers.
     parameter int CoverMaxCredit = MaxCredit,
-    // If 1, then assert there are no valid bits asserted at the end of the test.
+    // If 1, assert there are no valid transfers at the end of the test.
+    // Raw push valids are ignored while either reset is asserted.
     parameter bit EnableAssertFinalNotValid = 1,
     // If 1, then at the end of simulation, assert that the credit counter value equals
     // the minimum number of credits that it stored at any point during the test.
@@ -136,13 +143,18 @@ module br_credit_receiver #(
   logic [  CounterWidth:0] occupancy_next;
   logic [CounterWidth-1:0] occupancy_incr;
 
+  // pop_valid already gates push_valid with !(rst || push_sender_in_reset).
+  // Count it so reset-held X valids cannot poison occupancy, while unknown
+  // valids outside reset still propagate into the checker.
   always_comb begin
     occupancy_incr = '0;
     for (int i = 0; i < NumFlows; i++) begin
-      occupancy_incr += push_valid[i];
+      occupancy_incr += pop_valid[i];
     end
   end
 
+  // The buffer shares rst only: do not clear occupancy or mask its returned
+  // credits merely because the sender has entered reset first.
   // ri lint_check_off ARITH_ARGS
   assign occupancy_next = occupancy + occupancy_incr - CounterWidth'(pop_credit);
   // ri lint_check_on ARITH_ARGS
@@ -150,7 +162,7 @@ module br_credit_receiver #(
   `BR_REG(occupancy, occupancy_next[CounterWidth-1:0])
 `endif  // BR_DISABLE_INTG_CHECKS
 `endif  // BR_ASSERT_ON
-  `BR_ASSERT_INTG(no_push_overflow_a, (|push_valid) |-> (occupancy_next <= MaxCredit))
+  `BR_ASSERT_INTG(no_push_overflow_a, (|pop_valid) |-> (occupancy_next <= MaxCredit))
   `BR_ASSERT_INTG(pop_credit_in_range_a, pop_credit <= PopCreditMaxChange)
 
   if (EnableCoverPushSenderInReset) begin : gen_cover_push_sender_in_reset
@@ -166,7 +178,7 @@ module br_credit_receiver #(
   end
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
-    `BR_ASSERT_FINAL(final_not_push_valid_a, push_valid == '0)
+    `BR_ASSERT_FINAL(final_not_push_valid_a, rst || push_sender_in_reset || push_valid == '0)
     `BR_ASSERT_FINAL(final_not_pop_valid_a, pop_valid == '0)
   end
 

--- a/credit/rtl/br_credit_receiver.sv
+++ b/credit/rtl/br_credit_receiver.sv
@@ -27,7 +27,7 @@
 //   - Users will likely want to register the push-side interface (e.g., with br_delay_valid).
 //
 // Reset:
-//   - If either the sender or this receiver resets, then the other side must also reset
+//   - If either this sender or the receiver resets, then the other side must also reset
 //     to ensure they collectively have a coherent view of the total credits and an empty receiver
 //     buffer.
 //     - If there is no reset skew between sender and receiver, the push_sender_in_reset and
@@ -36,21 +36,16 @@
 //       then the push_sender_in_reset and push_receiver_in_reset signals should be connected accordingly
 //       between sender and receiver.
 //     - Note that this is *NOT* a general-purpose substitute for a higher-level reset protocol and
-//       architectural reset domain crossing (RDC). Both endpoints and the receiver buffer must
-//       complete the coordinated reset, with stale in-flight traffic discarded, before traffic resumes.
-//   - When rst or push_sender_in_reset is high, this module:
-//     - Ignores (drops) incoming push valids, which may be unknown during this reset hold.
-//     - Deasserts pop_valid. The unqualified push_data-to-pop_data wire may still carry unknown data.
-//     - Stops issuing push credits. RegisterPushOutputs delays this by one cycle, so a previously
-//       registered credit may remain visible during the first reset cycle.
-//     - Loads credit_initial into the functional credit counter on each clock edge, discarding
-//       incoming pop credits from that pool.
-//   - The attached receiver buffer resets only with rst, not push_sender_in_reset. While rst is low,
-//     pop_credit must remain known and report actual buffer releases, including during sender reset
-//     skew. The occupancy checker retains buffered entries and subtracts those releases until rst.
-//     When rst is high, pop_credit is ignored by both the credit pool and occupancy checker.
-//   - Outside a known reset hold, push_valid must be known and obey the credit protocol; data must
-//     be valid for each accepted flow. Unknown valids are not treated as zero by the checker.
+//       architectural reset domain crossing (RDC). All it does is make sure the sender and receiver
+//       can be reset with skew or completely independently without causing a permanent loss of credits and
+//       broken flow control.
+//   - When in reset (the rst port and/or the push_sender_in_reset port is high), this module:
+//     - Ignores (drops) any incoming push valids.
+//       Incoming push valid/data may be unknown during reset.
+//     - Does not send output credits on the push interface.
+//     - Ignores (drops) any incoming pop credits.
+//     - Does not send output valids on the pop interface.
+//     - Loads the initial value for the credit counter from the credit_initial port.
 
 `include "br_asserts_internal.svh"
 `include "br_registers.svh"
@@ -126,6 +121,12 @@ module br_credit_receiver #(
     output logic [CounterWidth-1:0] credit_available
 );
 
+  logic either_rst;
+  assign either_rst = rst || push_sender_in_reset;
+
+  logic [NumFlows-1:0] push_valid_gated;
+  assign push_valid_gated = push_valid & {NumFlows{!either_rst}};
+
   //------------------------------------------
   // Integration checks
   //------------------------------------------
@@ -143,13 +144,12 @@ module br_credit_receiver #(
   logic [  CounterWidth:0] occupancy_next;
   logic [CounterWidth-1:0] occupancy_incr;
 
-  // pop_valid already gates push_valid with !(rst || push_sender_in_reset).
-  // Count it so reset-held X valids cannot poison occupancy, while unknown
+  // Count push_valid_gated so reset-held X valids cannot poison occupancy, while unknown
   // valids outside reset still propagate into the checker.
   always_comb begin
     occupancy_incr = '0;
     for (int i = 0; i < NumFlows; i++) begin
-      occupancy_incr += pop_valid[i];
+      occupancy_incr += push_valid_gated[i];
     end
   end
 
@@ -162,7 +162,7 @@ module br_credit_receiver #(
   `BR_REG(occupancy, occupancy_next[CounterWidth-1:0])
 `endif  // BR_DISABLE_INTG_CHECKS
 `endif  // BR_ASSERT_ON
-  `BR_ASSERT_INTG(no_push_overflow_a, (|pop_valid) |-> (occupancy_next <= MaxCredit))
+  `BR_ASSERT_INTG(no_push_overflow_a, (|push_valid_gated) |-> (occupancy_next <= MaxCredit))
   `BR_ASSERT_INTG(pop_credit_in_range_a, pop_credit <= PopCreditMaxChange)
 
   if (EnableCoverPushSenderInReset) begin : gen_cover_push_sender_in_reset
@@ -189,9 +189,6 @@ module br_credit_receiver #(
   //------------------------------------------
   localparam int CreditCounterMaxChange = br_math::max2(PushCreditMaxChange, PopCreditMaxChange);
   localparam int CreditCounterChangeWidth = $clog2(CreditCounterMaxChange + 1);
-
-  logic either_rst;
-  assign either_rst = rst || push_sender_in_reset;
 
   logic credit_decr_valid;
   logic credit_decr_ready;
@@ -250,7 +247,7 @@ module br_credit_receiver #(
         PushCreditWidth'(credit_decr) : '0;
   end
 
-  assign pop_valid = push_valid & {NumFlows{!either_rst}};
+  assign pop_valid = push_valid_gated;
   assign pop_data  = push_data;
 
   if (RegisterPushOutputs) begin : gen_reg_push

--- a/credit/rtl/br_credit_receiver.sv
+++ b/credit/rtl/br_credit_receiver.sv
@@ -41,7 +41,7 @@
 //       broken flow control.
 //   - When in reset (the rst port and/or the push_sender_in_reset port is high), this module:
 //     - Ignores (drops) any incoming push valids.
-//       Incoming push valid/data may be unknown during reset.
+//       Set EnableAssertPushValidInReset=0 to tolerate unknown push valids during reset.
 //     - Does not send output credits on the push interface.
 //     - Ignores (drops) any incoming pop credits.
 //     - Does not send output valids on the pop interface.
@@ -76,12 +76,17 @@ module br_credit_receiver #(
     parameter bit EnableCoverPushCreditStall = 1,
     // The maximum credit count value that will be checked by covers.
     parameter int CoverMaxCredit = MaxCredit,
-    // If 1, assert there are no valid transfers at the end of the test.
-    // Raw push valids are ignored while either reset is asserted.
+    // If 1, then assert there are no valid bits asserted at the end of the test.
+    // Raw push valids during reset are ignored only if EnableAssertPushValidInReset is 0.
     parameter bit EnableAssertFinalNotValid = 1,
     // If 1, then at the end of simulation, assert that the credit counter value equals
     // the minimum number of credits that it stored at any point during the test.
     parameter bit EnableAssertFinalMinValue = 1,
+    // If 1, use raw push_valid for occupancy/overflow checks, including during sender reset.
+    // If 0, use reset-gated push_valid for those checks and the final push-valid check.
+    // This only changes assertions; functional reset gating is unchanged.
+    // ri lint_check_waive PARAM_NOT_USED
+    parameter bit EnableAssertPushValidInReset = 1,
     localparam int CounterWidth = $clog2(MaxCredit + 1),
     localparam int PushCreditWidth = $clog2(PushCreditMaxChange + 1),
     localparam int PopCreditChangeWidth = $clog2(PopCreditMaxChange + 1)
@@ -143,13 +148,20 @@ module br_credit_receiver #(
   logic [CounterWidth-1:0] occupancy;
   logic [  CounterWidth:0] occupancy_next;
   logic [CounterWidth-1:0] occupancy_incr;
+  logic [    NumFlows-1:0] push_valid_checked;
 
-  // Count push_valid_gated so reset-held X valids cannot poison occupancy, while unknown
-  // valids outside reset still propagate into the checker.
+  // Preserve raw-valid checking by default. The gated mode ignores reset-held
+  // valids, while unknown valids outside reset still propagate into the checker.
+  if (EnableAssertPushValidInReset) begin : gen_check_raw_push_valid
+    assign push_valid_checked = push_valid;
+  end else begin : gen_check_gated_push_valid
+    assign push_valid_checked = push_valid_gated;
+  end
+
   always_comb begin
     occupancy_incr = '0;
     for (int i = 0; i < NumFlows; i++) begin
-      occupancy_incr += push_valid_gated[i];
+      occupancy_incr += push_valid_checked[i];
     end
   end
 
@@ -162,7 +174,7 @@ module br_credit_receiver #(
   `BR_REG(occupancy, occupancy_next[CounterWidth-1:0])
 `endif  // BR_DISABLE_INTG_CHECKS
 `endif  // BR_ASSERT_ON
-  `BR_ASSERT_INTG(no_push_overflow_a, (|push_valid_gated) |-> (occupancy_next <= MaxCredit))
+  `BR_ASSERT_INTG(no_push_overflow_a, (|push_valid_checked) |-> (occupancy_next <= MaxCredit))
   `BR_ASSERT_INTG(pop_credit_in_range_a, pop_credit <= PopCreditMaxChange)
 
   if (EnableCoverPushSenderInReset) begin : gen_cover_push_sender_in_reset
@@ -178,7 +190,8 @@ module br_credit_receiver #(
   end
 
   if (EnableAssertFinalNotValid) begin : gen_assert_final
-    `BR_ASSERT_FINAL(final_not_push_valid_a, rst || push_sender_in_reset || push_valid == '0)
+    `BR_ASSERT_FINAL(final_not_push_valid_a,
+                     (!EnableAssertPushValidInReset && either_rst) || push_valid == '0)
     `BR_ASSERT_FINAL(final_not_pop_valid_a, pop_valid == '0)
   end
 


### PR DESCRIPTION
# Summary
gate assert with push_valid gated by the reset signals, to effectively ignore push valid when either reset signals are high 