### PR TITLE
Disable unreachable stable data pop backpressure covers

### DIFF
--- a/cdc/rtl/br_cdc_stable_data.sv
+++ b/cdc/rtl/br_cdc_stable_data.sv
@@ -57,7 +57,9 @@ module br_cdc_stable_data #(
       .RegisterResetActive(RegisterResetActive),
       .NumSyncStages(NumSyncStages),
       // There musn't be push backpressure
-      .EnableCoverPushBackpressure(0)
+      .EnableCoverPushBackpressure(0),
+      // Destination is always ready, so pop backpressure is unreachable.
+      .EnableCoverPopBackpressure(0)
   ) br_cdc_reg_inst (
       .push_clk  (src_clk),    // ri lint_check_waive SAME_CLOCK_NAME
       .push_rst  (src_rst),

--- a/cdc/rtl/br_cdc_stable_data.sv
+++ b/cdc/rtl/br_cdc_stable_data.sv
@@ -56,7 +56,7 @@ module br_cdc_stable_data #(
       .Width(Width),
       .RegisterResetActive(RegisterResetActive),
       .NumSyncStages(NumSyncStages),
-      // There musn't be push backpressure
+      // There mustn't be push backpressure
       .EnableCoverPushBackpressure(0),
       // Destination is always ready, so pop backpressure is unreachable.
       .EnableCoverPopBackpressure(0)

--- a/cdc/rtl/br_cdc_stable_data_autoupdate.sv
+++ b/cdc/rtl/br_cdc_stable_data_autoupdate.sv
@@ -41,7 +41,7 @@ module br_cdc_stable_data_autoupdate #(
 
   // Send into the register if the data has changed but hasn't been
   // crossed over yet.
-  assign src_valid = src_data != src_data_reg;
+  assign src_valid = !src_rst && src_data != src_data_reg;
 
   br_cdc_reg #(
       .Width(Width),

--- a/cdc/rtl/br_cdc_stable_data_autoupdate.sv
+++ b/cdc/rtl/br_cdc_stable_data_autoupdate.sv
@@ -49,7 +49,9 @@ module br_cdc_stable_data_autoupdate #(
       .NumSyncStages(NumSyncStages),
       // Both valid and data can change if src_data changes while the register is backpressured.
       .EnableAssertPushValidStability(0),
-      .EnableAssertPushDataStability(0)
+      .EnableAssertPushDataStability(0),
+      // Destination is always ready, so pop backpressure is unreachable.
+      .EnableCoverPopBackpressure(0)
   ) br_cdc_reg_inst (
       .push_clk  (src_clk),    // ri lint_check_waive SAME_CLOCK_NAME
       .push_rst  (src_rst),


### PR DESCRIPTION
## Summary

`br_cdc_stable_data` and `br_cdc_stable_data_autoupdate` always drive:

```systemverilog
.pop_ready(1'b1)
```
Their internal br_cdc_reg instances still had pop-backpressure coverage enabled, which generated unreachable backpressure precondition covers and caused the FPV targets to fail despite all functional assertions proving.
## Validation
- pre-commit run --all-files
- Ran all 48 stable-data/autoupdate FPV parameter configurations
- 48/48 Bazel targets pass
- 0 CEX
- 0 unreachable
- 0 undetermined
- 0 timeout