### PR TITLE
[amba][fpv] Limit AXI-Lite write arbiter proof runtime

### DIFF
--- a/amba/fpv/br_amba_axil_write_arbiter_fpv.jg.tcl
+++ b/amba/fpv/br_amba_axil_write_arbiter_fpv.jg.tcl
@@ -35,5 +35,8 @@ cover -disable *monitor.downstream*master_w_aw_wstrb_valid_non_dbc:precondition1
 cover -disable *monitor.downstream*master_aw_awvalid_eventually:precondition1
 cover -disable *monitor.downstream*master_w_wvalid_eventually:precondition1
 
+# limit run time to 30-mins
+set_prove_time_limit 30m
+
 # Prove command
 prove -all


### PR DESCRIPTION
## Summary

- Set the AXI-Lite write-arbiter FPV proof time limit to 30 minutes.
- Align this test with the other AMBA FPV blocks and ensure Jasper exits before the 40-minute regression allocation expires.

