### PR TITLE
[DO NOT MERGE] Measure warm-cache CI with foo.txt

### DIFF
--- a/foo.txt
+++ b/foo.txt
@@ -1,0 +1,1 @@
+Temporary CI cache-warmth probe. Do not merge.


### PR DESCRIPTION
# Problem

We want to measure CI latency after the Bazel disk-cache refresh fix in #1293, using a change that does not alter RTL or Bazel test inputs. Warm caches should make test execution fast, but queueing and setup still contribute to total runtime; a 100% cache-hit rate is a hypothesis to verify, not an assumption.

# Solution

Add only an unreferenced root-level `foo.txt`, based on latest `main` at `3a2579816e39e6befcdba28efe86d7d86e2e55e4`. Leave workflows, Docker configuration, RTL, and Bazel configuration unchanged.

Keep this PR in draft as a temporary measurement probe; do not merge. Compare queue, setup, and public Bazel test-step durations with the cache-warming main run [33200088839](https://github.com/xlsynth/bedrock-rtl/actions/runs/33200088839). Report cache-hit evidence separately from timing.

Validation: repository-wide `pre-commit run --all-files` and `git diff --check`.
