### PR TITLE
[br_cdc_stable_data_autoupdate] Gate src_valid with src_rst

### DIFF
--- a/cdc/rtl/br_cdc_stable_data_autoupdate.sv
+++ b/cdc/rtl/br_cdc_stable_data_autoupdate.sv
@@ -41,7 +41,7 @@ module br_cdc_stable_data_autoupdate #(
 
   // Send into the register if the data has changed but hasn't been
   // crossed over yet.
-  assign src_valid = src_data != src_data_reg;
+  assign src_valid = !src_rst && src_data != src_data_reg;
 
   br_cdc_reg #(
       .Width(Width),


### PR DESCRIPTION
If src_data is different from the initial value during src_rst, we could potentially get an erroneous destination update after coming out of reset. Gating the src_valid fixes the issue.