### PR TITLE
Cancel superseded pull request CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   # Allow manual triggers
   workflow_dispatch: {}
 
+# Supersede CI for the same PR without cancelling other PRs, main pushes, or
+# manual runs. Non-PR events get a unique group for each workflow run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04
@@ -297,7 +303,7 @@ jobs:
           python3.12 "$HELPER" check "${check_args[@]}"
           EOF
       - name: Upload public shard result
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         # actions/upload-artifact v7.0.1
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -310,7 +316,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       - name: Check public shard result
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: |
           check_args=(
             --results-dir "bazel-oss-results/${{ matrix.suite }}-${{ matrix.shard_index }}-of-${{ matrix.shard_count }}"
@@ -523,7 +529,7 @@ jobs:
   bazel-oss-tool-test:
     runs-on: ubuntu-24.04
     needs: bazel-oss-tool-test-shard
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     permissions:
       contents: read
     outputs:


### PR DESCRIPTION
# Problem

CI runs for successive commits to the same PR currently overlap, consuming runner capacity after their results are stale. Public result collection also uses `always()`, which can keep work running after cancellation.

# Solution

- Add workflow-level concurrency keyed by workflow, event, and PR number, with cancellation enabled only for PR runs. Main pushes and manual runs use unique run-ID groups; different PRs remain independent.
- Use `!cancelled()` for public shard uploads/checks and the aggregate check, preserving result collection after test failures while allowing cancelled runs to stop.
- Leave nightly CI, Pages concurrency, and main-only badge publishing unchanged.

Validation: `pre-commit run --all-files`, actionlint v1.7.12 (`-shellcheck= -pyflakes=`), `git diff --check`, and a parsed-YAML comparison confirming that only the concurrency block and three collector conditions changed all passed. Live supersession behavior has not yet been exercised.

Rollout: existing runs without this concurrency group are not retroactively cancelled. Stacked PRs need the updated workflow propagated to their branches. Native concurrency is run-arrival based, not a current-head check; manually rerunning an older PR commit can supersede a newer run.
