### PR TITLE
[fv] Add formal verification for lockstep flow fork and join

### DIFF
--- a/flow/fpv/fork/BUILD.bazel
+++ b/flow/fpv/fork/BUILD.bazel
@@ -118,13 +118,6 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_fork_lockstep_fpv_monitor_elab_test",
-    defines = [
-        "BR_ASSERT_ON",
-        "BR_ENABLE_IMPL_CHECKS",
-        "BR_DISABLE_FINAL_CHECKS",
-        "BR_ENABLE_FPV",
-        "BR_DISABLE_ASSERT_IMM",
-    ],
     tool = "slang",
     top = "br_flow_fork_lockstep",
     deps = [":br_flow_fork_lockstep_fpv_monitor"],
@@ -132,13 +125,6 @@ verilog_elab_test(
 
 verilog_elab_test(
     name = "br_flow_fork_lockstep_fpv_monitor_multiflow_elab_test",
-    defines = [
-        "BR_ASSERT_ON",
-        "BR_ENABLE_IMPL_CHECKS",
-        "BR_DISABLE_FINAL_CHECKS",
-        "BR_ENABLE_FPV",
-        "BR_DISABLE_ASSERT_IMM",
-    ],
     params = {"NumFlows": "5"},
     tool = "slang",
     top = "br_flow_fork_lockstep",

--- a/flow/fpv/fork/BUILD.bazel
+++ b/flow/fpv/fork/BUILD.bazel
@@ -103,3 +103,87 @@ br_verilog_fpv_test_tools_suite(
     top = "br_flow_fork_select_multihot",
     deps = [":br_flow_fork_select_multihot_fpv_monitor"],
 )
+
+# Bedrock-RTL Lockstep Flow Fork
+
+verilog_library(
+    name = "br_flow_fork_lockstep_fpv_monitor",
+    srcs = ["br_flow_fork_lockstep_fpv_monitor.sv"],
+    deps = [
+        "//flow/rtl:br_flow_fork_lockstep",
+        "//macros:br_asserts",
+        "//macros:br_registers",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_fork_lockstep_fpv_monitor_elab_test",
+    defines = [
+        "BR_ASSERT_ON",
+        "BR_ENABLE_IMPL_CHECKS",
+        "BR_DISABLE_FINAL_CHECKS",
+        "BR_ENABLE_FPV",
+        "BR_DISABLE_ASSERT_IMM",
+    ],
+    tool = "slang",
+    top = "br_flow_fork_lockstep",
+    deps = [":br_flow_fork_lockstep_fpv_monitor"],
+)
+
+verilog_elab_test(
+    name = "br_flow_fork_lockstep_fpv_monitor_multiflow_elab_test",
+    defines = [
+        "BR_ASSERT_ON",
+        "BR_ENABLE_IMPL_CHECKS",
+        "BR_DISABLE_FINAL_CHECKS",
+        "BR_ENABLE_FPV",
+        "BR_DISABLE_ASSERT_IMM",
+    ],
+    params = {"NumFlows": "5"},
+    tool = "slang",
+    top = "br_flow_fork_lockstep",
+    deps = [":br_flow_fork_lockstep_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_flow_fork_lockstep_test_suite",
+    illegal_param_combinations = {
+        (
+            "EnableAssertPushValidStability",
+            "EnableCoverPushBackpressure",
+        ): [
+            ("1", "0"),
+        ],
+        (
+            "EnableAssertNoPushBackpressure",
+            "EnableCoverPushBackpressure",
+        ): [
+            ("1", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertNoPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "1",
+            "2",
+            "4",
+            "5",
+        ],
+    },
+    tools = {
+        "jg": "",
+    },
+    top = "br_flow_fork_lockstep",
+    deps = [":br_flow_fork_lockstep_fpv_monitor"],
+)

--- a/flow/fpv/fork/br_flow_fork_lockstep_fpv_monitor.sv
+++ b/flow/fpv/fork/br_flow_fork_lockstep_fpv_monitor.sv
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// FPV testplan: br_flow_fork_lockstep
+//
+// Design specification:
+// - Control-only, combinational 1-to-NumFlows fork with no storage or datapath.
+// - All downstream pop_ready bits must be equal.
+// - Replicate push_valid to every pop_valid bit and return pop_ready[0] on
+//   push_ready. Every downstream transfer coincides with the upstream transfer.
+// - clk and synchronous active-high rst serve assertions only; reset does not
+//   clear, gate, or register the flow-control outputs.
+//
+// Input assumptions (all expressed using primary inputs):
+// - pop_ready_lockstep_a: pop_ready == {NumFlows{pop_ready[0]}}.
+// - push_valid_stable_a: when EnableAssertPushValidStability is enabled,
+//   push_valid && !pop_ready[0] requires push_valid on the following cycle.
+// - no_push_backpressure_a: when EnableAssertNoPushBackpressure is enabled,
+//   push_valid implies pop_ready[0]. Do not constrain readiness while idle.
+// - No readiness fairness is needed: progress is checked in the same cycle that
+//   the source is valid and the sinks are ready. Permanent stalls remain legal
+//   when backpressure is allowed.
+//
+// Output assertions:
+// - pop_valid_a: every pop_valid bit equals push_valid, including idle cycles.
+// - push_ready_a: push_ready equals pop_ready[0], independent of push_valid.
+// - transfer_lockstep_a: for each flow, pop_valid[i] && pop_ready[i] equals
+//   push_valid && push_ready (no partial, lost, duplicated, or spurious transfer).
+// - pop_valid_stable_a: valid persists under backpressure when source-valid
+//   stability is enabled.
+// - no_pop_backpressure_a: no valid output is stalled in no-backpressure mode.
+// - forward_progress_a: valid input with ready sinks transfers on every output
+//   immediately; no eventual-ready assumption or liveness bound is required.
+//
+// Covers:
+// - Idle with all sinks ready and idle with all sinks not ready.
+// - All flows transfer together, then transfer again on the next cycle.
+// - When EnableCoverPushBackpressure is enabled, sustained all-flow stall and
+//   release of a stall into a simultaneous transfer.
+// - When source stability is disabled and backpressure coverage is enabled,
+//   withdraw push_valid while all sinks remain stalled.
+//
+// Parameter and proof boundaries:
+// - Sweep NumFlows = 1, 2, 4, 5 and all four legal combinations of the three
+//   backpressure/stability flags (16 configurations).
+// - Exclude NumFlows < 1, stability enabled with backpressure coverage disabled,
+//   and no-backpressure assertion enabled with backpressure coverage enabled.
+// - EnableAssertFinalNotValid is forwarded; the standard FPV wrapper disables
+//   simulation-only final checks. No payload ordering scoreboard is applicable.
+// - Normal startup reset only; properties are disabled during reset.
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_flow_fork_lockstep_fpv_monitor #(
+    parameter int NumFlows = 1,
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertFinalNotValid = 1,
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push-side interface
+    input logic push_ready,
+    input logic push_valid,
+
+    // Pop-side interfaces
+    input logic [NumFlows-1:0] pop_ready,
+    input logic [NumFlows-1:0] pop_valid
+);
+
+  // ----------Input assumptions----------
+  // The fork forwards one ready bit, so every sink must agree with that bit.
+  `BR_ASSUME(pop_ready_lockstep_a, pop_ready == {NumFlows{pop_ready[0]}})
+
+  if (EnableAssertPushValidStability) begin : gen_push_valid_stability
+    // A stalled source retains valid when this interface contract is enabled.
+    `BR_ASSUME(push_valid_stable_a, push_valid && !pop_ready[0] |=> push_valid)
+  end
+
+  if (EnableAssertNoPushBackpressure) begin : gen_no_push_backpressure
+    // No-backpressure mode permits a valid source only when all sinks are ready.
+    `BR_ASSUME(no_push_backpressure_a, push_valid |-> pop_ready[0])
+  end
+
+  // ----------Transfer observations----------
+  logic fv_push_transfer;
+  logic [NumFlows-1:0] fv_pop_transfer;
+  logic fv_stall;
+
+  assign fv_push_transfer = push_valid && push_ready;
+  assign fv_pop_transfer = pop_valid & pop_ready;
+  assign fv_stall = push_valid && !push_ready && (&pop_valid) && (pop_ready == '0);
+
+  // ----------Output assertions----------
+  // Readiness propagates even during idle cycles; valid cannot gate it.
+  `BR_ASSERT(push_ready_a, push_ready == pop_ready[0])
+
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks
+    // Every output follows the source valid, including when the source is idle.
+    `BR_ASSERT(pop_valid_a, pop_valid[i] == push_valid)
+
+    // Each sink accepts exactly when the source does, forbidding partial transfers.
+    `BR_ASSERT(transfer_lockstep_a, fv_pop_transfer[i] == fv_push_transfer)
+
+    if (EnableAssertPushValidStability) begin : gen_pop_valid_stability
+      // The source hold contract must propagate to each backpressured output.
+      `BR_ASSERT(pop_valid_stable_a, pop_valid[i] && !pop_ready[i] |=> pop_valid[i])
+    end
+
+    if (EnableAssertNoPushBackpressure) begin : gen_no_pop_backpressure
+      // A valid output cannot be stalled under the no-backpressure input contract.
+      `BR_ASSERT(no_pop_backpressure_a, pop_valid[i] |-> pop_ready[i])
+    end
+  end
+
+  // Available input and ready sinks must transfer together without adding latency.
+  `BR_ASSERT(forward_progress_a,
+             push_valid && (&pop_ready) |-> fv_push_transfer && (&fv_pop_transfer))
+
+  // ----------Covers----------
+  // Readiness may remain low while the source is idle in every parameter mode.
+  `BR_COVER(idle_not_ready_c, !push_valid && (pop_valid == '0) && !push_ready && (pop_ready == '0))
+
+  // An idle source does not prevent readiness from reaching the push interface.
+  `BR_COVER(idle_ready_c, !push_valid && (pop_valid == '0) && push_ready && (&pop_ready))
+
+  // Exercise a transfer accepted by the source and every sink in the same cycle.
+  `BR_COVER(all_flows_transfer_c, fv_push_transfer && (&fv_pop_transfer))
+
+  // Exercise full throughput without inserting a bubble between transfers.
+  `BR_COVER(consecutive_transfers_c,
+            fv_push_transfer && (&fv_pop_transfer) ##1 fv_push_transfer && (&fv_pop_transfer))
+
+  if (EnableCoverPushBackpressure) begin : gen_backpressure_covers
+    // All outputs may remain stalled together for more than one cycle.
+    `BR_COVER(sustained_stall_c, fv_stall ##1 fv_stall)
+
+    // A sustained stall can release directly into a simultaneous transfer.
+    `BR_COVER(stall_then_transfer_c,
+              fv_stall ##1 fv_stall ##1 fv_push_transfer && (&fv_pop_transfer))
+
+    if (!EnableAssertPushValidStability) begin : gen_unstable_valid_cover
+      // Without the source hold contract, valid may withdraw while sinks stay stalled.
+      `BR_COVER(valid_withdrawal_c,
+                fv_stall ##1
+               !push_valid && (pop_valid == '0) && !push_ready && (pop_ready == '0))
+    end
+  end
+
+endmodule : br_flow_fork_lockstep_fpv_monitor
+
+bind br_flow_fork_lockstep br_flow_fork_lockstep_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure)
+) monitor (.*);

--- a/flow/fpv/join/BUILD.bazel
+++ b/flow/fpv/join/BUILD.bazel
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("//bazel:br_verilog.bzl", "br_verilog_fpv_test_tools_suite")
+load("//bazel:verilog.bzl", "verilog_elab_test")
+
+package(default_visibility = ["//visibility:private"])
+
+# Bedrock-RTL Lockstep Flow Join
+
+verilog_library(
+    name = "br_flow_join_lockstep_fpv_monitor",
+    srcs = ["br_flow_join_lockstep_fpv_monitor.sv"],
+    deps = [
+        "//flow/rtl:br_flow_join_lockstep",
+        "//macros:br_asserts",
+        "//macros:br_registers",
+    ],
+)
+
+verilog_elab_test(
+    name = "br_flow_join_lockstep_fpv_monitor_elab_test",
+    defines = [
+        "BR_ASSERT_ON",
+        "BR_ENABLE_IMPL_CHECKS",
+        "BR_DISABLE_FINAL_CHECKS",
+        "BR_ENABLE_FPV",
+        "BR_DISABLE_ASSERT_IMM",
+    ],
+    tool = "slang",
+    top = "br_flow_join_lockstep",
+    deps = [":br_flow_join_lockstep_fpv_monitor"],
+)
+
+verilog_elab_test(
+    name = "br_flow_join_lockstep_fpv_monitor_multiflow_elab_test",
+    defines = [
+        "BR_ASSERT_ON",
+        "BR_ENABLE_IMPL_CHECKS",
+        "BR_DISABLE_FINAL_CHECKS",
+        "BR_ENABLE_FPV",
+        "BR_DISABLE_ASSERT_IMM",
+    ],
+    params = {"NumFlows": "5"},
+    tool = "slang",
+    top = "br_flow_join_lockstep",
+    deps = [":br_flow_join_lockstep_fpv_monitor"],
+)
+
+br_verilog_fpv_test_tools_suite(
+    name = "br_flow_join_lockstep_test_suite",
+    illegal_param_combinations = {
+        (
+            "EnableAssertPushValidStability",
+            "EnableCoverPushBackpressure",
+        ): [
+            ("1", "0"),
+        ],
+        (
+            "EnableAssertNoPushBackpressure",
+            "EnableCoverPushBackpressure",
+        ): [
+            ("1", "1"),
+        ],
+    },
+    params = {
+        "EnableAssertNoPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "EnableAssertPushValidStability": [
+            "0",
+            "1",
+        ],
+        "EnableCoverPushBackpressure": [
+            "0",
+            "1",
+        ],
+        "NumFlows": [
+            "1",
+            "2",
+            "4",
+            "5",
+        ],
+    },
+    tools = {
+        "jg": "",
+    },
+    top = "br_flow_join_lockstep",
+    deps = [":br_flow_join_lockstep_fpv_monitor"],
+)

--- a/flow/fpv/join/BUILD.bazel
+++ b/flow/fpv/join/BUILD.bazel
@@ -20,13 +20,6 @@ verilog_library(
 
 verilog_elab_test(
     name = "br_flow_join_lockstep_fpv_monitor_elab_test",
-    defines = [
-        "BR_ASSERT_ON",
-        "BR_ENABLE_IMPL_CHECKS",
-        "BR_DISABLE_FINAL_CHECKS",
-        "BR_ENABLE_FPV",
-        "BR_DISABLE_ASSERT_IMM",
-    ],
     tool = "slang",
     top = "br_flow_join_lockstep",
     deps = [":br_flow_join_lockstep_fpv_monitor"],
@@ -34,13 +27,6 @@ verilog_elab_test(
 
 verilog_elab_test(
     name = "br_flow_join_lockstep_fpv_monitor_multiflow_elab_test",
-    defines = [
-        "BR_ASSERT_ON",
-        "BR_ENABLE_IMPL_CHECKS",
-        "BR_DISABLE_FINAL_CHECKS",
-        "BR_ENABLE_FPV",
-        "BR_DISABLE_ASSERT_IMM",
-    ],
     params = {"NumFlows": "5"},
     tool = "slang",
     top = "br_flow_join_lockstep",

--- a/flow/fpv/join/br_flow_join_lockstep_fpv_monitor.sv
+++ b/flow/fpv/join/br_flow_join_lockstep_fpv_monitor.sv
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// FPV testplan: br_flow_join_lockstep
+//
+// Design specification:
+// - Control-only, combinational NumFlows-to-1 join with no storage or datapath.
+// - All upstream push_valid bits must be equal.
+// - Pass push_valid[0] to pop_valid and replicate pop_ready to every push_ready
+//   bit. Every upstream transfer coincides with the downstream transfer.
+// - clk and synchronous active-high rst serve assertions only; reset does not
+//   clear, gate, or register the flow-control outputs.
+//
+// Input assumptions (all expressed using primary inputs):
+// - push_valid_lockstep_a: push_valid == {NumFlows{push_valid[0]}}.
+// - push_valid_stable_a: when EnableAssertPushValidStability is enabled,
+//   push_valid[i] && !pop_ready requires push_valid[i] on the following cycle.
+// - no_push_backpressure_a: when EnableAssertNoPushBackpressure is enabled,
+//   push_valid[0] implies pop_ready. Do not constrain readiness while idle.
+// - No readiness fairness is needed: progress is checked in the same cycle that
+//   the sources are valid and the sink is ready. Permanent stalls remain legal
+//   when backpressure is allowed.
+//
+// Output assertions:
+// - pop_valid_a: pop_valid equals push_valid[0], including idle cycles.
+// - push_ready_a: every push_ready bit equals pop_ready, independent of valid.
+// - transfer_lockstep_a: for each flow, push_valid[i] && push_ready[i] equals
+//   pop_valid && pop_ready (no partial, lost, duplicated, or spurious transfer).
+// - pop_valid_stable_a: valid persists under backpressure when source-valid
+//   stability is enabled.
+// - no_pop_backpressure_a: the valid output is never stalled in
+//   no-backpressure mode.
+// - forward_progress_a: valid sources with a ready sink all transfer
+//   immediately; no eventual-ready assumption or liveness bound is required.
+//
+// Covers:
+// - All sources idle with the sink ready and with the sink not ready.
+// - All sources transfer together, then transfer again on the next cycle.
+// - When EnableCoverPushBackpressure is enabled, sustained all-source stall and
+//   release of a stall into a simultaneous transfer.
+// - When source stability is disabled and backpressure coverage is enabled,
+//   withdraw all push_valid bits together while the sink remains stalled.
+//
+// Parameter and proof boundaries:
+// - Sweep NumFlows = 1, 2, 4, 5 and all four legal combinations of the three
+//   backpressure/stability flags (16 configurations).
+// - Exclude NumFlows < 1, stability enabled with backpressure coverage disabled,
+//   and no-backpressure assertion enabled with backpressure coverage enabled.
+// - EnableAssertFinalNotValid is forwarded; the standard FPV wrapper disables
+//   simulation-only final checks. No payload ordering scoreboard is applicable.
+// - Normal startup reset only; properties are disabled during reset.
+
+`include "br_asserts.svh"
+`include "br_registers.svh"
+
+module br_flow_join_lockstep_fpv_monitor #(
+    parameter int NumFlows = 1,
+    parameter bit EnableCoverPushBackpressure = 1,
+    parameter bit EnableAssertPushValidStability = EnableCoverPushBackpressure,
+    parameter bit EnableAssertFinalNotValid = 1,
+    parameter bit EnableAssertNoPushBackpressure = !EnableCoverPushBackpressure
+) (
+    input logic clk,
+    input logic rst,
+
+    // Push-side interfaces
+    input logic [NumFlows-1:0] push_ready,
+    input logic [NumFlows-1:0] push_valid,
+
+    // Pop-side interface
+    input logic pop_ready,
+    input logic pop_valid
+);
+
+  // ----------FV assumptions----------
+  // The upstream sources present their valid bits in lockstep.
+  `BR_ASSUME(push_valid_lockstep_a, push_valid == {NumFlows{push_valid[0]}})
+
+  if (EnableAssertPushValidStability) begin : gen_push_valid_stability
+    for (genvar i = 0; i < NumFlows; i++) begin : gen_flow
+      // A stalled source retains valid until it can transfer.
+      `BR_ASSUME(push_valid_stable_a, push_valid[i] && !pop_ready |=> push_valid[i])
+    end
+  end
+
+  if (EnableAssertNoPushBackpressure) begin : gen_no_push_backpressure
+    // The sink is ready whenever the lockstep sources present a transfer.
+    `BR_ASSUME(no_push_backpressure_a, push_valid[0] |-> pop_ready)
+  end
+
+  // ----------FV assertions----------
+  // The joined valid follows the source valid even when the sink is stalled.
+  `BR_ASSERT(pop_valid_a, pop_valid == push_valid[0])
+
+  for (genvar i = 0; i < NumFlows; i++) begin : gen_flow_checks
+    // Every source receives the sink readiness, including when all sources are idle.
+    `BR_ASSERT(push_ready_a, push_ready[i] == pop_ready)
+
+    // Each source transfers exactly when the joined output transfers.
+    `BR_ASSERT(transfer_lockstep_a, (push_valid[i] && push_ready[i]) == (pop_valid && pop_ready))
+
+    // A valid source and ready sink complete the transfer in the current cycle.
+    `BR_ASSERT(forward_progress_a, push_valid[i] && pop_ready |-> push_ready[i] && pop_valid)
+  end
+
+  if (EnableAssertPushValidStability) begin : gen_pop_valid_stability
+    // The joined valid obeys the source stability contract while stalled.
+    `BR_ASSERT(pop_valid_stable_a, pop_valid && !pop_ready |=> pop_valid)
+  end
+
+  if (EnableAssertNoPushBackpressure) begin : gen_no_pop_backpressure
+    // The no-backpressure source contract also prevents a stalled joined output.
+    `BR_ASSERT(no_pop_backpressure_a, pop_valid |-> pop_ready)
+  end
+
+  // ----------FV covers----------
+  // All sources can be idle while the sink is not ready.
+  `BR_COVER(idle_not_ready_c, !(|push_valid) && !pop_ready)
+
+  // All sources can be idle while the sink is ready.
+  `BR_COVER(idle_ready_c, !(|push_valid) && pop_ready)
+
+  // All sources and the joined output can transfer together.
+  `BR_COVER(transfer_c, (&push_valid) && (&push_ready) && pop_valid && pop_ready)
+
+  // The join can sustain a transfer on consecutive cycles without inserting a bubble.
+  `BR_COVER(consecutive_transfers_c,
+            ((&push_valid) && (&push_ready) && pop_valid && pop_ready) [* 2])
+
+  if (EnableCoverPushBackpressure) begin : gen_backpressure_covers
+    // All sources and the joined output can remain stalled for multiple cycles.
+    `BR_COVER(sustained_stall_c, ((&push_valid) && !(|push_ready) && pop_valid && !pop_ready) [* 3])
+
+    // A sustained stall can end with a simultaneous source and output transfer.
+    `BR_COVER(stall_release_c,
+              ((&push_valid) && !(|push_ready) && pop_valid && !pop_ready)[*3] ##1
+              ((&push_valid) && (&push_ready) && pop_valid && pop_ready))
+
+    if (!EnableAssertPushValidStability) begin : gen_valid_withdrawal
+      // The relaxed source contract allows all valid bits to fall while still stalled.
+      `BR_COVER(valid_withdrawal_c,
+                ((&push_valid) && pop_valid && !pop_ready) ##1
+                (!(|push_valid) && !pop_valid && !pop_ready))
+    end
+  end
+
+endmodule : br_flow_join_lockstep_fpv_monitor
+
+bind br_flow_join_lockstep br_flow_join_lockstep_fpv_monitor #(
+    .NumFlows(NumFlows),
+    .EnableCoverPushBackpressure(EnableCoverPushBackpressure),
+    .EnableAssertPushValidStability(EnableAssertPushValidStability),
+    .EnableAssertFinalNotValid(EnableAssertFinalNotValid),
+    .EnableAssertNoPushBackpressure(EnableAssertNoPushBackpressure)
+) monitor (.*);


### PR DESCRIPTION
Add FV monitors and parameterized Jasper suites for `br_flow_fork_lockstep` and `br_flow_join_lockstep` #1253. The environments assume equal downstream `pop_ready` inputs for the fork and equal upstream `push_valid` inputs for the join, plus parameter-enabled source stability and no-backpressure contracts. Assertions check ready/valid propagation, simultaneous per-flow transfers, immediate progress when ready, and output backpressure behavior. Covers exercise idle cycles, consecutive transfers, sustained stalls and release, and valid withdrawal where allowed.

Verification passed for `NumFlows = 1, 2, 4, 5` across all four legal backpressure/stability modes: 32 configurations using autogenerated Jasper Tcl, with 544 DUT/monitor assertions proven, 512 covers/preconditions reached, and no counterexamples, unreachable covers, or unresolved properties. `pre-commit run --all-files` passed.