### PR TITLE
[enc] Add onehot encoder assertion control

### DIFF
--- a/enc/rtl/BUILD.bazel
+++ b/enc/rtl/BUILD.bazel
@@ -162,6 +162,10 @@ br_verilog_elab_and_lint_test_suite(
 br_verilog_elab_and_lint_test_suite(
     name = "br_enc_onehot2bin_test_suite",
     params = {
+        "EnableAssertInputOnehot": [
+            "0",
+            "1",
+        ],
         "NumValues": [
             "1",
             "2",

--- a/enc/rtl/br_enc_onehot2bin.sv
+++ b/enc/rtl/br_enc_onehot2bin.sv
@@ -43,7 +43,11 @@
 module br_enc_onehot2bin #(
     parameter int NumValues = 2,  // Must be at least 1
     // Width of the binary-encoded value. Must be at least $clog2(NumValues).
-    parameter int BinWidth = br_math::clamped_clog2(NumValues)
+    parameter int BinWidth = br_math::clamped_clog2(NumValues),
+    // If 1, assert that the input is onehot0 and the output is within range.
+    // If 0, the caller must check onehot0 when consuming the output.
+    // The output remains undefined for multi-hot inputs.
+    parameter bit EnableAssertInputOnehot = 1
 ) (
     // ri lint_check_waive INPUT_NOT_READ HIER_NET_NOT_READ HIER_BRANCH_NOT_READ
     input  logic                 clk,        // Used only for assertions
@@ -61,7 +65,9 @@ module br_enc_onehot2bin #(
   `BR_ASSERT_STATIC(binwidth_gte_log2_num_values_a, BinWidth >= br_math::clamped_clog2(NumValues))
   // This is necessary to avoid an integer overflow in the for-loop below.
   `BR_ASSERT_STATIC(binwidth_lt_32_a, BinWidth < 32)
-  `BR_ASSERT_INTG(in_onehot_a, $onehot0(in))
+  if (EnableAssertInputOnehot) begin : gen_assert_input_onehot
+    `BR_ASSERT_INTG(in_onehot_a, $onehot0(in))
+  end
 
   //------------------------------------------
   // Implementation
@@ -84,6 +90,8 @@ module br_enc_onehot2bin #(
   //------------------------------------------
   // Implementation checks
   //------------------------------------------
-  `BR_ASSERT_IMPL(out_within_range_a, out < NumValues)
+  if (EnableAssertInputOnehot) begin : gen_assert_output_range
+    `BR_ASSERT_IMPL(out_within_range_a, out < NumValues)
+  end
 
 endmodule : br_enc_onehot2bin

--- a/enc/sim/BUILD.bazel
+++ b/enc/sim/BUILD.bazel
@@ -173,6 +173,18 @@ verilog_elab_test(
 
 br_verilog_sim_test_tools_suite(
     name = "br_enc_onehot2bin_tb_sim_test_suite",
+    params = {
+        "NumValues": [
+            "2",
+            "3",
+            "4",
+            "5",
+        ],
+        "EnableAssertInputOnehot": [
+            "0",
+            "1",
+        ],
+    },
     tools = [
         "vcs",
         "verilator",

--- a/enc/sim/br_enc_onehot2bin_tb.sv
+++ b/enc/sim/br_enc_onehot2bin_tb.sv
@@ -26,6 +26,7 @@ module br_enc_onehot2bin_tb;
   //===========================================================
   parameter int NumValues = 2;
   parameter int BinWidth = $clog2(NumValues);
+  parameter bit EnableAssertInputOnehot = 1;
 
   //===========================================================
   // Clock and Reset Signals
@@ -45,7 +46,8 @@ module br_enc_onehot2bin_tb;
   //===========================================================
   br_enc_onehot2bin #(
       .NumValues(NumValues),
-      .BinWidth (BinWidth)
+      .BinWidth(BinWidth),
+      .EnableAssertInputOnehot(EnableAssertInputOnehot)
   ) dut (
       .clk(clk),
       .rst(rst),
@@ -104,6 +106,7 @@ module br_enc_onehot2bin_tb;
   //===========================================================
   initial begin
     reset_dut();
+    if (!EnableAssertInputOnehot) test_MultiHotIdleInput();
     test_NormalConversion();
 
     reset_dut();
@@ -123,6 +126,18 @@ module br_enc_onehot2bin_tb;
       $finish(0);
     end
   end
+
+
+  task automatic test_MultiHotIdleInput;
+    // Ignore outputs during idle cycles, then check legal inputs without a reset.
+    for (int i = 0; i < NumValues; i++) begin
+      for (int j = i + 1; j < NumValues; j++) begin
+        @(cb_clk);
+        cb_clk.in <= (NumValues'(1) << i) | (NumValues'(1) << j);
+        @(cb_clk);
+      end
+    end
+  endtask
 
 
   task automatic test_NormalConversion;


### PR DESCRIPTION
- Add default-enabled `EnableAssertInputOnehot` to `br_enc_onehot2bin`, controlling the onehot0 input assertion and its dependent output-range assertion so callers can apply valid-qualified checks with their real reset.
- Preserve encoder logic and static parameter checks; exercise both settings and recovery from multi-hot idle inputs across power-of-two and irregular sizes.
- Validation: 16 VCS/Verilator simulations, lint/elaboration, default-assertion and static-check negative tests, and all pre-commit checks passed.
